### PR TITLE
docs: document Codex git restrictions and add bridge contract prohibition

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ agent_bridge/
 - Single Codex thread, no multi-session support yet
 - Single Claude foreground connection; a new Claude session replaces the previous one
 
+### Codex git restrictions
+
+Codex runs in a sandboxed environment that **blocks all writes to the `.git` directory**. This means Codex cannot run `git commit`, `git push`, `git pull`, `git checkout -b`, `git merge`, or any other command that modifies git metadata. Attempting these commands will cause the Codex session to hang indefinitely.
+
+This restriction is especially relevant when Claude Code uses **git worktrees** — the worktree shares `.git` internals with the main repository, which can further tighten sandbox constraints.
+
+**Recommendation:** Let Claude Code handle all git operations (branching, committing, pushing, creating PRs). Codex should focus on code changes and report completed work via `agentMessage`, then Claude Code takes care of the git workflow.
+
 ## Roadmap
 
 - **v1.x (current)**: Improve the single-bridge experience without architectural refactoring — less noise, better turn discipline, and clearer collaboration modes. See [docs/v1-roadmap.md](docs/v1-roadmap.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -144,6 +144,14 @@ agent_bridge/
 - 当前只支持单个 Codex thread，不支持多会话
 - 当前只支持单个 Claude 前台连接；新的 Claude 会话会替换旧连接
 
+### Codex 的 Git 操作限制
+
+Codex 运行在沙箱环境中，**禁止对 `.git` 目录进行任何写操作**。这意味着 Codex 无法执行 `git commit`、`git push`、`git pull`、`git checkout -b`、`git merge` 等任何修改 Git 元数据的命令。尝试执行这些命令会导致 Codex 会话无限期挂起。
+
+当 Claude Code 使用了 **git worktree** 时，这个限制尤其需要注意 — worktree 与主仓库共享 `.git` 内部结构，可能会进一步收紧沙箱的约束。
+
+**建议做法：** 让 Claude Code 负责所有 Git 操作（创建分支、提交、推送、创建 PR）。Codex 专注于代码修改，通过 `agentMessage` 汇报完成的工作，由 Claude Code 负责 Git 工作流。
+
 ## Roadmap
 
 ### v1.x（当前） — 单桥体验优化

--- a/src/message-filter.ts
+++ b/src/message-filter.ts
@@ -41,6 +41,13 @@ const BRIDGE_CONTRACT_REMINDER = `[Bridge Contract] When sending agentMessage, p
 The marker MUST be the first text in the message (e.g. "[IMPORTANT] Task done", not "Task done [IMPORTANT]").
 Keep agentMessage for high-value communication only.
 
+[Git Operations — FORBIDDEN]
+You MUST NOT execute any git write commands. This includes but is not limited to:
+git commit, git push, git pull, git fetch, git checkout -b, git branch, git merge, git rebase, git cherry-pick, git tag, git stash.
+These commands write to the .git directory, which is blocked by your sandbox. Attempting them will cause your session to hang indefinitely.
+Read-only git commands (git status, git log, git diff, git show, git rev-parse) are allowed.
+All git write operations must be delegated to Claude Code via agentMessage. Report what you changed and let Claude handle branching, committing, and pushing.
+
 [Role Guidance for Codex]
 - Your default role: Implementer, Executor, Verifier
 - Analytical/review tasks: Independent Analysis & Convergence

--- a/src/role-patterns.test.ts
+++ b/src/role-patterns.test.ts
@@ -35,6 +35,13 @@ describe("role-aware collaboration guidance", () => {
     expect(BRIDGE_CONTRACT_REMINDER).toContain("MUST be the first text");
   });
 
+  test("bridge contract reminder forbids git write operations", () => {
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("Git Operations — FORBIDDEN");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("MUST NOT execute any git write commands");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("hang indefinitely");
+    expect(BRIDGE_CONTRACT_REMINDER).toContain("delegated to Claude Code");
+  });
+
   test("CLAUDE_INSTRUCTIONS is wired into MCP Server", () => {
     const adapter = new ClaudeAdapter() as any;
     // Verify the exported constant is actually passed to the Server constructor


### PR DESCRIPTION
## Summary
- Add `[Git Operations — FORBIDDEN]` section to Codex's bridge contract reminder, explicitly listing prohibited git commands and explaining they will cause the session to hang
- Document the Codex git sandbox limitation in README.md and README.zh-CN.md under "Current Limitations"
- Recommend all git operations be handled by Claude Code

## Test plan
- [x] 63 tests pass (`bun test src/`)
- [x] Typecheck passes
- [ ] Verify Codex receives the prohibition in bridge contract during a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)