### PR TITLE
Complete log path migration to StateDirResolver for adapters

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -9,6 +9,7 @@ import { ConfigService } from "./config-service";
 import type { BridgeMessage } from "./types";
 
 const stateDir = new StateDirResolver();
+stateDir.ensure();
 const configService = new ConfigService();
 const config = configService.loadOrDefault();
 
@@ -16,7 +17,7 @@ const CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 const CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 
-const claude = new ClaudeAdapter();
+const claude = new ClaudeAdapter(stateDir.logFile);
 const daemonClient = new DaemonClient(CONTROL_WS_URL);
 
 let shuttingDown = false;

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -20,6 +20,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { EventEmitter } from "node:events";
 import { appendFileSync } from "node:fs";
+import { StateDirResolver } from "./state-dir";
 import type { BridgeMessage } from "./types";
 
 export type ReplySender = (msg: BridgeMessage) => Promise<{ success: boolean; error?: string }>;
@@ -54,13 +55,12 @@ export const CLAUDE_INSTRUCTIONS = [
   "- If the reply tool returns a busy error, Codex is still executing a turn. Wait and try again later.",
 ].join("\n");
 
-const LOG_FILE = "/tmp/agentbridge.log";
-
 export class ClaudeAdapter extends EventEmitter {
   private server: Server;
   private notificationSeq = 0;
   private sessionId: string;
   private replySender: ReplySender | null = null;
+  private readonly logFile: string;
 
   // Dual-mode transport
   private readonly configuredMode: DeliveryMode;
@@ -69,9 +69,10 @@ export class ClaudeAdapter extends EventEmitter {
   private readonly maxBufferedMessages: number;
   private droppedMessageCount = 0;
 
-  constructor() {
+  constructor(logFile = new StateDirResolver().logFile) {
     super();
     this.sessionId = `codex_${Date.now()}`;
+    this.logFile = logFile;
 
     const envMode = process.env.AGENTBRIDGE_MODE as DeliveryMode | undefined;
     this.configuredMode = envMode && ["push", "pull", "auto"].includes(envMode) ? envMode : "auto";
@@ -325,7 +326,7 @@ export class ClaudeAdapter extends EventEmitter {
     const line = `[${new Date().toISOString()}] [ClaudeAdapter] ${msg}\n`;
     process.stderr.write(line);
     try {
-      appendFileSync(LOG_FILE, line);
+      appendFileSync(this.logFile, line);
     } catch {}
   }
 }

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -13,6 +13,7 @@ import { spawn, execSync, type ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
 import { EventEmitter } from "node:events";
 import { appendFileSync } from "node:fs";
+import { StateDirResolver } from "./state-dir";
 import type { BridgeMessage, CodexItem } from "./types";
 import type { ServerWebSocket } from "bun";
 
@@ -20,7 +21,6 @@ interface TuiSocketData {
   connId: number;
 }
 
-const LOG_FILE = "/tmp/agentbridge.log";
 const TRACKED_REQUEST_METHODS = new Set(["thread/start", "thread/resume", "turn/start"]);
 
 type TrackedRequestMethod = "thread/start" | "thread/resume" | "turn/start";
@@ -43,6 +43,7 @@ export class CodexAdapter extends EventEmitter {
   private nextInjectionId = -1;
   private appPort: number;
   private proxyPort: number;
+  private readonly logFile: string;
   private tuiConnId = 0; // tracks which TUI connection is "current"
 
   private agentMessageBuffers = new Map<string, string[]>();
@@ -57,10 +58,15 @@ export class CodexAdapter extends EventEmitter {
   private bridgeRequestIds = new Map<number, ReturnType<typeof setTimeout>>();
   private intentionalDisconnect = false;
 
-  constructor(appPort = 4500, proxyPort = 4501) {
+  constructor(
+    appPort = 4500,
+    proxyPort = 4501,
+    logFile = new StateDirResolver().logFile,
+  ) {
     super();
     this.appPort = appPort;
     this.proxyPort = proxyPort;
+    this.logFile = logFile;
   }
 
   get appServerUrl() { return `ws://127.0.0.1:${this.appPort}`; }
@@ -744,6 +750,6 @@ export class CodexAdapter extends EventEmitter {
   private log(msg: string) {
     const line = `[${new Date().toISOString()}] [CodexAdapter] ${msg}\n`;
     process.stderr.write(line);
-    try { appendFileSync(LOG_FILE, line); } catch {}
+    try { appendFileSync(this.logFile, line); } catch {}
   }
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -38,7 +38,7 @@ const ATTENTION_WINDOW_MS = parseInt(process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS
 
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 
-const codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT);
+const codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
 const attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 
 let controlServer: ReturnType<typeof Bun.serve> | null = null;


### PR DESCRIPTION
## Summary

Completes the logging path migration that was partially done in `feat/bootstrap-command`.

- `codex-adapter.ts` and `claude-adapter.ts` still hardcoded `/tmp/agentbridge.log`
- `bridge.ts` and `daemon.ts` had already been migrated to `stateDir.logFile`

This PR finishes the migration so all four components use the same resolved log path.

Closes #21

## Changes

- **`src/codex-adapter.ts`**: Remove hardcoded `LOG_FILE`, accept `logFile` via constructor (defaults to `StateDirResolver().logFile`)
- **`src/claude-adapter.ts`**: Same pattern — remove `LOG_FILE` constant, accept injectable `logFile`
- **`src/daemon.ts`**: Pass `stateDir.logFile` to `CodexAdapter`
- **`src/bridge.ts`**: Add `stateDir.ensure()`, pass `stateDir.logFile` to `ClaudeAdapter`

## Design notes

- Constructor defaults use `new StateDirResolver().logFile` so existing callers (including tests) work without changes
- No new dependencies — `StateDirResolver` was already in the codebase
- Backward compatible — zero test changes needed

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test src` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)