### PR TITLE
fix: defer approval replay until thread/resume completes

### DIFF
--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -251,7 +251,7 @@ class CodexAdapter extends EventEmitter {
         oldWs.close();
       } catch {}
     }
-    this.clearResponseTrackingState();
+    this.clearResponseTrackingStateForAppServerReconnect();
     this.activeTurnIds.clear();
     this.turnInProgress = false;
     try {
@@ -355,7 +355,6 @@ class CodexAdapter extends EventEmitter {
     if (previousConnId !== null) {
       this.retireConnectionState(previousConnId);
     }
-    this.replayPendingServerRequests(ws);
   }
   setupSecondaryConnection(ws, connId) {
     const appWs = new WebSocket(this.appServerUrl);
@@ -396,9 +395,14 @@ class CodexAdapter extends EventEmitter {
       }
     };
   }
-  replayPendingServerRequests(ws) {
+  replayPendingForThread(resumedThreadId, ws) {
     const remaining = [];
     for (const buffered of this.pendingServerRequests) {
+      const belongsToThread = buffered.threadId === null || buffered.threadId === resumedThreadId;
+      if (!belongsToThread) {
+        remaining.push(buffered);
+        continue;
+      }
       const proxyId = this.nextProxyId++;
       try {
         const parsed = JSON.parse(buffered.raw);
@@ -409,13 +413,32 @@ class CodexAdapter extends EventEmitter {
           serverId: buffered.serverId,
           connId: this.tuiConnId,
           method: buffered.method,
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          threadId: buffered.threadId
         });
-        this.log(`Replayed buffered server request: ${buffered.method} (server id=${buffered.serverId} \u2192 proxy id=${proxyId})`);
+        if (buffered.threadId === null) {
+          this.log(`WARNING: Replaying pending server request with unknown threadId (experimental fallback, may surface orphan UI on wrong thread): ${buffered.method} (server id=${buffered.serverId} \u2192 proxy id=${proxyId})`);
+        } else {
+          this.log(`Replayed buffered server request on thread/resume: ${buffered.method} (server id=${buffered.serverId} \u2192 proxy id=${proxyId}, threadId=${buffered.threadId})`);
+        }
       } catch (e) {
         this.log(`Failed to replay buffered server request: ${buffered.method} (server id=${buffered.serverId}): ${e.message}`);
         remaining.push(buffered);
       }
+    }
+    this.pendingServerRequests = remaining;
+  }
+  dropOrphanPendingRequests(reason, matchThreadId = null) {
+    if (this.pendingServerRequests.length === 0)
+      return;
+    const remaining = [];
+    for (const buffered of this.pendingServerRequests) {
+      const shouldDrop = matchThreadId === null ? true : buffered.threadId !== null && buffered.threadId !== matchThreadId;
+      if (shouldDrop) {
+        this.log(`Dropped orphan pending server request: ${buffered.method} (server id=${buffered.serverId}, threadId=${buffered.threadId ?? "unknown"}, reason=${reason})`);
+        continue;
+      }
+      remaining.push(buffered);
     }
     this.pendingServerRequests = remaining;
   }
@@ -461,8 +484,7 @@ class CodexAdapter extends EventEmitter {
       return;
     }
     if (connId !== this.tuiConnId) {
-      const preview = data.length > 300 ? data.slice(0, 300) + "\u2026" : data;
-      this.log(`Dropping message from stale TUI conn #${connId} (current is #${this.tuiConnId}): ${preview}`);
+      this.log(`Dropping message from stale TUI conn #${connId} (current is #${this.tuiConnId})`);
       return;
     }
     try {
@@ -540,8 +562,6 @@ class CodexAdapter extends EventEmitter {
   handleAppServerPayload(raw) {
     try {
       const parsed = JSON.parse(raw);
-      const preview = raw.length > 200 ? raw.slice(0, 200) + "\u2026" : raw;
-      this.log(`app-server \u2192 proxy: ${preview}`);
       if (isAppServerNotification(parsed) || typeof parsed === "object" && parsed !== null && !("id" in parsed)) {
         const notificationLike = parsed;
         const forwarded = this.patchResponse(notificationLike, raw);
@@ -564,9 +584,10 @@ class CodexAdapter extends EventEmitter {
   handleServerRequest(parsed, raw) {
     const serverId = parsed.id;
     const method = parsed.method;
+    const threadId = this.extractThreadIdFromParams(parsed.params);
     if (!this.tuiWs) {
-      this.pendingServerRequests.push({ raw, serverId, method });
-      this.log(`Server request buffered (no TUI): ${method} (server id=${serverId})`);
+      this.pendingServerRequests.push({ raw, serverId, method, threadId });
+      this.log(`Server request buffered (no TUI): ${method} (server id=${serverId}, threadId=${threadId ?? "unknown"})`);
       return;
     }
     const proxyId = this.nextProxyId++;
@@ -575,7 +596,7 @@ class CodexAdapter extends EventEmitter {
       this.tuiWs.send(JSON.stringify(parsed));
     } catch (e) {
       this.log(`Server request send failed, buffering: ${method} (server id=${serverId}): ${e.message}`);
-      this.pendingServerRequests.push({ raw, serverId, method });
+      this.pendingServerRequests.push({ raw, serverId, method, threadId });
       return;
     }
     this.serverRequestToProxy.set(proxyId, {
@@ -583,9 +604,16 @@ class CodexAdapter extends EventEmitter {
       serverId,
       connId: this.tuiConnId,
       method,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      threadId
     });
-    this.log(`Server request: ${method} (server id=${serverId} \u2192 proxy id=${proxyId}, conn #${this.tuiConnId})`);
+    this.log(`Server request: ${method} (server id=${serverId} \u2192 proxy id=${proxyId}, conn #${this.tuiConnId}, threadId=${threadId ?? "unknown"})`);
+  }
+  extractThreadIdFromParams(params) {
+    if (typeof params !== "object" || params === null)
+      return null;
+    const tid = params.threadId;
+    return typeof tid === "string" && tid.length > 0 ? tid : null;
   }
   normalizeNumericId(id) {
     if (typeof id === "number")
@@ -742,7 +770,6 @@ class CodexAdapter extends EventEmitter {
     const rpcId = "id" in message ? message.id : undefined;
     const method = "method" in message && typeof message.method === "string" ? message.method : undefined;
     const key = this.pendingKey(rpcId, connId);
-    this.log(`[track] method=${method} id=${rpcId} (type=${typeof rpcId}) key=${key}`);
     if (!key || !isTrackedAppServerRequestMethod(method))
       return;
     const pending = { method };
@@ -780,12 +807,17 @@ class CodexAdapter extends EventEmitter {
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/start response ${key}`);
         }
+        this.dropOrphanPendingRequests(`thread/start (new session)`);
         break;
       }
       case "thread/resume": {
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/resume response ${key}`);
+          if (this.tuiWs) {
+            this.replayPendingForThread(threadId, this.tuiWs);
+          }
+          this.dropOrphanPendingRequests(`thread/resume to ${threadId}`, threadId);
         }
         break;
       }
@@ -852,17 +884,15 @@ class CodexAdapter extends EventEmitter {
         requeuedServerRequests.push({
           raw: pending.raw,
           serverId: pending.serverId,
-          method: pending.method
+          method: pending.method,
+          threadId: pending.threadId
         });
-        this.log(`Requeued in-flight server request after TUI disconnect (proxy id=${proxyId}, server id=${pending.serverId}, method=${pending.method})`);
+        this.log(`Requeued in-flight server request after TUI disconnect (proxy id=${proxyId}, server id=${pending.serverId}, method=${pending.method}, threadId=${pending.threadId ?? "unknown"})`);
       }
     }
     if (requeuedServerRequests.length === 0)
       return;
     this.pendingServerRequests.push(...requeuedServerRequests);
-    if (this.tuiWs && this.tuiConnId !== connId) {
-      this.replayPendingServerRequests(this.tuiWs);
-    }
   }
   trackStaleProxyId(proxyId) {
     this.clearTrackedId(this.staleProxyIds, proxyId);
@@ -913,6 +943,20 @@ class CodexAdapter extends EventEmitter {
     this.clearTransientResponseTrackingState();
     this.serverRequestToProxy.clear();
     this.pendingServerRequests = [];
+    this.pendingServerResponses.clear();
+  }
+  clearResponseTrackingStateForAppServerReconnect() {
+    this.clearTransientResponseTrackingState();
+    for (const pending of this.serverRequestToProxy.values()) {
+      this.pendingServerRequests.push({
+        raw: pending.raw,
+        serverId: pending.serverId,
+        method: pending.method,
+        threadId: pending.threadId
+      });
+      this.log(`Requeued in-flight server request on app-server reconnect (server id=${pending.serverId}, method=${pending.method}, threadId=${pending.threadId ?? "unknown"})`);
+    }
+    this.serverRequestToProxy.clear();
     this.pendingServerResponses.clear();
   }
   async checkPorts() {

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -39,6 +39,14 @@ interface PendingServerRequest {
   connId: number;
   method: AppServerServerRequestMethod | string;
   timestamp: number;
+  threadId: string | null;
+}
+
+interface BufferedServerRequest {
+  raw: string;
+  serverId: number | string;
+  method: AppServerServerRequestMethod | string;
+  threadId: string | null;
 }
 
 interface PendingServerResponse {
@@ -87,7 +95,7 @@ export class CodexAdapter extends EventEmitter {
   private nextProxyId = 100000;
   private upstreamToClient = new Map<number, { connId: number; clientId: number | string }>();
   private serverRequestToProxy = new Map<number, PendingServerRequest>();
-  private pendingServerRequests: Array<{ raw: string; serverId: number | string; method: string }> = [];
+  private pendingServerRequests: BufferedServerRequest[] = [];
   private pendingServerResponses = new Map<number, PendingServerResponse>();
   private staleProxyIds = new Map<number, ReturnType<typeof setTimeout>>();
   private bridgeRequestIds = new Map<number, ReturnType<typeof setTimeout>>();
@@ -286,10 +294,10 @@ export class CodexAdapter extends EventEmitter {
       try { oldWs.close(); } catch {}
     }
 
-    // Clear ALL connection-scoped state (including upstreamToClient).
-    // Buffered messages are raw (un-rewritten), so replay through onTuiMessage
-    // will create fresh id mappings after the new connection is established.
-    this.clearResponseTrackingState();
+    // Clear connection-scoped state (upstreamToClient etc.) but preserve
+    // pendingServerRequests — those must survive the intentional reconnect
+    // so they can be replayed after the TUI completes thread/resume.
+    this.clearResponseTrackingStateForAppServerReconnect();
     this.activeTurnIds.clear();
     this.turnInProgress = false;
 
@@ -423,7 +431,9 @@ export class CodexAdapter extends EventEmitter {
     if (previousConnId !== null) {
       this.retireConnectionState(previousConnId);
     }
-    this.replayPendingServerRequests(ws);
+    // Do not replay pendingServerRequests here — defer until TUI completes its
+    // handshake (thread/resume to matching thread, or thread/start which drops
+    // orphan entries). See handleTrackedResponse and dropOrphanPendingRequests.
   }
 
   /** Set up a secondary (picker) connection with its own dedicated app-server WS. */
@@ -467,9 +477,22 @@ export class CodexAdapter extends EventEmitter {
     };
   }
 
-  private replayPendingServerRequests(ws: ServerWebSocket<TuiSocketData>) {
-    const remaining: typeof this.pendingServerRequests = [];
+  /**
+   * Replay buffered server requests that belong to the given thread.
+   *
+   * Entries are replayed when their threadId matches `resumedThreadId`, or
+   * when they have no threadId (fallback: cannot attribute, so assume they
+   * belong to whatever the TUI is resuming). Non-matching entries stay in
+   * the buffer — they may match a subsequent resume.
+   */
+  private replayPendingForThread(resumedThreadId: string, ws: ServerWebSocket<TuiSocketData>) {
+    const remaining: BufferedServerRequest[] = [];
     for (const buffered of this.pendingServerRequests) {
+      const belongsToThread = buffered.threadId === null || buffered.threadId === resumedThreadId;
+      if (!belongsToThread) {
+        remaining.push(buffered);
+        continue;
+      }
       const proxyId = this.nextProxyId++;
       try {
         const parsed = JSON.parse(buffered.raw);
@@ -481,12 +504,40 @@ export class CodexAdapter extends EventEmitter {
           connId: this.tuiConnId,
           method: buffered.method,
           timestamp: Date.now(),
+          threadId: buffered.threadId,
         });
-        this.log(`Replayed buffered server request: ${buffered.method} (server id=${buffered.serverId} → proxy id=${proxyId})`);
+        if (buffered.threadId === null) {
+          this.log(`WARNING: Replaying pending server request with unknown threadId (experimental fallback, may surface orphan UI on wrong thread): ${buffered.method} (server id=${buffered.serverId} → proxy id=${proxyId})`);
+        } else {
+          this.log(`Replayed buffered server request on thread/resume: ${buffered.method} (server id=${buffered.serverId} → proxy id=${proxyId}, threadId=${buffered.threadId})`);
+        }
       } catch (e: any) {
         this.log(`Failed to replay buffered server request: ${buffered.method} (server id=${buffered.serverId}): ${e.message}`);
         remaining.push(buffered);
       }
+    }
+    this.pendingServerRequests = remaining;
+  }
+
+  /**
+   * Drop buffered server requests that cannot be delivered because the TUI
+   * has started a brand-new thread (thread/start), or has resumed a thread
+   * that does not match the entry's threadId. The original listener in the
+   * app-server is already dead for these entries, so keeping them would
+   * just produce orphan approval UI on subsequent reconnects.
+   */
+  private dropOrphanPendingRequests(reason: string, matchThreadId: string | null = null) {
+    if (this.pendingServerRequests.length === 0) return;
+    const remaining: BufferedServerRequest[] = [];
+    for (const buffered of this.pendingServerRequests) {
+      const shouldDrop = matchThreadId === null
+        ? true
+        : buffered.threadId !== null && buffered.threadId !== matchThreadId;
+      if (shouldDrop) {
+        this.log(`Dropped orphan pending server request: ${buffered.method} (server id=${buffered.serverId}, threadId=${buffered.threadId ?? "unknown"}, reason=${reason})`);
+        continue;
+      }
+      remaining.push(buffered);
     }
     this.pendingServerRequests = remaining;
   }
@@ -668,10 +719,11 @@ export class CodexAdapter extends EventEmitter {
   private handleServerRequest(parsed: AppServerRequest, raw: string): void {
     const serverId = parsed.id;
     const method = parsed.method;
+    const threadId = this.extractThreadIdFromParams(parsed.params);
 
     if (!this.tuiWs) {
-      this.pendingServerRequests.push({ raw, serverId, method });
-      this.log(`Server request buffered (no TUI): ${method} (server id=${serverId})`);
+      this.pendingServerRequests.push({ raw, serverId, method, threadId });
+      this.log(`Server request buffered (no TUI): ${method} (server id=${serverId}, threadId=${threadId ?? "unknown"})`);
       return;
     }
 
@@ -682,7 +734,7 @@ export class CodexAdapter extends EventEmitter {
       this.tuiWs.send(JSON.stringify(parsed));
     } catch (e: any) {
       this.log(`Server request send failed, buffering: ${method} (server id=${serverId}): ${e.message}`);
-      this.pendingServerRequests.push({ raw, serverId, method });
+      this.pendingServerRequests.push({ raw, serverId, method, threadId });
       return;
     }
 
@@ -692,8 +744,15 @@ export class CodexAdapter extends EventEmitter {
       connId: this.tuiConnId,
       method,
       timestamp: Date.now(),
+      threadId,
     });
-    this.log(`Server request: ${method} (server id=${serverId} → proxy id=${proxyId}, conn #${this.tuiConnId})`);
+    this.log(`Server request: ${method} (server id=${serverId} → proxy id=${proxyId}, conn #${this.tuiConnId}, threadId=${threadId ?? "unknown"})`);
+  }
+
+  private extractThreadIdFromParams(params: unknown): string | null {
+    if (typeof params !== "object" || params === null) return null;
+    const tid = (params as Record<string, unknown>).threadId;
+    return typeof tid === "string" && tid.length > 0 ? tid : null;
   }
 
   /** Normalize a JSON-RPC id to a number. Returns NaN for non-numeric strings. */
@@ -919,12 +978,22 @@ export class CodexAdapter extends EventEmitter {
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/start response ${key}`);
         }
+        // User started a brand-new session — any buffered server requests
+        // belong to a thread the user has abandoned. Drop them so they do
+        // not surface as orphan approval UI.
+        this.dropOrphanPendingRequests(`thread/start (new session)`);
         break;
       }
       case "thread/resume": {
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/resume response ${key}`);
+          if (this.tuiWs) {
+            this.replayPendingForThread(threadId, this.tuiWs);
+          }
+          // Drop any entries that belong to a different thread than the
+          // resumed one — the user did not return to them.
+          this.dropOrphanPendingRequests(`thread/resume to ${threadId}`, threadId);
         }
         break;
       }
@@ -992,7 +1061,7 @@ export class CodexAdapter extends EventEmitter {
       this.trackStaleProxyId(upId);
     }
 
-    const requeuedServerRequests: typeof this.pendingServerRequests = [];
+    const requeuedServerRequests: BufferedServerRequest[] = [];
     for (const [proxyId, pending] of this.serverRequestToProxy.entries()) {
       if (pending.connId === connId) {
         this.serverRequestToProxy.delete(proxyId);
@@ -1000,8 +1069,9 @@ export class CodexAdapter extends EventEmitter {
           raw: pending.raw,
           serverId: pending.serverId,
           method: pending.method,
+          threadId: pending.threadId,
         });
-        this.log(`Requeued in-flight server request after TUI disconnect (proxy id=${proxyId}, server id=${pending.serverId}, method=${pending.method})`);
+        this.log(`Requeued in-flight server request after TUI disconnect (proxy id=${proxyId}, server id=${pending.serverId}, method=${pending.method}, threadId=${pending.threadId ?? "unknown"})`);
       }
     }
 
@@ -1009,9 +1079,9 @@ export class CodexAdapter extends EventEmitter {
 
     this.pendingServerRequests.push(...requeuedServerRequests);
 
-    if (this.tuiWs && this.tuiConnId !== connId) {
-      this.replayPendingServerRequests(this.tuiWs);
-    }
+    // Do not replay immediately even if a new primary is already connected.
+    // Replay is deferred until the new TUI completes thread/resume to a
+    // matching thread — see handleTrackedResponse.
   }
 
   private trackStaleProxyId(proxyId: number) {
@@ -1073,6 +1143,31 @@ export class CodexAdapter extends EventEmitter {
     this.clearTransientResponseTrackingState();
     this.serverRequestToProxy.clear();
     this.pendingServerRequests = [];
+    this.pendingServerResponses.clear();
+  }
+
+  /**
+   * Variant used by the intentional app-server reconnect triggered by a TUI
+   * `initialize` message. Preserves `pendingServerRequests` so they can be
+   * replayed after the TUI completes `thread/resume`. In-flight server
+   * requests are moved into the pending buffer so they get the same
+   * replay-on-resume treatment. The serverIds are stale with respect to
+   * the new app-server session — the subsequent response will most likely
+   * be rejected upstream, which is precisely what the A' experiment tests.
+   */
+  private clearResponseTrackingStateForAppServerReconnect() {
+    this.clearTransientResponseTrackingState();
+    for (const pending of this.serverRequestToProxy.values()) {
+      this.pendingServerRequests.push({
+        raw: pending.raw,
+        serverId: pending.serverId,
+        method: pending.method,
+        threadId: pending.threadId,
+      });
+      this.log(`Requeued in-flight server request on app-server reconnect (server id=${pending.serverId}, method=${pending.method}, threadId=${pending.threadId ?? "unknown"})`);
+    }
+    this.serverRequestToProxy.clear();
+    // Intentionally preserve pendingServerRequests across the reconnect.
     this.pendingServerResponses.clear();
   }
 

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -576,24 +576,128 @@ describe("CodexAdapter server-to-client request passthrough", () => {
     adapter.clearResponseTrackingState();
   });
 
-  test("replays buffered server requests on TUI reconnect", () => {
+  test("defers buffered server request replay until thread/resume", () => {
     const adapter = createAdapter();
     const sent: string[] = [];
 
     adapter.pendingServerRequests = [
-      { raw: JSON.stringify({ id: 50, method: "item/fileChange/requestApproval", params: { file: "test.ts" } }), serverId: 50, method: "item/fileChange/requestApproval" },
+      {
+        raw: JSON.stringify({ id: 50, method: "item/fileChange/requestApproval", params: { threadId: "thread-A", file: "test.ts" } }),
+        serverId: 50,
+        method: "item/fileChange/requestApproval",
+        threadId: "thread-A",
+      },
     ];
 
     const ws = { data: { connId: 0 }, send: (data: string) => sent.push(data) } as any;
     adapter.onTuiConnect(ws);
 
+    // Nothing should be replayed until the TUI completes thread/resume
+    expect(adapter.pendingServerRequests.length).toBe(1);
+    expect(sent.length).toBe(0);
+
+    // Simulate thread/resume request tracking + response
+    adapter.trackPendingRequest({ id: 1, method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse(
+      { id: 1, result: { thread: { id: "thread-A" } } },
+      adapter.tuiConnId,
+    );
+
     expect(adapter.pendingServerRequests.length).toBe(0);
     expect(sent.length).toBe(1);
     const parsed = JSON.parse(sent[0]);
     expect(parsed.method).toBe("item/fileChange/requestApproval");
-    expect(parsed.params).toEqual({ file: "test.ts" });
+    expect(parsed.params).toMatchObject({ file: "test.ts" });
     expect(parsed.id).not.toBe(50);
     expect(adapter.serverRequestToProxy.size).toBe(1);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("drops orphan pending request on thread/resume to a different thread", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+
+    adapter.pendingServerRequests = [
+      {
+        raw: JSON.stringify({ id: 51, method: "item/commandExecution/requestApproval", params: { threadId: "thread-A", command: "ls" } }),
+        serverId: 51,
+        method: "item/commandExecution/requestApproval",
+        threadId: "thread-A",
+      },
+    ];
+
+    const ws = { data: { connId: 0 }, send: (data: string) => sent.push(data) } as any;
+    adapter.onTuiConnect(ws);
+
+    // Resume to a DIFFERENT thread (thread-B)
+    adapter.trackPendingRequest({ id: 2, method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse(
+      { id: 2, result: { thread: { id: "thread-B" } } },
+      adapter.tuiConnId,
+    );
+
+    expect(adapter.pendingServerRequests.length).toBe(0);
+    expect(sent.length).toBe(0);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("drops pending requests on thread/start (new session)", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+
+    adapter.pendingServerRequests = [
+      {
+        raw: JSON.stringify({ id: 52, method: "item/commandExecution/requestApproval", params: { threadId: "thread-A", command: "ls" } }),
+        serverId: 52,
+        method: "item/commandExecution/requestApproval",
+        threadId: "thread-A",
+      },
+    ];
+
+    const ws = { data: { connId: 0 }, send: (data: string) => sent.push(data) } as any;
+    adapter.onTuiConnect(ws);
+
+    // User starts a new session
+    adapter.trackPendingRequest({ id: 3, method: "thread/start" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse(
+      { id: 3, result: { thread: { id: "thread-NEW" } } },
+      adapter.tuiConnId,
+    );
+
+    expect(adapter.pendingServerRequests.length).toBe(0);
+    expect(sent.length).toBe(0);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("fallback: entry without threadId is replayed on any thread/resume", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+
+    adapter.pendingServerRequests = [
+      {
+        raw: JSON.stringify({ id: 53, method: "item/permissions/requestApproval", params: {} }),
+        serverId: 53,
+        method: "item/permissions/requestApproval",
+        threadId: null,
+      },
+    ];
+
+    const ws = { data: { connId: 0 }, send: (data: string) => sent.push(data) } as any;
+    adapter.onTuiConnect(ws);
+
+    adapter.trackPendingRequest({ id: 4, method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse(
+      { id: 4, result: { thread: { id: "thread-X" } } },
+      adapter.tuiConnId,
+    );
+
+    expect(adapter.pendingServerRequests.length).toBe(0);
+    expect(sent.length).toBe(1);
 
     adapter.clearResponseTrackingState();
   });
@@ -602,11 +706,24 @@ describe("CodexAdapter server-to-client request passthrough", () => {
     const adapter = createAdapter();
 
     adapter.pendingServerRequests = [
-      { raw: JSON.stringify({ id: 60, method: "item/permissions/requestApproval", params: {} }), serverId: 60, method: "item/permissions/requestApproval" },
+      {
+        raw: JSON.stringify({ id: 60, method: "item/permissions/requestApproval", params: { threadId: "thread-A" } }),
+        serverId: 60,
+        method: "item/permissions/requestApproval",
+        threadId: "thread-A",
+      },
     ];
 
     const ws = { data: { connId: 0 }, send: () => { throw new Error("connection reset"); } } as any;
     adapter.onTuiConnect(ws);
+
+    // Trigger replay via thread/resume to matching thread — send throws,
+    // but the entry must stay buffered and no phantom mapping created
+    adapter.trackPendingRequest({ id: 5, method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse(
+      { id: 5, result: { thread: { id: "thread-A" } } },
+      adapter.tuiConnId,
+    );
 
     expect(adapter.serverRequestToProxy.size).toBe(0);
     expect(adapter.pendingServerRequests.length).toBe(1);
@@ -614,13 +731,13 @@ describe("CodexAdapter server-to-client request passthrough", () => {
     adapter.clearResponseTrackingState();
   });
 
-  test("requeues in-flight server requests on TUI disconnect and replays them on reconnect", () => {
+  test("requeues in-flight server requests on TUI disconnect and replays them after thread/resume", () => {
     const adapter = createAdapter();
     adapter.tuiConnId = 1;
     const raw = JSON.stringify({
       id: 70,
       method: "item/permissions/requestApproval",
-      params: { permission: "network" },
+      params: { threadId: "thread-A", permission: "network" },
     });
 
     adapter.serverRequestToProxy.set(100400, {
@@ -629,6 +746,7 @@ describe("CodexAdapter server-to-client request passthrough", () => {
       method: "item/permissions/requestApproval",
       raw,
       timestamp: Date.now(),
+      threadId: "thread-A",
     });
 
     adapter.retireConnectionState(1);
@@ -638,12 +756,24 @@ describe("CodexAdapter server-to-client request passthrough", () => {
         raw,
         serverId: 70,
         method: "item/permissions/requestApproval",
+        threadId: "thread-A",
       },
     ]);
 
     const sent: string[] = [];
     const ws = { data: { connId: 0 }, send: (data: string) => sent.push(data) } as any;
     adapter.onTuiConnect(ws);
+
+    // Replay is deferred until thread/resume
+    expect(adapter.pendingServerRequests.length).toBe(1);
+    expect(sent.length).toBe(0);
+
+    // Simulate TUI completing thread/resume to the matching thread
+    adapter.trackPendingRequest({ id: 6, method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse(
+      { id: 6, result: { thread: { id: "thread-A" } } },
+      adapter.tuiConnId,
+    );
 
     expect(adapter.pendingServerRequests.length).toBe(0);
     expect(sent.length).toBe(1);
@@ -663,7 +793,7 @@ describe("CodexAdapter server-to-client request passthrough", () => {
     adapter.clearResponseTrackingState();
   });
 
-  test("new TUI connection replays in-flight server requests after old primary disconnects", () => {
+  test("new TUI connection defers replay until thread/resume after old primary disconnects", () => {
     const adapter = createAdapter();
     const sent: string[] = [];
 
@@ -675,12 +805,13 @@ describe("CodexAdapter server-to-client request passthrough", () => {
       raw: JSON.stringify({
         id: 91,
         method: "item/fileChange/requestApproval",
-        params: { file: "draft.txt" },
+        params: { threadId: "thread-A", file: "draft.txt" },
       }),
       serverId: 91,
       connId: 1,
       method: "item/fileChange/requestApproval",
       timestamp: Date.now(),
+      threadId: "thread-A",
     });
 
     // Primary disconnects — retires state, moves server requests to pending
@@ -688,14 +819,24 @@ describe("CodexAdapter server-to-client request passthrough", () => {
     expect(adapter.tuiWs).toBeNull();
     expect(adapter.pendingServerRequests.length).toBe(1);
 
-    // New TUI opens — becomes primary (no active tuiWs), replays pending requests
+    // New TUI opens — becomes primary but does NOT replay yet
     const ws = { data: { connId: 0 }, send: (data: string) => sent.push(data) } as any;
     adapter.onTuiConnect(ws);
+
+    expect(sent.length).toBe(0);
+    expect(adapter.pendingServerRequests.length).toBe(1);
+
+    // TUI completes thread/resume to the same thread — triggers replay
+    adapter.trackPendingRequest({ id: 7, method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse(
+      { id: 7, result: { thread: { id: "thread-A" } } },
+      adapter.tuiConnId,
+    );
 
     expect(sent.length).toBe(1);
     const replayed = JSON.parse(sent[0]);
     expect(replayed.method).toBe("item/fileChange/requestApproval");
-    expect(replayed.params).toEqual({ file: "draft.txt" });
+    expect(replayed.params).toEqual({ threadId: "thread-A", file: "draft.txt" });
     expect(replayed.id).not.toBe(91);
     expect(adapter.serverRequestToProxy.has(100700)).toBe(false);
     expect(adapter.serverRequestToProxy.size).toBe(1);


### PR DESCRIPTION
## Summary
- 延迟重放缓冲的审批请求（`requestApproval`）到 `thread/resume` 响应确认 threadId 后
- `thread/start`（新会话）时正确丢弃孤儿缓冲请求
- app-server 重连时保留 `pendingServerRequests` 而非清空
- 新增 `BufferedServerRequest` 接口，所有缓冲/requeue 条目携带 `threadId`

## 背景 / Background
旧行为：TUI 重连时立即重放 approval 请求 → app-server 的 thread listener 尚未就绪 → `"thread listener is not running"` 错误 → 审批被静默丢弃。

A' 方案：将重放时机从 `onTuiConnect` 延迟到 `handleTrackedResponse` 中 `thread/resume` 或 `thread/start` 路径。

## 改动
- `src/codex-adapter.ts`: +131 行
  - `BufferedServerRequest` 接口（带 threadId）
  - `replayPendingForThread()` 替代 `replayPendingServerRequests()`
  - `dropOrphanPendingRequests()` 清理不匹配 thread 的孤儿条目
  - `extractThreadIdFromParams()` 从 server request params 提取 threadId
  - `clearResponseTrackingStateForAppServerReconnect()` 保留 pending 缓冲
  - `handleTrackedResponse` 中 thread/start → drop，thread/resume → replay
  - `retireConnectionState` 中 requeue 携带 threadId，不再即时重放
- `src/unit-test/codex-adapter.test.ts`: +161 行
  - 新增 4 个测试 + 更新 3 个现有测试

## E2E 验证

| 层级 | 结果 | 说明 |
|------|------|------|
| Proxy (A' 补丁) | **PASS** | 延迟重放到 thread/resume 后才发送，无即时重放 |
| App-server | **改善** | thread/resume 后重放无 `thread listener is not running` 错误 |
| TUI | **FAIL/upstream** | `resume --last` 闪退，Codex TUI 已知 bug |

## Test plan
- [x] `bun run typecheck` 通过
- [x] `bun test src/` 174 pass / 0 fail
- [x] E2E: kill -9 TUI → resume --last → 日志确认延迟重放 + 无 app-server 错误
- [ ] 完整 E2E approval 流程（被 Codex TUI resume bug 阻塞）