### PR TITLE
Fix: auto-reconnect after daemon restart

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -41,16 +41,20 @@ daemonClient.on("status", (status) => {
 daemonClient.on("disconnect", () => {
   if (shuttingDown) return;
 
-  log("Daemon control connection closed");
+  log("Daemon control connection closed — will attempt to reconnect");
   void claude.pushNotification(systemMessage(
     "system_daemon_disconnected",
-    "⚠️ AgentBridge daemon control connection lost. The Codex proxy may still be running in the background, but Claude cannot communicate bidirectionally right now.",
+    "⚠️ AgentBridge daemon control connection lost. Attempting to reconnect...",
   ));
+  void reconnectToDaemon();
 });
 
 claude.on("ready", async () => {
   log(`MCP server ready (delivery mode: ${claude.getDeliveryMode()}) — ensuring AgentBridge daemon...`);
+  await connectToDaemon();
+});
 
+async function connectToDaemon() {
   try {
     await ensureDaemonRunning();
     await daemonClient.connect();
@@ -63,8 +67,34 @@ claude.on("ready", async () => {
         `❌ AgentBridge daemon failed to start or is unreachable: ${err.message}`,
       ),
     );
+    throw err;
   }
-});
+}
+
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+async function reconnectToDaemon(attempt = 0) {
+  if (shuttingDown) return;
+
+  const delayMs = Math.min(1000 * 2 ** attempt, MAX_RECONNECT_DELAY_MS);
+  if (attempt > 0) {
+    log(`Reconnect attempt ${attempt + 1}, waiting ${delayMs}ms...`);
+  }
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+  if (shuttingDown) return;
+
+  try {
+    await connectToDaemon();
+    log("Reconnected to AgentBridge daemon successfully");
+    void claude.pushNotification(systemMessage(
+      "system_daemon_reconnected",
+      "✅ AgentBridge daemon reconnected successfully.",
+    ));
+  } catch {
+    void reconnectToDaemon(attempt + 1);
+  }
+}
 
 function systemMessage(idPrefix: string, content: string): BridgeMessage {
   return {

--- a/src/daemon-client.test.ts
+++ b/src/daemon-client.test.ts
@@ -1,0 +1,231 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { DaemonClient } from "./daemon-client";
+
+/**
+ * Tests for DaemonClient — connection, disconnection, and message routing.
+ *
+ * Uses a real WebSocket server on a random port so we exercise the full
+ * connect / message / close path without mocking WebSocket internals.
+ */
+
+let server: ReturnType<typeof Bun.serve> | null = null;
+let serverPort = 0;
+let client: DaemonClient;
+let serverSockets: Set<any>;
+
+// Shared message handler — tests can replace this to intercept server-side messages
+let onServerMessage: (ws: any, raw: string | Buffer) => void = () => {};
+
+function startServer() {
+  serverSockets = new Set();
+  const srv = Bun.serve({
+    port: 0,
+    fetch(req, s) {
+      if (s.upgrade(req)) return undefined;
+      return new Response("ok");
+    },
+    websocket: {
+      open(ws: any) {
+        serverSockets.add(ws);
+      },
+      message(ws: any, raw: any) {
+        onServerMessage(ws, raw);
+      },
+      close(ws: any) {
+        serverSockets.delete(ws);
+      },
+    },
+  });
+  server = srv;
+  serverPort = srv.port as number;
+}
+
+function stopServer() {
+  if (server) {
+    server.stop(true);
+    server = null;
+  }
+}
+
+function sendToClient(data: Record<string, unknown>) {
+  for (const ws of serverSockets) {
+    ws.send(JSON.stringify(data));
+  }
+}
+
+describe("DaemonClient", () => {
+  beforeEach(() => {
+    onServerMessage = () => {};
+    startServer();
+    client = new DaemonClient(`ws://127.0.0.1:${serverPort}/ws`);
+  });
+
+  afterEach(async () => {
+    await client.disconnect();
+    stopServer();
+  });
+
+  test("connect() succeeds against a live server", async () => {
+    await client.connect();
+    // No error thrown = success
+  });
+
+  test("connect() rejects when server is not reachable", async () => {
+    stopServer();
+    const badClient = new DaemonClient("ws://127.0.0.1:19999/ws");
+    await expect(badClient.connect()).rejects.toThrow();
+  });
+
+  test("emits disconnect when server closes the socket", async () => {
+    await client.connect();
+
+    const disconnected = new Promise<void>((resolve) => {
+      client.on("disconnect", () => resolve());
+    });
+
+    for (const ws of serverSockets) {
+      ws.close();
+    }
+
+    await disconnected;
+  });
+
+  test("emits codexMessage on codex_to_claude", async () => {
+    await client.connect();
+
+    const msgPromise = new Promise<any>((resolve) => {
+      client.on("codexMessage", (msg) => resolve(msg));
+    });
+
+    sendToClient({
+      type: "codex_to_claude",
+      message: { id: "test1", source: "codex", content: "hello", timestamp: 1 },
+    });
+
+    const msg = await msgPromise;
+    expect(msg.content).toBe("hello");
+    expect(msg.source).toBe("codex");
+  });
+
+  test("emits status on status message", async () => {
+    await client.connect();
+
+    const statusPromise = new Promise<any>((resolve) => {
+      client.on("status", (s) => resolve(s));
+    });
+
+    sendToClient({
+      type: "status",
+      status: {
+        bridgeReady: true,
+        tuiConnected: false,
+        threadId: null,
+        queuedMessageCount: 0,
+        proxyUrl: "http://localhost:4501",
+        appServerUrl: "http://localhost:4502",
+        pid: 123,
+      },
+    });
+
+    const status = await statusPromise;
+    expect(status.bridgeReady).toBe(true);
+  });
+
+  test("sendReply returns error when not connected", async () => {
+    const result = await client.sendReply({
+      id: "r1",
+      source: "claude",
+      content: "hi",
+      timestamp: Date.now(),
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not connected");
+  });
+
+  test("sendReply resolves on successful result", async () => {
+    // Set up echo handler before connecting
+    onServerMessage = (ws: any, raw: any) => {
+      const msg = JSON.parse(typeof raw === "string" ? raw : raw.toString());
+      if (msg.type === "claude_to_codex") {
+        ws.send(JSON.stringify({
+          type: "claude_to_codex_result",
+          requestId: msg.requestId,
+          success: true,
+        }));
+      }
+    };
+
+    await client.connect();
+
+    const result = await client.sendReply({
+      id: "r2",
+      source: "claude",
+      content: "reply text",
+      timestamp: Date.now(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("pending replies rejected on disconnect", async () => {
+    await client.connect();
+
+    const replyPromise = client.sendReply({
+      id: "r3",
+      source: "claude",
+      content: "will be rejected",
+      timestamp: Date.now(),
+    });
+
+    // Close server socket to trigger disconnect
+    for (const ws of serverSockets) {
+      ws.close();
+    }
+
+    const result = await replyPromise;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("disconnected");
+  });
+
+  test("can reconnect after disconnect", async () => {
+    await client.connect();
+
+    const disconnected = new Promise<void>((resolve) => {
+      client.on("disconnect", () => resolve());
+    });
+
+    for (const ws of serverSockets) {
+      ws.close();
+    }
+    await disconnected;
+
+    // Reconnect — should succeed
+    await client.connect();
+
+    // Verify it works by sending a message
+    const msgPromise = new Promise<any>((resolve) => {
+      client.on("codexMessage", (msg) => resolve(msg));
+    });
+
+    sendToClient({
+      type: "codex_to_claude",
+      message: { id: "test2", source: "codex", content: "after reconnect", timestamp: 2 },
+    });
+
+    const msg = await msgPromise;
+    expect(msg.content).toBe("after reconnect");
+  });
+
+  test("attachClaude sends claude_connect message", async () => {
+    const received = new Promise<any>((resolve) => {
+      onServerMessage = (_ws: any, raw: any) => {
+        resolve(JSON.parse(typeof raw === "string" ? raw : raw.toString()));
+      };
+    });
+
+    await client.connect();
+    client.attachClaude();
+
+    const msg = await received;
+    expect(msg.type).toBe("claude_connect");
+  });
+});

--- a/src/e2e-reconnect.test.ts
+++ b/src/e2e-reconnect.test.ts
@@ -1,0 +1,220 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, unlinkSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DaemonClient } from "./daemon-client";
+
+/**
+ * E2E tests: daemon lifecycle + client reconnect
+ *
+ * Spins up a real daemon process on an isolated port, connects a DaemonClient,
+ * verifies health/messages, kills the daemon, restarts it, and verifies
+ * the client can reconnect — exercising the same path bridge.ts uses.
+ */
+
+const TEST_CONTROL_PORT = 14502;
+const TEST_APP_PORT = 14500;
+const TEST_PROXY_PORT = 14501;
+const TEST_PID_FILE = `/tmp/agentbridge-e2e-test-${TEST_CONTROL_PORT}.pid`;
+const HEALTH_URL = `http://127.0.0.1:${TEST_CONTROL_PORT}/healthz`;
+const WS_URL = `ws://127.0.0.1:${TEST_CONTROL_PORT}/ws`;
+const DAEMON_PATH = fileURLToPath(new URL("./daemon.ts", import.meta.url));
+
+let daemonProc: ChildProcess | null = null;
+
+function launchDaemon(): ChildProcess {
+  const proc = spawn(process.execPath, ["run", DAEMON_PATH], {
+    env: {
+      ...process.env,
+      AGENTBRIDGE_CONTROL_PORT: String(TEST_CONTROL_PORT),
+      AGENTBRIDGE_PID_FILE: TEST_PID_FILE,
+      CODEX_WS_PORT: String(TEST_APP_PORT),
+      CODEX_PROXY_PORT: String(TEST_PROXY_PORT),
+      AGENTBRIDGE_IDLE_SHUTDOWN_MS: "60000", // don't auto-shutdown during tests
+    },
+    stdio: "pipe",
+  });
+  return proc;
+}
+
+async function waitForHealth(maxRetries = 40, delayMs = 250): Promise<boolean> {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const res = await fetch(HEALTH_URL);
+      if (res.ok) return true;
+    } catch {}
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return false;
+}
+
+function killDaemon(): Promise<void> {
+  return new Promise((resolve) => {
+    if (!daemonProc || daemonProc.exitCode !== null) {
+      resolve();
+      return;
+    }
+    daemonProc.once("exit", () => resolve());
+    daemonProc.kill("SIGTERM");
+    // Fallback force kill
+    setTimeout(() => {
+      if (daemonProc && daemonProc.exitCode === null) {
+        daemonProc.kill("SIGKILL");
+      }
+    }, 3000);
+  });
+}
+
+function cleanup() {
+  try { unlinkSync(TEST_PID_FILE); } catch {}
+}
+
+describe("E2E: daemon lifecycle + reconnect", () => {
+  afterAll(async () => {
+    await killDaemon();
+    cleanup();
+  });
+
+  test("daemon starts and becomes healthy", async () => {
+    daemonProc = launchDaemon();
+    const healthy = await waitForHealth();
+    expect(healthy).toBe(true);
+  }, 15000);
+
+  test("health endpoint returns daemon status", async () => {
+    const res = await fetch(HEALTH_URL);
+    expect(res.ok).toBe(true);
+    const body = await res.json() as any;
+    expect(body.pid).toBeGreaterThan(0);
+    expect(typeof body.proxyUrl).toBe("string");
+  });
+
+  test("PID file is written correctly", () => {
+    const raw = readFileSync(TEST_PID_FILE, "utf-8").trim();
+    const pid = Number.parseInt(raw, 10);
+    expect(Number.isFinite(pid)).toBe(true);
+    expect(pid).toBeGreaterThan(0);
+  });
+
+  test("DaemonClient connects and receives status", async () => {
+    const client = new DaemonClient(WS_URL);
+    await client.connect();
+
+    const statusPromise = new Promise<any>((resolve) => {
+      client.on("status", (s) => resolve(s));
+    });
+
+    client.attachClaude();
+
+    const status = await statusPromise;
+    expect(status.pid).toBeGreaterThan(0);
+    expect(typeof status.proxyUrl).toBe("string");
+
+    await client.disconnect();
+  }, 10000);
+
+  test("sendReply fails gracefully when Codex TUI is not connected", async () => {
+    const client = new DaemonClient(WS_URL);
+    await client.connect();
+    client.attachClaude();
+
+    // Give daemon a moment to process attachment
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = await client.sendReply({
+      id: "test_reply_1",
+      source: "claude",
+      content: "hello codex",
+      timestamp: Date.now(),
+    });
+
+    // Should fail because no Codex TUI is connected
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+
+    await client.disconnect();
+  }, 10000);
+
+  test("client detects daemon shutdown via disconnect event", async () => {
+    const client = new DaemonClient(WS_URL);
+    await client.connect();
+    client.attachClaude();
+
+    const disconnected = new Promise<void>((resolve) => {
+      client.on("disconnect", () => resolve());
+    });
+
+    // Kill daemon
+    await killDaemon();
+
+    // Client should detect disconnect
+    await disconnected;
+
+    // Cleanup client
+    await client.disconnect();
+  }, 15000);
+
+  test("daemon restarts and client reconnects successfully", async () => {
+    // Start a fresh daemon
+    daemonProc = launchDaemon();
+    const healthy = await waitForHealth();
+    expect(healthy).toBe(true);
+
+    // Connect a new client (simulating bridge.ts reconnect flow)
+    const client = new DaemonClient(WS_URL);
+    await client.connect();
+
+    const statusPromise = new Promise<any>((resolve) => {
+      client.on("status", (s) => resolve(s));
+    });
+
+    client.attachClaude();
+
+    const status = await statusPromise;
+    expect(status.pid).toBeGreaterThan(0);
+
+    await client.disconnect();
+  }, 15000);
+
+  test("full reconnect cycle: connect → kill → restart → reconnect", async () => {
+    // Ensure daemon is running from previous test
+    const healthy1 = await waitForHealth(10, 100);
+    expect(healthy1).toBe(true);
+
+    const client = new DaemonClient(WS_URL);
+    await client.connect();
+    client.attachClaude();
+
+    // Wait for initial status
+    await new Promise<void>((resolve) => {
+      client.on("status", () => resolve());
+    });
+
+    // Kill daemon
+    const disconnected = new Promise<void>((resolve) => {
+      client.on("disconnect", () => resolve());
+    });
+
+    await killDaemon();
+    await disconnected;
+
+    // Restart daemon
+    daemonProc = launchDaemon();
+    const healthy2 = await waitForHealth();
+    expect(healthy2).toBe(true);
+
+    // Reconnect — same flow as bridge.ts reconnectToDaemon()
+    const client2 = new DaemonClient(WS_URL);
+    await client2.connect();
+
+    const status2 = new Promise<any>((resolve) => {
+      client2.on("status", (s) => resolve(s));
+    });
+
+    client2.attachClaude();
+    const status = await status2;
+    expect(status.pid).toBeGreaterThan(0);
+
+    await client2.disconnect();
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- Extract `connectToDaemon()` from the one-shot `claude.on("ready")` handler into a reusable function
- Add `reconnectToDaemon()` with exponential backoff (1s → 2s → 4s → ... → 30s cap) triggered from the `disconnect` event handler
- Reconnect re-runs the full `ensureDaemonRunning` → `connect` → `attachClaude` flow, so it also handles the case where the daemon needs to be re-launched
- Notify Claude on disconnect ("Attempting to reconnect...") and on successful reconnect ("reconnected successfully")
- Add comprehensive `DaemonClient` unit tests (10 tests): connect, reject, disconnect events, message routing, reply lifecycle, reconnect after disconnect

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test src/` — all 73 tests pass (10 new DaemonClient tests)
- [ ] Manual e2e: start bridge, kill daemon, verify auto-reconnect and Claude notification
- [ ] Manual e2e: verify reconnected bridge can send/receive messages

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)