### PR TITLE
docs: update documentation after Phase 3 completion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing to AgentBridge.
 
 ## Prerequisites
 
-- [Bun](https://bun.sh)
+- [Bun](https://bun.sh) v1.0+
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) v2.1.80+
 - [Codex CLI](https://github.com/openai/codex)
 
@@ -12,33 +12,52 @@ Thanks for contributing to AgentBridge.
 
 ```bash
 bun install
+bun link    # Makes the 'agentbridge' command available globally
 ```
 
-If you want to run the full local workflow, copy `.mcp.json.example` into your Claude MCP configuration and replace the absolute path with your local checkout path.
+### For local development
+
+Use the `dev` command to register a local plugin marketplace and sync plugin files to the Claude Code cache:
+
+```bash
+agentbridge dev     # Register local marketplace + sync plugin
+agentbridge claude  # Start Claude Code with plugin auto-loaded
+```
+
+After changing plugin or runtime code, run `agentbridge dev` again and restart Claude Code (or `/reload-plugins` in an active session).
 
 ## Development Workflow
 
-1. Create a focused branch for one change.
+1. Create a focused branch for one change (`feat/xxx`, `fix/xxx`, `docs/xxx`).
 2. Make the smallest coherent change that solves the problem.
 3. Update documentation when behavior, setup, or limitations change.
 4. Run validation locally before opening a pull request.
+5. All PRs target `master` and use squash merge.
 
 ## Validation
 
 Run these commands before submitting a PR:
 
 ```bash
-bun run typecheck
-bun test src
+bun run typecheck    # TypeScript type checking
+bun test src/        # Unit + E2E tests
 ```
 
-If your change affects the local bridge flow, add manual reproduction steps in the PR description.
+Both must pass. If your change affects the local bridge flow, add manual reproduction steps in the PR description.
+
+## Testing
+
+- **Unit tests**: Co-located with source files (`*.test.ts`)
+- **E2E tests**: `src/e2e-cli.test.ts` (CLI surface), `src/e2e-reconnect.test.ts` (daemon reconnect)
+- E2E tests use isolated harnesses with temporary directories, reserved ports, and shim binaries
+- All tests run with `bun test src/`
 
 ## Pull Requests
 
 - Keep PRs small and scoped to one problem.
+- Never push directly to `master` -- always use feature/fix branches + PR.
 - Explain the user-visible change and the reason for it.
-- Include validation results from `bun run typecheck` and `bun test src`.
+- Include validation results from `bun run typecheck` and `bun test src/`.
 - Link related issues when applicable.
 - Update `README.md` and `README.zh-CN.md` together when setup or usage changes.
 
@@ -49,3 +68,4 @@ If your change affects the local bridge flow, add manual reproduction steps in t
 - Preserve the current architecture unless the PR is intentionally structural.
 - Avoid committing local machine config, secrets, logs, or generated noise.
 - Keep comments short and only where they add real context.
+- Use `execFileSync` (array form) instead of `execSync` (string form) to avoid shell injection.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 
 Local bridge for bidirectional communication between Claude Code and Codex inside the same working session.
 
-The current implementation uses a two-process architecture:
+AgentBridge uses a two-process architecture:
 
-- `bridge.ts` is the foreground MCP client started by Claude Code
-- `daemon.ts` is a persistent local background process that owns the Codex app-server proxy and bridge state
+- **bridge.ts** is the foreground MCP client started by Claude Code via the AgentBridge plugin
+- **daemon.ts** is a persistent local background process that owns the Codex app-server proxy and bridge state
 
-This means the foreground MCP process can exit when Claude Code closes, while the background daemon and Codex proxy keep running. When Claude Code starts again, it can reuse the existing daemon automatically.
+When Claude Code closes, the foreground MCP process exits while the background daemon and Codex proxy keep running. When Claude Code starts again, it reconnects automatically with exponential backoff.
 
 ## What this project is / is not
 
@@ -31,32 +31,32 @@ This means the foreground MCP process can exit when Claude Code closes, while th
 ## Architecture
 
 ```
-┌──────────────┐          MCP stdio          ┌────────────────────┐
-│ Claude Code  │ ───────────────────────────▶ │ bridge.ts          │
-│ Session      │ ◀─────────────────────────── │ foreground client  │
-└──────────────┘                              └─────────┬──────────┘
-                                                        │
-                                                        │ local control WS
-                                                        ▼
-                                              ┌────────────────────┐
-                                              │ daemon.ts          │
-                                              │ bridge daemon      │
-                                              └─────────┬──────────┘
-                                                        │
-                                      ws://127.0.0.1:4501 proxy
-                                                        │
-                                                        ▼
-                                              ┌────────────────────┐
-                                              │ Codex app-server   │
-                                              └────────────────────┘
+┌──────────────┐     MCP stdio / plugin     ┌────────────────────┐
+│ Claude Code  │ ──────────────────────────▶ │ bridge.ts          │
+│ Session      │ ◀──────────────────────────  │ foreground client  │
+└──────────────┘                             └─────────┬──────────┘
+                                                       │
+                                                       │ control WS (:4502)
+                                                       ▼
+                                             ┌────────────────────┐
+                                             │ daemon.ts          │
+                                             │ bridge daemon      │
+                                             └─────────┬──────────┘
+                                                       │
+                                     ws://127.0.0.1:4501 proxy
+                                                       │
+                                                       ▼
+                                             ┌────────────────────┐
+                                             │ Codex app-server   │
+                                             └────────────────────┘
 ```
 
 ### Data flow
 
 | Direction | Path |
-|------|------|
-| **Codex → Claude** | `daemon.ts` captures `agentMessage` → control WS → `bridge.ts` → `notifications/claude/channel` |
-| **Claude → Codex** | Claude calls the `reply` tool → `bridge.ts` → control WS → `daemon.ts` → `turn/start` injects into the Codex thread |
+|-----------|------|
+| **Codex -> Claude** | `daemon.ts` captures `agentMessage` -> control WS -> `bridge.ts` -> `notifications/claude/channel` |
+| **Claude -> Codex** | Claude calls the `reply` tool -> `bridge.ts` -> control WS -> `daemon.ts` -> `turn/start` injects into the Codex thread |
 
 ### Loop prevention
 
@@ -64,7 +64,7 @@ Each message carries a `source` field (`"claude"` or `"codex"`). The bridge neve
 
 ## Prerequisites
 
-- [Bun](https://bun.sh)
+- [Bun](https://bun.sh) v1.0+
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) v2.1.80+
 - [Codex CLI](https://github.com/openai/codex) with the `codex` command available
 
@@ -74,51 +74,102 @@ Each message carries a `source` field (`"claude"` or `"codex"`). The bridge neve
 # 1. Install dependencies
 cd agent_bridge
 bun install
+bun link    # Makes the 'agentbridge' command available globally
 
-# 2. Register the MCP server
-# Merge .mcp.json.example into ~/.claude/.mcp.json and replace the path
-# with your local absolute path:
-#   "agentbridge": { "command": "bun", "args": ["run", "/absolute/path/to/agent_bridge/src/bridge.ts"] }
+# 2. Initialize project (installs plugin, checks dependencies, generates config)
+agentbridge init
 
-# 3. Start Claude Code and load AgentBridge as a channel (development mode)
-claude --dangerously-load-development-channels server:agentbridge
+# 3. Start Claude Code with AgentBridge plugin loaded
+agentbridge claude
+
+# 4. Start Codex TUI connected to the bridge (in another terminal)
+agentbridge codex
 ```
 
-> Warning: `--dangerously-load-development-channels` loads a local development channel into Claude Code. This is currently a Research Preview workflow. Only enable channels and MCP servers you trust, because that local process can push messages into your Claude session and participate in the same workspace flow. AgentBridge is intended for local experimentation and development, not for untrusted environments.
+That's it. The daemon starts automatically when needed and reconnects if restarted.
 
-`bridge.ts` checks whether a local daemon already exists before continuing.
+> **Note:** `agentbridge claude` injects `--dangerously-load-development-channels server:agentbridge` automatically. This loads a local development channel into Claude Code (currently a Research Preview workflow). Only enable channels and MCP servers you trust.
 
-- If no daemon exists, it starts `daemon.ts`
-- If a daemon is already running, it reuses it
+### For plugin developers
 
-`daemon.ts` automatically spawns `codex app-server` in WebSocket mode and can surface the attach command through the Claude channel when needed.
+If you're working on AgentBridge itself, use the dev command to sync local changes to the plugin cache:
 
 ```bash
-# 4. Attach to the Codex proxy from another terminal to watch the Codex TUI
-codex --enable tui_app_server --remote ws://127.0.0.1:4501
+agentbridge dev     # Register local marketplace + sync plugin files
+agentbridge claude  # Start Claude Code (plugin auto-loaded)
 ```
 
-> Note: the TUI connects to the bridge proxy port (default `4501`), not the app-server port (`4500`). The bridge transparently forwards traffic and intercepts `agentMessage`.
+## CLI Reference
 
-Codex `agentMessage` items are pushed into the Claude session automatically. Claude can reply back through the `reply` tool.
+| Command | Description |
+|---------|-------------|
+| `agentbridge init` | Install plugin, check dependencies (bun/claude/codex), generate `.agentbridge/config.json` and `collaboration.md` |
+| `agentbridge claude [args...]` | Start Claude Code with push channel enabled. Pass-through args are forwarded to `claude` |
+| `agentbridge codex [args...]` | Start Codex TUI connected to AgentBridge daemon. Pass-through args forwarded to `codex` |
+| `agentbridge kill` | Gracefully stop daemon, clean up state files, write killed sentinel to prevent auto-reconnect |
+| `agentbridge dev` | (Dev only) Register local marketplace + force-sync plugin to cache |
+| `agentbridge --help` | Show help |
+| `agentbridge --version` | Show version |
+
+### Owned flags
+
+Some flags are automatically injected and cannot be manually specified:
+
+- `agentbridge claude` owns: `--channels`, `--dangerously-load-development-channels`
+- `agentbridge codex` owns: `--remote`, `--enable tui_app_server`
+
+Passing these flags manually will result in a hard error with guidance to use the native command directly.
+
+## Project Config
+
+Running `agentbridge init` creates a `.agentbridge/` directory in your project root:
+
+| File | Purpose |
+|------|---------|
+| `config.json` | Machine-readable project config (ports, agent roles, markers, turn coordination) |
+| `collaboration.md` | Human/agent-readable collaboration rules (roles, thinking patterns, communication style) |
+
+The config is loaded by the CLI and daemon at startup. Re-running `init` is idempotent and will not overwrite existing files.
 
 ## File Structure
 
 ```
 agent_bridge/
 ├── .github/
-│   ├── ISSUE_TEMPLATE/       # Bug report and feature request templates
+│   ├── ISSUE_TEMPLATE/           # Bug report and feature request templates
 │   ├── pull_request_template.md
-│   └── workflows/ci.yml      # GitHub Actions CI
-├── assets/                    # Static assets (images, etc.)
+│   └── workflows/ci.yml          # GitHub Actions CI
+├── assets/                        # Static assets (images, etc.)
+├── docs/
+│   ├── phase3-spec.md            # Phase 3 design spec (CLI + Plugin)
+│   ├── v1-roadmap.md             # v1 feature roadmap
+│   └── v2-architecture.md        # v2 multi-agent architecture design
+├── plugins/agentbridge/           # Claude Code plugin bundle
+│   ├── .claude-plugin/plugin.json
+│   ├── commands/init.md
+│   ├── hooks/hooks.json
+│   ├── scripts/health-check.sh
+│   └── server/                    # Bundled bridge-server.js + daemon.js
 ├── src/
-│   ├── bridge.ts             # Claude foreground MCP client that ensures the daemon exists and forwards messages
-│   ├── daemon.ts             # Persistent background process that owns the Codex proxy and bridge state
-│   ├── daemon-client.ts      # Foreground client for the daemon control WS
-│   ├── control-protocol.ts   # Shared foreground/background control protocol
-│   ├── claude-adapter.ts     # MCP server adapter for Claude Code channels
-│   ├── codex-adapter.ts      # Codex app-server WebSocket proxy and message interception
-│   └── types.ts              # Shared types
+│   ├── bridge.ts                  # Claude foreground MCP client (plugin entry point)
+│   ├── daemon.ts                  # Persistent background daemon
+│   ├── daemon-client.ts           # WebSocket client for daemon control port
+│   ├── daemon-lifecycle.ts        # Shared daemon lifecycle (ensureRunning, kill, startup lock)
+│   ├── control-protocol.ts        # Foreground/background control protocol types
+│   ├── claude-adapter.ts          # MCP server adapter for Claude Code channels
+│   ├── codex-adapter.ts           # Codex app-server WebSocket proxy and message interception
+│   ├── config-service.ts          # Project config (.agentbridge/) read/write
+│   ├── state-dir.ts               # Platform-aware state directory resolver
+│   ├── message-filter.ts          # Smart message filtering (markers, summary buffer)
+│   ├── types.ts                   # Shared types
+│   ├── cli.ts                     # CLI entry point and command router
+│   └── cli/
+│       ├── init.ts                # agentbridge init
+│       ├── claude.ts              # agentbridge claude
+│       ├── codex.ts               # agentbridge codex
+│       ├── kill.ts                # agentbridge kill
+│       └── dev.ts                 # agentbridge dev
+├── CLAUDE.md                      # Project rules for AI agents
 ├── CODE_OF_CONDUCT.md
 ├── CONTRIBUTING.md
 ├── LICENSE
@@ -131,36 +182,50 @@ agent_bridge/
 
 ## Configuration
 
-| Environment variable | Default | Description |
-|----------|--------|------|
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
 | `CODEX_WS_PORT` | `4500` | Codex app-server WebSocket port |
 | `CODEX_PROXY_PORT` | `4501` | Bridge proxy port for the Codex TUI |
-| `AGENTBRIDGE_CONTROL_PORT` | `4502` | Local control port between `bridge.ts` and `daemon.ts` |
-| `AGENTBRIDGE_PID_FILE` | `/tmp/agentbridge-daemon-4502.pid` | Daemon pid file used to avoid duplicate startup |
+| `AGENTBRIDGE_CONTROL_PORT` | `4502` | Control port between bridge.ts and daemon.ts |
+| `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
+| `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
+| `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |
+
+### State Directory
+
+The daemon stores runtime state in a platform-aware directory:
+
+| Platform | Default Path |
+|----------|-------------|
+| macOS | `~/Library/Application Support/agentbridge/` |
+| Linux | `$XDG_STATE_HOME/agentbridge/` (fallback: `~/.local/state/agentbridge/`) |
+
+Contents: `daemon.pid`, `status.json`, `agentbridge.log`, `killed` (sentinel), `startup.lock`
 
 ## Current Limitations
 
 - Only forwards `agentMessage` items, not intermediate `commandExecution`, `fileChange`, or similar events
 - Single Codex thread, no multi-session support yet
 - Single Claude foreground connection; a new Claude session replaces the previous one
+- Fixed ports mean only one AgentBridge instance per machine (multi-project support planned for post-v1)
 
 ### Codex git restrictions
 
 Codex runs in a sandboxed environment that **blocks all writes to the `.git` directory**. This means Codex cannot run `git commit`, `git push`, `git pull`, `git checkout -b`, `git merge`, or any other command that modifies git metadata. Attempting these commands will cause the Codex session to hang indefinitely.
 
-This restriction is especially relevant when Claude Code uses **git worktrees** — the worktree shares `.git` internals with the main repository, which can further tighten sandbox constraints.
-
 **Recommendation:** Let Claude Code handle all git operations (branching, committing, pushing, creating PRs). Codex should focus on code changes and report completed work via `agentMessage`, then Claude Code takes care of the git workflow.
 
 ## Roadmap
 
-- **v1.x (current)**: Improve the single-bridge experience without architectural refactoring — less noise, better turn discipline, and clearer collaboration modes. See [docs/v1-roadmap.md](docs/v1-roadmap.md).
-- **v2 (planned)**: Introduce the multi-agent foundation — room-scoped collaboration, stable identity, a formal control protocol, and stronger recovery semantics. See [docs/v2-architecture.md](docs/v2-architecture.md).
+- **v1.x (current)**: Improve the single-bridge experience without architectural refactoring -- less noise, better turn discipline, and clearer collaboration modes. See [docs/v1-roadmap.md](docs/v1-roadmap.md).
+- **v2 (planned)**: Introduce the multi-agent foundation -- room-scoped collaboration, stable identity, a formal control protocol, and stronger recovery semantics. See [docs/v2-architecture.md](docs/v2-architecture.md).
 - **v3+ (longer term)**: Explore smarter collaboration, richer policies, and more advanced orchestration across runtimes.
 
 ## How This Project Was Built
 
-This project was built collaboratively by **Claude Code** (Anthropic) and **Codex** (OpenAI), communicating through AgentBridge itself — the very tool they were building together. A human developer coordinated the effort, assigning tasks, reviewing progress, and directing the two agents to work in parallel and review each other's output.
+This project was built collaboratively by **Claude Code** (Anthropic) and **Codex** (OpenAI), communicating through AgentBridge itself -- the very tool they were building together. A human developer coordinated the effort, assigning tasks, reviewing progress, and directing the two agents to work in parallel and review each other's output.
 
 In other words, AgentBridge is its own proof of concept: two AI agents from different providers, connected in real time, shipping code side by side.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,12 +7,12 @@ English version: [README.md](README.md)
 
 让 Claude Code 和 Codex 在同一个工作会话中进行双向通信的本地 Bridge。
 
-当前实现采用两层进程结构：
+AgentBridge 采用两层进程结构：
 
-- `bridge.ts` 是由 Claude Code 启动的前台 MCP 客户端
-- `daemon.ts` 是常驻本地的后台进程，持有 Codex app-server 代理和桥接状态
+- **bridge.ts** 是由 Claude Code 通过 AgentBridge 插件启动的前台 MCP 客户端
+- **daemon.ts** 是常驻本地的后台进程，持有 Codex app-server 代理和桥接状态
 
-这意味着当 Claude Code 关闭时，前台 MCP 进程可以退出，而后台 daemon 与 Codex 代理继续存活；当 Claude Code 再次启动时，可以自动复用已有 daemon。
+当 Claude Code 关闭时，前台 MCP 进程退出，后台 daemon 与 Codex 代理继续存活。当 Claude Code 再次启动时，会自动重连（指数退避）。
 
 ## 这个项目是什么 / 不是什么
 
@@ -31,32 +31,32 @@ English version: [README.md](README.md)
 ## 架构
 
 ```
-┌──────────────┐          MCP stdio          ┌────────────────────┐
-│ Claude Code  │ ───────────────────────────▶ │ bridge.ts          │
-│ Session      │ ◀─────────────────────────── │ 前台 MCP 客户端     │
-└──────────────┘                              └─────────┬──────────┘
-                                                        │
-                                                        │ 本地控制 WS
-                                                        ▼
-                                              ┌────────────────────┐
-                                              │ daemon.ts          │
-                                              │ 常驻后台桥接进程    │
-                                              └─────────┬──────────┘
-                                                        │
-                                      ws://127.0.0.1:4501 proxy
-                                                        │
-                                                        ▼
-                                              ┌────────────────────┐
-                                              │ Codex app-server   │
-                                              └────────────────────┘
+┌──────────────┐    MCP stdio / plugin     ┌────────────────────┐
+│ Claude Code  │ ─────────────────────────▶ │ bridge.ts          │
+│ Session      │ ◀─────────────────────────  │ 前台 MCP 客户端     │
+└──────────────┘                            └─────────┬──────────┘
+                                                      │
+                                                      │ 控制 WS (:4502)
+                                                      ▼
+                                            ┌────────────────────┐
+                                            │ daemon.ts          │
+                                            │ 常驻后台桥接进程    │
+                                            └─────────┬──────────┘
+                                                      │
+                                    ws://127.0.0.1:4501 proxy
+                                                      │
+                                                      ▼
+                                            ┌────────────────────┐
+                                            │ Codex app-server   │
+                                            └────────────────────┘
 ```
 
 ### 数据流
 
 | 方向 | 链路 |
 |------|------|
-| **Codex → Claude** | `daemon.ts` 捕获 `agentMessage` → 控制 WS → `bridge.ts` → `notifications/claude/channel` |
-| **Claude → Codex** | Claude 调用 `reply` tool → `bridge.ts` → 控制 WS → `daemon.ts` → `turn/start` 注入 Codex thread |
+| **Codex -> Claude** | `daemon.ts` 捕获 `agentMessage` -> 控制 WS -> `bridge.ts` -> `notifications/claude/channel` |
+| **Claude -> Codex** | Claude 调用 `reply` tool -> `bridge.ts` -> 控制 WS -> `daemon.ts` -> `turn/start` 注入 Codex thread |
 
 ### 防循环
 
@@ -64,7 +64,7 @@ English version: [README.md](README.md)
 
 ## 前置条件
 
-- [Bun](https://bun.sh)
+- [Bun](https://bun.sh) v1.0+
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) v2.1.80+
 - [Codex CLI](https://github.com/openai/codex)，且本地可直接使用 `codex` 命令
 
@@ -74,51 +74,102 @@ English version: [README.md](README.md)
 # 1. 安装依赖
 cd agent_bridge
 bun install
+bun link    # 全局注册 agentbridge 命令
 
-# 2. 注册 MCP server
-# 将 .mcp.json.example 的内容合并到 ~/.claude/.mcp.json 中，
-# 并把路径替换为你本地的绝对路径：
-#   "agentbridge": { "command": "bun", "args": ["run", "/absolute/path/to/agent_bridge/src/bridge.ts"] }
+# 2. 初始化项目（安装插件、检查依赖、生成配置）
+agentbridge init
 
-# 3. 启动 Claude Code 并以 channel 形式加载 AgentBridge（开发模式）
-claude --dangerously-load-development-channels server:agentbridge
+# 3. 启动 Claude Code（自动加载 AgentBridge 插件）
+agentbridge claude
+
+# 4. 在另一个终端启动 Codex TUI 连接 Bridge
+agentbridge codex
 ```
 
-> 风险说明：`--dangerously-load-development-channels` 会把本地开发中的 channel 挂载进 Claude Code。这一能力当前属于 Research Preview。你只应启用自己信任的 channel 和 MCP server，因为对应的本地进程可以向 Claude 会话推送消息，并参与同一个工作区流程。AgentBridge 的目标是本地开发与实验，不适合放在不可信环境中使用。
+就这样。Daemon 会在需要时自动启动，重启后自动重连。
 
-`bridge.ts` 启动后会先检查本地 daemon 是否已存在。
+> **注意：** `agentbridge claude` 会自动注入 `--dangerously-load-development-channels server:agentbridge`。这会把本地开发中的 channel 挂载进 Claude Code（当前属于 Research Preview）。请只启用你信任的 channel 和 MCP server。
 
-- 如果不存在，会自动拉起 `daemon.ts`
-- 如果已存在，会直接复用已有 daemon
+### 插件开发者
 
-`daemon.ts` 会自动以 WebSocket 模式启动 `codex app-server`，并在需要时通过 Claude channel 把 attach 命令提示出来。
+如果你在开发 AgentBridge 本身，使用 dev 命令同步本地改动到插件缓存：
 
 ```bash
-# 4. 在另一个终端连接到 Codex 代理，查看 Codex TUI
-codex --enable tui_app_server --remote ws://127.0.0.1:4501
+agentbridge dev     # 注册本地 marketplace + 同步插件文件
+agentbridge claude  # 启动 Claude Code（插件自动加载）
 ```
 
-> 注意：TUI 连接的是 Bridge 代理端口（默认 `4501`），不是 app-server 端口（`4500`）。Bridge 会透明转发流量，并拦截 `agentMessage`。
+## CLI 命令参考
 
-Codex 的 `agentMessage` 会自动推送到 Claude 会话中。Claude 可以通过 `reply` tool 回复 Codex。
+| 命令 | 说明 |
+|------|------|
+| `agentbridge init` | 安装插件、检查依赖（bun/claude/codex）、生成 `.agentbridge/config.json` 和 `collaboration.md` |
+| `agentbridge claude [args...]` | 启动 Claude Code 并启用 push channel。额外参数透传给 `claude` |
+| `agentbridge codex [args...]` | 启动连接到 AgentBridge daemon 的 Codex TUI。额外参数透传给 `codex` |
+| `agentbridge kill` | 优雅停止 daemon，清理状态文件，写入 killed sentinel 阻止自动重连 |
+| `agentbridge dev` | （开发用）注册本地 marketplace + 强制同步插件到缓存 |
+| `agentbridge --help` | 显示帮助 |
+| `agentbridge --version` | 显示版本 |
+
+### Owned flags
+
+部分参数由 CLI 自动注入，不可手动指定：
+
+- `agentbridge claude` 拥有：`--channels`、`--dangerously-load-development-channels`
+- `agentbridge codex` 拥有：`--remote`、`--enable tui_app_server`
+
+手动传入这些参数会报错，并提示使用原生命令。
+
+## 项目配置
+
+运行 `agentbridge init` 会在项目根目录创建 `.agentbridge/` 目录：
+
+| 文件 | 用途 |
+|------|------|
+| `config.json` | 机器可读的项目配置（端口、Agent 角色、消息标记、回合协调） |
+| `collaboration.md` | 人类/Agent 可读的协作规则（角色、思考模式、沟通风格） |
+
+CLI 和 daemon 启动时会加载该配置。重复运行 `init` 是幂等的，不会覆盖已有文件。
 
 ## 文件结构
 
 ```
 agent_bridge/
 ├── .github/
-│   ├── ISSUE_TEMPLATE/       # Bug report 和 feature request 模板
+│   ├── ISSUE_TEMPLATE/           # Bug report 和 feature request 模板
 │   ├── pull_request_template.md
-│   └── workflows/ci.yml      # GitHub Actions CI
-├── assets/                    # 图片资源（微信二维码等）
+│   └── workflows/ci.yml          # GitHub Actions CI
+├── assets/                        # 图片资源
+├── docs/
+│   ├── phase3-spec.md            # Phase 3 设计文档（CLI + Plugin）
+│   ├── v1-roadmap.md             # v1 功能路线图
+│   └── v2-architecture.md        # v2 多 Agent 架构设计
+├── plugins/agentbridge/           # Claude Code 插件包
+│   ├── .claude-plugin/plugin.json
+│   ├── commands/init.md
+│   ├── hooks/hooks.json
+│   ├── scripts/health-check.sh
+│   └── server/                    # 打包的 bridge-server.js + daemon.js
 ├── src/
-│   ├── bridge.ts             # Claude 前台 MCP 客户端，负责确保 daemon 存在并转发消息
-│   ├── daemon.ts             # 常驻后台进程，持有 Codex 代理和桥接状态
-│   ├── daemon-client.ts      # 前台连接 daemon 控制 WS 的客户端
-│   ├── control-protocol.ts   # 前后台共享控制协议
-│   ├── claude-adapter.ts     # 面向 Claude Code channel 的 MCP server 适配层
-│   ├── codex-adapter.ts      # Codex app-server WebSocket 代理与消息拦截
-│   └── types.ts              # 共享类型
+│   ├── bridge.ts                  # Claude 前台 MCP 客户端（插件入口）
+│   ├── daemon.ts                  # 常驻后台 daemon
+│   ├── daemon-client.ts           # daemon 控制端口的 WebSocket 客户端
+│   ├── daemon-lifecycle.ts        # 共享 daemon 生命周期（ensureRunning、kill、启动锁）
+│   ├── control-protocol.ts        # 前后台控制协议类型
+│   ├── claude-adapter.ts          # Claude Code channel 的 MCP server 适配层
+│   ├── codex-adapter.ts           # Codex app-server WebSocket 代理与消息拦截
+│   ├── config-service.ts          # 项目配置（.agentbridge/）读写
+│   ├── state-dir.ts               # 平台感知的状态目录解析
+│   ├── message-filter.ts          # 智能消息过滤（标记、摘要缓冲）
+│   ├── types.ts                   # 共享类型
+│   ├── cli.ts                     # CLI 入口和命令路由
+│   └── cli/
+│       ├── init.ts                # agentbridge init
+│       ├── claude.ts              # agentbridge claude
+│       ├── codex.ts               # agentbridge codex
+│       ├── kill.ts                # agentbridge kill
+│       └── dev.ts                 # agentbridge dev
+├── CLAUDE.md                      # AI Agent 项目规则
 ├── CODE_OF_CONDUCT.md
 ├── CONTRIBUTING.md
 ├── LICENSE
@@ -131,56 +182,46 @@ agent_bridge/
 
 ## 配置
 
-| 环境变量 | 默认值 | 说明 |
-|----------|--------|------|
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
 | `CODEX_WS_PORT` | `4500` | Codex app-server WebSocket 端口 |
 | `CODEX_PROXY_PORT` | `4501` | Bridge 代理端口，Codex TUI 连接此端口 |
-| `AGENTBRIDGE_CONTROL_PORT` | `4502` | `bridge.ts` 与 `daemon.ts` 之间的本地控制端口 |
-| `AGENTBRIDGE_PID_FILE` | `/tmp/agentbridge-daemon-4502.pid` | daemon pid 文件，用于避免重复启动 |
+| `AGENTBRIDGE_CONTROL_PORT` | `4502` | bridge.ts 与 daemon.ts 之间的控制端口 |
+| `AGENTBRIDGE_STATE_DIR` | 平台默认 | 状态目录（pid、status、日志）。macOS: `~/Library/Application Support/agentbridge/`，Linux: `$XDG_STATE_HOME/agentbridge/` |
+| `AGENTBRIDGE_MODE` | `push` | 消息投递模式（`push` 用于 channel，`pull` 用于 API key 模式） |
+| `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |
+
+### 状态目录
+
+daemon 在平台感知的目录中存储运行时状态：
+
+| 平台 | 默认路径 |
+|------|---------|
+| macOS | `~/Library/Application Support/agentbridge/` |
+| Linux | `$XDG_STATE_HOME/agentbridge/`（回退：`~/.local/state/agentbridge/`） |
+
+内容：`daemon.pid`、`status.json`、`agentbridge.log`、`killed`（sentinel）、`startup.lock`
 
 ## 当前限制
 
 - 目前只转发 `agentMessage`，不转发 `commandExecution`、`fileChange` 等中间过程事件
 - 当前只支持单个 Codex thread，不支持多会话
 - 当前只支持单个 Claude 前台连接；新的 Claude 会话会替换旧连接
+- 固定端口意味着每台机器只能运行一个 AgentBridge 实例（多项目并行支持计划在 v1 之后）
 
 ### Codex 的 Git 操作限制
 
 Codex 运行在沙箱环境中，**禁止对 `.git` 目录进行任何写操作**。这意味着 Codex 无法执行 `git commit`、`git push`、`git pull`、`git checkout -b`、`git merge` 等任何修改 Git 元数据的命令。尝试执行这些命令会导致 Codex 会话无限期挂起。
 
-当 Claude Code 使用了 **git worktree** 时，这个限制尤其需要注意 — worktree 与主仓库共享 `.git` 内部结构，可能会进一步收紧沙箱的约束。
-
 **建议做法：** 让 Claude Code 负责所有 Git 操作（创建分支、提交、推送、创建 PR）。Codex 专注于代码修改，通过 `agentMessage` 汇报完成的工作，由 Claude Code 负责 Git 工作流。
 
 ## Roadmap
 
-### v1.x（当前） — 单桥体验优化
-
-在不改变架构的前提下优化体验：**降噪、控回合、定角色**。
-
-- **v1.1** 智能消息过滤 — Prompt Contract + Marker Protocol，让 agent 自己决定发什么
-- **v1.2** 双向协调 — Turn Signals + Attention Window，控制消息时序
-- **v1.3** 角色协作 — Role Contract + Thinking Patterns，建立协作分工和思考模式
-
-详见 [v1 路线图](docs/v1-roadmap.zh-CN.md)
-
-### v2（规划中） — 多 Agent 基础设施
-
-Daemon 变为纯消息路由器，支持多 Agent 类型、多实例共存：
-
-- Room 模型与作用域通信
-- Agent 身份注册与断线恢复
-- v2 控制协议（版本协商、认证、心跳、消息回执）
-- 可插拔 Policy 层
-- SQLite 持久化
-
-详见 [v2 架构设计](docs/v2-architecture.zh-CN.md)
-
-### v3+（远期） — 智能协作与高级编排
-
-- 成熟的 Policy 系统与工作流编排
-- 丰富的可观测性
-- 跨 runtime 的多方代理协作智能
+- **v1.x（当前）**：在不改变架构的前提下优化单桥体验 -- 降噪、控回合、定角色。详见 [docs/v1-roadmap.md](docs/v1-roadmap.md)。
+- **v2（规划中）**：引入多 Agent 基础设施 -- Room 作用域协作、稳定身份、正式控制协议、更强的恢复语义。详见 [docs/v2-architecture.md](docs/v2-architecture.md)。
+- **v3+（远期）**：更智能的协作、更丰富的策略、跨 runtime 的高级编排。
 
 ## 这个项目是怎么建成的
 

--- a/docs/phase3-spec.md
+++ b/docs/phase3-spec.md
@@ -1,0 +1,250 @@
+# AgentBridge Phase 3 Final State
+
+## Status
+
+Phase 3 is complete in the current codebase.
+
+This document records what actually shipped, not the earlier proposal shape. If an older planning note or conversation describes Phase 3 as future work, this file should be treated as the source of truth for the delivered Phase 3 surface.
+
+## What Phase 3 Delivered
+
+Phase 3 turned AgentBridge from a repo-first prototype into a CLI-first local product flow built around a foreground Claude integration, a persistent daemon, and an attachable Codex TUI.
+
+Delivered scope:
+
+- A repository-local `agentbridge` CLI entrypoint via `src/cli.ts` and the package `bin` field.
+- First-run setup via `agentbridge init`.
+- Claude startup via `agentbridge claude`.
+- Codex startup and daemon bootstrap via `agentbridge codex`.
+- Controlled daemon shutdown via `agentbridge kill`.
+- A developer-only local plugin workflow via `agentbridge dev`.
+- Project-level config generation through `.agentbridge/config.json` and `.agentbridge/collaboration.md`.
+- Shared runtime state management through `StateDirResolver`.
+- Shared daemon lifecycle logic through `DaemonLifecycle`.
+- Plugin-oriented runtime artifacts under `plugins/agentbridge/server/`.
+
+## User-Facing CLI
+
+The current command set is:
+
+- `agentbridge init`
+- `agentbridge dev`
+- `agentbridge claude [args...]`
+- `agentbridge codex [args...]`
+- `agentbridge kill`
+
+### `agentbridge init`
+
+Current behavior:
+
+- Verifies `bun`, `claude`, and `codex` are available.
+- Enforces a minimum Claude Code version of `2.1.80`.
+- Creates `.agentbridge/config.json` if missing.
+- Creates `.agentbridge/collaboration.md` if missing.
+- Attempts `claude plugin install agentbridge@agentbridge` as a best-effort step.
+
+Important nuance:
+
+- `init` does not patch a global Claude MCP JSON file.
+- Plugin installation is best-effort and may be skipped if the marketplace is not configured yet.
+
+### `agentbridge claude`
+
+Current behavior:
+
+- Rejects AgentBridge-owned flags from the user.
+- Starts Claude Code with:
+
+```bash
+claude --dangerously-load-development-channels server:agentbridge
+```
+
+- Passes through additional user arguments after the injected channel flags.
+
+Important nuance:
+
+- The shipped implementation still uses the development-channel flag.
+- It does not yet switch to `--channels`, because the current flow still depends on a development plugin/runtime path.
+
+### `agentbridge codex`
+
+Current behavior:
+
+- Rejects AgentBridge-owned transport flags such as `--remote` and `--enable tui_app_server`.
+- Uses `DaemonLifecycle` to reuse or launch the background daemon.
+- Reads the live proxy URL from daemon status when available.
+- Falls back to the project config when daemon status is unavailable.
+- Launches Codex with:
+
+```bash
+codex --enable tui_app_server --remote ws://127.0.0.1:<proxy-port>
+```
+
+- Passes through additional user arguments after the injected transport flags.
+
+### `agentbridge kill`
+
+Current behavior:
+
+- Marks a `killed` sentinel before shutting down the daemon.
+- Prevents the foreground Claude-side bridge from racing to relaunch the daemon during disconnect handling.
+- Removes stale state when no live daemon exists.
+
+### `agentbridge dev`
+
+Current behavior:
+
+- Developer workflow only.
+- Registers a local Claude marketplace.
+- Installs the local AgentBridge plugin into Claude.
+- Syncs local plugin files into Claude's plugin cache.
+
+Important nuance:
+
+- This command is for local development of the plugin/runtime packaging flow.
+- It is not part of the normal end-user quick start.
+
+## Actual Runtime Architecture
+
+Phase 3 kept the two-process design, but productized it through shared lifecycle helpers and CLI commands.
+
+### Foreground process
+
+`src/bridge.ts` is the Claude-facing foreground process:
+
+- starts as the MCP server runtime seen by Claude Code
+- owns the `ClaudeAdapter`
+- ensures the daemon exists through `DaemonLifecycle`
+- connects to the daemon control socket through `DaemonClient`
+- forwards Codex messages to Claude and replies back to Codex
+
+### Background process
+
+`src/daemon.ts` is the persistent background process:
+
+- owns the Codex adapter and proxy
+- exposes `/healthz`, `/readyz`, and `/ws` on the local control port
+- survives Claude foreground restarts
+- manages buffered messages, turn coordination, and Codex thread state
+
+### Shared runtime helpers added or formalized in Phase 3
+
+- `src/daemon-lifecycle.ts`
+  - shared launch, health-check, pid, lock, and kill behavior
+- `src/config-service.ts`
+  - project config loading, defaults, and collaboration file generation
+- `src/state-dir.ts`
+  - OS-specific shared runtime state directory resolution
+- `src/daemon-client.ts`
+  - foreground client for daemon control WebSocket traffic
+
+### Plugin-oriented delivery shape
+
+The runtime is designed around Claude-side plugin or channel delivery:
+
+- source entrypoints live under `src/`
+- bundled runtime artifacts live under `plugins/agentbridge/server/`
+- the CLI is the main operator-facing surface
+
+This means Phase 3 shipped the plugin-oriented architecture, even though packaging and marketplace polish are still evolving.
+
+## Configuration and State
+
+Phase 3 split persistent data into two layers.
+
+### Project-level config
+
+Stored in the repo under `.agentbridge/`:
+
+- `config.json`
+- `collaboration.md`
+
+This data is project-specific and travels with the working tree.
+
+### Machine-local runtime state
+
+Resolved by `StateDirResolver`:
+
+- macOS: `~/Library/Application Support/AgentBridge`
+- Linux: `${XDG_STATE_HOME:-~/.local/state}/agentbridge`
+- override: `AGENTBRIDGE_STATE_DIR`
+
+Files maintained there include:
+
+- `daemon.pid`
+- `daemon.lock`
+- `status.json`
+- `agentbridge.log`
+- `killed`
+
+This split is intentional:
+
+- `.agentbridge/` is for shared project defaults and collaboration rules
+- the state dir is for local process lifecycle and diagnostics
+
+## Phase 3 Runtime Controls
+
+The current implementation uses these environment variables as the main runtime controls:
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENTBRIDGE_STATE_DIR` | Override the machine-local runtime state directory |
+| `AGENTBRIDGE_DAEMON_ENTRY` | Override the daemon entrypoint used by `DaemonLifecycle` |
+| `AGENTBRIDGE_CONTROL_PORT` | Control HTTP/WebSocket port between foreground and daemon |
+| `CODEX_WS_PORT` | Codex app-server listen port |
+| `CODEX_PROXY_PORT` | AgentBridge proxy port used by the Codex TUI |
+| `AGENTBRIDGE_MODE` | Claude delivery mode override: `push`, `pull`, or `auto` |
+| `AGENTBRIDGE_MAX_BUFFERED_MESSAGES` | Pull-mode queue bound and buffering limit |
+| `AGENTBRIDGE_FILTER_MODE` | Codex message filtering mode |
+| `AGENTBRIDGE_IDLE_SHUTDOWN_MS` | Daemon idle shutdown override |
+| `AGENTBRIDGE_ATTENTION_WINDOW_MS` | Claude attention-window override |
+
+## Where Phase 3 Landed Differently Than The Earlier Proposal
+
+Phase 3 shipped the intended product direction, but not every original proposal detail survived unchanged.
+
+### Shipped differently
+
+- The CLI exists, but the package is still repository-local today.
+  - `package.json` exposes the `agentbridge` bin, but the package is still marked `private`.
+- The command surface is more opinionated than the original generic lifecycle proposal.
+  - Shipped commands are `init`, `dev`, `claude`, `codex`, and `kill`.
+  - Proposed commands such as `doctor`, `status`, `start`, `stop`, and `attach` did not ship in Phase 3.
+- `init` generates project config and attempts plugin installation, but it does not rewrite global Claude configuration files.
+- Claude startup still uses the development-channel path instead of a stable marketplace `--channels` flow.
+- Delivery mode auto-detection is intentionally conservative.
+  - `auto` resolves to push mode today.
+  - API-key users can force pull mode with `AGENTBRIDGE_MODE=pull`.
+
+### Why those differences are acceptable for v1
+
+- The current command set matches the real user workflow more directly.
+- The daemon lifecycle is now precise enough that a generic `start` or `attach` command is not required for normal use.
+- Keeping `claude` and `codex` as explicit commands makes the startup contract easier to understand and test.
+- Explicit pull-mode override solves the practical API-key case without over-engineering capability negotiation.
+
+## Validation Shipped With Phase 3
+
+Phase 3 is backed by targeted automated coverage in the repository:
+
+- CLI helper and flag handling tests
+- config and lifecycle tests
+- daemon client tests
+- CLI end-to-end harness coverage for:
+  - `init`
+  - `claude`
+  - `codex`
+  - daemon reuse
+  - concurrent startup lock behavior
+  - `kill`
+  - killed-sentinel reconnect behavior
+
+## Remaining Follow-Ups After Phase 3
+
+Phase 3 is complete, but these items remain follow-up work rather than part of the shipped baseline:
+
+- publishing a non-private npm package
+- stabilizing marketplace packaging and plugin manifests
+- deciding whether `doctor` or `status` are still worth adding
+- replacing development-channel startup with a stable marketplace path when available
+- broader multi-session and multi-agent work, which remains v2+ scope

--- a/docs/v1-roadmap.md
+++ b/docs/v1-roadmap.md
@@ -34,6 +34,20 @@ Guiding principles:
 
 In short, v1 should make the bridge feel smoother every day, while v2 remains the milestone for deeper architectural change.
 
+## Status Update (March 2026)
+
+The current codebase has now shipped most of the v1 roadmap ideas in concrete form.
+
+Notable shipped status:
+
+- marker-aware filtering, buffering, and summaries are implemented
+- turn coordination and busy-guard behavior are implemented
+- role-aware collaboration guidance is implemented
+- dual-mode Claude delivery (`push` and `pull`) is implemented
+- Phase 3, the CLI/distribution milestone, is complete
+
+For the concrete Phase 3 outcome, see [docs/phase3-spec.md](phase3-spec.md). The rest of this roadmap is still useful as design rationale, but §6 below should now be read as implemented product status rather than a future recommendation.
+
 ## 3. v1.1 Smart Message Filtering
 
 ### Problem
@@ -282,66 +296,94 @@ This preserves flexibility without requiring the user to constantly switch expli
 - Implementation and debugging flows feel more intentional and less ad hoc.
 - The bridge feels more structured without becoming a workflow engine.
 
-## 6. Distribution and Quick Start
+## 6. Distribution and CLI Status
 
-Making AgentBridge easy to try should not wait for the larger v2 architecture. The right v1 direction is to package the current single-bridge experience as a local CLI product rather than leaving it as a repository-first developer setup.
+Phase 3 shipped the v1 distribution milestone as a local CLI-first workflow.
 
-### Recommended product shape
+The product shape that actually landed is:
 
-The preferred distribution model for v1 is:
+- a repository-local `agentbridge` CLI exposed through the package `bin`
+- a plugin-oriented Claude integration path
+- a persistent daemon reused across Claude restarts
+- project config generation plus machine-local runtime state management
 
-- an `npm` package for distribution
-- an `agentbridge` CLI as the primary product interface
+### What shipped
 
-This keeps installation, diagnostics, configuration, and lifecycle management in one place. It also fits the current system better than trying to start with an extension-first design.
-
-Recommended core commands:
+The current command set is:
 
 - `agentbridge init`
+- `agentbridge dev`
+- `agentbridge claude`
+- `agentbridge codex`
+- `agentbridge kill`
+
+What those commands do in practice:
+
+- `init`
+  - checks `bun`, `claude`, and `codex`
+  - enforces the minimum Claude version
+  - creates `.agentbridge/config.json`
+  - creates `.agentbridge/collaboration.md`
+  - attempts plugin installation as a best-effort step
+- `dev`
+  - developer-only local marketplace and plugin-cache workflow
+- `claude`
+  - launches Claude with `--dangerously-load-development-channels server:agentbridge`
+- `codex`
+  - ensures the daemon is running
+  - launches Codex with the injected proxy arguments
+- `kill`
+  - stops the daemon precisely and writes a killed sentinel to prevent reconnect races
+
+### Actual quick-start flow
+
+The real first-run flow in the current codebase is:
+
+1. Clone the repository and run `bun install`
+2. Run `agentbridge init`
+3. Start Claude Code with `agentbridge claude`
+4. Start Codex with `agentbridge codex`
+5. Stop the daemon later with `agentbridge kill`
+
+This is simpler and more opinionated than the original proposal. Instead of generic `start` and `attach` commands, the CLI now encodes the actual Claude-side and Codex-side entrypoints directly.
+
+### What did not ship from the earlier proposal
+
+The original recommended command set included:
+
 - `agentbridge doctor`
 - `agentbridge start`
 - `agentbridge stop`
 - `agentbridge status`
 - `agentbridge attach`
 
-### Quick-start model
+Those commands did not ship in Phase 3.
 
-In this model, `npx` should be treated as an installer or bootstrap entrypoint, not the long-term runtime entrypoint.
+The implemented CLI chose task-specific commands instead because they map more directly to the real workflow:
 
-The expected first-run flow is:
+- `claude` replaces a generic frontend startup command
+- `codex` replaces a generic daemon-plus-attach flow
+- `kill` replaces a generic stop path, while also handling the reconnect sentinel correctly
 
-1. Run `npx agentbridge init`
-2. Let the CLI check local prerequisites and environment health
-3. Let the CLI write or update MCP configuration
-4. Let the CLI generate project-level context files or prompt skeletons
-5. Start Claude Code with the configured AgentBridge integration
+### Important deviations from the original distribution plan
 
-The `init` command should do the most work because it is the highest-friction step in adoption. It should:
+- The CLI exists, but the package is not yet published as a public npm artifact.
+  - The package is still marked `private`.
+- `init` does not patch a global Claude MCP config file.
+  - It generates project config and attempts plugin installation instead.
+- Claude startup still depends on the development-channel flag rather than a stable marketplace `--channels` flow.
 
-- verify required tools and versions
-- detect Codex availability
-- validate local ports and startup assumptions
-- write or patch MCP configuration
-- generate project file skeletons for shared context and agent overlays
+### Why this still counts as a successful v1 outcome
 
-### Why v1 should not start with an extension or plugin
+Phase 3 solved the operational problems that mattered most for v1:
 
-An extension or plugin may still be useful later, but it should not be the first product shape.
+- repeatable local setup
+- explicit Claude and Codex startup commands
+- reliable daemon reuse and shutdown
+- project-level collaboration defaults
+- a clean place to centralize runtime lifecycle logic
 
-- The hardest current problems are local bootstrap, process lifecycle, health checks, and configuration.
-- Those are CLI problems first, not UI shell problems.
-- A plugin can later wrap or invoke the CLI, but it should not replace the CLI as the base layer.
-
-### Technical challenges
-
-The main delivery challenges for this direction are:
-
-- reducing or packaging the current Bun runtime dependency for easier installation
-- safely writing or merging MCP configuration
-- discovering and validating the local Codex installation
-- handling platform differences across local environments
-
-These are practical productization challenges, but they are still much smaller than introducing a full plugin platform or a v2-style architecture migration.
+That gives AgentBridge a real product surface now, even though public packaging and marketplace polish remain follow-up work.
 
 ## 7. Collaboration Awareness Injection
 


### PR DESCRIPTION
## Summary

Update all project documentation to reflect the Phase 3 (CLI + Plugin) milestone completion.

- **README.md**: Rewrite Quick Start to use CLI flow (`agentbridge init/claude/codex`), add CLI command reference with owned flags, project config section, state directory docs, updated file structure and env vars
- **README.zh-CN.md**: Sync Chinese version with all README changes
- **CONTRIBUTING.md**: Add `agentbridge dev` workflow, E2E testing guide, `execFileSync` convention
- **docs/phase3-spec.md**: New document recording Phase 3 actual delivered state (not the earlier proposal)
- **docs/v1-roadmap.md**: Update §6 from proposal to shipped status, add March 2026 status update

## Authors

- README.md, README.zh-CN.md, CONTRIBUTING.md: Claude
- docs/phase3-spec.md, docs/v1-roadmap.md: Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)