### PR TITLE
feat: add automated npm publish on GitHub Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   check:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Run tests
+        run: bun test src
+
+      - name: Build
+        run: bun run prepublishOnly
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish
+        run: npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- New GitHub Actions workflow: automatically publish to npm when a GitHub Release is created
- Fix CI branch name from `main` to `master`

### Workflow: `publish.yml`

Triggered by `release: [published]`, runs:
1. Typecheck
2. Tests
3. Build (CLI + plugin bundles)
4. `npm publish --access=public`

### Setup Required

Add `NPM_TOKEN` secret to repo settings:
1. Go to repo Settings → Secrets and variables → Actions
2. Add `NPM_TOKEN` with a granular access token that has publish + bypass-2FA permissions

### Release Flow (after merge)

```bash
# 1. Bump version in package.json, plugin.json, marketplace.json
# 2. Commit and merge to master
# 3. Create GitHub Release:
gh release create v0.1.2 --title "v0.1.2" --notes "..." --target master
# 4. publish.yml automatically publishes to npm
```

## Test plan

- [x] Workflow YAML syntax valid
- [ ] E2E: create a release after adding NPM_TOKEN secret, verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)