### PR TITLE
fix: use scoped npm package name @raysonmeng/agentbridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then install the CLI tool:
 
 ```bash
 # 4. Install the CLI globally
-npm install -g agentbridge
+npm install -g @raysonmeng/agentbridge
 
 # 5. Generate project config (optional)
 abg init

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,7 +93,7 @@ AgentBridge 采用两层进程结构：
 
 ```bash
 # 4. 全局安装 CLI
-npm install -g agentbridge
+npm install -g @raysonmeng/agentbridge
 
 # 5. 生成项目配置（可选）
 abg init

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentbridge",
+  "name": "@raysonmeng/agentbridge",
   "version": "0.1.0",
   "description": "Bridge between Claude Code and Codex — bidirectional agent communication via MCP Channel + JSON-RPC",
   "type": "module",


### PR DESCRIPTION
## Summary

- npm rejected `agentbridge` as too similar to existing `agent-bridge`
- Rename to `@raysonmeng/agentbridge` (already published as v0.1.0)
- Update README install commands: `npm install -g @raysonmeng/agentbridge`

## Test plan

- [x] Package already published and verified: `@raysonmeng/agentbridge@0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)