### PR TITLE
fix: npm install 后自动注册 marketplace 和安装插件 (#28, #23)

### DIFF
--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -1,16 +1,26 @@
 #!/usr/bin/env node
 
 /**
- * postinstall check: verify that Bun is available.
- * This runs after `npm install -g agentbridge` to warn users early
- * rather than letting them hit a cryptic "bun: No such file or directory".
+ * postinstall: verify Bun, register marketplace, install plugin.
+ * Runs after `npm install -g @raysonmeng/agentbridge`.
+ *
+ * All steps are best-effort — a failure here does not block the npm install.
+ * Users can always fall back to `abg init` for manual setup.
  */
 
 const { execFileSync } = require("child_process");
+const path = require("path");
 
+const PACKAGE_ROOT = path.resolve(__dirname, "..");
+const MARKETPLACE_NAME = "agentbridge";
+const PLUGIN_NAME = "agentbridge";
+
+// Step 1: Check Bun
+let bunOk = false;
 try {
   const version = execFileSync("bun", ["--version"], { encoding: "utf-8" }).trim();
   console.log(`\x1b[32m✔\x1b[0m AgentBridge: Bun ${version} detected.`);
+  bunOk = true;
 } catch {
   console.warn(`
 \x1b[33m⚠ AgentBridge requires Bun (v1.0+) as its runtime.\x1b[0m
@@ -22,6 +32,36 @@ Install Bun with:
 
 Then restart your terminal and run:
 
-  abg --help
+  abg init
 `);
+}
+
+// Step 2: Register marketplace + install plugin (requires Claude Code)
+if (bunOk) {
+  try {
+    execFileSync("claude", ["--version"], { encoding: "utf-8" });
+  } catch {
+    console.log(`\x1b[33m⚠\x1b[0m AgentBridge: Claude Code not found — skipping plugin install.`);
+    console.log(`  After installing Claude Code, run: abg init`);
+    process.exit(0);
+  }
+
+  try {
+    execFileSync("claude", ["plugin", "marketplace", "add", PACKAGE_ROOT], {
+      stdio: "pipe",
+    });
+    console.log(`\x1b[32m✔\x1b[0m AgentBridge: Marketplace registered.`);
+  } catch (e) {
+    console.log(`\x1b[33m⚠\x1b[0m AgentBridge: Marketplace registration failed — run \`abg init\` to retry.`);
+    process.exit(0);
+  }
+
+  try {
+    execFileSync("claude", ["plugin", "install", `${PLUGIN_NAME}@${MARKETPLACE_NAME}`], {
+      stdio: "pipe",
+    });
+    console.log(`\x1b[32m✔\x1b[0m AgentBridge: Plugin installed. Run \`abg claude\` to start.`);
+  } catch (e) {
+    console.log(`\x1b[33m⚠\x1b[0m AgentBridge: Plugin install failed — run \`abg init\` to retry.`);
+  }
 }


### PR DESCRIPTION
## Summary
- postinstall.cjs 增强：npm install 完成后自动注册 marketplace 并安装 Claude Code 插件
- 解决 `claude plugin install agentbridge@agentbridge` 报 "Plugin not found" 的问题
- 所有步骤 best-effort，失败不阻塞 npm install，用户可 fallback 到 `abg init`

## Changes
- `scripts/postinstall.cjs`：新增 marketplace 注册 + plugin install 步骤

## Test plan
- [x] 本地运行 `node scripts/postinstall.cjs` 成功
- [x] `claude plugin list` 确认插件已安装
- [x] 175 tests pass, typecheck pass

Closes #28
Closes #23