### PR TITLE
fix: default auto mode to pull to prevent silent message loss

### DIFF
--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -5,7 +5,7 @@
  *   - Push mode (OAuth): real-time via notifications/claude/channel
  *   - Pull mode (API key): message queue + get_messages tool
  *
- * Mode defaults to push in auto mode, or set explicitly via AGENTBRIDGE_MODE env var.
+ * Mode defaults to pull in auto mode, or set explicitly via AGENTBRIDGE_MODE env var.
  *
  * Emits:
  *   - "ready"   ()                   — MCP connected, mode resolved
@@ -133,13 +133,12 @@ export class ClaudeAdapter extends EventEmitter {
       this.resolvedMode = this.configuredMode;
       this.log(`Delivery mode set by AGENTBRIDGE_MODE: ${this.resolvedMode}`);
     } else {
-      // Default to push — Claude Code doesn't declare channel support in
-      // client capabilities, so we can't detect it. Push is the better default
-      // because it's real-time; if channels aren't available, notifications
-      // are silently ignored (no error), and users can set AGENTBRIDGE_MODE=pull
-      // explicitly for API key setups.
-      this.resolvedMode = "push";
-      this.log("Delivery mode defaulting to push (set AGENTBRIDGE_MODE=pull for API key mode)");
+      // Default to pull — Claude Code doesn't declare channel support in
+      // client capabilities, so we can't reliably detect whether channel
+      // delivery is actually working. Users can opt into push explicitly with
+      // AGENTBRIDGE_MODE=push when their setup is known to support it.
+      this.resolvedMode = "pull";
+      this.log("Delivery mode defaulting to pull (set AGENTBRIDGE_MODE=push to opt into channel delivery)");
     }
   }
 
@@ -175,8 +174,7 @@ export class ClaudeAdapter extends EventEmitter {
       this.log(`Pushed notification: ${msgId}`);
     } catch (e: any) {
       this.log(`Push notification failed: ${e.message}`);
-      // Do NOT fall back to queue — the notification may have been partially
-      // delivered, and queuing would risk duplicate messages when Claude polls.
+      this.queueForPull(message);
     }
   }
 

--- a/src/unit-test/dual-mode.test.ts
+++ b/src/unit-test/dual-mode.test.ts
@@ -59,11 +59,11 @@ describe("Dual-mode transport: mode resolution", () => {
     expect(adapter.configuredMode).toBe("auto");
   });
 
-  test("auto mode defaults to push", () => {
+  test("auto mode defaults to pull", () => {
     const adapter = createAdapter();
     adapter.resolveMode();
-    expect(adapter.resolvedMode).toBe("push");
-    expect(adapter.getDeliveryMode()).toBe("push");
+    expect(adapter.resolvedMode).toBe("pull");
+    expect(adapter.getDeliveryMode()).toBe("pull");
   });
 
   test("resolveMode sets 'push' when configuredMode is 'push'", () => {
@@ -144,6 +144,22 @@ describe("Dual-mode transport: pull mode message queue", () => {
     expect(secondId).toMatch(/^codex_msg_[a-f0-9]{12}_2$/);
     expect(firstId.replace(/_1$/, "")).toBe(secondId.replace(/_2$/, ""));
     expect(firstId).not.toBe("codex_msg_1");
+  });
+
+  test("pushNotification falls back to the pull queue when push delivery throws", async () => {
+    const adapter = createAdapter("push");
+    adapter.resolveMode();
+
+    adapter.server = {
+      notification: async () => {
+        throw new Error("channel unavailable");
+      },
+    };
+
+    await adapter.pushNotification(makeBridgeMessage("fallback msg"));
+
+    expect(adapter.pendingMessages).toHaveLength(1);
+    expect(adapter.pendingMessages[0].content).toBe("fallback msg");
   });
 });
 


### PR DESCRIPTION
## Summary
- `auto` 模式默认从 `push` 改为 `pull`，避免 channel 不可用时消息被静默丢弃
- `push` 模式下 `server.notification()` 抛错时 fallback 到 pull queue
- `AGENTBRIDGE_MODE=push` 保留为显式 opt-in

## 背景 / Background
#18 和 #32 报告了同一根因：`auto` 模式默认 `push`，但 `server.notification()` 在 channel 不可用时不抛错，消息永久丢失且 `get_messages` 无法恢复。

**方案选择**（Claude + Codex 协商）：
- ~~方案 C: push + 启发式去重~~ — 否决，时序依赖丢失更难排查
- **方案 B: auto → pull** — P0 止血首选，零丢失，最小改动
- 真正的 hybrid 需要先补 ack/cursor 协议（后续做）

## 改动
- `src/claude-adapter.ts`: auto 默认 pull + push fallback to queue (+14/-13)
- `src/unit-test/dual-mode.test.ts`: 更新 auto 默认值测试 + 新增 push fallback 回归测试

Closes #18, Closes #32

## Test plan
- [x] `bun run typecheck` 通过
- [x] `bun test src/` 175 pass / 0 fail
- [x] 现有 push/pull 模式测试全部通过
- [x] 新增 push fallback 回归测试通过