### PR TITLE
fix: 补全 #64 诊断日志覆盖 / complete diagnostic logging (#64)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13809,6 +13809,7 @@ class ClaudeAdapter extends EventEmitter {
     }
   }
   async pushNotification(message) {
+    this.log(`pushNotification (instance=${this.instanceId}, mode=${this.resolvedMode}, msgId=${message.id}, len=${message.content.length})`);
     if (this.resolvedMode === "push") {
       await this.pushViaChannel(message);
     } else {
@@ -13874,6 +13875,7 @@ Codex: ${msg.content}`;
     }).join(`
 
 `);
+    this.log(`get_messages returning ${count} message(s) (instance=${this.instanceId}, dropped=${dropped})`);
     return {
       content: [
         {

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -149,6 +149,7 @@ export class ClaudeAdapter extends EventEmitter {
   // ── Message Delivery ───────────────────────────────────────
 
   async pushNotification(message: BridgeMessage) {
+    this.log(`pushNotification (instance=${this.instanceId}, mode=${this.resolvedMode}, msgId=${message.id}, len=${message.content.length})`);
     if (this.resolvedMode === "push") {
       await this.pushViaChannel(message);
     } else {
@@ -222,6 +223,7 @@ export class ClaudeAdapter extends EventEmitter {
       })
       .join("\n\n");
 
+    this.log(`get_messages returning ${count} message(s) (instance=${this.instanceId}, dropped=${dropped})`);
     return {
       content: [
         {


### PR DESCRIPTION
## Summary

补全 ClaudeAdapter 诊断日志的两处盲区：

- **pushNotification 入口**: 记录 instanceId/mode/msgId/len，能看到消息到达时走了 push 还是 pull 分支
- **drainMessages 返回**: 记录实际返回的消息数，闭合 queue → drain 全链路追踪

现在下次 #64 复现时，日志链路完整覆盖 pushNotification → queueForPull → get_messages → return。

## Test plan
- [x] bun run typecheck — 通过
- [x] bun test src/ — 175 pass / 0 fail
- [x] 纯日志添加，不影响功能逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)