### PR TITLE
feat: add role-aware collaboration and thinking patterns (v1.3)

### DIFF
--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -25,6 +25,40 @@ import type { BridgeMessage } from "./types";
 export type ReplySender = (msg: BridgeMessage) => Promise<{ success: boolean; error?: string }>;
 export type DeliveryMode = "push" | "pull" | "auto";
 
+export const CLAUDE_INSTRUCTIONS = [
+  "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
+  "",
+  "## Message delivery",
+  "Messages from Codex may arrive in two ways depending on the connection mode:",
+  "- As <channel source=\"agentbridge\" chat_id=\"...\" user=\"Codex\" ...> tags (push mode)",
+  "- Via the get_messages tool (pull mode)",
+  "",
+  "## Collaboration roles",
+  "Default roles in this setup:",
+  "- Claude: Reviewer, Planner, Hypothesis Challenger",
+  "- Codex: Implementer, Executor, Reproducer/Verifier",
+  "- Expect Codex to provide independent technical judgment and evidence, not passive agreement.",
+  "",
+  "## Thinking patterns (task-driven)",
+  "- Analytical/review tasks: Independent Analysis & Convergence",
+  "- Implementation tasks: Architect -> Builder -> Critic",
+  "- Debugging tasks: Hypothesis -> Experiment -> Interpretation",
+  "",
+  "## Collaboration language",
+  "- Use explicit phrases such as \"My independent view is:\", \"I agree on:\", \"I disagree on:\", and \"Current consensus:\".",
+  "",
+  "## How to interact",
+  "- Use the reply tool to send messages back to Codex — pass chat_id back.",
+  "- Use the get_messages tool to check for pending messages from Codex.",
+  "- After sending a reply, call get_messages to check for responses.",
+  "- When the user asks about Codex status or progress, call get_messages.",
+  "",
+  "## Turn coordination",
+  "- When you see '⏳ Codex is working', do NOT call the reply tool — wait for '✅ Codex finished'.",
+  "- After Codex finishes a turn, you have an attention window to review and respond before new messages arrive.",
+  "- If the reply tool returns a busy error, Codex is still executing — wait and try again later.",
+].join("\n");
+
 const LOG_FILE = "/tmp/agentbridge.log";
 
 export class ClaudeAdapter extends EventEmitter {
@@ -55,20 +89,7 @@ export class ClaudeAdapter extends EventEmitter {
           experimental: { "claude/channel": {} },
           tools: {},
         },
-        instructions: [
-          "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
-          "",
-          "## Message delivery",
-          "Messages from Codex may arrive in two ways depending on the connection mode:",
-          "- As <channel source=\"agentbridge\" chat_id=\"...\" user=\"Codex\" ...> tags (push mode)",
-          "- Via the get_messages tool (pull mode)",
-          "",
-          "## How to interact",
-          "- Use the reply tool to send messages back to Codex — pass chat_id back.",
-          "- Use the get_messages tool to check for pending messages from Codex.",
-          "- After sending a reply, call get_messages to check for responses.",
-          "- When the user asks about Codex status or progress, call get_messages.",
-        ].join("\n"),
+        instructions: CLAUDE_INSTRUCTIONS,
       },
     );
 

--- a/src/message-filter.ts
+++ b/src/message-filter.ts
@@ -34,11 +34,20 @@ export function classifyMessage(content: string, mode: FilterMode): FilterResult
   }
 }
 
-const BRIDGE_CONTRACT_REMINDER = `[Bridge Contract] When sending agentMessage, use markers:
+const BRIDGE_CONTRACT_REMINDER = `[Bridge Contract] When sending agentMessage, put the marker at the very start of the message:
 - [IMPORTANT] for decisions, reviews, completions, blockers
 - [STATUS] for progress updates
 - [FYI] for background context
-Keep agentMessage for high-value communication only.`;
+The marker MUST be the first text in the message (e.g. "[IMPORTANT] Task done", not "Task done [IMPORTANT]").
+Keep agentMessage for high-value communication only.
+
+[Role Guidance for Codex]
+- Your default role: Implementer, Executor, Verifier
+- Analytical/review tasks: Independent Analysis & Convergence
+- Implementation tasks: Architect -> Builder -> Critic
+- Debugging tasks: Hypothesis -> Experiment -> Interpretation
+- Do not blindly follow Claude - challenge with evidence when you disagree
+- Use explicit collaboration phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:"`;
 
 export { BRIDGE_CONTRACT_REMINDER };
 

--- a/src/role-patterns.test.ts
+++ b/src/role-patterns.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { ClaudeAdapter, CLAUDE_INSTRUCTIONS } from "./claude-adapter";
+import { BRIDGE_CONTRACT_REMINDER } from "./message-filter";
+
+describe("role-aware collaboration guidance", () => {
+  test("claude instructions include role keywords and thinking patterns", () => {
+    expect(CLAUDE_INSTRUCTIONS).toContain("Claude: Reviewer, Planner, Hypothesis Challenger");
+    expect(CLAUDE_INSTRUCTIONS).toContain("Codex: Implementer, Executor, Reproducer/Verifier");
+    expect(CLAUDE_INSTRUCTIONS).toContain("Independent Analysis & Convergence");
+    expect(CLAUDE_INSTRUCTIONS).toContain("Architect -> Builder -> Critic");
+    expect(CLAUDE_INSTRUCTIONS).toContain("Hypothesis -> Experiment -> Interpretation");
+    expect(CLAUDE_INSTRUCTIONS).toContain("My independent view is:");
+    expect(CLAUDE_INSTRUCTIONS).toContain("I agree on:");
+    expect(CLAUDE_INSTRUCTIONS).toContain("I disagree on:");
+    expect(CLAUDE_INSTRUCTIONS).toContain("Current consensus:");
+  });
+
+  test("claude instructions include turn coordination guidance", () => {
+    expect(CLAUDE_INSTRUCTIONS).toContain("Codex is working");
+    expect(CLAUDE_INSTRUCTIONS).toContain("Codex finished");
+    expect(CLAUDE_INSTRUCTIONS).toContain("busy error");
+  });
+
+  test("bridge contract reminder includes codex role guidance", () => {
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("Your default role: Implementer, Executor, Verifier");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("Independent Analysis & Convergence");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("Architect -> Builder -> Critic");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("Hypothesis -> Experiment -> Interpretation");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("Do not blindly follow Claude");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("My independent view is:");
+  });
+
+  test("bridge contract reminder specifies marker must be at start", () => {
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("at the very start");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("MUST be the first text");
+  });
+
+  test("CLAUDE_INSTRUCTIONS is wired into MCP Server", () => {
+    const adapter = new ClaudeAdapter() as any;
+    // Verify the exported constant is actually passed to the Server constructor
+    const serverInstructions = adapter.server._instructions;
+    expect(serverInstructions).toBe(CLAUDE_INSTRUCTIONS);
+  });
+});


### PR DESCRIPTION
## Summary

- Add default role contract: Claude (Reviewer/Planner) + Codex (Implementer/Executor)
- Add task-driven thinking patterns in Claude instructions
- Expand bridge contract reminder with Codex role guidance
- Encourage independent analysis and explicit collaboration language

## Files changed

- `src/claude-adapter.ts` — role and thinking pattern instructions
- `src/message-filter.ts` — expanded contract reminder with Codex role guidance
- `src/role-patterns.test.ts` — 2 tests verifying role keywords in instructions and contract

## Author

Codex (OpenAI) — reviewed by Claude

## Test plan

- [x] All existing tests pass
- [x] 2 new role-patterns tests pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex](https://openai.com/codex)