### PR TITLE
fix: evict stale Claude frontend via liveness probe (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ agent_bridge/
 | `CODEX_WS_PORT` | `4500` | Codex app-server WebSocket port |
 | `CODEX_PROXY_PORT` | `4501` | Bridge proxy port for the Codex TUI |
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | Control port between bridge.ts and daemon.ts |
+| `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | Maximum wait for incumbent Claude pong before evicting on contention (issue #68) |
 | `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
 | `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |
@@ -253,6 +254,18 @@ The daemon stores runtime state in a platform-aware directory:
 | Linux | `$XDG_STATE_HOME/agentbridge/` (fallback: `~/.local/state/agentbridge/`) |
 
 Contents: `daemon.pid`, `status.json`, `agentbridge.log`, `killed` (sentinel), `startup.lock`
+
+### Disabled Bridge States
+
+The bridge can enter several dormant states when it cannot accept new MCP replies. Each state surfaces to the agent as an error message (and, for the transient ones, an in-band push notification):
+
+| State | Cause | Recovery |
+|-------|-------|----------|
+| `killed` | `agentbridge kill` was run, sentinel file present. | Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume`. |
+| `rejected` | Daemon rejected the connection: another Claude session is already attached. | Close the other session, or run `agentbridge kill` to reset, then `agentbridge claude` again. |
+| `evicted` | A newer session evicted this one after the incumbent failed a liveness probe (issue #68). | Close this session and start a fresh one with `agentbridge claude`. |
+| `probe_in_progress` | A liveness probe is currently checking the incumbent — contention window. Transient (auto-recovers within `DISABLED_RECOVERY_INTERVAL_MS` × cap, ~30 s). | None needed; the recovery poller reconnects automatically when the slot clears. |
+| `auto_recovery_exhausted` | The auto-recovery poller for `probe_in_progress` ran its full retry budget (6 attempts, ~30 s) without succeeding. Terminal. | Retry manually with `agentbridge claude`. |
 
 ## Current Limitations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -239,6 +239,7 @@ agent_bridge/
 | `CODEX_WS_PORT` | `4500` | Codex app-server WebSocket 端口 |
 | `CODEX_PROXY_PORT` | `4501` | Bridge 代理端口，Codex TUI 连接此端口 |
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | bridge.ts 与 daemon.ts 之间的控制端口 |
+| `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | 等待在位 Claude pong 的最长时间，超时后在争用时驱逐（issue #68） |
 | `AGENTBRIDGE_STATE_DIR` | 平台默认 | 状态目录（pid、status、日志）。macOS: `~/Library/Application Support/agentbridge/`，Linux: `$XDG_STATE_HOME/agentbridge/` |
 | `AGENTBRIDGE_MODE` | `push` | 消息投递模式（`push` 用于 channel，`pull` 用于 API key 模式） |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |
@@ -253,6 +254,18 @@ daemon 在平台感知的目录中存储运行时状态：
 | Linux | `$XDG_STATE_HOME/agentbridge/`（回退：`~/.local/state/agentbridge/`） |
 
 内容：`daemon.pid`、`status.json`、`agentbridge.log`、`killed`（sentinel）、`startup.lock`
+
+### Bridge 禁用状态
+
+Bridge 在无法接受新 MCP 回复时会进入若干休眠状态。每种状态都会以错误信息返回给 agent；瞬态状态还会推送一条带内通知：
+
+| 状态 | 原因 | 恢复方式 |
+|------|------|---------|
+| `killed` | 运行过 `agentbridge kill`，存在 sentinel 文件。 | 重启 Claude Code（`agentbridge claude`），切换到新会话，或运行 `/resume`。 |
+| `rejected` | daemon 拒绝连接：已有另一个 Claude 会话连接中。 | 先关闭另一个会话，或运行 `agentbridge kill` 重置，然后重新 `agentbridge claude`。 |
+| `evicted` | 在位会话未响应存活探测，被更新的会话驱逐（issue #68）。 | 关闭本会话，用 `agentbridge claude` 重新启动一个。 |
+| `probe_in_progress` | 当前正在对在位会话执行存活探测——争用窗口期。瞬态（在 `DISABLED_RECOVERY_INTERVAL_MS` × 重试上限内自动恢复，约 30 秒）。 | 无需操作；恢复轮询会在槽位释放后自动重连。 |
+| `auto_recovery_exhausted` | `probe_in_progress` 的自动恢复轮询用尽了完整的重试预算（6 次，约 30 秒）仍未成功。终态。 | 手动用 `agentbridge claude` 重试。 |
 
 ## 当前限制
 

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13991,6 +13991,7 @@ import { EventEmitter as EventEmitter2 } from "events";
 
 // src/control-protocol.ts
 var CLOSE_CODE_REPLACED = 4001;
+var CLOSE_CODE_EVICTED_STALE = 4002;
 
 // src/daemon-client.ts
 var nextSocketId = 0;
@@ -14111,8 +14112,8 @@ class DaemonClient extends EventEmitter2 {
       if (isCurrent) {
         this.ws = null;
         this.rejectPendingReplies("AgentBridge daemon disconnected.");
-        if (event.code === CLOSE_CODE_REPLACED) {
-          this.emit("rejected");
+        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE) {
+          this.emit("rejected", event.code);
         } else {
           this.emit("disconnect");
         }
@@ -14556,13 +14557,15 @@ daemonClient.on("disconnect", () => {
   }
   reconnectToDaemon();
 });
-daemonClient.on("rejected", async () => {
+daemonClient.on("rejected", async (code) => {
   if (shuttingDown || daemonDisabled)
     return;
-  log("Daemon rejected this session (close code 4001) \u2014 another Claude session is already connected");
+  const wasEvicted = code === CLOSE_CODE_EVICTED_STALE;
+  log(`Daemon rejected this session (close code ${code}) \u2014 ${wasEvicted ? "evicted as stale by a newer session" : "another Claude session is already connected"}`);
   daemonDisabled = true;
   daemonDisabledReason = "rejected";
-  await claude.pushNotification(systemMessage("system_bridge_replaced", "\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge \u5B88\u62A4\u8FDB\u7A0B\u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u53E6\u4E00\u4E2A Claude Code \u4F1A\u8BDD\u5DF2\u5728\u8FDE\u63A5\u4E2D\u3002\u8BF7\u5148\u5173\u95ED\u53E6\u4E00\u4E2A\u4F1A\u8BDD\uFF0C\u6216\u8FD0\u884C `agentbridge kill` \u91CD\u7F6E\u3002"));
+  const notificationContent = wasEvicted ? "\u26A0\uFE0F AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge \u56E0\u6B64\u4F1A\u8BDD\u672A\u54CD\u5E94\u5B58\u6D3B\u63A2\u6D4B\u800C\u5C06\u5176\u9A71\u9010\u2014\u2014\u66F4\u65B0\u7684 Claude Code \u4F1A\u8BDD\u5DF2\u63A5\u7BA1\u3002\u5982\u9700\u91CD\u8FDE\uFF0C\u8BF7\u5173\u95ED\u6B64\u4F1A\u8BDD\u5E76\u8FD0\u884C `agentbridge claude` \u542F\u52A8\u65B0\u4F1A\u8BDD\u3002" : "\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge \u5B88\u62A4\u8FDB\u7A0B\u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u53E6\u4E00\u4E2A Claude Code \u4F1A\u8BDD\u5DF2\u5728\u8FDE\u63A5\u4E2D\u3002\u8BF7\u5148\u5173\u95ED\u53E6\u4E00\u4E2A\u4F1A\u8BDD\uFF0C\u6216\u8FD0\u884C `agentbridge kill` \u91CD\u7F6E\u3002";
+  await claude.pushNotification(systemMessage(wasEvicted ? "system_bridge_evicted" : "system_bridge_replaced", notificationContent));
   await daemonClient.disconnect();
 });
 claude.on("ready", async () => {

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13992,6 +13992,7 @@ import { EventEmitter as EventEmitter2 } from "events";
 // src/control-protocol.ts
 var CLOSE_CODE_REPLACED = 4001;
 var CLOSE_CODE_EVICTED_STALE = 4002;
+var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 
 // src/daemon-client.ts
 var nextSocketId = 0;
@@ -14047,6 +14048,45 @@ class DaemonClient extends EventEmitter2 {
   }
   attachClaude() {
     this.send({ type: "claude_connect" });
+  }
+  async attachClaudeAndWaitForStatus(timeoutMs = 1000) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+    return await new Promise((resolve) => {
+      let settled = false;
+      let timer = null;
+      const cleanup = () => {
+        if (settled)
+          return;
+        settled = true;
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        this.off("status", onStatus);
+        this.off("rejected", onRejected);
+        this.off("disconnect", onDisconnect);
+      };
+      const finish = (value) => {
+        cleanup();
+        resolve(value);
+      };
+      const onStatus = () => finish(true);
+      const onRejected = () => finish(false);
+      const onDisconnect = () => finish(false);
+      this.on("status", onStatus);
+      this.on("rejected", onRejected);
+      this.on("disconnect", onDisconnect);
+      timer = setTimeout(() => {
+        finish(false);
+      }, timeoutMs);
+      try {
+        this.attachClaude();
+      } catch {
+        finish(false);
+      }
+    });
   }
   async disconnect() {
     if (!this.ws)
@@ -14112,7 +14152,7 @@ class DaemonClient extends EventEmitter2 {
       if (isCurrent) {
         this.ws = null;
         this.rejectPendingReplies("AgentBridge daemon disconnected.");
-        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE) {
+        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE || event.code === CLOSE_CODE_PROBE_IN_PROGRESS) {
           this.emit("rejected", event.code);
         } else {
           this.emit("disconnect");
@@ -14501,6 +14541,12 @@ function disabledReplyError(reason) {
   switch (reason) {
     case "rejected":
       return "AgentBridge rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset.";
+    case "evicted":
+      return "AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude`.";
+    case "probe_in_progress":
+      return "AgentBridge rejected this session \u2014 a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with `agentbridge claude`.";
+    case "auto_recovery_exhausted":
+      return "AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`.";
     case "killed":
       return "AgentBridge is disabled by `agentbridge kill`. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.";
   }
@@ -14525,6 +14571,9 @@ var lastDisconnectNotifyTs = 0;
 var lastReconnectNotifyTs = 0;
 var disabledRecoveryTimer = null;
 var disabledRecoveryInFlight = false;
+var disabledRecoveryAttempts = 0;
+var DISABLED_RECOVERY_MAX_ATTEMPTS = 6;
+var DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS = 1000;
 claude.setReplySender(async (msg, requireReply) => {
   if (msg.source !== "claude") {
     return { success: false, error: "Invalid message source" };
@@ -14560,13 +14609,35 @@ daemonClient.on("disconnect", () => {
 daemonClient.on("rejected", async (code) => {
   if (shuttingDown || daemonDisabled)
     return;
-  const wasEvicted = code === CLOSE_CODE_EVICTED_STALE;
-  log(`Daemon rejected this session (close code ${code}) \u2014 ${wasEvicted ? "evicted as stale by a newer session" : "another Claude session is already connected"}`);
+  let reason;
+  let notificationId;
+  let notificationContent;
+  switch (code) {
+    case CLOSE_CODE_EVICTED_STALE:
+      reason = "evicted";
+      notificationId = "system_bridge_evicted";
+      notificationContent = "\u26A0\uFE0F AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge \u56E0\u6B64\u4F1A\u8BDD\u672A\u54CD\u5E94\u5B58\u6D3B\u63A2\u6D4B\u800C\u5C06\u5176\u9A71\u9010\u2014\u2014\u66F4\u65B0\u7684 Claude Code \u4F1A\u8BDD\u5DF2\u63A5\u7BA1\u3002\u5982\u9700\u91CD\u8FDE\uFF0C\u8BF7\u5173\u95ED\u6B64\u4F1A\u8BDD\u5E76\u8FD0\u884C `agentbridge claude` \u542F\u52A8\u65B0\u4F1A\u8BDD\u3002";
+      break;
+    case CLOSE_CODE_PROBE_IN_PROGRESS:
+      reason = "probe_in_progress";
+      notificationId = "system_bridge_probe_in_progress";
+      notificationContent = "\u26A0\uFE0F AgentBridge rejected this session \u2014 a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with `agentbridge claude`. AgentBridge \u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u6B63\u5728\u901A\u8FC7\u5B58\u6D3B\u63A2\u6D4B\u68C0\u67E5\u73B0\u6709 Claude \u4F1A\u8BDD\u662F\u5426\u4ECD\u7136\u5728\u7EBF\u3002\u8BF7\u7A0D\u540E\u7528 `agentbridge claude` \u91CD\u8BD5\u3002";
+      break;
+    default:
+      reason = "rejected";
+      notificationId = "system_bridge_replaced";
+      notificationContent = "\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge \u5B88\u62A4\u8FDB\u7A0B\u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u53E6\u4E00\u4E2A Claude Code \u4F1A\u8BDD\u5DF2\u5728\u8FDE\u63A5\u4E2D\u3002\u8BF7\u5148\u5173\u95ED\u53E6\u4E00\u4E2A\u4F1A\u8BDD\uFF0C\u6216\u8FD0\u884C `agentbridge kill` \u91CD\u7F6E\u3002";
+      break;
+  }
+  log(`Daemon rejected this session (close code ${code}, reason=${reason})`);
   daemonDisabled = true;
-  daemonDisabledReason = "rejected";
-  const notificationContent = wasEvicted ? "\u26A0\uFE0F AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge \u56E0\u6B64\u4F1A\u8BDD\u672A\u54CD\u5E94\u5B58\u6D3B\u63A2\u6D4B\u800C\u5C06\u5176\u9A71\u9010\u2014\u2014\u66F4\u65B0\u7684 Claude Code \u4F1A\u8BDD\u5DF2\u63A5\u7BA1\u3002\u5982\u9700\u91CD\u8FDE\uFF0C\u8BF7\u5173\u95ED\u6B64\u4F1A\u8BDD\u5E76\u8FD0\u884C `agentbridge claude` \u542F\u52A8\u65B0\u4F1A\u8BDD\u3002" : "\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge \u5B88\u62A4\u8FDB\u7A0B\u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u53E6\u4E00\u4E2A Claude Code \u4F1A\u8BDD\u5DF2\u5728\u8FDE\u63A5\u4E2D\u3002\u8BF7\u5148\u5173\u95ED\u53E6\u4E00\u4E2A\u4F1A\u8BDD\uFF0C\u6216\u8FD0\u884C `agentbridge kill` \u91CD\u7F6E\u3002";
-  await claude.pushNotification(systemMessage(wasEvicted ? "system_bridge_evicted" : "system_bridge_replaced", notificationContent));
+  daemonDisabledReason = reason;
+  await claude.pushNotification(systemMessage(notificationId, notificationContent));
   await daemonClient.disconnect();
+  if (reason === "probe_in_progress") {
+    disabledRecoveryAttempts = 0;
+    startDisabledRecoveryPoller();
+  }
 });
 claude.on("ready", async () => {
   log(`MCP server ready (delivery mode: ${claude.getDeliveryMode()}) \u2014 ensuring AgentBridge daemon...`);
@@ -14683,20 +14754,72 @@ async function pollDisabledRecovery() {
     if (!healthy) {
       return;
     }
-    log("Disabled-state recovery conditions met \u2014 attempting direct daemon reconnect");
-    try {
-      await daemonClient.connect();
-      daemonClient.attachClaude();
-      daemonDisabled = false;
-      daemonDisabledReason = null;
-      stopDisabledRecoveryPoller();
-      claude.pushNotification(systemMessage("system_bridge_recovered", "\u2705 AgentBridge recovered after the killed sentinel was cleared. Daemon reconnected."));
-    } catch (err) {
-      log(`Disabled-state direct reconnect failed: ${err.message}`);
-      daemonDisabled = false;
-      daemonDisabledReason = null;
-      stopDisabledRecoveryPoller();
-      reconnectToDaemon();
+    const recoveredFrom = daemonDisabledReason;
+    switch (recoveredFrom) {
+      case "probe_in_progress": {
+        if (disabledRecoveryAttempts >= DISABLED_RECOVERY_MAX_ATTEMPTS) {
+          log(`Disabled-state auto-recovery gave up after ${DISABLED_RECOVERY_MAX_ATTEMPTS} attempts ` + "\u2014 switching to auto_recovery_exhausted terminal state");
+          daemonDisabledReason = "auto_recovery_exhausted";
+          disabledRecoveryAttempts = 0;
+          stopDisabledRecoveryPoller();
+          claude.pushNotification(systemMessage("system_bridge_auto_recovery_gave_up", "\u26A0\uFE0F AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`. AgentBridge \u81EA\u52A8\u6062\u590D\u5DF2\u653E\u5F03\u2014\u2014\u5B58\u6D3B\u63A2\u6D4B\u4E89\u7528\u7684\u91CD\u8BD5\u9884\u7B97\u5DF2\u7528\u5C3D\u3002\u8BF7\u4F7F\u7528 `agentbridge claude` \u624B\u52A8\u91CD\u8BD5\u3002"));
+          return;
+        }
+        disabledRecoveryAttempts += 1;
+        log(`Disabled-state recovery attempt ${disabledRecoveryAttempts}/${DISABLED_RECOVERY_MAX_ATTEMPTS} ` + "for probe_in_progress \u2014 attempting direct daemon reconnect");
+        try {
+          await daemonClient.connect();
+          const attached = await daemonClient.attachClaudeAndWaitForStatus(DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS);
+          if (!attached) {
+            log(`Disabled-state probe_in_progress recovery attempt ${disabledRecoveryAttempts} did not confirm readiness`);
+            await daemonClient.disconnect();
+            return;
+          }
+          daemonDisabled = false;
+          daemonDisabledReason = null;
+          disabledRecoveryAttempts = 0;
+          stopDisabledRecoveryPoller();
+          claude.pushNotification(systemMessage("system_bridge_recovered", "\u2705 AgentBridge recovered after the liveness probe completed. Daemon reconnected."));
+        } catch (err) {
+          log(`Disabled-state probe_in_progress recovery attempt failed: ${err.message}`);
+          await daemonClient.disconnect();
+        }
+        return;
+      }
+      case "killed": {
+        log("Disabled-state recovery conditions met \u2014 attempting direct daemon reconnect");
+        try {
+          await daemonClient.connect();
+          const attached = await daemonClient.attachClaudeAndWaitForStatus(DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS);
+          if (!attached) {
+            throw new Error("daemon did not confirm reconnect");
+          }
+          daemonDisabled = false;
+          daemonDisabledReason = null;
+          disabledRecoveryAttempts = 0;
+          stopDisabledRecoveryPoller();
+          claude.pushNotification(systemMessage("system_bridge_recovered", "\u2705 AgentBridge recovered after the killed sentinel was cleared. Daemon reconnected."));
+        } catch (err) {
+          log(`Disabled-state direct reconnect failed: ${err.message}`);
+          daemonDisabled = false;
+          daemonDisabledReason = null;
+          disabledRecoveryAttempts = 0;
+          stopDisabledRecoveryPoller();
+          reconnectToDaemon();
+        }
+        return;
+      }
+      case "evicted":
+      case "rejected":
+      case "auto_recovery_exhausted":
+      case null:
+        log(`Disabled-state recovery poller encountered terminal/unexpected reason ${recoveredFrom ?? "null"} \u2014 stopping`);
+        stopDisabledRecoveryPoller();
+        return;
+      default: {
+        const exhaustive = recoveredFrom;
+        return exhaustive;
+      }
     }
   } finally {
     disabledRecoveryInFlight = false;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1624,6 +1624,35 @@ class ConfigService {
 
 // src/control-protocol.ts
 var CLOSE_CODE_REPLACED = 4001;
+var CLOSE_CODE_EVICTED_STALE = 4002;
+
+// src/liveness-probe.ts
+var OPEN = 1;
+async function probeLiveness(target, options) {
+  const {
+    timeoutMs,
+    pollMs = 50,
+    now = Date.now,
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+  } = options;
+  if (target.readyState !== OPEN)
+    return false;
+  const baseline = target.lastPongAt;
+  try {
+    target.ping();
+  } catch {
+    return false;
+  }
+  const deadline = now() + timeoutMs;
+  while (now() < deadline) {
+    if (target.lastPongAt > baseline)
+      return true;
+    if (target.readyState !== OPEN)
+      return false;
+    await sleep(pollMs);
+  }
+  return target.lastPongAt > baseline;
+}
 
 // src/daemon.ts
 var stateDir = new StateDirResolver;
@@ -1658,6 +1687,9 @@ var claudeOnlineNoticeSent = false;
 var claudeOfflineNoticeShown = false;
 var lastAttachStatusSentTs = 0;
 var ATTACH_STATUS_COOLDOWN_MS = 30000;
+var LIVENESS_PROBE_TIMEOUT_MS = parseInt(process.env.AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS ?? "3000", 10);
+var LIVENESS_PROBE_POLL_MS = 50;
+var challengeInProgress = false;
 var bufferedMessages = [];
 var tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
@@ -1770,7 +1802,7 @@ function startControlServer() {
       if (url.pathname === "/readyz") {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false } })) {
+      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now() } })) {
         return;
       }
       return new Response("AgentBridge daemon");
@@ -1780,6 +1812,7 @@ function startControlServer() {
       sendPings: true,
       open: (ws) => {
         ws.data.clientId = ++nextControlClientId;
+        ws.data.lastPongAt = Date.now();
         log(`Frontend socket opened (#${ws.data.clientId})`);
       },
       close: (ws, code, reason) => {
@@ -1790,6 +1823,9 @@ function startControlServer() {
       },
       message: (ws, raw) => {
         handleControlMessage(ws, raw);
+      },
+      pong: (ws) => {
+        ws.data.lastPongAt = Date.now();
       }
     }
   });
@@ -1805,7 +1841,9 @@ function handleControlMessage(ws, raw) {
   }
   switch (message.type) {
     case "claude_connect":
-      attachClaude(ws);
+      attachClaude(ws).catch((err) => {
+        log(`attachClaude threw for #${ws.data.clientId}: ${err?.message ?? err}`);
+      });
       return;
     case "claude_disconnect":
       detachClaude(ws, "frontend requested disconnect");
@@ -1865,9 +1903,39 @@ function handleControlMessage(ws, raw) {
     }
   }
 }
-function attachClaude(ws) {
+async function attachClaude(ws) {
+  const occupant = attachedClaude;
+  if (occupant && occupant !== ws && occupant.readyState !== WebSocket.CLOSED) {
+    const msSincePong = Date.now() - occupant.data.lastPongAt;
+    log(`Claude frontend contest: new=#${ws.data.clientId}, incumbent=#${occupant.data.clientId} ` + `(readyState=${occupant.readyState}, msSincePong=${msSincePong})`);
+    if (challengeInProgress) {
+      log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 another liveness probe already in flight`);
+      ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+      return;
+    }
+    challengeInProgress = true;
+    let incumbentAlive = false;
+    try {
+      incumbentAlive = await probeLiveness2(occupant, LIVENESS_PROBE_TIMEOUT_MS);
+    } finally {
+      challengeInProgress = false;
+    }
+    if (ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+      log(`Contestant #${ws.data.clientId} disappeared during probe \u2014 aborting`);
+      if (!incumbentAlive) {
+        evictStale(occupant, "contestant gone but probe still failed");
+      }
+      return;
+    }
+    if (incumbentAlive) {
+      log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 incumbent #${occupant.data.clientId} responded to liveness probe`);
+      ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+      return;
+    }
+    evictStale(occupant, `liveness probe timed out after ${LIVENESS_PROBE_TIMEOUT_MS}ms`);
+  }
   if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
-    log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 another session (#${attachedClaude.data.clientId}) is already attached (readyState=${attachedClaude.readyState})`);
+    log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 slot re-acquired by #${attachedClaude.data.clientId} after probe`);
     ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
     return;
   }
@@ -1902,6 +1970,30 @@ function detachClaude(ws, reason) {
   log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
   scheduleClaudeDisconnectNotification(ws.data.clientId);
   scheduleIdleShutdown();
+}
+async function probeLiveness2(ws, timeoutMs) {
+  return probeLiveness({
+    get readyState() {
+      return ws.readyState;
+    },
+    get lastPongAt() {
+      return ws.data.lastPongAt;
+    },
+    ping: () => {
+      ws.ping();
+    }
+  }, { timeoutMs, pollMs: LIVENESS_PROBE_POLL_MS });
+}
+function evictStale(ws, reason) {
+  log(`Evicting stale Claude frontend #${ws.data.clientId}: ${reason}`);
+  if (attachedClaude === ws) {
+    detachClaude(ws, `evicted: ${reason}`);
+  }
+  try {
+    ws.close(CLOSE_CODE_EVICTED_STALE, "stale frontend evicted by newer session");
+  } catch (err) {
+    log(`Evict close threw on #${ws.data.clientId}: ${err.message}`);
+  }
 }
 function startAttentionWindow() {
   clearAttentionWindow();

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1625,6 +1625,20 @@ class ConfigService {
 // src/control-protocol.ts
 var CLOSE_CODE_REPLACED = 4001;
 var CLOSE_CODE_EVICTED_STALE = 4002;
+var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
+
+// src/env-utils.ts
+function parsePositiveIntEnv(name, fallback, log = () => {}) {
+  const raw = process.env[name];
+  if (raw == null || raw === "")
+    return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > Number.MAX_SAFE_INTEGER) {
+    log(`Invalid ${name}=${JSON.stringify(raw)} (must be a positive integer within ` + `Number.MAX_SAFE_INTEGER); falling back to ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
 
 // src/liveness-probe.ts
 var OPEN = 1;
@@ -1637,7 +1651,7 @@ async function probeLiveness(target, options) {
   } = options;
   if (target.readyState !== OPEN)
     return false;
-  const baseline = target.lastPongAt;
+  const baseline = Math.max(target.lastPongAt, now());
   try {
     target.ping();
   } catch {
@@ -1687,7 +1701,7 @@ var claudeOnlineNoticeSent = false;
 var claudeOfflineNoticeShown = false;
 var lastAttachStatusSentTs = 0;
 var ATTACH_STATUS_COOLDOWN_MS = 30000;
-var LIVENESS_PROBE_TIMEOUT_MS = parseInt(process.env.AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS ?? "3000", 10);
+var LIVENESS_PROBE_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS", 3000, log);
 var LIVENESS_PROBE_POLL_MS = 50;
 var challengeInProgress = false;
 var bufferedMessages = [];
@@ -1910,7 +1924,7 @@ async function attachClaude(ws) {
     log(`Claude frontend contest: new=#${ws.data.clientId}, incumbent=#${occupant.data.clientId} ` + `(readyState=${occupant.readyState}, msSincePong=${msSincePong})`);
     if (challengeInProgress) {
       log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 another liveness probe already in flight`);
-      ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+      ws.close(CLOSE_CODE_PROBE_IN_PROGRESS, "liveness probe in progress, retry shortly");
       return;
     }
     challengeInProgress = true;

--- a/src/bridge-disabled-state.ts
+++ b/src/bridge-disabled-state.ts
@@ -1,9 +1,20 @@
-export type BridgeDisabledReason = "killed" | "rejected";
+export type BridgeDisabledReason =
+  | "killed"
+  | "rejected"
+  | "evicted"
+  | "probe_in_progress"
+  | "auto_recovery_exhausted";
 
 export function disabledReplyError(reason: BridgeDisabledReason): string {
   switch (reason) {
     case "rejected":
       return "AgentBridge rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset.";
+    case "evicted":
+      return "AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude`.";
+    case "probe_in_progress":
+      return "AgentBridge rejected this session — a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with `agentbridge claude`.";
+    case "auto_recovery_exhausted":
+      return "AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`.";
     case "killed":
       return "AgentBridge is disabled by `agentbridge kill`. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.";
   }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,6 +7,7 @@ import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
 import { ConfigService } from "./config-service";
 import { disabledReplyError, type BridgeDisabledReason } from "./bridge-disabled-state";
+import { CLOSE_CODE_EVICTED_STALE } from "./control-protocol";
 import type { BridgeMessage } from "./types";
 
 const stateDir = new StateDirResolver();
@@ -77,19 +78,23 @@ daemonClient.on("disconnect", () => {
   void reconnectToDaemon();
 });
 
-daemonClient.on("rejected", async () => {
+daemonClient.on("rejected", async (code: number) => {
   if (shuttingDown || daemonDisabled) return;
 
-  log("Daemon rejected this session (close code 4001) — another Claude session is already connected");
+  const wasEvicted = code === CLOSE_CODE_EVICTED_STALE;
+  log(`Daemon rejected this session (close code ${code}) — ${wasEvicted ? "evicted as stale by a newer session" : "another Claude session is already connected"}`);
 
-  // The daemon now rejects NEW connections when an existing session is active.
-  // This session was the latecomer, so it should enter dormant state permanently
-  // and not try to reconnect (which would just get rejected again).
+  // Both codes mean the slot is owned by someone else now: reconnecting would
+  // either be rejected (4001) or kick the legitimate new session back out,
+  // so this session enters dormant state and waits for the user to intervene.
   daemonDisabled = true;
   daemonDisabledReason = "rejected";
+  const notificationContent = wasEvicted
+    ? "⚠️ AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge 因此会话未响应存活探测而将其驱逐——更新的 Claude Code 会话已接管。如需重连，请关闭此会话并运行 `agentbridge claude` 启动新会话。"
+    : "⚠️ AgentBridge daemon rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge 守护进程拒绝了此会话——另一个 Claude Code 会话已在连接中。请先关闭另一个会话，或运行 `agentbridge kill` 重置。";
   await claude.pushNotification(systemMessage(
-    "system_bridge_replaced",
-    "⚠️ AgentBridge daemon rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge 守护进程拒绝了此会话——另一个 Claude Code 会话已在连接中。请先关闭另一个会话，或运行 `agentbridge kill` 重置。",
+    wasEvicted ? "system_bridge_evicted" : "system_bridge_replaced",
+    notificationContent,
   ));
   await daemonClient.disconnect();
 });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,7 +7,10 @@ import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
 import { ConfigService } from "./config-service";
 import { disabledReplyError, type BridgeDisabledReason } from "./bridge-disabled-state";
-import { CLOSE_CODE_EVICTED_STALE } from "./control-protocol";
+import {
+  CLOSE_CODE_EVICTED_STALE,
+  CLOSE_CODE_PROBE_IN_PROGRESS,
+} from "./control-protocol";
 import type { BridgeMessage } from "./types";
 
 const stateDir = new StateDirResolver();
@@ -33,6 +36,10 @@ let lastDisconnectNotifyTs = 0;
 let lastReconnectNotifyTs = 0;
 let disabledRecoveryTimer: ReturnType<typeof setInterval> | null = null;
 let disabledRecoveryInFlight = false;
+let disabledRecoveryAttempts = 0;
+
+const DISABLED_RECOVERY_MAX_ATTEMPTS = 6;
+const DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS = 1000;
 
 claude.setReplySender(async (msg: BridgeMessage, requireReply?: boolean) => {
   if (msg.source !== "claude") {
@@ -81,22 +88,41 @@ daemonClient.on("disconnect", () => {
 daemonClient.on("rejected", async (code: number) => {
   if (shuttingDown || daemonDisabled) return;
 
-  const wasEvicted = code === CLOSE_CODE_EVICTED_STALE;
-  log(`Daemon rejected this session (close code ${code}) — ${wasEvicted ? "evicted as stale by a newer session" : "another Claude session is already connected"}`);
+  let reason: BridgeDisabledReason;
+  let notificationId: string;
+  let notificationContent: string;
+  switch (code) {
+    case CLOSE_CODE_EVICTED_STALE:
+      reason = "evicted";
+      notificationId = "system_bridge_evicted";
+      notificationContent = "⚠️ AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge 因此会话未响应存活探测而将其驱逐——更新的 Claude Code 会话已接管。如需重连，请关闭此会话并运行 `agentbridge claude` 启动新会话。";
+      break;
+    case CLOSE_CODE_PROBE_IN_PROGRESS:
+      reason = "probe_in_progress";
+      notificationId = "system_bridge_probe_in_progress";
+      notificationContent = "⚠️ AgentBridge rejected this session — a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with `agentbridge claude`. AgentBridge 拒绝了此会话——正在通过存活探测检查现有 Claude 会话是否仍然在线。请稍后用 `agentbridge claude` 重试。";
+      break;
+    default:
+      reason = "rejected";
+      notificationId = "system_bridge_replaced";
+      notificationContent = "⚠️ AgentBridge daemon rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge 守护进程拒绝了此会话——另一个 Claude Code 会话已在连接中。请先关闭另一个会话，或运行 `agentbridge kill` 重置。";
+      break;
+  }
+  log(`Daemon rejected this session (close code ${code}, reason=${reason})`);
 
-  // Both codes mean the slot is owned by someone else now: reconnecting would
-  // either be rejected (4001) or kick the legitimate new session back out,
-  // so this session enters dormant state and waits for the user to intervene.
+  // Eviction and replacement are terminal until the user intervenes: the
+  // legitimate new session must not be kicked out by an auto-reconnect. But
+  // probe_in_progress is transient by definition (the probe resolves within
+  // LIVENESS_PROBE_TIMEOUT_MS, default 3s), so we start the recovery poller
+  // and let it auto-reconnect once the slot becomes available.
   daemonDisabled = true;
-  daemonDisabledReason = "rejected";
-  const notificationContent = wasEvicted
-    ? "⚠️ AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge 因此会话未响应存活探测而将其驱逐——更新的 Claude Code 会话已接管。如需重连，请关闭此会话并运行 `agentbridge claude` 启动新会话。"
-    : "⚠️ AgentBridge daemon rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge 守护进程拒绝了此会话——另一个 Claude Code 会话已在连接中。请先关闭另一个会话，或运行 `agentbridge kill` 重置。";
-  await claude.pushNotification(systemMessage(
-    wasEvicted ? "system_bridge_evicted" : "system_bridge_replaced",
-    notificationContent,
-  ));
+  daemonDisabledReason = reason;
+  await claude.pushNotification(systemMessage(notificationId, notificationContent));
   await daemonClient.disconnect();
+  if (reason === "probe_in_progress") {
+    disabledRecoveryAttempts = 0;
+    startDisabledRecoveryPoller();
+  }
 });
 
 claude.on("ready", async () => {
@@ -252,23 +278,103 @@ async function pollDisabledRecovery() {
       return;
     }
 
-    log("Disabled-state recovery conditions met — attempting direct daemon reconnect");
-    try {
-      await daemonClient.connect();
-      daemonClient.attachClaude();
-      daemonDisabled = false;
-      daemonDisabledReason = null;
-      stopDisabledRecoveryPoller();
-      void claude.pushNotification(systemMessage(
-        "system_bridge_recovered",
-        "✅ AgentBridge recovered after the killed sentinel was cleared. Daemon reconnected.",
-      ));
-    } catch (err: any) {
-      log(`Disabled-state direct reconnect failed: ${err.message}`);
-      daemonDisabled = false;
-      daemonDisabledReason = null;
-      stopDisabledRecoveryPoller();
-      void reconnectToDaemon();
+    const recoveredFrom = daemonDisabledReason;
+    switch (recoveredFrom) {
+      case "probe_in_progress": {
+        if (disabledRecoveryAttempts >= DISABLED_RECOVERY_MAX_ATTEMPTS) {
+          log(
+            `Disabled-state auto-recovery gave up after ${DISABLED_RECOVERY_MAX_ATTEMPTS} attempts ` +
+            "— switching to auto_recovery_exhausted terminal state",
+          );
+          daemonDisabledReason = "auto_recovery_exhausted";
+          disabledRecoveryAttempts = 0;
+          stopDisabledRecoveryPoller();
+          void claude.pushNotification(systemMessage(
+            "system_bridge_auto_recovery_gave_up",
+            "⚠️ AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`. AgentBridge 自动恢复已放弃——存活探测争用的重试预算已用尽。请使用 `agentbridge claude` 手动重试。",
+          ));
+          return;
+        }
+
+        disabledRecoveryAttempts += 1;
+        log(
+          `Disabled-state recovery attempt ${disabledRecoveryAttempts}/${DISABLED_RECOVERY_MAX_ATTEMPTS} ` +
+          "for probe_in_progress — attempting direct daemon reconnect",
+        );
+
+        try {
+          await daemonClient.connect();
+          const attached = await daemonClient.attachClaudeAndWaitForStatus(
+            DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS,
+          );
+          if (!attached) {
+            log(
+              `Disabled-state probe_in_progress recovery attempt ${disabledRecoveryAttempts} did not confirm readiness`,
+            );
+            await daemonClient.disconnect();
+            return;
+          }
+
+          daemonDisabled = false;
+          daemonDisabledReason = null;
+          disabledRecoveryAttempts = 0;
+          stopDisabledRecoveryPoller();
+          // We're inside the `probe_in_progress` case branch — TS has narrowed
+          // recoveredFrom to that single value, so use the matching message
+          // directly. The outer switch (with its `never` exhaustive default)
+          // is what enforces compile-time coverage of every BridgeDisabledReason.
+          void claude.pushNotification(systemMessage(
+            "system_bridge_recovered",
+            "✅ AgentBridge recovered after the liveness probe completed. Daemon reconnected.",
+          ));
+        } catch (err: any) {
+          log(`Disabled-state probe_in_progress recovery attempt failed: ${err.message}`);
+          await daemonClient.disconnect();
+        }
+        return;
+      }
+      case "killed": {
+        log("Disabled-state recovery conditions met — attempting direct daemon reconnect");
+        try {
+          await daemonClient.connect();
+          const attached = await daemonClient.attachClaudeAndWaitForStatus(
+            DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS,
+          );
+          if (!attached) {
+            throw new Error("daemon did not confirm reconnect");
+          }
+
+          daemonDisabled = false;
+          daemonDisabledReason = null;
+          disabledRecoveryAttempts = 0;
+          stopDisabledRecoveryPoller();
+          void claude.pushNotification(systemMessage(
+            "system_bridge_recovered",
+            "✅ AgentBridge recovered after the killed sentinel was cleared. Daemon reconnected.",
+          ));
+        } catch (err: any) {
+          log(`Disabled-state direct reconnect failed: ${err.message}`);
+          daemonDisabled = false;
+          daemonDisabledReason = null;
+          disabledRecoveryAttempts = 0;
+          stopDisabledRecoveryPoller();
+          void reconnectToDaemon();
+        }
+        return;
+      }
+      case "evicted":
+      case "rejected":
+      case "auto_recovery_exhausted":
+      case null:
+        log(
+          `Disabled-state recovery poller encountered terminal/unexpected reason ${recoveredFrom ?? "null"} — stopping`,
+        );
+        stopDisabledRecoveryPoller();
+        return;
+      default: {
+        const exhaustive: never = recoveredFrom;
+        return exhaustive;
+      }
     }
   } finally {
     disabledRecoveryInFlight = false;

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -23,3 +23,10 @@ export type ControlServerMessage =
 
 /** WebSocket close code sent by the daemon when a newer Claude session replaces the current one. */
 export const CLOSE_CODE_REPLACED = 4001;
+
+/**
+ * WebSocket close code sent by the daemon when it evicts a stale Claude frontend
+ * that failed to respond to a liveness probe. Used by challenge-on-contest admission
+ * so a newer session can take over when the OS never surfaced FIN on a dead peer.
+ */
+export const CLOSE_CODE_EVICTED_STALE = 4002;

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -30,3 +30,11 @@ export const CLOSE_CODE_REPLACED = 4001;
  * so a newer session can take over when the OS never surfaced FIN on a dead peer.
  */
 export const CLOSE_CODE_EVICTED_STALE = 4002;
+
+/**
+ * WebSocket close code sent by the daemon when a contestant arrives while a
+ * liveness probe is already in flight against the incumbent. Distinct from
+ * CLOSE_CODE_REPLACED so the contestant's UI can suggest retrying shortly
+ * (the in-flight probe will conclude within LIVENESS_PROBE_TIMEOUT_MS).
+ */
+export const CLOSE_CODE_PROBE_IN_PROGRESS = 4003;

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -1,12 +1,12 @@
 import { EventEmitter } from "node:events";
 import type { BridgeMessage } from "./types";
-import { CLOSE_CODE_REPLACED } from "./control-protocol";
+import { CLOSE_CODE_REPLACED, CLOSE_CODE_EVICTED_STALE } from "./control-protocol";
 import type { ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
 
 interface DaemonClientEvents {
   codexMessage: [BridgeMessage];
   disconnect: [];
-  rejected: [];
+  rejected: [number];
   status: [DaemonStatus];
 }
 
@@ -147,8 +147,8 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       if (isCurrent) {
         this.ws = null;
         this.rejectPendingReplies("AgentBridge daemon disconnected.");
-        if (event.code === CLOSE_CODE_REPLACED) {
-          this.emit("rejected");
+        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE) {
+          this.emit("rejected", event.code);
         } else {
           this.emit("disconnect");
         }

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -1,6 +1,10 @@
 import { EventEmitter } from "node:events";
 import type { BridgeMessage } from "./types";
-import { CLOSE_CODE_REPLACED, CLOSE_CODE_EVICTED_STALE } from "./control-protocol";
+import {
+  CLOSE_CODE_REPLACED,
+  CLOSE_CODE_EVICTED_STALE,
+  CLOSE_CODE_PROBE_IN_PROGRESS,
+} from "./control-protocol";
 import type { ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
 
 interface DaemonClientEvents {
@@ -75,6 +79,52 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     this.send({ type: "claude_connect" });
   }
 
+  async attachClaudeAndWaitForStatus(timeoutMs = 1000): Promise<boolean> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+
+    return await new Promise<boolean>((resolve) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      const cleanup = () => {
+        if (settled) return;
+        settled = true;
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        this.off("status", onStatus);
+        this.off("rejected", onRejected);
+        this.off("disconnect", onDisconnect);
+      };
+
+      const finish = (value: boolean) => {
+        cleanup();
+        resolve(value);
+      };
+
+      const onStatus = () => finish(true);
+      const onRejected = () => finish(false);
+      const onDisconnect = () => finish(false);
+
+      this.on("status", onStatus);
+      this.on("rejected", onRejected);
+      this.on("disconnect", onDisconnect);
+
+      timer = setTimeout(() => {
+        finish(false);
+      }, timeoutMs);
+
+      try {
+        this.attachClaude();
+      } catch {
+        finish(false);
+      }
+    });
+  }
+
   async disconnect() {
     if (!this.ws) return;
 
@@ -147,7 +197,11 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       if (isCurrent) {
         this.ws = null;
         this.rejectPendingReplies("AgentBridge daemon disconnected.");
-        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE) {
+        if (
+          event.code === CLOSE_CODE_REPLACED ||
+          event.code === CLOSE_CODE_EVICTED_STALE ||
+          event.code === CLOSE_CODE_PROBE_IN_PROGRESS
+        ) {
           this.emit("rejected", event.code);
         } else {
           this.emit("disconnect");

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -14,13 +14,15 @@ import { TuiConnectionState } from "./tui-connection-state";
 import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
 import { ConfigService } from "./config-service";
-import { CLOSE_CODE_REPLACED } from "./control-protocol";
+import { CLOSE_CODE_REPLACED, CLOSE_CODE_EVICTED_STALE } from "./control-protocol";
 import type { ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
 import type { BridgeMessage } from "./types";
+import { probeLiveness as probeLivenessImpl } from "./liveness-probe";
 
 interface ControlSocketData {
   clientId: number;
   attached: boolean;
+  lastPongAt: number;
 }
 
 const stateDir = new StateDirResolver();
@@ -60,6 +62,17 @@ let claudeOnlineNoticeSent = false;
 let claudeOfflineNoticeShown = false;
 let lastAttachStatusSentTs = 0;
 const ATTACH_STATUS_COOLDOWN_MS = 30_000; // Don't re-send status on rapid reattach
+
+// Liveness probe used by challenge-on-contest admission. Issue #68: OS may never
+// surface FIN on a half-open TCP, so readyState alone can't tell us the old peer
+// is gone. When a new frontend arrives while a socket is still OPEN, we ping the
+// old peer; if no pong within this window, we evict it and accept the new one.
+const LIVENESS_PROBE_TIMEOUT_MS = parseInt(
+  process.env.AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS ?? "3000",
+  10,
+);
+const LIVENESS_PROBE_POLL_MS = 50;
+let challengeInProgress = false;
 
 const bufferedMessages: BridgeMessage[] = [];
 
@@ -231,7 +244,7 @@ function startControlServer() {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
 
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false } })) {
+      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now() } })) {
         return undefined;
       }
 
@@ -242,6 +255,7 @@ function startControlServer() {
       sendPings: true,
       open: (ws: ServerWebSocket<ControlSocketData>) => {
         ws.data.clientId = ++nextControlClientId;
+        ws.data.lastPongAt = Date.now();
         log(`Frontend socket opened (#${ws.data.clientId})`);
       },
       close: (ws: ServerWebSocket<ControlSocketData>, code: number, reason: string) => {
@@ -252,6 +266,9 @@ function startControlServer() {
       },
       message: (ws: ServerWebSocket<ControlSocketData>, raw) => {
         handleControlMessage(ws, raw);
+      },
+      pong: (ws: ServerWebSocket<ControlSocketData>) => {
+        ws.data.lastPongAt = Date.now();
       },
     },
   });
@@ -269,7 +286,9 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
 
   switch (message.type) {
     case "claude_connect":
-      attachClaude(ws);
+      attachClaude(ws).catch((err) => {
+        log(`attachClaude threw for #${ws.data.clientId}: ${err?.message ?? err}`);
+      });
       return;
     case "claude_disconnect":
       detachClaude(ws, "frontend requested disconnect");
@@ -332,13 +351,61 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
   }
 }
 
-function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
+async function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
+  const occupant = attachedClaude;
+  if (occupant && occupant !== ws && occupant.readyState !== WebSocket.CLOSED) {
+    // Slot is occupied by another socket that hasn't yet shown us FIN.
+    // Issue #68: OS may never surface a FIN for a crashed peer, so readyState
+    // stays OPEN forever. Probe the incumbent with a ping before rejecting.
+    const msSincePong = Date.now() - occupant.data.lastPongAt;
+    log(
+      `Claude frontend contest: new=#${ws.data.clientId}, incumbent=#${occupant.data.clientId} ` +
+      `(readyState=${occupant.readyState}, msSincePong=${msSincePong})`,
+    );
+
+    if (challengeInProgress) {
+      log(
+        `Rejecting Claude frontend #${ws.data.clientId} — another liveness probe already in flight`,
+      );
+      ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+      return;
+    }
+
+    challengeInProgress = true;
+    let incumbentAlive = false;
+    try {
+      incumbentAlive = await probeLiveness(occupant, LIVENESS_PROBE_TIMEOUT_MS);
+    } finally {
+      challengeInProgress = false;
+    }
+
+    // Slot may have cleared during the probe (real close fired, or the new ws
+    // left). Re-read state before committing a decision.
+    if (ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+      log(`Contestant #${ws.data.clientId} disappeared during probe — aborting`);
+      if (!incumbentAlive) {
+        evictStale(occupant, "contestant gone but probe still failed");
+      }
+      return;
+    }
+
+    if (incumbentAlive) {
+      log(
+        `Rejecting Claude frontend #${ws.data.clientId} — incumbent #${occupant.data.clientId} responded to liveness probe`,
+      );
+      ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+      return;
+    }
+
+    evictStale(occupant, `liveness probe timed out after ${LIVENESS_PROBE_TIMEOUT_MS}ms`);
+    // Fall through to accept path below.
+  }
+
   if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
-    // Reject the new connection — don't disrupt the existing active session.
-    // Check !== CLOSED (not === OPEN) so that CLOSING state is also treated as
-    // "slot occupied", preventing a race where a new session slips in before
-    // the old one finishes its close handshake.
-    log(`Rejecting Claude frontend #${ws.data.clientId} — another session (#${attachedClaude.data.clientId}) is already attached (readyState=${attachedClaude.readyState})`);
+    // Another contestant may have raced in between the probe and here. Reject.
+    log(
+      `Rejecting Claude frontend #${ws.data.clientId} — slot re-acquired by #${attachedClaude.data.clientId} after probe`,
+    );
     ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
     return;
   }
@@ -383,6 +450,37 @@ function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
   scheduleClaudeDisconnectNotification(ws.data.clientId);
 
   scheduleIdleShutdown();
+}
+
+async function probeLiveness(
+  ws: ServerWebSocket<ControlSocketData>,
+  timeoutMs: number,
+): Promise<boolean> {
+  return probeLivenessImpl(
+    {
+      get readyState() { return ws.readyState; },
+      get lastPongAt() { return ws.data.lastPongAt; },
+      ping: () => { ws.ping(); },
+    },
+    { timeoutMs, pollMs: LIVENESS_PROBE_POLL_MS },
+  );
+}
+
+/**
+ * Evict the incumbent Claude frontend so a newer session can take over.
+ * Sends CLOSE_CODE_EVICTED_STALE (4002) and releases the slot so the next
+ * attachClaude call can accept a contestant.
+ */
+function evictStale(ws: ServerWebSocket<ControlSocketData>, reason: string) {
+  log(`Evicting stale Claude frontend #${ws.data.clientId}: ${reason}`);
+  if (attachedClaude === ws) {
+    detachClaude(ws, `evicted: ${reason}`);
+  }
+  try {
+    ws.close(CLOSE_CODE_EVICTED_STALE, "stale frontend evicted by newer session");
+  } catch (err: any) {
+    log(`Evict close threw on #${ws.data.clientId}: ${err.message}`);
+  }
 }
 
 function startAttentionWindow() {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -14,7 +14,12 @@ import { TuiConnectionState } from "./tui-connection-state";
 import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
 import { ConfigService } from "./config-service";
-import { CLOSE_CODE_REPLACED, CLOSE_CODE_EVICTED_STALE } from "./control-protocol";
+import {
+  CLOSE_CODE_REPLACED,
+  CLOSE_CODE_EVICTED_STALE,
+  CLOSE_CODE_PROBE_IN_PROGRESS,
+} from "./control-protocol";
+import { parsePositiveIntEnv } from "./env-utils";
 import type { ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
 import type { BridgeMessage } from "./types";
 import { probeLiveness as probeLivenessImpl } from "./liveness-probe";
@@ -67,9 +72,10 @@ const ATTACH_STATUS_COOLDOWN_MS = 30_000; // Don't re-send status on rapid reatt
 // surface FIN on a half-open TCP, so readyState alone can't tell us the old peer
 // is gone. When a new frontend arrives while a socket is still OPEN, we ping the
 // old peer; if no pong within this window, we evict it and accept the new one.
-const LIVENESS_PROBE_TIMEOUT_MS = parseInt(
-  process.env.AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS ?? "3000",
-  10,
+const LIVENESS_PROBE_TIMEOUT_MS = parsePositiveIntEnv(
+  "AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS",
+  3000,
+  log,
 );
 const LIVENESS_PROBE_POLL_MS = 50;
 let challengeInProgress = false;
@@ -367,7 +373,10 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
       log(
         `Rejecting Claude frontend #${ws.data.clientId} — another liveness probe already in flight`,
       );
-      ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+      ws.close(
+        CLOSE_CODE_PROBE_IN_PROGRESS,
+        "liveness probe in progress, retry shortly",
+      );
       return;
     }
 
@@ -470,6 +479,14 @@ async function probeLiveness(
  * Evict the incumbent Claude frontend so a newer session can take over.
  * Sends CLOSE_CODE_EVICTED_STALE (4002) and releases the slot so the next
  * attachClaude call can accept a contestant.
+ *
+ * detachClaude arms a 5s grace timer that pings Codex with "Claude went
+ * offline" if nobody re-attaches in that window. For the *handoff* eviction
+ * path (a new frontend is about to attach in the same JS task), attachClaude
+ * cancels that timer at the "Claude frontend attached" step before any
+ * 5s window can elapse. For the *cleanup* eviction path (no replacement —
+ * contestant disappeared mid-probe), letting the timer fire is the correct
+ * behavior: Codex genuinely has no Claude attached.
  */
 function evictStale(ws: ServerWebSocket<ControlSocketData>, reason: string) {
   log(`Evicting stale Claude frontend #${ws.data.clientId}: ${reason}`);

--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -1,0 +1,23 @@
+export function parsePositiveIntEnv(
+  name: string,
+  fallback: number,
+  log: (message: string) => void = () => {},
+): number {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return fallback;
+
+  // Use Number() (not parseInt) so values like "1.5" and "10abc" fail validation
+  // instead of being silently truncated to 1 or 10. Number.isInteger then enforces
+  // the integer constraint; >0 enforces positivity; the MAX_SAFE_INTEGER guard
+  // blocks IEEE rounding from silently accepting values beyond the safe range.
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > Number.MAX_SAFE_INTEGER) {
+    log(
+      `Invalid ${name}=${JSON.stringify(raw)} (must be a positive integer within ` +
+      `Number.MAX_SAFE_INTEGER); falling back to ${fallback}`,
+    );
+    return fallback;
+  }
+
+  return parsed;
+}

--- a/src/liveness-probe.ts
+++ b/src/liveness-probe.ts
@@ -1,0 +1,62 @@
+/**
+ * Liveness probe for half-open WebSocket detection.
+ *
+ * Sends a WebSocket ping and waits up to `timeoutMs` for a pong. Returns true
+ * if a pong is observed (via `lastPongAt` monotonically advancing past the
+ * baseline snapshot). Used by challenge-on-contest admission in daemon.ts to
+ * detect half-open dead peers that still report readyState=OPEN (issue #68).
+ *
+ * Accepts a minimal probe target interface so the loop can be unit-tested
+ * against an in-memory fake without spinning up a real WebSocket.
+ */
+
+export interface ProbeTarget {
+  /** WebSocket.OPEN = 1. Anything else aborts the probe. */
+  readyState: number;
+  /**
+   * Monotonic timestamp (ms) of the last pong frame observed. Caller updates
+   * this from the `pong` handler. The probe only trusts values strictly
+   * greater than the baseline taken before ping().
+   */
+  lastPongAt: number;
+  /** Send a ping frame. May throw synchronously on a failed write. */
+  ping(): void;
+}
+
+export interface ProbeLivenessOptions {
+  timeoutMs: number;
+  pollMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const OPEN = 1;
+
+export async function probeLiveness(
+  target: ProbeTarget,
+  options: ProbeLivenessOptions,
+): Promise<boolean> {
+  const {
+    timeoutMs,
+    pollMs = 50,
+    now = Date.now,
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+  } = options;
+
+  if (target.readyState !== OPEN) return false;
+
+  const baseline = target.lastPongAt;
+  try {
+    target.ping();
+  } catch {
+    return false;
+  }
+
+  const deadline = now() + timeoutMs;
+  while (now() < deadline) {
+    if (target.lastPongAt > baseline) return true;
+    if (target.readyState !== OPEN) return false;
+    await sleep(pollMs);
+  }
+  return target.lastPongAt > baseline;
+}

--- a/src/liveness-probe.ts
+++ b/src/liveness-probe.ts
@@ -45,7 +45,14 @@ export async function probeLiveness(
 
   if (target.readyState !== OPEN) return false;
 
-  const baseline = target.lastPongAt;
+  // Defensive baseline: take max(lastPongAt, now()) so that ONLY pongs that
+  // physically arrive after we initiated the probe count as proof of liveness.
+  // Why: with Bun's `sendPings: true`, background heartbeat pongs also update
+  // lastPongAt, so a pong from a prior heartbeat that landed just before us
+  // would falsely satisfy `lastPongAt > target.lastPongAt`. Using `now()` as
+  // the floor anchors the probe to wall-clock time, not to whatever past pong
+  // happened to be recorded last.
+  const baseline = Math.max(target.lastPongAt, now());
   try {
     target.ping();
   } catch {

--- a/src/unit-test/bridge-disabled-state.test.ts
+++ b/src/unit-test/bridge-disabled-state.test.ts
@@ -14,4 +14,33 @@ describe("bridge disabled-state messaging", () => {
     expect(message).toContain("agentbridge kill");
     expect(message).not.toContain("/resume");
   });
+
+  test("evicted sessions explain liveness probe failure and how to retry", () => {
+    const message = disabledReplyError("evicted");
+    expect(message).toContain("evicted this session");
+    expect(message).toContain("liveness probes");
+    expect(message).toContain("agentbridge claude");
+    // Evicted is not the same as "another session connected" — must not reuse that wording
+    expect(message).not.toContain("another Claude Code session is already connected");
+  });
+
+  test("probe-in-progress sessions tell the user to retry shortly", () => {
+    const message = disabledReplyError("probe_in_progress");
+    expect(message).toContain("liveness probe");
+    expect(message).toContain("Retry");
+    expect(message).toContain("agentbridge claude");
+    // Probe-in-progress is transient — must not tell the user to run `agentbridge kill`
+    expect(message).not.toContain("agentbridge kill");
+  });
+
+  test("auto_recovery_exhausted explains the retry budget gave up, not 'another session'", () => {
+    const message = disabledReplyError("auto_recovery_exhausted");
+    expect(message).toContain("auto-recovery gave up");
+    expect(message).toContain("retry budget");
+    expect(message).toContain("agentbridge claude");
+    // Must NOT borrow the misleading "another session connected" wording from
+    // the bare "rejected" reason — the cause here is exhausted retries, not
+    // an active competing session.
+    expect(message).not.toContain("another Claude Code session is already connected");
+  });
 });

--- a/src/unit-test/daemon-client.test.ts
+++ b/src/unit-test/daemon-client.test.ts
@@ -96,21 +96,42 @@ describe("DaemonClient", () => {
     let disconnectEmitted = false;
     client.on("disconnect", () => { disconnectEmitted = true; });
 
-    const rejected = new Promise<void>((resolve) => {
-      client.on("rejected", () => resolve());
+    const rejected = new Promise<number>((resolve) => {
+      client.on("rejected", (code) => resolve(code));
     });
 
     for (const ws of serverSockets) {
       ws.close(4001, "another Claude session is already connected");
     }
 
-    await rejected;
+    const code = await rejected;
+    expect(code).toBe(4001);
     // Give a tick for any stray disconnect to fire
     await new Promise((r) => setTimeout(r, 50));
     expect(disconnectEmitted).toBe(false);
   });
 
-  test("emits disconnect (not rejected) for non-4001 close codes", async () => {
+  test("emits rejected (not disconnect) when server closes with code 4002 (evicted stale)", async () => {
+    await client.connect();
+
+    let disconnectEmitted = false;
+    client.on("disconnect", () => { disconnectEmitted = true; });
+
+    const rejected = new Promise<number>((resolve) => {
+      client.on("rejected", (code) => resolve(code));
+    });
+
+    for (const ws of serverSockets) {
+      ws.close(4002, "stale frontend evicted by newer session");
+    }
+
+    const code = await rejected;
+    expect(code).toBe(4002);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(disconnectEmitted).toBe(false);
+  });
+
+  test("emits disconnect (not rejected) for non-rejection close codes", async () => {
     await client.connect();
 
     let rejectedEmitted = false;

--- a/src/unit-test/daemon-client.test.ts
+++ b/src/unit-test/daemon-client.test.ts
@@ -131,6 +131,80 @@ describe("DaemonClient", () => {
     expect(disconnectEmitted).toBe(false);
   });
 
+  test("emits rejected (not disconnect) when server closes with code 4003 (probe in progress)", async () => {
+    await client.connect();
+
+    let disconnectEmitted = false;
+    client.on("disconnect", () => { disconnectEmitted = true; });
+
+    const rejected = new Promise<number>((resolve) => {
+      client.on("rejected", (code) => resolve(code));
+    });
+
+    for (const ws of serverSockets) {
+      ws.close(4003, "liveness probe in progress, retry shortly");
+    }
+
+    const code = await rejected;
+    expect(code).toBe(4003);
+    await new Promise((r) => setTimeout(r, 50));
+    // Critical: must NOT trigger the disconnect path, which would cause the
+    // contestant to reconnect-loop during the probe window.
+    expect(disconnectEmitted).toBe(false);
+  });
+
+  test("attachClaudeAndWaitForStatus resolves true when the daemon confirms attachment", async () => {
+    onServerMessage = (ws, raw) => {
+      const message = JSON.parse(raw.toString());
+      if (message.type === "claude_connect") {
+        ws.send(JSON.stringify({
+          type: "status",
+          status: {
+            bridgeReady: true,
+            tuiConnected: false,
+            threadId: null,
+            queuedMessageCount: 0,
+            proxyUrl: "ws://127.0.0.1:4501",
+            appServerUrl: "ws://127.0.0.1:4500",
+            pid: 12345,
+          },
+        }));
+      }
+    };
+
+    await client.connect();
+    await expect(client.attachClaudeAndWaitForStatus(250)).resolves.toBe(true);
+  });
+
+  test("attachClaudeAndWaitForStatus resolves false when the daemon rejects the attach", async () => {
+    onServerMessage = (ws, raw) => {
+      const message = JSON.parse(raw.toString());
+      if (message.type === "claude_connect") {
+        ws.close(4003, "liveness probe in progress, retry shortly");
+      }
+    };
+
+    await client.connect();
+    await expect(client.attachClaudeAndWaitForStatus(250)).resolves.toBe(false);
+  });
+
+  test("attachClaudeAndWaitForStatus resolves false on timeout when daemon never responds", async () => {
+    // Server intentionally swallows claude_connect — no status, no close, no anything.
+    // Critical path for the recovery poller: a hung daemon must let the caller proceed.
+    onServerMessage = () => {};
+
+    await client.connect();
+    const start = Date.now();
+    const result = await client.attachClaudeAndWaitForStatus(150);
+    const elapsed = Date.now() - start;
+
+    expect(result).toBe(false);
+    // Must actually wait for the timeout, not resolve instantly.
+    expect(elapsed).toBeGreaterThanOrEqual(140);
+    // Sanity check on upper bound to catch event-listener leaks that delay GC.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
   test("emits disconnect (not rejected) for non-rejection close codes", async () => {
     await client.connect();
 

--- a/src/unit-test/e2e/issue-68-stale-frontend.md
+++ b/src/unit-test/e2e/issue-68-stale-frontend.md
@@ -1,0 +1,90 @@
+# Issue #68 — E2E Test Plan
+
+## fix: evict stale Claude frontend via liveness probe (challenge-on-contest)
+
+Related:
+- Issue: https://github.com/raysonmeng/agent-bridge/issues/68
+- Source of truth: `docs/issues-2026-04-18-codex-stuck-and-resume.md` (Issue A)
+
+The bug: when Claude Code crashed/was killed hard, the OS never sent FIN, so the
+daemon's WebSocket reported `readyState=OPEN` forever. New sessions were rejected
+with close code `4001` for up to an hour (log: conn #2 through #19 all rejected).
+
+The fix: when a second frontend arrives while the slot is "occupied", ping the
+incumbent and wait up to 3 s for a pong. If no pong, evict the incumbent with
+close code `4002` (`CLOSE_CODE_EVICTED_STALE`) and admit the newcomer.
+
+### Test 1 — happy path unchanged
+
+**Goal:** verify normal single-session admission still works.
+
+1. Terminal A: `agentbridge claude` — verify `✅ AgentBridge bridge is ready`.
+2. Terminal B: `agentbridge codex`.
+3. Confirm Claude and Codex can exchange a message round-trip.
+
+**Pass:** normal flow works; no new log lines about liveness probes because
+the slot is never contested.
+
+### Test 2 — rejection still blocks a live second session
+
+**Goal:** verify two **live** Claude sessions can't coexist (regression guard
+for PR #57 admission semantics).
+
+1. Terminal A: `agentbridge claude` — wait for bridge ready.
+2. Terminal C: `agentbridge claude` from the same machine.
+3. Confirm Terminal C shows `⚠️ AgentBridge daemon rejected this session — another Claude Code session is already connected.`
+4. In `agentbridge.log` confirm:
+   - `Claude frontend contest: new=#N, incumbent=#M (readyState=1, msSincePong=...)`
+   - `Rejecting Claude frontend #N — incumbent #M responded to liveness probe`
+5. Terminal A is still healthy and can talk to Codex.
+
+**Pass:** Terminal C rejected with code `4001`; Terminal A unaffected.
+
+### Test 3 — stale frontend evicted when old process is killed hard
+
+**Goal:** the core fix. Reproduce the half-open-dead incumbent scenario and
+verify the contender is admitted within the probe window.
+
+1. Terminal A: `agentbridge claude`.
+2. Find the Claude Code PID (from process list or `agentbridge.log`).
+3. `kill -9 <pid>` in Terminal A's process **without** letting it shut down the
+   WebSocket. This simulates the crash that produced Issue #68.
+4. Terminal B: `agentbridge claude` within 30 s.
+5. Verify Terminal B becomes `✅ AgentBridge bridge is ready` within ~3-5 s.
+6. In `agentbridge.log` confirm in order:
+   - `Claude frontend contest: new=#N, incumbent=#M (readyState=1, msSincePong=...)`
+   - `Evicting stale Claude frontend #M: liveness probe timed out after 3000ms`
+   - `Claude frontend attached (#N)`
+
+**Pass:** the newcomer attaches within ~`LIVENESS_PROBE_TIMEOUT_MS + 1s`;
+no more endless reject loop on reconnect.
+
+### Test 4 — concurrent contestants serialize safely
+
+**Goal:** when two fresh sessions arrive simultaneously and the incumbent is
+dead, exactly one wins, the other retries, and no double-attach occurs.
+
+1. Simulate dead incumbent as in Test 3.
+2. Start two `agentbridge claude` terminals within 200 ms of each other.
+3. Confirm one becomes `✅ bridge is ready` and the other shows the rejection
+   message (then it can retry — operator can restart it manually).
+4. Log should contain `another liveness probe already in flight` for the loser.
+
+**Pass:** only one session ends up attached; daemon state remains consistent.
+
+### Test 5 — `kill` sentinel still wins
+
+**Goal:** `agentbridge kill` disables the daemon globally; the probe must not
+accidentally revive a session.
+
+1. Terminals as in Test 1.
+2. Run `agentbridge kill`.
+3. Try `agentbridge claude` — should see `AgentBridge is disabled by agentbridge kill`.
+4. No probe-related log lines appear (daemon has exited).
+
+**Pass:** kill sentinel behavior is unaffected by the new admission path.
+
+### Automated coverage
+
+- Unit: `src/unit-test/liveness-probe.test.ts` — pure probe state machine (7 scenarios, fake clock)
+- Integration: `src/unit-test/daemon-client.test.ts`, `src/unit-test/e2e-reconnect.test.ts` still green

--- a/src/unit-test/env-utils.test.ts
+++ b/src/unit-test/env-utils.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { parsePositiveIntEnv } from "../env-utils";
+
+describe("parsePositiveIntEnv", () => {
+  const envName = "AGENTBRIDGE_TEST_POSITIVE_INT";
+
+  afterEach(() => {
+    delete process.env[envName];
+  });
+
+  test("returns a safe positive integer when the env var is valid", () => {
+    process.env[envName] = "3000";
+    expect(parsePositiveIntEnv(envName, 123)).toBe(3000);
+  });
+
+  test("falls back when the value exceeds Number.MAX_SAFE_INTEGER", () => {
+    process.env[envName] = "9007199254740993";
+    expect(parsePositiveIntEnv(envName, 123)).toBe(123);
+  });
+
+  test("falls back for the negative overflow analog", () => {
+    process.env[envName] = "-9007199254740993";
+    expect(parsePositiveIntEnv(envName, 123)).toBe(123);
+  });
+});

--- a/src/unit-test/liveness-probe.test.ts
+++ b/src/unit-test/liveness-probe.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from "bun:test";
+import { probeLiveness, type ProbeTarget } from "../liveness-probe";
+
+const OPEN = 1;
+const CLOSED = 3;
+
+function makeTarget(initial: Partial<ProbeTarget> = {}): ProbeTarget & { pingCount: number } {
+  return {
+    readyState: OPEN,
+    lastPongAt: 1_000,
+    pingCount: 0,
+    ping() { this.pingCount++; },
+    ...initial,
+  } as ProbeTarget & { pingCount: number };
+}
+
+describe("probeLiveness", () => {
+  test("returns true when pong observed before timeout", async () => {
+    const target = makeTarget();
+
+    const promise = probeLiveness(target, { timeoutMs: 500, pollMs: 10 });
+    // Simulate a pong landing after the first poll tick.
+    setTimeout(() => { target.lastPongAt = 2_000; }, 30);
+
+    expect(await promise).toBe(true);
+    expect(target.pingCount).toBe(1);
+  });
+
+  test("returns false when no pong within timeout", async () => {
+    const target = makeTarget();
+    const result = await probeLiveness(target, { timeoutMs: 120, pollMs: 20 });
+    expect(result).toBe(false);
+    expect(target.pingCount).toBe(1);
+  });
+
+  test("returns false immediately when socket is not OPEN", async () => {
+    const target = makeTarget({ readyState: CLOSED });
+    const result = await probeLiveness(target, { timeoutMs: 500, pollMs: 10 });
+    expect(result).toBe(false);
+    expect(target.pingCount).toBe(0);
+  });
+
+  test("returns false when ping throws", async () => {
+    const target = makeTarget({
+      ping() { throw new Error("socket broken"); },
+    });
+    const result = await probeLiveness(target, { timeoutMs: 500, pollMs: 10 });
+    expect(result).toBe(false);
+  });
+
+  test("returns false if readyState transitions to CLOSED mid-probe", async () => {
+    const target = makeTarget();
+    setTimeout(() => { target.readyState = CLOSED; }, 30);
+    const result = await probeLiveness(target, { timeoutMs: 500, pollMs: 10 });
+    expect(result).toBe(false);
+  });
+
+  test("treats pong received before ping (baseline = same value) as NOT alive", async () => {
+    // Critical: a stale pong that landed before the probe started must not
+    // be interpreted as proof of liveness. Only pongs arriving AFTER the
+    // ping count.
+    const target = makeTarget({ lastPongAt: 5_000 });
+    const result = await probeLiveness(target, { timeoutMs: 80, pollMs: 20 });
+    expect(result).toBe(false);
+  });
+
+  test("uses injected clock and sleep for deterministic timeout", async () => {
+    let fakeNow = 0;
+    const sleeps: number[] = [];
+    const target = makeTarget();
+    const result = await probeLiveness(target, {
+      timeoutMs: 100,
+      pollMs: 25,
+      now: () => fakeNow,
+      sleep: async (ms) => { sleeps.push(ms); fakeNow += ms; },
+    });
+    expect(result).toBe(false);
+    // With a 100ms budget and 25ms polls, expect 4 sleeps then timeout.
+    expect(sleeps.length).toBe(4);
+    expect(sleeps.every((s) => s === 25)).toBe(true);
+  });
+});

--- a/src/unit-test/liveness-probe.test.ts
+++ b/src/unit-test/liveness-probe.test.ts
@@ -5,9 +5,12 @@ const OPEN = 1;
 const CLOSED = 3;
 
 function makeTarget(initial: Partial<ProbeTarget> = {}): ProbeTarget & { pingCount: number } {
+  // Seed lastPongAt at "now - 1s" so the defensive baseline (max(lastPongAt, now()))
+  // resolves to now() rather than a synthetic-stale value — preserves the assertion
+  // semantics for tests that simulate a real-time pong arriving during the probe.
   return {
     readyState: OPEN,
-    lastPongAt: 1_000,
+    lastPongAt: Date.now() - 1_000,
     pingCount: 0,
     ping() { this.pingCount++; },
     ...initial,
@@ -19,8 +22,10 @@ describe("probeLiveness", () => {
     const target = makeTarget();
 
     const promise = probeLiveness(target, { timeoutMs: 500, pollMs: 10 });
-    // Simulate a pong landing after the first poll tick.
-    setTimeout(() => { target.lastPongAt = 2_000; }, 30);
+    // Simulate a pong landing after the first poll tick. The timestamp must
+    // exceed Date.now() at the moment the probe takes its baseline; using
+    // `Date.now() + 60_000` is safely far enough in the future for the assertion.
+    setTimeout(() => { target.lastPongAt = Date.now() + 60_000; }, 30);
 
     expect(await promise).toBe(true);
     expect(target.pingCount).toBe(1);
@@ -58,8 +63,10 @@ describe("probeLiveness", () => {
   test("treats pong received before ping (baseline = same value) as NOT alive", async () => {
     // Critical: a stale pong that landed before the probe started must not
     // be interpreted as proof of liveness. Only pongs arriving AFTER the
-    // ping count.
-    const target = makeTarget({ lastPongAt: 5_000 });
+    // ping count. The defensive baseline takes max(lastPongAt, now()) so a
+    // recent-but-pre-probe pong is also filtered out — see the dedicated
+    // defensive-baseline tests below for that case.
+    const target = makeTarget({ lastPongAt: Date.now() - 500 });
     const result = await probeLiveness(target, { timeoutMs: 80, pollMs: 20 });
     expect(result).toBe(false);
   });
@@ -78,5 +85,42 @@ describe("probeLiveness", () => {
     // With a 100ms budget and 25ms polls, expect 4 sleeps then timeout.
     expect(sleeps.length).toBe(4);
     expect(sleeps.every((s) => s === 25)).toBe(true);
+  });
+
+  test("defensive baseline: pongs older than probe start are ignored even if newer than lastPongAt seed", async () => {
+    // Regression for Bun's sendPings: true. Without max(lastPongAt, now()),
+    // a recent-but-pre-probe pong (e.g. from Bun's background heartbeat that
+    // landed during the same JS tick before our ping() ran) would falsely
+    // satisfy `lastPongAt > baseline`. Use an injected clock so we can stage
+    // the timestamp ordering deterministically.
+    let fakeNow = 10_000;
+    const target = makeTarget({ lastPongAt: 9_500 });
+    const result = await probeLiveness(target, {
+      timeoutMs: 100,
+      pollMs: 25,
+      now: () => fakeNow,
+      sleep: async (ms) => { fakeNow += ms; },
+    });
+    expect(result).toBe(false);
+  });
+
+  test("defensive baseline: pong arriving DURING probe (after now()) is accepted", async () => {
+    let fakeNow = 10_000;
+    // lastPongAt seeded BELOW now() — proves we anchor baseline to now(), not lastPongAt.
+    const target = makeTarget({ lastPongAt: 9_500 });
+    let pingCalls = 0;
+    target.ping = () => {
+      pingCalls++;
+      // Simulate peer responding with a pong AFTER the probe started.
+      target.lastPongAt = fakeNow + 1; // strictly greater than baseline (=fakeNow)
+    };
+    const result = await probeLiveness(target, {
+      timeoutMs: 100,
+      pollMs: 25,
+      now: () => fakeNow,
+      sleep: async (ms) => { fakeNow += ms; },
+    });
+    expect(result).toBe(true);
+    expect(pingCalls).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #68 — P0 from `docs/issues-2026-04-18-codex-stuck-and-resume.md` (Issue A).

When Claude Code crashed or was killed hard (e.g., OOM, SIGKILL), the OS never
surfaced FIN on the control WebSocket, so the daemon's `readyState` stayed `OPEN`
forever and new sessions got rejected with close code `4001` for up to an hour
(reproduced in the failing log: conn #2 through #19 all rejected).

**Fix:** challenge-on-contest admission. When a second frontend arrives and the
slot is "occupied", the daemon pings the incumbent and waits up to 3 s for a
pong. If no pong, it evicts the incumbent with a new close code
`4002` (`CLOSE_CODE_EVICTED_STALE`) and admits the newcomer.

修复 #68 — 来自 `docs/issues-2026-04-18-codex-stuck-and-resume.md` 的 Issue A
（P0）。当 Claude Code 崩溃或强杀时操作系统可能不送 FIN，守护进程认为旧连接
仍然 OPEN，新会话被 4001 无限拒绝。修复方案：新前端到达时向既有连接发 ping，
3 秒内未收到 pong 则以 4002 驱逐旧连接，让新会话接管。

## Key changes

- `src/control-protocol.ts` — new `CLOSE_CODE_EVICTED_STALE = 4002`.
- `src/daemon.ts` — challenge-on-contest admission; `attachClaude` is now async;
  tracks `lastPongAt` per socket; new `pong` handler; `challengeInProgress`
  serialization so concurrent contestants can't double-attach.
- `src/liveness-probe.ts` (new) — pure-ish probe primitive with injected clock
  + sleep for deterministic unit tests.
- `src/daemon-client.ts` — treats 4002 the same as 4001 (emits `rejected` + code),
  so an evicted session stops its reconnect loop instead of flapping.
- `src/bridge.ts` — distinct bilingual user-facing message for 4002 ("evicted as
  stale") vs 4001 ("another session already connected"), so the user knows which
  branch applies.
- Env knob: `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` (default `3000`).

## Tests

- **Unit — `src/unit-test/liveness-probe.test.ts`** (7 tests): pong-before-timeout,
  no-pong-timeout, not-OPEN-early-return, ping-throws, readyState-transitions-mid-probe,
  stale-pong-not-trusted (baseline semantic), injected-clock-deterministic-timeout.
- **Unit — `src/unit-test/daemon-client.test.ts`**: extended existing 4001 coverage
  with a mirrored 4002 test and asserts the `rejected` event now carries the
  close code.
- **Full suite:** 183 pass / 0 fail / 510 expect() calls.
- **`bun run check` clean:** typecheck + tests + plugin-sync + plugin version align.

## Test plan

See `src/unit-test/e2e/issue-68-stale-frontend.md` for the 5-scenario plan:

- [ ] Test 1 — happy path unchanged (single-session admission still works)
- [ ] Test 2 — rejection still blocks a live second session (4001 regression guard)
- [ ] Test 3 — stale frontend evicted when old process is killed hard (the core fix;
  `kill -9` the Claude PID, start a new `agentbridge claude` within 30 s, verify
  new session becomes ready within ~3-5 s)
- [ ] Test 4 — concurrent contestants serialize safely (one wins, no double-attach)
- [ ] Test 5 — `agentbridge kill` sentinel still wins (probe doesn't revive a session)

Please run `Test 3` at minimum — it's the exact repro for the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)