### PR TITLE
refactor: 配置契约清理 + 诊断日志 (#40, #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ After modifying AgentBridge source code, re-run `agentbridge dev` to sync change
 
 | Command | Description |
 |---------|-------------|
-| `abg init` | Install plugin, check dependencies (bun/claude/codex), generate `.agentbridge/config.json` and `collaboration.md` |
+| `abg init` | Install plugin, check dependencies (bun/claude/codex), generate `.agentbridge/config.json` |
 | `abg claude [args...]` | Start Claude Code with push channel enabled. Clears any killed sentinel from a previous `kill`. Pass-through args are forwarded to `claude` |
 | `abg codex [args...]` | Start Codex TUI connected to AgentBridge daemon. Manages TUI process lifecycle (pid tracking, cleanup). Pass-through args forwarded to `codex` |
 | `abg kill` | Gracefully stop both daemon and managed Codex TUI, clean up state files, write killed sentinel |
@@ -177,8 +177,7 @@ Running `agentbridge init` creates a `.agentbridge/` directory in your project r
 
 | File | Purpose |
 |------|---------|
-| `config.json` | Machine-readable project config (ports, agent roles, markers, turn coordination) |
-| `collaboration.md` | Human/agent-readable collaboration rules (roles, thinking patterns, communication style) |
+| `config.json` | Machine-readable project config (Codex ports, turn coordination, idle shutdown) |
 
 The config is loaded by the CLI and daemon at startup. Re-running `init` is idempotent and will not overwrite existing files.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,7 +154,7 @@ agentbridge codex
 
 | 命令 | 说明 |
 |------|------|
-| `abg init` | 安装插件、检查依赖（bun/claude/codex）、生成 `.agentbridge/config.json` 和 `collaboration.md` |
+| `abg init` | 安装插件、检查依赖（bun/claude/codex）、生成 `.agentbridge/config.json` |
 | `abg claude [args...]` | 启动 Claude Code 并启用 push channel。自动清除之前 `kill` 留下的 sentinel。额外参数透传给 `claude` |
 | `abg codex [args...]` | 启动连接到 AgentBridge daemon 的 Codex TUI。管理 TUI 进程生命周期（pid 跟踪、清理）。额外参数透传给 `codex` |
 | `abg kill` | 优雅停止 daemon 和托管的 Codex TUI，清理状态文件，写入 killed sentinel |
@@ -177,8 +177,7 @@ agentbridge codex
 
 | 文件 | 用途 |
 |------|------|
-| `config.json` | 机器可读的项目配置（端口、Agent 角色、消息标记、回合协调） |
-| `collaboration.md` | 人类/Agent 可读的协作规则（角色、思考模式、沟通风格） |
+| `config.json` | 机器可读的项目配置（Codex 端口、回合协调、空闲关闭） |
 
 CLI 和 daemon 启动时会加载该配置。重复运行 `init` 是幂等的，不会覆盖已有文件。
 

--- a/docs/phase3-spec.md
+++ b/docs/phase3-spec.md
@@ -18,7 +18,7 @@ Delivered scope:
 - Codex startup and daemon bootstrap via `agentbridge codex`.
 - Controlled daemon shutdown via `agentbridge kill`.
 - A developer-only local plugin workflow via `agentbridge dev`.
-- Project-level config generation through `.agentbridge/config.json` and `.agentbridge/collaboration.md`.
+- Project-level config generation through `.agentbridge/config.json`.
 - Shared runtime state management through `StateDirResolver`.
 - Shared daemon lifecycle logic through `DaemonLifecycle`.
 - Plugin-oriented runtime artifacts under `plugins/agentbridge/server/`.
@@ -40,7 +40,6 @@ Current behavior:
 - Verifies `bun`, `claude`, and `codex` are available.
 - Enforces a minimum Claude Code version of `2.1.80`.
 - Creates `.agentbridge/config.json` if missing.
-- Creates `.agentbridge/collaboration.md` if missing.
 - Attempts `claude plugin install agentbridge@agentbridge` as a best-effort step.
 
 Important nuance:
@@ -132,7 +131,7 @@ Phase 3 kept the two-process design, but productized it through shared lifecycle
 - `src/daemon-lifecycle.ts`
   - shared launch, health-check, pid, lock, and kill behavior
 - `src/config-service.ts`
-  - project config loading, defaults, and collaboration file generation
+  - project config loading and default generation
 - `src/state-dir.ts`
   - OS-specific shared runtime state directory resolution
 - `src/daemon-client.ts`
@@ -157,7 +156,6 @@ Phase 3 split persistent data into two layers.
 Stored in the repo under `.agentbridge/`:
 
 - `config.json`
-- `collaboration.md`
 
 This data is project-specific and travels with the working tree.
 
@@ -179,7 +177,7 @@ Files maintained there include:
 
 This split is intentional:
 
-- `.agentbridge/` is for shared project defaults and collaboration rules
+ - `.agentbridge/` is for shared project defaults
 - the state dir is for local process lifecycle and diagnostics
 
 ## Phase 3 Runtime Controls
@@ -205,16 +203,16 @@ Phase 3 shipped the intended product direction, but not every original proposal 
 
 ### Shipped differently
 
-- The CLI exists, but the package is still repository-local today.
-  - `package.json` exposes the `agentbridge` bin, but the package is still marked `private`.
+- The CLI exists, but packaging/distribution is still evolving.
+  - `package.json` exposes the `agentbridge` bin, but marketplace and npm packaging are still follow-up work.
 - The command surface is more opinionated than the original generic lifecycle proposal.
   - Shipped commands are `init`, `dev`, `claude`, `codex`, and `kill`.
   - Proposed commands such as `doctor`, `status`, `start`, `stop`, and `attach` did not ship in Phase 3.
 - `init` generates project config and attempts plugin installation, but it does not rewrite global Claude configuration files.
 - Claude startup still uses the development-channel path instead of a stable marketplace `--channels` flow.
 - Delivery mode auto-detection is intentionally conservative.
-  - `auto` resolves to push mode today.
-  - API-key users can force pull mode with `AGENTBRIDGE_MODE=pull`.
+  - `auto` resolves to pull mode today.
+  - Users can opt into channel delivery with `AGENTBRIDGE_MODE=push`.
 
 ### Why those differences are acceptable for v1
 
@@ -243,7 +241,7 @@ Phase 3 is backed by targeted automated coverage in the repository:
 
 Phase 3 is complete, but these items remain follow-up work rather than part of the shipped baseline:
 
-- publishing a non-private npm package
+- publishing a public npm package
 - stabilizing marketplace packaging and plugin manifests
 - deciding whether `doctor` or `status` are still worth adding
 - replacing development-channel startup with a stable marketplace path when available

--- a/docs/v1-roadmap.md
+++ b/docs/v1-roadmap.md
@@ -323,7 +323,6 @@ What those commands do in practice:
   - checks `bun`, `claude`, and `codex`
   - enforces the minimum Claude version
   - creates `.agentbridge/config.json`
-  - creates `.agentbridge/collaboration.md`
   - attempts plugin installation as a best-effort step
 - `dev`
   - developer-only local marketplace and plugin-cache workflow
@@ -368,7 +367,6 @@ The implemented CLI chose task-specific commands instead because they map more d
 ### Important deviations from the original distribution plan
 
 - The CLI exists, but the package is not yet published as a public npm artifact.
-  - The package is still marked `private`.
 - `init` does not patch a global Claude MCP config file.
   - It generates project config and attempts plugin installation instead.
 - Claude startup still depends on the development-channel flag rather than a stable marketplace `--channels` flow.
@@ -433,7 +431,7 @@ The bridge itself should establish that shared awareness automatically when the 
 
 ### Problem
 
-The current bridge relies entirely on Claude Code's experimental Channel capability (`notifications/claude/channel`) for delivering Codex messages to Claude in real time. This requires the user to start Claude Code with `--dangerously-load-development-channels`, which in turn mandates OAuth authentication. Users who authenticate with an API key cannot use AgentBridge at all.
+The current bridge can use Claude Code's experimental Channel capability (`notifications/claude/channel`) for real-time Codex → Claude delivery, but it no longer depends on it exclusively. When channel delivery is unavailable or untrusted, AgentBridge can fall back to pull mode via `get_messages`.
 
 This is a hard adoption blocker. API key users are a significant portion of the Claude Code user base, and requiring OAuth just to use a local development tool is an unnecessary barrier.
 

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13663,6 +13663,57 @@ class StdioServerTransport {
 import { EventEmitter } from "events";
 import { randomUUID } from "crypto";
 import { appendFileSync } from "fs";
+
+// src/state-dir.ts
+import { mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir, platform } from "os";
+
+class StateDirResolver {
+  stateDir;
+  constructor(envOverride) {
+    const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
+    if (override) {
+      this.stateDir = override;
+    } else if (platform() === "darwin") {
+      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
+    } else {
+      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+      this.stateDir = join(xdgState, "agentbridge");
+    }
+  }
+  ensure() {
+    if (!existsSync(this.stateDir)) {
+      mkdirSync(this.stateDir, { recursive: true });
+    }
+  }
+  get dir() {
+    return this.stateDir;
+  }
+  get pidFile() {
+    return join(this.stateDir, "daemon.pid");
+  }
+  get tuiPidFile() {
+    return join(this.stateDir, "codex-tui.pid");
+  }
+  get lockFile() {
+    return join(this.stateDir, "daemon.lock");
+  }
+  get statusFile() {
+    return join(this.stateDir, "status.json");
+  }
+  get portsFile() {
+    return join(this.stateDir, "ports.json");
+  }
+  get logFile() {
+    return join(this.stateDir, "agentbridge.log");
+  }
+  get killedFile() {
+    return join(this.stateDir, "killed");
+  }
+}
+
+// src/claude-adapter.ts
 var CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
   "",
@@ -13697,23 +13748,27 @@ var CLAUDE_INSTRUCTIONS = [
   "- If the reply tool returns a busy error, Codex is still executing \u2014 wait and try again later."
 ].join(`
 `);
-var LOG_FILE = "/tmp/agentbridge.log";
 
 class ClaudeAdapter extends EventEmitter {
   server;
   notificationSeq = 0;
   sessionId;
   notificationIdPrefix;
+  instanceId;
   replySender = null;
+  logFile;
   configuredMode;
   resolvedMode = null;
   pendingMessages = [];
   maxBufferedMessages;
   droppedMessageCount = 0;
-  constructor() {
+  constructor(logFile = new StateDirResolver().logFile) {
     super();
+    this.logFile = logFile;
+    this.instanceId = randomUUID().slice(0, 8);
     this.sessionId = `codex_${Date.now()}`;
     this.notificationIdPrefix = randomUUID().replace(/-/g, "").slice(0, 12);
+    this.log(`ClaudeAdapter created (instance=${this.instanceId})`);
     const envMode = process.env.AGENTBRIDGE_MODE;
     this.configuredMode = envMode && ["push", "pull", "auto"].includes(envMode) ? envMode : "auto";
     this.maxBufferedMessages = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
@@ -13791,9 +13846,10 @@ class ClaudeAdapter extends EventEmitter {
       this.log(`Message queue full, dropped oldest message (total dropped: ${this.droppedMessageCount})`);
     }
     this.pendingMessages.push(message);
-    this.log(`Queued message for pull (${this.pendingMessages.length} pending)`);
+    this.log(`Queued message for pull (${this.pendingMessages.length} pending, instance=${this.instanceId})`);
   }
   drainMessages() {
+    this.log(`get_messages called (instance=${this.instanceId}, pending=${this.pendingMessages.length}, dropped=${this.droppedMessageCount})`);
     if (this.pendingMessages.length === 0 && this.droppedMessageCount === 0) {
       return {
         content: [{ type: "text", text: "No new messages from Codex." }]
@@ -13923,7 +13979,7 @@ ${formatted}`
 `;
     process.stderr.write(line);
     try {
-      appendFileSync(LOG_FILE, line);
+      appendFileSync(this.logFile, line);
     } catch {}
   }
 }
@@ -14083,7 +14139,7 @@ class DaemonClient extends EventEmitter2 {
 
 // src/daemon-lifecycle.ts
 import { spawn, execFileSync } from "child_process";
-import { existsSync, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
+import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
@@ -14221,7 +14277,7 @@ class DaemonLifecycle {
     } catch {}
   }
   wasKilled() {
-    return existsSync(this.stateDir.killedFile);
+    return existsSync2(this.stateDir.killedFile);
   }
   launch() {
     this.stateDir.ensure();
@@ -14342,116 +14398,55 @@ function isProcessAlive(pid) {
   }
 }
 
-// src/state-dir.ts
-import { mkdirSync, existsSync as existsSync2 } from "fs";
-import { join } from "path";
-import { homedir, platform } from "os";
-
-class StateDirResolver {
-  stateDir;
-  constructor(envOverride) {
-    const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
-    if (override) {
-      this.stateDir = override;
-    } else if (platform() === "darwin") {
-      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
-    } else {
-      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-      this.stateDir = join(xdgState, "agentbridge");
-    }
-  }
-  ensure() {
-    if (!existsSync2(this.stateDir)) {
-      mkdirSync(this.stateDir, { recursive: true });
-    }
-  }
-  get dir() {
-    return this.stateDir;
-  }
-  get pidFile() {
-    return join(this.stateDir, "daemon.pid");
-  }
-  get tuiPidFile() {
-    return join(this.stateDir, "codex-tui.pid");
-  }
-  get lockFile() {
-    return join(this.stateDir, "daemon.lock");
-  }
-  get statusFile() {
-    return join(this.stateDir, "status.json");
-  }
-  get portsFile() {
-    return join(this.stateDir, "ports.json");
-  }
-  get logFile() {
-    return join(this.stateDir, "agentbridge.log");
-  }
-  get killedFile() {
-    return join(this.stateDir, "killed");
-  }
-}
-
 // src/config-service.ts
 import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, existsSync as existsSync3 } from "fs";
 import { join as join2 } from "path";
 var DEFAULT_CONFIG = {
   version: "1.0",
-  daemon: {
-    port: 4500,
+  codex: {
+    appPort: 4500,
     proxyPort: 4501
   },
-  agents: {
-    claude: {
-      role: "Reviewer, Planner",
-      mode: "push"
-    },
-    codex: {
-      role: "Implementer, Executor"
-    }
-  },
-  markers: ["IMPORTANT", "STATUS", "FYI"],
   turnCoordination: {
-    attentionWindowSeconds: 15,
-    busyGuard: true
+    attentionWindowSeconds: 15
   },
   idleShutdownSeconds: 30
 };
-var DEFAULT_COLLABORATION_MD = `# Collaboration Rules
-
-## Roles
-- Claude: Reviewer, Planner, Hypothesis Challenger
-- Codex: Implementer, Executor, Reproducer/Verifier
-
-## Thinking Patterns
-- Analytical/review tasks: Independent Analysis & Convergence
-- Implementation tasks: Architect -> Builder -> Critic
-- Debugging tasks: Hypothesis -> Experiment -> Interpretation
-
-## Communication
-- Use explicit phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:"
-- Tag messages with [IMPORTANT], [STATUS], or [FYI]
-
-## Review Process
-- Cross-review: author never reviews their own code
-- All changes go through feature/fix branches + PR
-- Merge via squash merge
-
-## Custom Rules
-<!-- Add your project-specific collaboration rules here -->
-`;
 var CONFIG_DIR = ".agentbridge";
 var CONFIG_FILE = "config.json";
-var COLLABORATION_FILE = "collaboration.md";
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function normalizeInteger(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+function normalizeConfig(raw) {
+  if (!isRecord(raw))
+    return null;
+  const config2 = raw;
+  const codex = isRecord(config2.codex) ? config2.codex : {};
+  const daemon = isRecord(config2.daemon) ? config2.daemon : {};
+  const turnCoordination = isRecord(config2.turnCoordination) ? config2.turnCoordination : {};
+  return {
+    version: typeof config2.version === "string" ? config2.version : DEFAULT_CONFIG.version,
+    codex: {
+      appPort: normalizeInteger(codex.appPort ?? daemon.port, DEFAULT_CONFIG.codex.appPort),
+      proxyPort: normalizeInteger(codex.proxyPort ?? daemon.proxyPort, DEFAULT_CONFIG.codex.proxyPort)
+    },
+    turnCoordination: {
+      attentionWindowSeconds: normalizeInteger(turnCoordination.attentionWindowSeconds, DEFAULT_CONFIG.turnCoordination.attentionWindowSeconds)
+    },
+    idleShutdownSeconds: normalizeInteger(config2.idleShutdownSeconds, DEFAULT_CONFIG.idleShutdownSeconds)
+  };
+}
 
 class ConfigService {
   configDir;
   configPath;
-  collaborationPath;
   constructor(projectRoot) {
     const root = projectRoot ?? process.cwd();
     this.configDir = join2(root, CONFIG_DIR);
     this.configPath = join2(this.configDir, CONFIG_FILE);
-    this.collaborationPath = join2(this.configDir, COLLABORATION_FILE);
   }
   hasConfig() {
     return existsSync3(this.configPath);
@@ -14459,7 +14454,7 @@ class ConfigService {
   load() {
     try {
       const raw = readFileSync2(this.configPath, "utf-8");
-      return JSON.parse(raw);
+      return normalizeConfig(JSON.parse(raw));
     } catch {
       return null;
     }
@@ -14472,17 +14467,6 @@ class ConfigService {
     writeFileSync2(this.configPath, JSON.stringify(config2, null, 2) + `
 `, "utf-8");
   }
-  loadCollaboration() {
-    try {
-      return readFileSync2(this.collaborationPath, "utf-8");
-    } catch {
-      return null;
-    }
-  }
-  saveCollaboration(content) {
-    this.ensureConfigDir();
-    writeFileSync2(this.collaborationPath, content, "utf-8");
-  }
   initDefaults() {
     this.ensureConfigDir();
     const created = [];
@@ -14490,17 +14474,10 @@ class ConfigService {
       this.save(DEFAULT_CONFIG);
       created.push(this.configPath);
     }
-    if (!existsSync3(this.collaborationPath)) {
-      this.saveCollaboration(DEFAULT_COLLABORATION_MD);
-      created.push(this.collaborationPath);
-    }
     return created;
   }
   get configFilePath() {
     return this.configPath;
-  }
-  get collaborationFilePath() {
-    return this.collaborationPath;
   }
   ensureConfigDir() {
     if (!existsSync3(this.configDir)) {
@@ -14521,12 +14498,13 @@ function disabledReplyError(reason) {
 
 // src/bridge.ts
 var stateDir = new StateDirResolver;
+stateDir.ensure();
 var configService = new ConfigService;
 var config2 = configService.loadOrDefault();
 var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
-var claude = new ClaudeAdapter;
+var claude = new ClaudeAdapter(stateDir.logFile);
 var daemonClient = new DaemonClient(CONTROL_WS_URL);
 var shuttingDown = false;
 var daemonDisabled = false;

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14418,7 +14418,14 @@ function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function normalizeInteger(value, fallback) {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  if (typeof value === "number" && Number.isFinite(value))
+    return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed))
+      return parsed;
+  }
+  return fallback;
 }
 function normalizeConfig(raw) {
   if (!isRecord(raw))

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -10,6 +10,55 @@ import { createInterface } from "readline";
 import { EventEmitter } from "events";
 import { appendFileSync } from "fs";
 
+// src/state-dir.ts
+import { mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir, platform } from "os";
+
+class StateDirResolver {
+  stateDir;
+  constructor(envOverride) {
+    const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
+    if (override) {
+      this.stateDir = override;
+    } else if (platform() === "darwin") {
+      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
+    } else {
+      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+      this.stateDir = join(xdgState, "agentbridge");
+    }
+  }
+  ensure() {
+    if (!existsSync(this.stateDir)) {
+      mkdirSync(this.stateDir, { recursive: true });
+    }
+  }
+  get dir() {
+    return this.stateDir;
+  }
+  get pidFile() {
+    return join(this.stateDir, "daemon.pid");
+  }
+  get tuiPidFile() {
+    return join(this.stateDir, "codex-tui.pid");
+  }
+  get lockFile() {
+    return join(this.stateDir, "daemon.lock");
+  }
+  get statusFile() {
+    return join(this.stateDir, "status.json");
+  }
+  get portsFile() {
+    return join(this.stateDir, "ports.json");
+  }
+  get logFile() {
+    return join(this.stateDir, "agentbridge.log");
+  }
+  get killedFile() {
+    return join(this.stateDir, "killed");
+  }
+}
+
 // src/app-server-protocol.ts
 var APP_SERVER_TRACKED_REQUEST_METHODS = [
   "thread/start",
@@ -54,8 +103,6 @@ function isAppServerResponseMessage(value) {
 }
 
 // src/codex-adapter.ts
-var LOG_FILE = "/tmp/agentbridge.log";
-
 class CodexAdapter extends EventEmitter {
   static RESPONSE_TRACKING_TTL_MS = 30000;
   proc = null;
@@ -66,6 +113,7 @@ class CodexAdapter extends EventEmitter {
   nextInjectionId = -1;
   appPort;
   proxyPort;
+  logFile;
   tuiConnId = 0;
   connIdCounter = 0;
   secondaryConnections = new Map;
@@ -85,10 +133,11 @@ class CodexAdapter extends EventEmitter {
   reconnectingForNewSession = false;
   replayingBufferedMessages = false;
   appServerGeneration = 0;
-  constructor(appPort = 4500, proxyPort = 4501) {
+  constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
     this.appPort = appPort;
     this.proxyPort = proxyPort;
+    this.logFile = logFile;
   }
   get appServerUrl() {
     return `ws://127.0.0.1:${this.appPort}`;
@@ -1011,7 +1060,7 @@ class CodexAdapter extends EventEmitter {
 `;
     process.stderr.write(line);
     try {
-      appendFileSync(LOG_FILE, line);
+      appendFileSync(this.logFile, line);
     } catch {}
   }
 }
@@ -1219,7 +1268,7 @@ class TuiConnectionState {
 
 // src/daemon-lifecycle.ts
 import { spawn as spawn2, execFileSync } from "child_process";
-import { existsSync, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
+import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
@@ -1357,7 +1406,7 @@ class DaemonLifecycle {
     } catch {}
   }
   wasKilled() {
-    return existsSync(this.stateDir.killedFile);
+    return existsSync2(this.stateDir.killedFile);
   }
   launch() {
     this.stateDir.ensure();
@@ -1478,116 +1527,55 @@ function isProcessAlive(pid) {
   }
 }
 
-// src/state-dir.ts
-import { mkdirSync, existsSync as existsSync2 } from "fs";
-import { join } from "path";
-import { homedir, platform } from "os";
-
-class StateDirResolver {
-  stateDir;
-  constructor(envOverride) {
-    const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
-    if (override) {
-      this.stateDir = override;
-    } else if (platform() === "darwin") {
-      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
-    } else {
-      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-      this.stateDir = join(xdgState, "agentbridge");
-    }
-  }
-  ensure() {
-    if (!existsSync2(this.stateDir)) {
-      mkdirSync(this.stateDir, { recursive: true });
-    }
-  }
-  get dir() {
-    return this.stateDir;
-  }
-  get pidFile() {
-    return join(this.stateDir, "daemon.pid");
-  }
-  get tuiPidFile() {
-    return join(this.stateDir, "codex-tui.pid");
-  }
-  get lockFile() {
-    return join(this.stateDir, "daemon.lock");
-  }
-  get statusFile() {
-    return join(this.stateDir, "status.json");
-  }
-  get portsFile() {
-    return join(this.stateDir, "ports.json");
-  }
-  get logFile() {
-    return join(this.stateDir, "agentbridge.log");
-  }
-  get killedFile() {
-    return join(this.stateDir, "killed");
-  }
-}
-
 // src/config-service.ts
 import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, existsSync as existsSync3 } from "fs";
 import { join as join2 } from "path";
 var DEFAULT_CONFIG = {
   version: "1.0",
-  daemon: {
-    port: 4500,
+  codex: {
+    appPort: 4500,
     proxyPort: 4501
   },
-  agents: {
-    claude: {
-      role: "Reviewer, Planner",
-      mode: "push"
-    },
-    codex: {
-      role: "Implementer, Executor"
-    }
-  },
-  markers: ["IMPORTANT", "STATUS", "FYI"],
   turnCoordination: {
-    attentionWindowSeconds: 15,
-    busyGuard: true
+    attentionWindowSeconds: 15
   },
   idleShutdownSeconds: 30
 };
-var DEFAULT_COLLABORATION_MD = `# Collaboration Rules
-
-## Roles
-- Claude: Reviewer, Planner, Hypothesis Challenger
-- Codex: Implementer, Executor, Reproducer/Verifier
-
-## Thinking Patterns
-- Analytical/review tasks: Independent Analysis & Convergence
-- Implementation tasks: Architect -> Builder -> Critic
-- Debugging tasks: Hypothesis -> Experiment -> Interpretation
-
-## Communication
-- Use explicit phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:"
-- Tag messages with [IMPORTANT], [STATUS], or [FYI]
-
-## Review Process
-- Cross-review: author never reviews their own code
-- All changes go through feature/fix branches + PR
-- Merge via squash merge
-
-## Custom Rules
-<!-- Add your project-specific collaboration rules here -->
-`;
 var CONFIG_DIR = ".agentbridge";
 var CONFIG_FILE = "config.json";
-var COLLABORATION_FILE = "collaboration.md";
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function normalizeInteger(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+function normalizeConfig(raw) {
+  if (!isRecord(raw))
+    return null;
+  const config = raw;
+  const codex = isRecord(config.codex) ? config.codex : {};
+  const daemon = isRecord(config.daemon) ? config.daemon : {};
+  const turnCoordination = isRecord(config.turnCoordination) ? config.turnCoordination : {};
+  return {
+    version: typeof config.version === "string" ? config.version : DEFAULT_CONFIG.version,
+    codex: {
+      appPort: normalizeInteger(codex.appPort ?? daemon.port, DEFAULT_CONFIG.codex.appPort),
+      proxyPort: normalizeInteger(codex.proxyPort ?? daemon.proxyPort, DEFAULT_CONFIG.codex.proxyPort)
+    },
+    turnCoordination: {
+      attentionWindowSeconds: normalizeInteger(turnCoordination.attentionWindowSeconds, DEFAULT_CONFIG.turnCoordination.attentionWindowSeconds)
+    },
+    idleShutdownSeconds: normalizeInteger(config.idleShutdownSeconds, DEFAULT_CONFIG.idleShutdownSeconds)
+  };
+}
 
 class ConfigService {
   configDir;
   configPath;
-  collaborationPath;
   constructor(projectRoot) {
     const root = projectRoot ?? process.cwd();
     this.configDir = join2(root, CONFIG_DIR);
     this.configPath = join2(this.configDir, CONFIG_FILE);
-    this.collaborationPath = join2(this.configDir, COLLABORATION_FILE);
   }
   hasConfig() {
     return existsSync3(this.configPath);
@@ -1595,7 +1583,7 @@ class ConfigService {
   load() {
     try {
       const raw = readFileSync2(this.configPath, "utf-8");
-      return JSON.parse(raw);
+      return normalizeConfig(JSON.parse(raw));
     } catch {
       return null;
     }
@@ -1608,17 +1596,6 @@ class ConfigService {
     writeFileSync2(this.configPath, JSON.stringify(config, null, 2) + `
 `, "utf-8");
   }
-  loadCollaboration() {
-    try {
-      return readFileSync2(this.collaborationPath, "utf-8");
-    } catch {
-      return null;
-    }
-  }
-  saveCollaboration(content) {
-    this.ensureConfigDir();
-    writeFileSync2(this.collaborationPath, content, "utf-8");
-  }
   initDefaults() {
     this.ensureConfigDir();
     const created = [];
@@ -1626,17 +1603,10 @@ class ConfigService {
       this.save(DEFAULT_CONFIG);
       created.push(this.configPath);
     }
-    if (!existsSync3(this.collaborationPath)) {
-      this.saveCollaboration(DEFAULT_COLLABORATION_MD);
-      created.push(this.collaborationPath);
-    }
     return created;
   }
   get configFilePath() {
     return this.configPath;
-  }
-  get collaborationFilePath() {
-    return this.collaborationPath;
   }
   ensureConfigDir() {
     if (!existsSync3(this.configDir)) {
@@ -1653,8 +1623,8 @@ var stateDir = new StateDirResolver;
 stateDir.ensure();
 var configService = new ConfigService;
 var config = configService.loadOrDefault();
-var CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.daemon.port), 10);
-var CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.daemon.proxyPort), 10);
+var CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.codex.appPort), 10);
+var CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.codex.proxyPort), 10);
 var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 var CLAUDE_DISCONNECT_GRACE_MS = 5000;
@@ -1663,7 +1633,7 @@ var FILTER_MODE = process.env.AGENTBRIDGE_FILTER_MODE === "full" ? "full" : "fil
 var IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
 var ATTENTION_WINDOW_MS = parseInt(process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS ?? String(config.turnCoordination.attentionWindowSeconds * 1000), 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
-var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT);
+var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
 var attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 var controlServer = null;
 var attachedClaude = null;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1547,7 +1547,14 @@ function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function normalizeInteger(value, fallback) {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  if (typeof value === "number" && Number.isFinite(value))
+    return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed))
+      return parsed;
+  }
+  return fallback;
 }
 function normalizeConfig(raw) {
   if (!isRecord(raw))

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -66,6 +66,7 @@ export class ClaudeAdapter extends EventEmitter {
   private notificationSeq = 0;
   private sessionId: string;
   private readonly notificationIdPrefix: string;
+  private readonly instanceId: string;
   private replySender: ReplySender | null = null;
   private readonly logFile: string;
 
@@ -79,8 +80,10 @@ export class ClaudeAdapter extends EventEmitter {
   constructor(logFile = new StateDirResolver().logFile) {
     super();
     this.logFile = logFile;
+    this.instanceId = randomUUID().slice(0, 8);
     this.sessionId = `codex_${Date.now()}`;
     this.notificationIdPrefix = randomUUID().replace(/-/g, "").slice(0, 12);
+    this.log(`ClaudeAdapter created (instance=${this.instanceId})`);
 
     const envMode = process.env.AGENTBRIDGE_MODE as DeliveryMode | undefined;
     this.configuredMode = envMode && ["push", "pull", "auto"].includes(envMode) ? envMode : "auto";
@@ -186,12 +189,13 @@ export class ClaudeAdapter extends EventEmitter {
       this.log(`Message queue full, dropped oldest message (total dropped: ${this.droppedMessageCount})`);
     }
     this.pendingMessages.push(message);
-    this.log(`Queued message for pull (${this.pendingMessages.length} pending)`);
+    this.log(`Queued message for pull (${this.pendingMessages.length} pending, instance=${this.instanceId})`);
   }
 
   // ── get_messages ───────────────────────────────────────────
 
   private drainMessages(): { content: Array<{ type: "text"; text: string }> } {
+    this.log(`get_messages called (instance=${this.instanceId}, pending=${this.pendingMessages.length}, dropped=${this.droppedMessageCount})`);
     if (this.pendingMessages.length === 0 && this.droppedMessageCount === 0) {
       return {
         content: [{ type: "text" as const, text: "No new messages from Codex." }],

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -59,7 +59,7 @@ export async function runCodex(args: string[]) {
   if (status?.proxyUrl) {
     proxyUrl = status.proxyUrl;
   } else {
-    proxyUrl = `ws://127.0.0.1:${config.daemon.proxyPort}`;
+    proxyUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
     console.error(`[agentbridge] No daemon status found, using config default: ${proxyUrl}`);
   }
 

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -50,7 +50,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function normalizeInteger(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
 }
 
 function normalizeConfig(raw: unknown): AgentBridgeConfig | null {

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -1,89 +1,99 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join } from "node:path";
 
 /** Machine-readable project config schema. */
 export interface AgentBridgeConfig {
   version: string;
-  daemon: {
-    port: number;
+  codex: {
+    appPort: number;
     proxyPort: number;
   };
-  agents: Record<
-    string,
-    {
-      role: string;
-      mode?: string;
-    }
-  >;
-  markers: string[];
   turnCoordination: {
     attentionWindowSeconds: number;
-    busyGuard: boolean;
   };
   idleShutdownSeconds: number;
 }
 
 const DEFAULT_CONFIG: AgentBridgeConfig = {
   version: "1.0",
-  daemon: {
-    port: 4500,
+  codex: {
+    appPort: 4500,
     proxyPort: 4501,
   },
-  agents: {
-    claude: {
-      role: "Reviewer, Planner",
-      mode: "push",
-    },
-    codex: {
-      role: "Implementer, Executor",
-    },
-  },
-  markers: ["IMPORTANT", "STATUS", "FYI"],
   turnCoordination: {
     attentionWindowSeconds: 15,
-    busyGuard: true,
   },
   idleShutdownSeconds: 30,
 };
 
-const DEFAULT_COLLABORATION_MD = `# Collaboration Rules
-
-## Roles
-- Claude: Reviewer, Planner, Hypothesis Challenger
-- Codex: Implementer, Executor, Reproducer/Verifier
-
-## Thinking Patterns
-- Analytical/review tasks: Independent Analysis & Convergence
-- Implementation tasks: Architect -> Builder -> Critic
-- Debugging tasks: Hypothesis -> Experiment -> Interpretation
-
-## Communication
-- Use explicit phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:"
-- Tag messages with [IMPORTANT], [STATUS], or [FYI]
-
-## Review Process
-- Cross-review: author never reviews their own code
-- All changes go through feature/fix branches + PR
-- Merge via squash merge
-
-## Custom Rules
-<!-- Add your project-specific collaboration rules here -->
-`;
-
 const CONFIG_DIR = ".agentbridge";
 const CONFIG_FILE = "config.json";
-const COLLABORATION_FILE = "collaboration.md";
+
+interface LegacyAgentBridgeConfig {
+  version?: unknown;
+  daemon?: {
+    port?: unknown;
+    proxyPort?: unknown;
+  };
+  codex?: {
+    appPort?: unknown;
+    proxyPort?: unknown;
+  };
+  turnCoordination?: {
+    attentionWindowSeconds?: unknown;
+  };
+  idleShutdownSeconds?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function normalizeConfig(raw: unknown): AgentBridgeConfig | null {
+  if (!isRecord(raw)) return null;
+
+  const config = raw as LegacyAgentBridgeConfig;
+  const codex = isRecord(config.codex) ? config.codex : {};
+  const daemon = isRecord(config.daemon) ? config.daemon : {};
+  const turnCoordination = isRecord(config.turnCoordination) ? config.turnCoordination : {};
+
+  return {
+    version: typeof config.version === "string" ? config.version : DEFAULT_CONFIG.version,
+    codex: {
+      appPort: normalizeInteger(
+        codex.appPort ?? daemon.port,
+        DEFAULT_CONFIG.codex.appPort,
+      ),
+      proxyPort: normalizeInteger(
+        codex.proxyPort ?? daemon.proxyPort,
+        DEFAULT_CONFIG.codex.proxyPort,
+      ),
+    },
+    turnCoordination: {
+      attentionWindowSeconds: normalizeInteger(
+        turnCoordination.attentionWindowSeconds,
+        DEFAULT_CONFIG.turnCoordination.attentionWindowSeconds,
+      ),
+    },
+    idleShutdownSeconds: normalizeInteger(
+      config.idleShutdownSeconds,
+      DEFAULT_CONFIG.idleShutdownSeconds,
+    ),
+  };
+}
 
 export class ConfigService {
   private readonly configDir: string;
   private readonly configPath: string;
-  private readonly collaborationPath: string;
 
   constructor(projectRoot?: string) {
     const root = projectRoot ?? process.cwd();
     this.configDir = join(root, CONFIG_DIR);
     this.configPath = join(this.configDir, CONFIG_FILE);
-    this.collaborationPath = join(this.configDir, COLLABORATION_FILE);
   }
 
   /** Check if project config exists. */
@@ -95,7 +105,7 @@ export class ConfigService {
   load(): AgentBridgeConfig | null {
     try {
       const raw = readFileSync(this.configPath, "utf-8");
-      return JSON.parse(raw) as AgentBridgeConfig;
+      return normalizeConfig(JSON.parse(raw));
     } catch {
       return null;
     }
@@ -112,21 +122,6 @@ export class ConfigService {
     writeFileSync(this.configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
   }
 
-  /** Load collaboration rules markdown. */
-  loadCollaboration(): string | null {
-    try {
-      return readFileSync(this.collaborationPath, "utf-8");
-    } catch {
-      return null;
-    }
-  }
-
-  /** Save collaboration rules markdown. */
-  saveCollaboration(content: string): void {
-    this.ensureConfigDir();
-    writeFileSync(this.collaborationPath, content, "utf-8");
-  }
-
   /** Generate default config files if they don't exist. Returns list of created files. */
   initDefaults(): string[] {
     this.ensureConfigDir();
@@ -137,20 +132,11 @@ export class ConfigService {
       created.push(this.configPath);
     }
 
-    if (!existsSync(this.collaborationPath)) {
-      this.saveCollaboration(DEFAULT_COLLABORATION_MD);
-      created.push(this.collaborationPath);
-    }
-
     return created;
   }
 
   get configFilePath(): string {
     return this.configPath;
-  }
-
-  get collaborationFilePath(): string {
-    return this.collaborationPath;
   }
 
   private ensureConfigDir(): void {
@@ -160,4 +146,4 @@ export class ConfigService {
   }
 }
 
-export { DEFAULT_CONFIG, DEFAULT_COLLABORATION_MD };
+export { DEFAULT_CONFIG };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -28,8 +28,8 @@ stateDir.ensure();
 const configService = new ConfigService();
 const config = configService.loadOrDefault();
 
-const CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.daemon.port), 10);
-const CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.daemon.proxyPort), 10);
+const CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.codex.appPort), 10);
+const CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.codex.proxyPort), 10);
 const CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 const TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 const CLAUDE_DISCONNECT_GRACE_MS = 5_000;

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -117,23 +117,12 @@ class CliE2EHarness {
       JSON.stringify(
         {
           version: "1.0",
-          daemon: {
-            port: appPort,
+          codex: {
+            appPort,
             proxyPort: configProxyPort,
           },
-          agents: {
-            claude: {
-              role: "Reviewer, Planner",
-              mode: "push",
-            },
-            codex: {
-              role: "Implementer, Executor",
-            },
-          },
-          markers: ["IMPORTANT", "STATUS", "FYI"],
           turnCoordination: {
             attentionWindowSeconds: 15,
-            busyGuard: true,
           },
           idleShutdownSeconds: 30,
         },
@@ -366,7 +355,7 @@ class CliE2EHarness {
 }
 
 describe("E2E: CLI surface", () => {
-  test("agentbridge init creates project config and collaboration rules", async () => {
+  test("agentbridge init creates project config", async () => {
     await withHarness(async (harness) => {
       rmSync(join(harness.projectDir, ".agentbridge"), { recursive: true, force: true });
 
@@ -374,19 +363,13 @@ describe("E2E: CLI surface", () => {
 
       expect(result.code).toBe(0);
       expect(existsSync(join(harness.projectDir, ".agentbridge", "config.json"))).toBe(true);
-      expect(existsSync(join(harness.projectDir, ".agentbridge", "collaboration.md"))).toBe(true);
+      expect(existsSync(join(harness.projectDir, ".agentbridge", "collaboration.md"))).toBe(false);
 
       const config = JSON.parse(
         readFileSync(join(harness.projectDir, ".agentbridge", "config.json"), "utf-8"),
-      ) as { daemon: { port: number; proxyPort: number } };
-      expect(config.daemon.port).toBe(4500);
-      expect(config.daemon.proxyPort).toBe(4501);
-
-      const collaboration = readFileSync(
-        join(harness.projectDir, ".agentbridge", "collaboration.md"),
-        "utf-8",
-      );
-      expect(collaboration).toContain("# Collaboration Rules");
+      ) as { codex: { appPort: number; proxyPort: number } };
+      expect(config.codex.appPort).toBe(4500);
+      expect(config.codex.proxyPort).toBe(4501);
       expect(result.stdout).toContain("Setup complete!");
       expect(harness.readShimCalls("claude").some((entry) => entry.args[0] === "plugin")).toBe(true);
       expect(harness.readShimCalls("codex").some((entry) => entry.args[0] === "--version")).toBe(true);
@@ -599,7 +582,7 @@ describe("E2E: CLI surface", () => {
 
       await waitFor(() => (pid ? !isProcessAlive(pid) : true), 60, 50);
       expect(existsSync(join(harness.projectDir, ".agentbridge", "config.json"))).toBe(true);
-      expect(existsSync(join(harness.projectDir, ".agentbridge", "collaboration.md"))).toBe(true);
+      expect(existsSync(join(harness.projectDir, ".agentbridge", "collaboration.md"))).toBe(false);
       expect(existsSync(join(harness.stateDir, "daemon.pid"))).toBe(false);
       expect(existsSync(join(harness.stateDir, "status.json"))).toBe(false);
       expect(existsSync(join(harness.stateDir, "killed"))).toBe(true);

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { ConfigService, DEFAULT_CONFIG, DEFAULT_COLLABORATION_MD } from "../config-service";
+import { ConfigService, DEFAULT_CONFIG } from "../config-service";
 
 describe("ConfigService", () => {
   let tempDir: string;
@@ -29,10 +29,9 @@ describe("ConfigService", () => {
     const svc = new ConfigService(tempDir);
     const config = svc.loadOrDefault();
     expect(config.version).toBe("1.0");
-    expect(config.daemon.port).toBe(4500);
-    expect(config.daemon.proxyPort).toBe(4501);
-    expect(config.agents.claude.role).toBe("Reviewer, Planner");
-    expect(config.agents.codex.role).toBe("Implementer, Executor");
+    expect(config.codex.appPort).toBe(4500);
+    expect(config.codex.proxyPort).toBe(4501);
+    expect(config.turnCoordination.attentionWindowSeconds).toBe(15);
   });
 
   test("save and load round-trips correctly", () => {
@@ -48,34 +47,50 @@ describe("ConfigService", () => {
     expect(loaded!.version).toBe("1.0");
   });
 
-  test("saveCollaboration and loadCollaboration round-trips", () => {
+  test("load normalizes legacy daemon config into codex config", () => {
     const svc = new ConfigService(tempDir);
-    const content = "# Custom rules\nBe nice.";
-    svc.saveCollaboration(content);
+    const configPath = join(tempDir, ".agentbridge", "config.json");
+    mkdirSync(join(tempDir, ".agentbridge"), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          version: "1.0",
+          daemon: {
+            port: 4600,
+            proxyPort: 4601,
+          },
+          turnCoordination: {
+            attentionWindowSeconds: 20,
+            busyGuard: true,
+          },
+          idleShutdownSeconds: 45,
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf-8",
+    );
 
-    const loaded = svc.loadCollaboration();
-    expect(loaded).toBe(content);
+    const loaded = svc.load();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.codex.appPort).toBe(4600);
+    expect(loaded!.codex.proxyPort).toBe(4601);
+    expect(loaded!.turnCoordination.attentionWindowSeconds).toBe(20);
+    expect(loaded!.idleShutdownSeconds).toBe(45);
   });
 
-  test("loadCollaboration returns null when file missing", () => {
-    const svc = new ConfigService(tempDir);
-    expect(svc.loadCollaboration()).toBeNull();
-  });
-
-  test("initDefaults creates both files", () => {
+  test("initDefaults creates only config.json", () => {
     const svc = new ConfigService(tempDir);
     const created = svc.initDefaults();
 
-    expect(created.length).toBe(2);
+    expect(created.length).toBe(1);
     expect(existsSync(svc.configFilePath)).toBe(true);
-    expect(existsSync(svc.collaborationFilePath)).toBe(true);
+    expect(existsSync(join(tempDir, ".agentbridge", "collaboration.md"))).toBe(false);
 
     // Verify content
     const config = svc.load();
     expect(config!.version).toBe("1.0");
-
-    const collab = svc.loadCollaboration();
-    expect(collab).toContain("# Collaboration Rules");
   });
 
   test("initDefaults does not overwrite existing files", () => {
@@ -85,9 +100,9 @@ describe("ConfigService", () => {
     const custom = { ...DEFAULT_CONFIG, idleShutdownSeconds: 99 };
     svc.save(custom);
 
-    // initDefaults should skip config.json but create collaboration.md
+    // initDefaults should skip config.json when it already exists
     const created = svc.initDefaults();
-    expect(created.length).toBe(1); // only collaboration.md
+    expect(created.length).toBe(0);
 
     const loaded = svc.load();
     expect(loaded!.idleShutdownSeconds).toBe(99); // not overwritten
@@ -96,6 +111,5 @@ describe("ConfigService", () => {
   test("config file paths are correct", () => {
     const svc = new ConfigService(tempDir);
     expect(svc.configFilePath).toBe(join(tempDir, ".agentbridge", "config.json"));
-    expect(svc.collaborationFilePath).toBe(join(tempDir, ".agentbridge", "collaboration.md"));
   });
 });

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -80,6 +80,38 @@ describe("ConfigService", () => {
     expect(loaded!.idleShutdownSeconds).toBe(45);
   });
 
+  test("load normalizes string numbers in legacy config", () => {
+    const svc = new ConfigService(tempDir);
+    const configPath = join(tempDir, ".agentbridge", "config.json");
+    mkdirSync(join(tempDir, ".agentbridge"), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          version: "1.0",
+          daemon: {
+            port: "4600",
+            proxyPort: "4601",
+          },
+          turnCoordination: {
+            attentionWindowSeconds: "20",
+          },
+          idleShutdownSeconds: "45",
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf-8",
+    );
+
+    const loaded = svc.load();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.codex.appPort).toBe(4600);
+    expect(loaded!.codex.proxyPort).toBe(4601);
+    expect(loaded!.turnCoordination.attentionWindowSeconds).toBe(20);
+    expect(loaded!.idleShutdownSeconds).toBe(45);
+  });
+
   test("initDefaults creates only config.json", () => {
     const svc = new ConfigService(tempDir);
     const created = svc.initDefaults();


### PR DESCRIPTION
## Summary

- **#40 配置契约清理**: `daemon.*` → `codex.appPort/proxyPort`，移除死字段 (`agents`, `markers`, `busyGuard`)，删除 `collaboration.md` 生成链路，添加旧配置向后兼容
- **#64 诊断日志**: 为 ClaudeAdapter 添加 `instanceId` 追踪，记录 `get_messages` 调用时的 instance/pending/dropped 状态，协助排查空返回 bug
- 同步文档 (README, phase3-spec, v1-roadmap) 和 plugin bundle

Config contract cleanup (#40): rename `daemon.*` → `codex.*`, remove dead fields, drop `collaboration.md`, add backward-compat normalization.
Diagnostic logging (#64): add `instanceId` to ClaudeAdapter for tracking `get_messages` empty response issues.

## Test plan
- [x] `bun run typecheck` — 通过
- [x] `bun test src/` — 174 pass / 0 fail
- [x] Legacy config normalization 单测覆盖
- [x] Plugin bundle 重新构建

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)