### PR TITLE
fix: passthrough server-to-client requests for Codex approval UI (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then install the CLI tool:
 
 ```bash
 # 4. Install the CLI globally
-npm install -g agentbridge
+npm install -g @raysonmeng/agentbridge
 
 # 5. Generate project config (optional)
 abg init

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,7 +93,7 @@ AgentBridge 采用两层进程结构：
 
 ```bash
 # 4. 全局安装 CLI
-npm install -g agentbridge
+npm install -g @raysonmeng/agentbridge
 
 # 5. 生成项目配置（可选）
 abg init

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentbridge",
+  "name": "@raysonmeng/agentbridge",
   "version": "0.1.0",
   "description": "Bridge between Claude Code and Codex — bidirectional agent communication via MCP Channel + JSON-RPC",
   "type": "module",

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -251,3 +251,172 @@ describe("CodexAdapter turn state machine", () => {
     expect(adapter.injectMessage("hello after reset")).toBe(true);
   });
 });
+
+describe("CodexAdapter server-to-client request passthrough", () => {
+  test("forwards server request (id + method) to TUI instead of dropping", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+    adapter.tuiWs = { send: (data: string) => sent.push(data) } as any;
+    adapter.tuiConnId = 1;
+
+    const serverRequest = JSON.stringify({
+      id: 42,
+      method: "item/permissions/requestApproval",
+      params: { permission: "network" },
+    });
+
+    const result = adapter.handleAppServerPayload(serverRequest);
+
+    expect(result).toBeNull();
+    expect(sent.length).toBe(1);
+    const parsed = JSON.parse(sent[0]);
+    expect(parsed.method).toBe("item/permissions/requestApproval");
+    expect(parsed.params).toEqual({ permission: "network" });
+    expect(parsed.id).not.toBe(42);
+    expect(adapter.serverRequestToProxy.size).toBe(1);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("existing response handling is not affected by server request passthrough", () => {
+    const adapter = createAdapter();
+    adapter.tuiConnId = 1;
+    adapter.upstreamToClient.set(100200, { connId: 1, clientId: "c1" });
+
+    const forwarded = adapter.handleAppServerPayload(JSON.stringify({
+      id: 100200,
+      result: { ok: true },
+    }));
+
+    expect(forwarded).not.toBeNull();
+    expect(JSON.parse(forwarded!).id).toBe("c1");
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("notifications without id still forwarded as before", () => {
+    const adapter = createAdapter();
+    const raw = JSON.stringify({ method: "item/started", params: { item: { id: "i1", type: "text" } } });
+    const forwarded = adapter.handleAppServerPayload(raw);
+    expect(forwarded).toBe(raw);
+    adapter.clearResponseTrackingState();
+  });
+
+  test("buffers server request when no TUI connected", () => {
+    const adapter = createAdapter();
+    adapter.tuiWs = null;
+
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: 50,
+      method: "item/fileChange/requestApproval",
+      params: { file: "test.ts" },
+    }));
+
+    expect(adapter.pendingServerRequests.length).toBe(1);
+    expect(adapter.pendingServerRequests[0].serverId).toBe(50);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("falls back to buffer when TUI send fails", () => {
+    const adapter = createAdapter();
+    adapter.tuiWs = { send: () => { throw new Error("broken pipe"); } } as any;
+    adapter.tuiConnId = 1;
+
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: 90,
+      method: "item/commandExecution/requestApproval",
+      params: {},
+    }));
+
+    expect(adapter.pendingServerRequests.length).toBe(1);
+    expect(adapter.pendingServerRequests[0].serverId).toBe(90);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("routes TUI approval response back to app-server with original server id", () => {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    adapter.tuiConnId = 1;
+
+    adapter.serverRequestToProxy.set(100300, {
+      serverId: 42,
+      connId: 1,
+      method: "item/permissions/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: 100300, result: { approved: true } }));
+
+    expect(appSent.length).toBe(1);
+    expect(JSON.parse(appSent[0]).id).toBe(42);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("rejects stale response from old TUI without deleting mapping", () => {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    adapter.tuiConnId = 2;
+
+    adapter.serverRequestToProxy.set(100301, {
+      serverId: 43,
+      connId: 1,
+      method: "item/fileChange/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    const ws = { data: { connId: 2 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: 100301, result: { approved: true } }));
+
+    expect(appSent.length).toBe(0);
+    expect(adapter.serverRequestToProxy.has(100301)).toBe(true);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("normalizes string ID to number when matching server request response", () => {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    adapter.tuiConnId = 1;
+
+    adapter.serverRequestToProxy.set(100302, {
+      serverId: 44,
+      connId: 1,
+      method: "item/commandExecution/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: "100302", result: { approved: false } }));
+
+    expect(appSent.length).toBe(1);
+    expect(JSON.parse(appSent[0]).id).toBe(44);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("unknown TUI response id falls through to normal client forwarding", () => {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    adapter.tuiConnId = 1;
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: 999, result: { ok: true } }));
+
+    expect(appSent.length).toBe(1);
+
+    adapter.clearResponseTrackingState();
+  });
+});

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -419,4 +419,128 @@ describe("CodexAdapter server-to-client request passthrough", () => {
 
     adapter.clearResponseTrackingState();
   });
+
+  test("approval response send failure retains mapping", () => {
+    const adapter = createAdapter();
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => { throw new Error("broken"); } } as any;
+    adapter.tuiConnId = 1;
+
+    adapter.serverRequestToProxy.set(100500, {
+      serverId: 99,
+      connId: 1,
+      method: "item/permissions/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: 100500, result: { approved: true } }));
+
+    // mapping should still exist after send failure
+    expect(adapter.serverRequestToProxy.has(100500)).toBe(true);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("replays buffered server requests on TUI reconnect", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+
+    adapter.pendingServerRequests = [
+      { raw: JSON.stringify({ id: 50, method: "item/fileChange/requestApproval", params: { file: "test.ts" } }), serverId: 50, method: "item/fileChange/requestApproval" },
+    ];
+
+    const ws = { data: { connId: 0 }, send: (data: string) => sent.push(data) } as any;
+    adapter.onTuiConnect(ws);
+
+    expect(adapter.pendingServerRequests.length).toBe(0);
+    expect(sent.length).toBe(1);
+    const parsed = JSON.parse(sent[0]);
+    expect(parsed.method).toBe("item/fileChange/requestApproval");
+    expect(parsed.id).not.toBe(50);
+    expect(adapter.serverRequestToProxy.size).toBe(1);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("replay send failure: no phantom mapping, request stays buffered", () => {
+    const adapter = createAdapter();
+
+    adapter.pendingServerRequests = [
+      { raw: JSON.stringify({ id: 60, method: "item/permissions/requestApproval", params: {} }), serverId: 60, method: "item/permissions/requestApproval" },
+    ];
+
+    const ws = { data: { connId: 0 }, send: () => { throw new Error("connection reset"); } } as any;
+    adapter.onTuiConnect(ws);
+
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+    expect(adapter.pendingServerRequests.length).toBe(1);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("server request mappings survive TUI disconnect (TTL cleanup)", () => {
+    const adapter = createAdapter();
+    adapter.tuiConnId = 1;
+
+    adapter.serverRequestToProxy.set(100400, {
+      serverId: 70,
+      connId: 1,
+      method: "item/permissions/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    adapter.retireConnectionState(1);
+    expect(adapter.serverRequestToProxy.has(100400)).toBe(true);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("app-server close clears all server request state", () => {
+    const adapter = createAdapter();
+
+    adapter.serverRequestToProxy.set(100401, {
+      serverId: 71,
+      connId: 1,
+      method: "item/permissions/requestApproval",
+      timestamp: Date.now(),
+    });
+    adapter.pendingServerRequests = [
+      { raw: "{}", serverId: 72, method: "item/fileChange/requestApproval" },
+    ];
+
+    adapter.clearResponseTrackingState();
+    adapter.activeTurnIds.clear();
+    adapter.turnInProgress = false;
+
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+    expect(adapter.pendingServerRequests.length).toBe(0);
+  });
+
+  test("server request and client request share nextProxyId without collision", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+    adapter.tuiWs = { send: (data: string) => sent.push(data) } as any;
+    adapter.tuiConnId = 1;
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: 80,
+      method: "item/permissions/requestApproval",
+      params: {},
+    }));
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({
+      id: "client-1",
+      method: "thread/start",
+      params: {},
+    }));
+
+    const serverProxyId = JSON.parse(sent[0]).id;
+    const clientMapping = [...adapter.upstreamToClient.entries()];
+    expect(clientMapping.length).toBe(1);
+    expect(clientMapping[0][0]).not.toBe(serverProxyId);
+
+    adapter.clearResponseTrackingState();
+  });
 });

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -420,6 +420,27 @@ describe("CodexAdapter server-to-client request passthrough", () => {
     adapter.clearResponseTrackingState();
   });
 
+  test("approval response when app-server disconnected is dropped gracefully", () => {
+    const adapter = createAdapter();
+    adapter.appServerWs = null;
+    adapter.tuiConnId = 1;
+
+    adapter.serverRequestToProxy.set(100600, {
+      serverId: 88,
+      connId: 1,
+      method: "item/permissions/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: 100600, result: { approved: true } }));
+
+    // mapping preserved (not deleted, not forwarded)
+    expect(adapter.serverRequestToProxy.has(100600)).toBe(true);
+
+    adapter.clearResponseTrackingState();
+  });
+
   test("approval response send failure retains mapping", () => {
     const adapter = createAdapter();
     adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => { throw new Error("broken"); } } as any;

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -293,6 +293,28 @@ export class CodexAdapter extends EventEmitter {
     this.tuiWs = ws;
     this.log(`TUI connected (conn #${this.tuiConnId})`);
     this.emit("tuiConnected", this.tuiConnId);
+
+    // Replay buffered server requests.
+    const remaining: typeof this.pendingServerRequests = [];
+    for (const buffered of this.pendingServerRequests) {
+      const proxyId = this.nextProxyId++;
+      try {
+        const parsed = JSON.parse(buffered.raw);
+        parsed.id = proxyId;
+        ws.send(JSON.stringify(parsed));
+        this.serverRequestToProxy.set(proxyId, {
+          serverId: buffered.serverId,
+          connId: this.tuiConnId,
+          method: buffered.method,
+          timestamp: Date.now(),
+        });
+        this.log(`Replayed buffered server request: ${buffered.method} (server id=${buffered.serverId} → proxy id=${proxyId})`);
+      } catch (e: any) {
+        this.log(`Failed to replay buffered server request: ${buffered.method} (server id=${buffered.serverId}): ${e.message}`);
+        remaining.push(buffered);
+      }
+    }
+    this.pendingServerRequests = remaining;
   }
 
   private onTuiDisconnect(ws: ServerWebSocket<TuiSocketData>) {
@@ -686,6 +708,19 @@ export class CodexAdapter extends EventEmitter {
       this.upstreamToClient.delete(upId);
       this.trackStaleProxyId(upId);
     }
+
+    // TTL cleanup for server request mappings belonging to this connection.
+    for (const [proxyId, pending] of this.serverRequestToProxy.entries()) {
+      if (pending.connId === connId) {
+        const timer = setTimeout(() => {
+          if (this.serverRequestToProxy.get(proxyId)?.connId === connId) {
+            this.serverRequestToProxy.delete(proxyId);
+            this.log(`Expired stale server request mapping (proxy id=${proxyId}, method=${pending.method})`);
+          }
+        }, CodexAdapter.RESPONSE_TRACKING_TTL_MS);
+        timer.unref?.();
+      }
+    }
   }
 
   private trackStaleProxyId(proxyId: number) {
@@ -741,6 +776,9 @@ export class CodexAdapter extends EventEmitter {
       clearTimeout(timer);
     }
     this.bridgeRequestIds.clear();
+
+    this.serverRequestToProxy.clear();
+    this.pendingServerRequests = [];
   }
 
   /**

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -355,9 +355,13 @@ export class CodexAdapter extends EventEmitter {
             this.log(`Dropping stale server request response (proxy id=${normalizedId}, expected conn #${pending.connId}, got #${connId})`);
             return;
           }
+          if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+            this.log(`Cannot forward approval response: app-server disconnected (proxy id=${normalizedId})`);
+            return;
+          }
           parsed.id = pending.serverId;
           try {
-            this.appServerWs!.send(JSON.stringify(parsed));
+            this.appServerWs.send(JSON.stringify(parsed));
             this.serverRequestToProxy.delete(normalizedId);
             this.log(`TUI → app-server: ${pending.method} response (proxy id=${normalizedId} → server id=${pending.serverId})`);
           } catch (e: any) {
@@ -410,7 +414,7 @@ export class CodexAdapter extends EventEmitter {
       }
 
       if (parsed.method !== undefined) {
-        this.handleServerRequest(parsed);
+        this.handleServerRequest(parsed, raw);
         return null;
       }
 
@@ -420,8 +424,7 @@ export class CodexAdapter extends EventEmitter {
     }
   }
 
-  private handleServerRequest(parsed: any): void {
-    const raw = JSON.stringify(parsed);
+  private handleServerRequest(parsed: any, raw: string): void {
     const serverId = parsed.id;
     const method = parsed.method;
 

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -20,6 +20,13 @@ interface TuiSocketData {
   connId: number;
 }
 
+interface PendingServerRequest {
+  serverId: number | string;
+  connId: number;
+  method: string;
+  timestamp: number;
+}
+
 const LOG_FILE = "/tmp/agentbridge.log";
 const TRACKED_REQUEST_METHODS = new Set(["thread/start", "thread/resume", "turn/start"]);
 
@@ -53,6 +60,8 @@ export class CodexAdapter extends EventEmitter {
   // Proxy-layer id rewriting: upstream uses globally unique ids
   private nextProxyId = 100000;
   private upstreamToClient = new Map<number, { connId: number; clientId: number | string }>();
+  private serverRequestToProxy = new Map<number, PendingServerRequest>();
+  private pendingServerRequests: Array<{ raw: string; serverId: number | string; method: string }> = [];
   private staleProxyIds = new Map<number, ReturnType<typeof setTimeout>>();
   private bridgeRequestIds = new Map<number, ReturnType<typeof setTimeout>>();
   private intentionalDisconnect = false;
@@ -310,6 +319,34 @@ export class CodexAdapter extends EventEmitter {
       return;
     }
 
+    // Check if this is a response to a server-originated request
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed.id !== undefined && !parsed.method) {
+        const rawId = parsed.id;
+        const normalizedId = typeof rawId === "number"
+          ? rawId
+          : (typeof rawId === "string" && /^-?\d+$/.test(rawId) ? Number(rawId) : NaN);
+        const pending = !isNaN(normalizedId) ? this.serverRequestToProxy.get(normalizedId) : undefined;
+        if (pending !== undefined) {
+          if (pending.connId !== connId) {
+            this.log(`Dropping stale server request response (proxy id=${normalizedId}, expected conn #${pending.connId}, got #${connId})`);
+            return;
+          }
+          parsed.id = pending.serverId;
+          try {
+            this.appServerWs!.send(JSON.stringify(parsed));
+            this.serverRequestToProxy.delete(normalizedId);
+            this.log(`TUI → app-server: ${pending.method} response (proxy id=${normalizedId} → server id=${pending.serverId})`);
+          } catch (e: any) {
+            parsed.id = normalizedId;
+            this.log(`Failed to forward approval response (proxy id=${normalizedId}): ${e.message}`);
+          }
+          return;
+        }
+      }
+    } catch {}
+
     let forwarded = data;
     try {
       const parsed = JSON.parse(data);
@@ -350,10 +387,41 @@ export class CodexAdapter extends EventEmitter {
         return forwarded;
       }
 
+      if (parsed.method !== undefined) {
+        this.handleServerRequest(parsed);
+        return null;
+      }
+
       return this.handleAppServerResponse(parsed, raw);
     } catch {
       return raw;
     }
+  }
+
+  private handleServerRequest(parsed: any): void {
+    const raw = JSON.stringify(parsed);
+    const serverId = parsed.id;
+    const method = parsed.method;
+
+    if (!this.tuiWs) {
+      this.pendingServerRequests.push({ raw, serverId, method });
+      this.log(`Server request buffered (no TUI): ${method} (server id=${serverId})`);
+      return;
+    }
+
+    const proxyId = this.nextProxyId++;
+    parsed.id = proxyId;
+
+    try {
+      this.tuiWs.send(JSON.stringify(parsed));
+    } catch (e: any) {
+      this.log(`Server request send failed, buffering: ${method} (server id=${serverId}): ${e.message}`);
+      this.pendingServerRequests.push({ raw, serverId, method });
+      return;
+    }
+
+    this.serverRequestToProxy.set(proxyId, { serverId, connId: this.tuiConnId, method, timestamp: Date.now() });
+    this.log(`Server request: ${method} (server id=${serverId} → proxy id=${proxyId}, conn #${this.tuiConnId})`);
   }
 
   private handleAppServerResponse(parsed: any, raw: string): string | null {

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -61,6 +61,7 @@ export class CodexAdapter extends EventEmitter {
   private nextProxyId = 100000;
   private upstreamToClient = new Map<number, { connId: number; clientId: number | string }>();
   private serverRequestToProxy = new Map<number, PendingServerRequest>();
+  private serverRequestTtlTimers = new Map<number, ReturnType<typeof setTimeout>>();
   private pendingServerRequests: Array<{ raw: string; serverId: number | string; method: string }> = [];
   private staleProxyIds = new Map<number, ReturnType<typeof setTimeout>>();
   private bridgeRequestIds = new Map<number, ReturnType<typeof setTimeout>>();
@@ -345,10 +346,7 @@ export class CodexAdapter extends EventEmitter {
     try {
       const parsed = JSON.parse(data);
       if (parsed.id !== undefined && !parsed.method) {
-        const rawId = parsed.id;
-        const normalizedId = typeof rawId === "number"
-          ? rawId
-          : (typeof rawId === "string" && /^-?\d+$/.test(rawId) ? Number(rawId) : NaN);
+        const normalizedId = this.normalizeNumericId(parsed.id);
         const pending = !isNaN(normalizedId) ? this.serverRequestToProxy.get(normalizedId) : undefined;
         if (pending !== undefined) {
           if (pending.connId !== connId) {
@@ -449,12 +447,16 @@ export class CodexAdapter extends EventEmitter {
     this.log(`Server request: ${method} (server id=${serverId} → proxy id=${proxyId}, conn #${this.tuiConnId})`);
   }
 
+  /** Normalize a JSON-RPC id to a number. Returns NaN for non-numeric strings. */
+  private normalizeNumericId(id: unknown): number {
+    if (typeof id === "number") return id;
+    if (typeof id === "string" && /^-?\d+$/.test(id)) return Number(id);
+    return NaN;
+  }
+
   private handleAppServerResponse(parsed: any, raw: string): string | null {
     const responseId = parsed.id;
-    // Handle response IDs that may arrive as numeric strings (e.g. "100005"
-    // instead of 100005). Non-numeric string IDs like "initialize" stay NaN
-    // and fall through to the unmatched response log at the end of this method.
-    const numericId = typeof responseId === "number" ? responseId : (typeof responseId === "string" && /^-?\d+$/.test(responseId) ? Number(responseId) : NaN);
+    const numericId = this.normalizeNumericId(responseId);
     const mapping = !isNaN(numericId) ? this.upstreamToClient.get(numericId) : undefined;
 
     if (mapping) {
@@ -715,13 +717,16 @@ export class CodexAdapter extends EventEmitter {
     // TTL cleanup for server request mappings belonging to this connection.
     for (const [proxyId, pending] of this.serverRequestToProxy.entries()) {
       if (pending.connId === connId) {
+        this.clearTrackedId(this.serverRequestTtlTimers, proxyId);
         const timer = setTimeout(() => {
+          this.serverRequestTtlTimers.delete(proxyId);
           if (this.serverRequestToProxy.get(proxyId)?.connId === connId) {
             this.serverRequestToProxy.delete(proxyId);
             this.log(`Expired stale server request mapping (proxy id=${proxyId}, method=${pending.method})`);
           }
         }, CodexAdapter.RESPONSE_TRACKING_TTL_MS);
         timer.unref?.();
+        this.serverRequestTtlTimers.set(proxyId, timer);
       }
     }
   }
@@ -780,6 +785,10 @@ export class CodexAdapter extends EventEmitter {
     }
     this.bridgeRequestIds.clear();
 
+    for (const timer of this.serverRequestTtlTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.serverRequestTtlTimers.clear();
     this.serverRequestToProxy.clear();
     this.pendingServerRequests = [];
   }


### PR DESCRIPTION
## Summary

Fixes #37 — Codex 审批请求（文件写入、命令执行、网络访问）被 WebSocket 代理误判为 response 并丢弃，导致 TUI 无法显示审批 UI，Codex 无限期卡死。

### Root Cause

`codex-adapter.ts` 的 `handleAppServerPayload` 只区分了 notification（无 `id`）和 response（有 `id`），未识别 server-to-client request（同时有 `id` + `method`）。审批请求如 `item/permissions/requestApproval` 被归入 response 路径，因无 upstream mapping 而在 "Dropping unmatched app-server response" 处被丢弃。

### Changes

**Phase 1 — 核心修复：**
- `handleAppServerPayload` 新增 `{ id, method }` 分支识别 server request
- `handleServerRequest()` 内部直接发送给 TUI（避免外层 handler 的 "log and drop" 路径），send 失败时回退到缓冲
- `onTuiMessage` 新增 server request 响应路由，含 ID 类型归一化（string→number）和 connId 验证

**Phase 2 — 重连与清理：**
- `onTuiConnect` 新增缓冲 server request 重放（逐条 try-catch，失败的保留）
- `retireConnectionState` 新增 TTL 清理（30s，与现有 response tracking 一致）
- `clearResponseTrackingState` 新增 server request 状态清理（app-server 重连时）

### Design

经过 Claude + Codex 4 轮交叉 review，设计文档从 v1 迭代到 v5，修复了 13 个设计级问题。
详见 `docs/issue-37-server-request-passthrough-design.md`

## Test plan

- [x] `bun run typecheck` — 通过
- [x] `bun test src/` — 148 tests, 0 fail
- [x] 28 个 codex-adapter 专项测试（原 12 + 新增 16），覆盖 v5 spec 的全部 17 个场景
- [ ] E2E: 启动 AgentBridge + Codex，触发审批操作，验证 TUI 显示审批 UI

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex](https://github.com/openai/codex) via AgentBridge