### PR TITLE
fix: response handling and terminal-safe TUI attach wrapper

### DIFF
--- a/scripts/agentbridge-attach.sh
+++ b/scripts/agentbridge-attach.sh
@@ -33,17 +33,26 @@ restore_terminal() {
   fi
 
   # Disable terminal modes that Codex TUI enables
-  # These are safe no-ops if the modes were never enabled
-  printf '\e[<u' 2>/dev/null || true        # Disable keyboard enhancement
-  printf '\e[?2004l' 2>/dev/null || true     # Disable bracketed paste
-  printf '\e[?1004l' 2>/dev/null || true     # Disable focus tracking
-  printf '\e[?1049l' 2>/dev/null || true     # Leave alternate screen
-  printf '\e[?25h' 2>/dev/null || true       # Show cursor
-  printf '\e[0m' 2>/dev/null || true         # Reset character attributes
+  # Write to /dev/tty when available to ensure sequences reach the terminal
+  # even if stdout has been redirected
+  local tty_target="/dev/tty"
+  if ! [ -w "$tty_target" ]; then
+    if [ -t 1 ]; then
+      tty_target="/dev/stdout"
+    else
+      return
+    fi
+  fi
+  printf '\e[<u' >"$tty_target" 2>/dev/null || true        # Disable keyboard enhancement
+  printf '\e[?2004l' >"$tty_target" 2>/dev/null || true     # Disable bracketed paste
+  printf '\e[?1004l' >"$tty_target" 2>/dev/null || true     # Disable focus tracking
+  printf '\e[?1049l' >"$tty_target" 2>/dev/null || true     # Leave alternate screen
+  printf '\e[?25h' >"$tty_target" 2>/dev/null || true       # Show cursor
+  printf '\e[0m' >"$tty_target" 2>/dev/null || true         # Reset character attributes
 }
 
 # Register cleanup on any exit
-trap restore_terminal EXIT
+trap restore_terminal EXIT INT TERM
 
 echo "Attaching Codex TUI to AgentBridge proxy at ${PROXY_URL}..."
 echo "(Terminal state saved — will be restored on exit)"

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -125,6 +125,32 @@ describe("CodexAdapter app-server response handling", () => {
     adapter.clearResponseTrackingState();
   });
 
+  test("treats empty string and non-integer string IDs as unmatched (not coerced to 0)", () => {
+    const adapter = createAdapter();
+    const intercepted: Array<{ message: any; connId?: number }> = [];
+    adapter.interceptServerMessage = (message: any, connId?: number) => intercepted.push({ message, connId });
+
+    // Map id 0 — if empty string were coerced to 0 via Number(""), it would falsely match
+    adapter.tuiConnId = 1;
+    adapter.upstreamToClient.set(0, { connId: 1, clientId: "client-zero" });
+
+    // Empty string id: should NOT match id 0
+    const empty = adapter.handleAppServerPayload(JSON.stringify({ id: "", result: {} }));
+    expect(empty).toBeNull();
+    expect(adapter.upstreamToClient.has(0)).toBe(true); // still there, not consumed
+
+    // Float string id: should NOT match
+    const float = adapter.handleAppServerPayload(JSON.stringify({ id: "1.5", result: {} }));
+    expect(float).toBeNull();
+
+    // Hex string id: should NOT match
+    const hex = adapter.handleAppServerPayload(JSON.stringify({ id: "0xff", result: {} }));
+    expect(hex).toBeNull();
+
+    expect(intercepted).toEqual([]);
+    adapter.clearResponseTrackingState();
+  });
+
   test("still forwards notifications with no response id", () => {
     const adapter = createAdapter();
     const intercepted: Array<{ message: any; connId?: number }> = [];

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -361,7 +361,7 @@ export class CodexAdapter extends EventEmitter {
     // Handle response IDs that may arrive as numeric strings (e.g. "100005"
     // instead of 100005). Non-numeric string IDs like "initialize" stay NaN
     // and fall through to the unmatched response log at the end of this method.
-    const numericId = typeof responseId === "number" ? responseId : (typeof responseId === "string" ? Number(responseId) : NaN);
+    const numericId = typeof responseId === "number" ? responseId : (typeof responseId === "string" && /^-?\d+$/.test(responseId) ? Number(responseId) : NaN);
     const mapping = !isNaN(numericId) ? this.upstreamToClient.get(numericId) : undefined;
 
     if (mapping) {


### PR DESCRIPTION
## Summary

Bug investigation with Codex cross-review found 2 fixable issues + 1 upstream bug:

- **Proxy**: support numeric-string response IDs, log when response arrives but no TUI connected
- **Terminal**: wrapper script saves/restores terminal state around Codex TUI launch
- **Resume hang**: confirmed as Codex upstream bug (GitHub #14470, #12382, #12515)

## Files changed

- `src/codex-adapter.ts` — numeric-string ID support in handleAppServerResponse, TUI-absent response logging
- `scripts/agentbridge-attach.sh` — new wrapper that protects terminal from corruption after kill -9

## Test plan

- [x] 61 tests pass
- [x] TypeScript type check passes
- [x] bash -n syntax check passes on wrapper
- [ ] Manual: kill -9 Codex TUI via wrapper, verify terminal recovers

## Review

Codex reviewed 2 rounds, all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex](https://openai.com/codex)