### PR TITLE
feat: bootstrap command delegates to ConfigService (Task 6B)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "bun run src/bridge.ts",
-    "build:plugin": "mkdir -p plugins/agentbridge/server && bun build src/bridge.ts --outfile plugins/agentbridge/server/bridge-server.js --target bun && bun build src/daemon.ts --outfile plugins/agentbridge/server/daemon.js --target bun",
+    "build:plugin": "mkdir -p plugins/agentbridge/server plugins/agentbridge/scripts && bun build src/bridge.ts --outfile plugins/agentbridge/server/bridge-server.js --target bun && bun build src/daemon.ts --outfile plugins/agentbridge/server/daemon.js --target bun && bun build src/plugin/init-project.ts --outfile plugins/agentbridge/scripts/init-project.js --target bun",
     "validate:plugin": "claude plugin validate plugins/agentbridge && claude plugin validate .claude-plugin/marketplace.json",
     "test": "bun test src",
     "typecheck": "tsc --noEmit",

--- a/plugins/agentbridge/README.md
+++ b/plugins/agentbridge/README.md
@@ -11,6 +11,7 @@ plugins/agentbridge/
 ├── commands/init.md
 ├── hooks/hooks.json
 ├── scripts/health-check.sh
+├── scripts/init-project.js
 └── server/
     ├── bridge-server.js
     └── daemon.js
@@ -28,6 +29,7 @@ This creates self-contained bundles at:
 
 - `plugins/agentbridge/server/bridge-server.js`
 - `plugins/agentbridge/server/daemon.js`
+- `plugins/agentbridge/scripts/init-project.js`
 
 ## Local Testing
 
@@ -39,4 +41,4 @@ This creates self-contained bundles at:
 
 - The plugin frontend launches the sibling daemon bundle via `AGENTBRIDGE_DAEMON_ENTRY=./daemon.js`.
 - The SessionStart hook is informational only. It never starts or stops the daemon.
-- The command at `/agentbridge:init` edits project-local `.agentbridge/` files only; plugin installation remains the job of terminal `agentbridge init`.
+- The command at `/agentbridge:init` runs the bundled `init-project.js` helper, which uses ConfigService to initialize project-local `.agentbridge/` files. Plugin installation remains the job of terminal `agentbridge init`.

--- a/plugins/agentbridge/commands/init.md
+++ b/plugins/agentbridge/commands/init.md
@@ -1,69 +1,29 @@
 ---
 description: Create or update the AgentBridge project config files in the current workspace
-allowed-tools: Read,Write,Edit,MultiEdit,LS
+allowed-tools: Bash
 ---
 
 Bootstrap or update AgentBridge's project-local configuration in this workspace.
 
 Follow these rules:
 
-1. Work only inside `.agentbridge/`.
-2. Do not install plugins or modify `.claude/settings.json` here. Terminal `agentbridge init` handles plugin installation and marketplace setup.
-3. Preserve user edits when the files already exist. Update only the fields the user asked to change.
-4. Keep `.agentbridge/config.json` valid JSON.
-5. Keep `.agentbridge/collaboration.md` human-editable and concise.
+1. Do not install plugins or modify `.claude/settings.json` here. Terminal `agentbridge init` handles plugin installation and marketplace setup.
+2. Do not hand-write `.agentbridge/config.json` or `.agentbridge/collaboration.md` in this command. Use the bundled bootstrap script so ConfigService remains the single source of truth.
+3. The bootstrap script checks prerequisites (`bun`, `codex`) and initializes defaults through ConfigService.
+4. Existing project config files must be preserved. If they already exist, report that they were left unchanged.
 
-If `.agentbridge/config.json` is missing, create it with this default template:
+Execute exactly this command with the Bash tool:
 
-```json
-{
-  "version": "1.0",
-  "daemon": {
-    "port": 4500,
-    "proxyPort": 4501
-  },
-  "agents": {
-    "claude": {
-      "role": "Reviewer, Planner",
-      "mode": "push"
-    },
-    "codex": {
-      "role": "Implementer, Executor"
-    }
-  },
-  "markers": ["IMPORTANT", "STATUS", "FYI"],
-  "turnCoordination": {
-    "attentionWindowSeconds": 15,
-    "busyGuard": true
-  },
-  "idleShutdownSeconds": 30
-}
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/scripts/init-project.js" "${CLAUDE_PROJECT_DIR:-$PWD}"
 ```
 
-If `.agentbridge/collaboration.md` is missing, create it with this default template:
+Then:
 
-```markdown
-# Collaboration Rules
-
-## Roles
-- Claude: Reviewer, Planner, Hypothesis Challenger
-- Codex: Implementer, Executor, Reproducer/Verifier
-
-## Thinking Patterns
-- Analytical/review tasks: Independent Analysis & Convergence
-- Implementation tasks: Architect -> Builder -> Critic
-- Debugging tasks: Hypothesis -> Experiment -> Interpretation
-
-## Communication
-- Use explicit phrases: "My independent view is:", "I agree on:", "I disagree on:", and "Current consensus:"
-- Tag messages with [IMPORTANT], [STATUS], or [FYI]
-
-## Review Process
-- Cross-review: author never reviews their own code
-- All changes go through feature/fix branches + PR
-
-## Custom Rules
-<!-- Add project-specific collaboration rules here -->
-```
-
-When you finish, briefly summarize what changed and point the user to the two files you updated.
+1. Parse the JSON output from the script.
+2. Tell the user which prerequisites were confirmed.
+3. Tell the user whether `.agentbridge/config.json` and `.agentbridge/collaboration.md` were created or already existed.
+4. End with concise next steps:
+   - Edit `.agentbridge/config.json` to customize roles and bridge behavior.
+   - Edit `.agentbridge/collaboration.md` to add project-specific collaboration rules.
+   - Use `agentbridge claude` and `agentbridge codex` from the terminal when they want to start the bridge runtime.

--- a/plugins/agentbridge/scripts/init-project.js
+++ b/plugins/agentbridge/scripts/init-project.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env bun
+// @bun
+
+// src/plugin/init-project.ts
+import { execSync } from "child_process";
+
+// src/config-service.ts
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { join } from "path";
+var DEFAULT_CONFIG = {
+  version: "1.0",
+  daemon: {
+    port: 4500,
+    proxyPort: 4501
+  },
+  agents: {
+    claude: {
+      role: "Reviewer, Planner",
+      mode: "push"
+    },
+    codex: {
+      role: "Implementer, Executor"
+    }
+  },
+  markers: ["IMPORTANT", "STATUS", "FYI"],
+  turnCoordination: {
+    attentionWindowSeconds: 15,
+    busyGuard: true
+  },
+  idleShutdownSeconds: 30
+};
+var DEFAULT_COLLABORATION_MD = `# Collaboration Rules
+
+## Roles
+- Claude: Reviewer, Planner, Hypothesis Challenger
+- Codex: Implementer, Executor, Reproducer/Verifier
+
+## Thinking Patterns
+- Analytical/review tasks: Independent Analysis & Convergence
+- Implementation tasks: Architect -> Builder -> Critic
+- Debugging tasks: Hypothesis -> Experiment -> Interpretation
+
+## Communication
+- Use explicit phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:"
+- Tag messages with [IMPORTANT], [STATUS], or [FYI]
+
+## Review Process
+- Cross-review: author never reviews their own code
+- All changes go through feature/fix branches + PR
+- Merge via squash merge
+
+## Custom Rules
+<!-- Add your project-specific collaboration rules here -->
+`;
+var CONFIG_DIR = ".agentbridge";
+var CONFIG_FILE = "config.json";
+var COLLABORATION_FILE = "collaboration.md";
+
+class ConfigService {
+  configDir;
+  configPath;
+  collaborationPath;
+  constructor(projectRoot) {
+    const root = projectRoot ?? process.cwd();
+    this.configDir = join(root, CONFIG_DIR);
+    this.configPath = join(this.configDir, CONFIG_FILE);
+    this.collaborationPath = join(this.configDir, COLLABORATION_FILE);
+  }
+  hasConfig() {
+    return existsSync(this.configPath);
+  }
+  load() {
+    try {
+      const raw = readFileSync(this.configPath, "utf-8");
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  loadOrDefault() {
+    return this.load() ?? { ...DEFAULT_CONFIG };
+  }
+  save(config) {
+    this.ensureConfigDir();
+    writeFileSync(this.configPath, JSON.stringify(config, null, 2) + `
+`, "utf-8");
+  }
+  loadCollaboration() {
+    try {
+      return readFileSync(this.collaborationPath, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+  saveCollaboration(content) {
+    this.ensureConfigDir();
+    writeFileSync(this.collaborationPath, content, "utf-8");
+  }
+  initDefaults() {
+    this.ensureConfigDir();
+    const created = [];
+    if (!existsSync(this.configPath)) {
+      this.save(DEFAULT_CONFIG);
+      created.push(this.configPath);
+    }
+    if (!existsSync(this.collaborationPath)) {
+      this.saveCollaboration(DEFAULT_COLLABORATION_MD);
+      created.push(this.collaborationPath);
+    }
+    return created;
+  }
+  get configFilePath() {
+    return this.configPath;
+  }
+  get collaborationFilePath() {
+    return this.collaborationPath;
+  }
+  ensureConfigDir() {
+    if (!existsSync(this.configDir)) {
+      mkdirSync(this.configDir, { recursive: true });
+    }
+  }
+}
+
+// src/plugin/init-project.ts
+function defaultRunCommand(command) {
+  return execSync(command, { encoding: "utf-8" }).trim();
+}
+function requireVersion(name, command, installHint, runCommand) {
+  try {
+    return runCommand(command);
+  } catch {
+    throw new Error(`${name} not found in PATH. ${installHint}`);
+  }
+}
+function initProjectDefaults(projectRoot = process.cwd(), runCommand = defaultRunCommand) {
+  const bunVersion = requireVersion("bun", "bun --version", "Install Bun: https://bun.sh", runCommand);
+  const codexVersion = requireVersion("codex", "codex --version", "Install Codex: https://github.com/openai/codex", runCommand);
+  const configService = new ConfigService(projectRoot);
+  const created = configService.initDefaults();
+  return {
+    checked: {
+      bun: bunVersion,
+      codex: codexVersion
+    },
+    created,
+    files: {
+      config: configService.configFilePath,
+      collaboration: configService.collaborationFilePath
+    }
+  };
+}
+function main() {
+  try {
+    const projectRoot = process.argv[2] || process.cwd();
+    const result = initProjectDefaults(projectRoot);
+    console.log(JSON.stringify(result, null, 2));
+  } catch (err) {
+    console.error(err.message ?? String(err));
+    process.exit(1);
+  }
+}
+if (import.meta.main) {
+  main();
+}
+export {
+  initProjectDefaults
+};

--- a/plugins/agentbridge/scripts/init-project.js
+++ b/plugins/agentbridge/scripts/init-project.js
@@ -2,7 +2,7 @@
 // @bun
 
 // src/plugin/init-project.ts
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
 // src/config-service.ts
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
@@ -123,19 +123,19 @@ class ConfigService {
 }
 
 // src/plugin/init-project.ts
-function defaultRunCommand(command) {
-  return execSync(command, { encoding: "utf-8" }).trim();
+function defaultRunCommand(command, args) {
+  return execFileSync(command, args, { encoding: "utf-8" }).trim();
 }
-function requireVersion(name, command, installHint, runCommand) {
+function requireVersion(name, command, args, installHint, runCommand) {
   try {
-    return runCommand(command);
+    return runCommand(command, args);
   } catch {
     throw new Error(`${name} not found in PATH. ${installHint}`);
   }
 }
 function initProjectDefaults(projectRoot = process.cwd(), runCommand = defaultRunCommand) {
-  const bunVersion = requireVersion("bun", "bun --version", "Install Bun: https://bun.sh", runCommand);
-  const codexVersion = requireVersion("codex", "codex --version", "Install Codex: https://github.com/openai/codex", runCommand);
+  const bunVersion = requireVersion("bun", "bun", ["--version"], "Install Bun: https://bun.sh", runCommand);
+  const codexVersion = requireVersion("codex", "codex", ["--version"], "Install Codex: https://github.com/openai/codex", runCommand);
   const configService = new ConfigService(projectRoot);
   const created = configService.initDefaults();
   return {

--- a/src/plugin/init-project.test.ts
+++ b/src/plugin/init-project.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { initProjectDefaults } from "./init-project";
+
+describe("plugin init-project bootstrap", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "agentbridge-plugin-init-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("checks prerequisites and creates default project config files", () => {
+    const result = initProjectDefaults(tempDir, (command) => {
+      if (command === "bun --version") return "1.3.11";
+      if (command === "codex --version") return "0.1.0";
+      throw new Error(`unexpected command: ${command}`);
+    });
+
+    expect(result.checked.bun).toBe("1.3.11");
+    expect(result.checked.codex).toBe("0.1.0");
+    expect(result.created).toContain(result.files.config);
+    expect(result.created).toContain(result.files.collaboration);
+    expect(existsSync(result.files.config)).toBe(true);
+    expect(existsSync(result.files.collaboration)).toBe(true);
+  });
+
+  test("does not overwrite existing config on repeated runs", () => {
+    const runCommand = (command: string) => {
+      if (command === "bun --version") return "1.3.11";
+      if (command === "codex --version") return "0.1.0";
+      throw new Error(`unexpected command: ${command}`);
+    };
+
+    const first = initProjectDefaults(tempDir, runCommand);
+    expect(first.created).toHaveLength(2);
+
+    const second = initProjectDefaults(tempDir, runCommand);
+    expect(second.created).toHaveLength(0);
+  });
+
+  test("fails with actionable error when codex is missing", () => {
+    expect(() =>
+      initProjectDefaults(tempDir, (command) => {
+        if (command === "bun --version") return "1.3.11";
+        throw new Error("not found");
+      }),
+    ).toThrow("codex not found in PATH. Install Codex: https://github.com/openai/codex");
+  });
+});

--- a/src/plugin/init-project.test.ts
+++ b/src/plugin/init-project.test.ts
@@ -16,10 +16,10 @@ describe("plugin init-project bootstrap", () => {
   });
 
   test("checks prerequisites and creates default project config files", () => {
-    const result = initProjectDefaults(tempDir, (command) => {
-      if (command === "bun --version") return "1.3.11";
-      if (command === "codex --version") return "0.1.0";
-      throw new Error(`unexpected command: ${command}`);
+    const result = initProjectDefaults(tempDir, (command, args) => {
+      if (command === "bun" && args.length === 1 && args[0] === "--version") return "1.3.11";
+      if (command === "codex" && args.length === 1 && args[0] === "--version") return "0.1.0";
+      throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
     });
 
     expect(result.checked.bun).toBe("1.3.11");
@@ -31,10 +31,10 @@ describe("plugin init-project bootstrap", () => {
   });
 
   test("does not overwrite existing config on repeated runs", () => {
-    const runCommand = (command: string) => {
-      if (command === "bun --version") return "1.3.11";
-      if (command === "codex --version") return "0.1.0";
-      throw new Error(`unexpected command: ${command}`);
+    const runCommand = (command: string, args: string[]) => {
+      if (command === "bun" && args.length === 1 && args[0] === "--version") return "1.3.11";
+      if (command === "codex" && args.length === 1 && args[0] === "--version") return "0.1.0";
+      throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
     };
 
     const first = initProjectDefaults(tempDir, runCommand);
@@ -44,10 +44,19 @@ describe("plugin init-project bootstrap", () => {
     expect(second.created).toHaveLength(0);
   });
 
+  test("fails with actionable error when bun is missing", () => {
+    expect(() =>
+      initProjectDefaults(tempDir, (command, args) => {
+        if (command === "codex" && args.length === 1 && args[0] === "--version") return "0.1.0";
+        throw new Error("not found");
+      }),
+    ).toThrow("bun not found in PATH. Install Bun: https://bun.sh");
+  });
+
   test("fails with actionable error when codex is missing", () => {
     expect(() =>
-      initProjectDefaults(tempDir, (command) => {
-        if (command === "bun --version") return "1.3.11";
+      initProjectDefaults(tempDir, (command, args) => {
+        if (command === "bun" && args.length === 1 && args[0] === "--version") return "1.3.11";
         throw new Error("not found");
       }),
     ).toThrow("codex not found in PATH. Install Codex: https://github.com/openai/codex");

--- a/src/plugin/init-project.ts
+++ b/src/plugin/init-project.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { ConfigService } from "../config-service";
 
-type RunCommand = (command: string) => string;
+type RunCommand = (command: string, args: string[]) => string;
 
 export interface InitProjectResult {
   checked: {
@@ -17,18 +17,19 @@ export interface InitProjectResult {
   };
 }
 
-function defaultRunCommand(command: string): string {
-  return execSync(command, { encoding: "utf-8" }).trim();
+function defaultRunCommand(command: string, args: string[]): string {
+  return execFileSync(command, args, { encoding: "utf-8" }).trim();
 }
 
 function requireVersion(
   name: string,
   command: string,
+  args: string[],
   installHint: string,
   runCommand: RunCommand,
 ): string {
   try {
-    return runCommand(command);
+    return runCommand(command, args);
   } catch {
     throw new Error(`${name} not found in PATH. ${installHint}`);
   }
@@ -38,8 +39,14 @@ export function initProjectDefaults(
   projectRoot = process.cwd(),
   runCommand: RunCommand = defaultRunCommand,
 ): InitProjectResult {
-  const bunVersion = requireVersion("bun", "bun --version", "Install Bun: https://bun.sh", runCommand);
-  const codexVersion = requireVersion("codex", "codex --version", "Install Codex: https://github.com/openai/codex", runCommand);
+  const bunVersion = requireVersion("bun", "bun", ["--version"], "Install Bun: https://bun.sh", runCommand);
+  const codexVersion = requireVersion(
+    "codex",
+    "codex",
+    ["--version"],
+    "Install Codex: https://github.com/openai/codex",
+    runCommand,
+  );
 
   const configService = new ConfigService(projectRoot);
   const created = configService.initDefaults();

--- a/src/plugin/init-project.ts
+++ b/src/plugin/init-project.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+
+import { execSync } from "node:child_process";
+import { ConfigService } from "../config-service";
+
+type RunCommand = (command: string) => string;
+
+export interface InitProjectResult {
+  checked: {
+    bun: string;
+    codex: string;
+  };
+  created: string[];
+  files: {
+    config: string;
+    collaboration: string;
+  };
+}
+
+function defaultRunCommand(command: string): string {
+  return execSync(command, { encoding: "utf-8" }).trim();
+}
+
+function requireVersion(
+  name: string,
+  command: string,
+  installHint: string,
+  runCommand: RunCommand,
+): string {
+  try {
+    return runCommand(command);
+  } catch {
+    throw new Error(`${name} not found in PATH. ${installHint}`);
+  }
+}
+
+export function initProjectDefaults(
+  projectRoot = process.cwd(),
+  runCommand: RunCommand = defaultRunCommand,
+): InitProjectResult {
+  const bunVersion = requireVersion("bun", "bun --version", "Install Bun: https://bun.sh", runCommand);
+  const codexVersion = requireVersion("codex", "codex --version", "Install Codex: https://github.com/openai/codex", runCommand);
+
+  const configService = new ConfigService(projectRoot);
+  const created = configService.initDefaults();
+
+  return {
+    checked: {
+      bun: bunVersion,
+      codex: codexVersion,
+    },
+    created,
+    files: {
+      config: configService.configFilePath,
+      collaboration: configService.collaborationFilePath,
+    },
+  };
+}
+
+function main() {
+  try {
+    const projectRoot = process.argv[2] || process.cwd();
+    const result = initProjectDefaults(projectRoot);
+    console.log(JSON.stringify(result, null, 2));
+  } catch (err: any) {
+    console.error(err.message ?? String(err));
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary
- `/agentbridge:init` delegates to bundled `init-project.js` helper
- Reuses `ConfigService.initDefaults()` — single source of truth
- 3 new tests: bootstrap, idempotent re-run, missing codex error

## Test plan
- [ ] Unit tests pass
- [ ] Smoke test: run init-project.js in temp directory
- [ ] End-to-end: `/agentbridge:init` in Claude Code session

**Implemented by**: Codex  
**Reviewed by**: Pending user review

🤖 Generated with [Claude Code](https://claude.com/claude-code)