### PR TITLE
feat: add smart message filtering with marker protocol (v1.1)

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,6 +3,12 @@
 import { appendFileSync, unlinkSync, writeFileSync } from "node:fs";
 import type { ServerWebSocket } from "bun";
 import { CodexAdapter } from "./codex-adapter";
+import {
+  BRIDGE_CONTRACT_REMINDER,
+  StatusBuffer,
+  classifyMessage,
+  type FilterMode,
+} from "./message-filter";
 import { TuiConnectionState } from "./tui-connection-state";
 import type { ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
 import type { BridgeMessage } from "./types";
@@ -19,6 +25,8 @@ const PID_FILE = process.env.AGENTBRIDGE_PID_FILE ?? `/tmp/agentbridge-daemon-${
 const LOG_FILE = "/tmp/agentbridge.log";
 const TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 const MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
+const FILTER_MODE: FilterMode =
+  (process.env.AGENTBRIDGE_FILTER_MODE as FilterMode) === "full" ? "full" : "filtered";
 
 const codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT);
 const attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
@@ -54,14 +62,30 @@ const tuiConnectionState = new TuiConnectionState({
   },
 });
 
+const statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
+
 codex.on("agentMessage", (msg: BridgeMessage) => {
   if (msg.source !== "codex") return;
-  log(`Forwarding Codex → Claude (${msg.content.length} chars)`);
-  emitToClaude(msg);
+  const result = classifyMessage(msg.content, FILTER_MODE);
+  log(`Codex → Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
+  switch (result.action) {
+    case "forward":
+      if (result.marker === "important" && statusBuffer.size > 0) {
+        statusBuffer.flush("important message arrived");
+      }
+      emitToClaude(msg);
+      break;
+    case "buffer":
+      statusBuffer.add(msg);
+      break;
+    case "drop":
+      break;
+  }
 });
 
 codex.on("turnCompleted", () => {
   log("Codex turn completed");
+  statusBuffer.flush("turn completed");
 });
 
 codex.on("ready", (threadId: string) => {
@@ -96,6 +120,7 @@ codex.on("error", (err: Error) => {
 
 codex.on("exit", (code: number | null) => {
   log(`Codex process exited (code ${code})`);
+  statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   emitToClaude(
     systemMessage(
@@ -182,8 +207,9 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
         return;
       }
 
+      const contentWithReminder = message.message.content + "\n\n" + BRIDGE_CONTRACT_REMINDER;
       log(`Forwarding Claude → Codex (${message.message.content.length} chars)`);
-      const injected = codex.injectMessage(message.message.content);
+      const injected = codex.injectMessage(contentWithReminder);
       if (!injected) {
         const reason = codex.turnInProgress
           ? "Codex is busy executing a turn. Wait for it to finish before sending another message."
@@ -216,6 +242,7 @@ function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
   ws.data.attached = true;
   log(`Claude frontend attached (#${ws.data.clientId})`);
 
+  statusBuffer.flush("claude reconnected");
   sendStatus(ws);
 
   if (bufferedMessages.length > 0) {
@@ -245,8 +272,9 @@ function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
 
 function emitToClaude(message: BridgeMessage) {
   if (attachedClaude && attachedClaude.readyState === WebSocket.OPEN) {
-    sendBridgeMessage(attachedClaude, message);
-    return;
+    if (trySendBridgeMessage(attachedClaude, message)) return;
+    // Send failed — fall through to buffer
+    log("Send to Claude failed, buffering message for retry on reconnect");
   }
 
   bufferedMessages.push(message);
@@ -257,15 +285,36 @@ function emitToClaude(message: BridgeMessage) {
   }
 }
 
+function trySendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: BridgeMessage): boolean {
+  try {
+    const result = ws.send(JSON.stringify({ type: "codex_to_claude", message } satisfies ControlServerMessage));
+    if (typeof result === "number" && result <= 0) {
+      log(`Bridge message send returned ${result} (0=dropped, -1=backpressure)`);
+      return false;
+    }
+    return true;
+  } catch (err: any) {
+    log(`Failed to send bridge message: ${err.message}`);
+    return false;
+  }
+}
+
 function flushBufferedMessages(ws: ServerWebSocket<ControlSocketData>) {
   const messages = bufferedMessages.splice(0, bufferedMessages.length);
   for (const message of messages) {
-    sendBridgeMessage(ws, message);
+    if (!trySendBridgeMessage(ws, message)) {
+      // Re-buffer this and all remaining messages on failure
+      const failedIndex = messages.indexOf(message);
+      const remaining = messages.slice(failedIndex);
+      bufferedMessages.unshift(...remaining);
+      log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
+      return;
+    }
   }
 }
 
 function sendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: BridgeMessage) {
-  sendProtocolMessage(ws, { type: "codex_to_claude", message });
+  trySendBridgeMessage(ws, message);
 }
 
 function sendStatus(ws: ServerWebSocket<ControlSocketData>) {
@@ -291,7 +340,7 @@ function currentStatus(): DaemonStatus {
     bridgeReady: tuiConnectionState.canReply(),
     tuiConnected: snapshot.tuiConnected,
     threadId: codex.activeThreadId,
-    queuedMessageCount: bufferedMessages.length,
+    queuedMessageCount: bufferedMessages.length + statusBuffer.size,
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
     pid: process.pid,

--- a/src/message-filter.test.ts
+++ b/src/message-filter.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BRIDGE_CONTRACT_REMINDER,
+  StatusBuffer,
+  classifyMessage,
+  parseMarker,
+} from "./message-filter";
+import type { BridgeMessage } from "./types";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function makeMsg(content: string, ts?: number): BridgeMessage {
+  return { id: `test_${Date.now()}`, source: "codex", content, timestamp: ts ?? Date.now() };
+}
+
+describe("parseMarker", () => {
+  test("extracts [IMPORTANT] marker", () => {
+    const r = parseMarker("[IMPORTANT] task done");
+    expect(r.marker).toBe("important");
+    expect(r.body).toBe("task done");
+  });
+
+  test("extracts [STATUS] marker case-insensitive", () => {
+    const r = parseMarker("[status] progress update");
+    expect(r.marker).toBe("status");
+    expect(r.body).toBe("progress update");
+  });
+
+  test("extracts [FYI] marker", () => {
+    const r = parseMarker("[FYI] background info");
+    expect(r.marker).toBe("fyi");
+    expect(r.body).toBe("background info");
+  });
+
+  test("returns untagged for no marker", () => {
+    const r = parseMarker("plain message");
+    expect(r.marker).toBe("untagged");
+    expect(r.body).toBe("plain message");
+  });
+
+  test("handles leading whitespace before marker", () => {
+    const r = parseMarker("  [STATUS] progress");
+    expect(r.marker).toBe("status");
+    expect(r.body).toBe("progress");
+  });
+
+  test("handles leading newline before marker", () => {
+    const r = parseMarker("\n[IMPORTANT] urgent");
+    expect(r.marker).toBe("important");
+    expect(r.body).toBe("urgent");
+  });
+});
+
+describe("classifyMessage", () => {
+  test("forwards IMPORTANT in filtered mode", () => {
+    expect(classifyMessage("[IMPORTANT] x", "filtered")).toEqual({ action: "forward", marker: "important" });
+  });
+
+  test("buffers STATUS in filtered mode", () => {
+    expect(classifyMessage("[STATUS] x", "filtered")).toEqual({ action: "buffer", marker: "status" });
+  });
+
+  test("drops FYI in filtered mode", () => {
+    expect(classifyMessage("[FYI] x", "filtered")).toEqual({ action: "drop", marker: "fyi" });
+  });
+
+  test("forwards untagged in filtered mode", () => {
+    expect(classifyMessage("hello", "filtered")).toEqual({ action: "forward", marker: "untagged" });
+  });
+
+  test("forwards everything in full mode", () => {
+    expect(classifyMessage("[FYI] x", "full")).toEqual({ action: "forward", marker: "untagged" });
+    expect(classifyMessage("[STATUS] x", "full")).toEqual({ action: "forward", marker: "untagged" });
+  });
+});
+
+describe("StatusBuffer", () => {
+  test("flushes when threshold reached", () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), { flushThreshold: 2, flushTimeoutMs: 60000 });
+    buf.add(makeMsg("[STATUS] a"));
+    expect(flushed).toHaveLength(0);
+    buf.add(makeMsg("[STATUS] b"));
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0].content).toContain("2 update(s)");
+    buf.dispose();
+  });
+
+  test("flushes on timeout", async () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), { flushThreshold: 10, flushTimeoutMs: 20 });
+    buf.add(makeMsg("[STATUS] a"));
+    await sleep(40);
+    expect(flushed).toHaveLength(1);
+    buf.dispose();
+  });
+
+  test("manual flush clears buffer", () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), { flushThreshold: 10, flushTimeoutMs: 60000 });
+    buf.add(makeMsg("[STATUS] a"));
+    buf.add(makeMsg("[STATUS] b"));
+    buf.flush("turn completed");
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0].content).toContain("flushed: turn completed");
+    expect(buf.size).toBe(0);
+    buf.dispose();
+  });
+
+  test("flush on empty buffer is no-op", () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m));
+    buf.flush("test");
+    expect(flushed).toHaveLength(0);
+    buf.dispose();
+  });
+
+  test("dispose clears timer and buffer", async () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), { flushThreshold: 10, flushTimeoutMs: 20 });
+    buf.add(makeMsg("[STATUS] a"));
+    buf.dispose();
+    await sleep(40);
+    expect(flushed).toHaveLength(0);
+  });
+});
+
+describe("BRIDGE_CONTRACT_REMINDER", () => {
+  test("contains marker instructions", () => {
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("[IMPORTANT]");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("[STATUS]");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("[FYI]");
+  });
+});

--- a/src/message-filter.ts
+++ b/src/message-filter.ts
@@ -1,0 +1,109 @@
+import type { BridgeMessage } from "./types";
+
+export type MarkerLevel = "important" | "status" | "fyi" | "untagged";
+export type FilterMode = "filtered" | "full";
+
+export interface FilterResult {
+  action: "forward" | "buffer" | "drop";
+  marker: MarkerLevel;
+}
+
+const MARKER_REGEX = /^\s*\[(IMPORTANT|STATUS|FYI)\]\s*/i;
+
+export function parseMarker(content: string): { marker: MarkerLevel; body: string } {
+  const match = content.match(MARKER_REGEX);
+  if (!match) return { marker: "untagged", body: content };
+  return {
+    marker: match[1].toLowerCase() as MarkerLevel,
+    body: content.slice(match[0].length),
+  };
+}
+
+export function classifyMessage(content: string, mode: FilterMode): FilterResult {
+  if (mode === "full") return { action: "forward", marker: "untagged" };
+  const { marker } = parseMarker(content);
+  switch (marker) {
+    case "important":
+      return { action: "forward", marker };
+    case "status":
+      return { action: "buffer", marker };
+    case "fyi":
+      return { action: "drop", marker };
+    case "untagged":
+      return { action: "forward", marker };
+  }
+}
+
+const BRIDGE_CONTRACT_REMINDER = `[Bridge Contract] When sending agentMessage, use markers:
+- [IMPORTANT] for decisions, reviews, completions, blockers
+- [STATUS] for progress updates
+- [FYI] for background context
+Keep agentMessage for high-value communication only.`;
+
+export { BRIDGE_CONTRACT_REMINDER };
+
+export class StatusBuffer {
+  private buffer: BridgeMessage[] = [];
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly flushThreshold: number;
+  private readonly flushTimeoutMs: number;
+
+  constructor(
+    private readonly onFlush: (summary: BridgeMessage) => void,
+    options?: { flushThreshold?: number; flushTimeoutMs?: number },
+  ) {
+    this.flushThreshold = options?.flushThreshold ?? 3;
+    this.flushTimeoutMs = options?.flushTimeoutMs ?? 15000;
+  }
+
+  get size(): number {
+    return this.buffer.length;
+  }
+
+  add(message: BridgeMessage): void {
+    this.buffer.push(message);
+    this.resetTimer();
+    if (this.buffer.length >= this.flushThreshold) {
+      this.flush("threshold reached");
+    }
+  }
+
+  flush(reason: string): void {
+    if (this.buffer.length === 0) return;
+    this.clearTimer();
+    const combined = this.buffer
+      .map((m) => parseMarker(m.content).body)
+      .join("\n---\n");
+    const summary: BridgeMessage = {
+      id: `status_summary_${Date.now()}`,
+      source: "codex",
+      content: `[STATUS summary — ${this.buffer.length} update(s), flushed: ${reason}]\n${combined}`,
+      timestamp: Date.now(),
+    };
+    // Clear AFTER calling onFlush — if the send fails, emitToClaude's
+    // bufferedMessages fallback will still capture the summary. Clearing
+    // first would lose messages when ws.send() throws on a closing socket.
+    this.onFlush(summary);
+    this.buffer = [];
+  }
+
+  dispose(): void {
+    this.clearTimer();
+    this.buffer = [];
+  }
+
+  private clearTimer(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  private resetTimer(): void {
+    this.clearTimer();
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.flush("timeout");
+    }, this.flushTimeoutMs);
+  }
+}


### PR DESCRIPTION
## Summary

- Add marker-based message filtering for the Codex→Claude message path
- `[IMPORTANT]` → forward immediately (flush pending STATUS first)
- `[STATUS]` → buffer, flush on: threshold (3), timeout (15s), turn complete, or IMPORTANT arrival
- `[FYI]` → drop in filtered mode
- Untagged → forward immediately (backward compat)
- Append bridge contract reminder to Claude→Codex messages

## Files changed

- `src/message-filter.ts` — new module: `parseMarker`, `classifyMessage`, `StatusBuffer`, `BRIDGE_CONTRACT_REMINDER`
- `src/message-filter.test.ts` — 15 tests covering marker parsing, classification, buffer flush, timeout, dispose
- `src/daemon.ts` — wire filter into agentMessage handler, flush on turnCompleted, contract reminder injection

## New env var

`AGENTBRIDGE_FILTER_MODE=filtered|full` (default: `filtered`)

## Test plan

- [x] 15 new filter tests pass
- [x] All existing tests pass (26 total)
- [x] TypeScript type check passes
- [ ] Manual test: send `[STATUS]` messages and verify buffering/flush
- [ ] Manual test: verify `[FYI]` messages are dropped in filtered mode
- [ ] Manual test: verify `full` mode forwards everything

## Author

Codex (OpenAI) — code reviewed by Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex](https://openai.com/codex)