### PR TITLE
fix: recover stale Claude attach sessions

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14103,6 +14103,9 @@ class DaemonClient extends EventEmitter2 {
         case "status":
           this.emit("status", message.status);
           return;
+        case "session_probe":
+          this.send({ type: "session_probe_ack", probeId: message.probeId });
+          return;
       }
     };
     ws.onclose = (event) => {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1635,6 +1635,7 @@ var CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.co
 var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 var CLAUDE_DISCONNECT_GRACE_MS = 5000;
+var CLAUDE_ATTACH_PROBE_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_ATTACH_PROBE_MS ?? "1500", 10);
 var MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 var FILTER_MODE = process.env.AGENTBRIDGE_FILTER_MODE === "full" ? "full" : "filtered";
 var IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
@@ -1657,6 +1658,8 @@ var claudeDisconnectTimer = null;
 var claudeOnlineNoticeSent = false;
 var claudeOfflineNoticeShown = false;
 var lastAttachStatusSentTs = 0;
+var pendingAttachProbe = null;
+var nextAttachProbeId = 0;
 var ATTACH_STATUS_COOLDOWN_MS = 30000;
 var bufferedMessages = [];
 var tuiConnectionState = new TuiConnectionState({
@@ -1784,6 +1787,7 @@ function startControlServer() {
       },
       close: (ws, code, reason) => {
         log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
+        cancelPendingAttachProbeFor(ws, "frontend socket closed");
         if (attachedClaude === ws) {
           detachClaude(ws, "frontend socket closed");
         }
@@ -1808,7 +1812,11 @@ function handleControlMessage(ws, raw) {
       attachClaude(ws);
       return;
     case "claude_disconnect":
+      cancelPendingAttachProbeFor(ws, "frontend requested disconnect");
       detachClaude(ws, "frontend requested disconnect");
+      return;
+    case "session_probe_ack":
+      handleAttachProbeAck(ws, message.probeId);
       return;
     case "status":
       sendStatus(ws);
@@ -1867,10 +1875,16 @@ function handleControlMessage(ws, raw) {
 }
 function attachClaude(ws) {
   if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
-    log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 another session (#${attachedClaude.data.clientId}) is already attached (readyState=${attachedClaude.readyState})`);
-    ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+    if (attachedClaude.readyState === WebSocket.OPEN) {
+      probeAttachedClaude(ws);
+      return;
+    }
+    replaceAttachedClaude(ws, `previous attached socket state=${attachedClaude.readyState}`);
     return;
   }
+  acceptClaude(ws);
+}
+function acceptClaude(ws) {
   clearPendingClaudeDisconnect("Claude frontend attached");
   attachedClaude = ws;
   ws.data.attached = true;
@@ -1892,6 +1906,84 @@ function attachClaude(ws) {
   lastAttachStatusSentTs = now;
   if (tuiConnectionState.canReply() && shouldNotifyCodexClaudeOnline()) {
     notifyCodexClaudeOnline();
+  }
+}
+function probeAttachedClaude(candidate) {
+  const incumbent = attachedClaude;
+  if (!incumbent || incumbent === candidate) {
+    acceptClaude(candidate);
+    return;
+  }
+  if (pendingAttachProbe) {
+    if (pendingAttachProbe.candidate !== candidate && pendingAttachProbe.candidate.readyState === WebSocket.OPEN) {
+      pendingAttachProbe.candidate.close(CLOSE_CODE_REPLACED, "superseded by a newer Claude attach attempt");
+    }
+    clearTimeout(pendingAttachProbe.timer);
+    pendingAttachProbe = null;
+  }
+  const probeId = `attach_probe_${++nextAttachProbeId}_${Date.now()}`;
+  pendingAttachProbe = {
+    probeId,
+    incumbent,
+    candidate,
+    timer: setTimeout(() => {
+      if (!pendingAttachProbe || pendingAttachProbe.probeId !== probeId)
+        return;
+      log(`Claude attach probe timed out (#${incumbent.data.clientId}); accepting candidate #${candidate.data.clientId}`);
+      pendingAttachProbe = null;
+      replaceAttachedClaude(candidate, `attach probe timed out after ${CLAUDE_ATTACH_PROBE_MS}ms`);
+    }, CLAUDE_ATTACH_PROBE_MS)
+  };
+  log(`Probing attached Claude frontend #${incumbent.data.clientId} before accepting candidate #${candidate.data.clientId}`);
+  if (!trySendProtocolMessage(incumbent, { type: "session_probe", probeId })) {
+    clearTimeout(pendingAttachProbe.timer);
+    pendingAttachProbe = null;
+    replaceAttachedClaude(candidate, "attach probe send failed");
+  }
+}
+function handleAttachProbeAck(ws, probeId) {
+  if (!pendingAttachProbe || pendingAttachProbe.probeId !== probeId)
+    return;
+  if (pendingAttachProbe.incumbent !== ws) {
+    log(`Ignoring attach probe ack from non-incumbent frontend #${ws.data.clientId}`);
+    return;
+  }
+  const candidate = pendingAttachProbe.candidate;
+  clearTimeout(pendingAttachProbe.timer);
+  pendingAttachProbe = null;
+  log(`Attached Claude frontend #${ws.data.clientId} responded to probe; rejecting candidate #${candidate.data.clientId}`);
+  if (candidate.readyState === WebSocket.OPEN) {
+    candidate.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+  }
+}
+function replaceAttachedClaude(candidate, reason) {
+  if (candidate.readyState !== WebSocket.OPEN) {
+    log(`Skipping Claude frontend replacement; candidate #${candidate.data.clientId} is not open (readyState=${candidate.readyState}, reason=${reason})`);
+    return;
+  }
+  const incumbent = attachedClaude;
+  if (incumbent && incumbent !== candidate) {
+    log(`Replacing Claude frontend #${incumbent.data.clientId} with #${candidate.data.clientId} (${reason})`);
+    incumbent.data.attached = false;
+    try {
+      incumbent.close(CLOSE_CODE_REPLACED, "replaced by a newer Claude session");
+    } catch {}
+  }
+  attachedClaude = null;
+  acceptClaude(candidate);
+}
+function cancelPendingAttachProbeFor(ws, reason) {
+  if (!pendingAttachProbe)
+    return;
+  if (pendingAttachProbe.incumbent !== ws && pendingAttachProbe.candidate !== ws)
+    return;
+  const candidate = pendingAttachProbe.candidate;
+  const incumbent = pendingAttachProbe.incumbent;
+  clearTimeout(pendingAttachProbe.timer);
+  pendingAttachProbe = null;
+  log(`Cancelled Claude attach probe involving frontend #${ws.data.clientId} (${reason})`);
+  if (incumbent === ws && candidate !== ws && candidate.readyState === WebSocket.OPEN) {
+    replaceAttachedClaude(candidate, `incumbent closed during attach probe: ${reason}`);
   }
 }
 function detachClaude(ws, reason) {
@@ -2028,10 +2120,19 @@ function broadcastStatus() {
   sendStatus(attachedClaude);
 }
 function sendProtocolMessage(ws, message) {
+  trySendProtocolMessage(ws, message);
+}
+function trySendProtocolMessage(ws, message) {
   try {
-    ws.send(JSON.stringify(message));
+    const result = ws.send(JSON.stringify(message));
+    if (typeof result === "number" && result <= 0) {
+      log(`Control message send returned ${result} (0=dropped, -1=backpressure)`);
+      return false;
+    }
+    return true;
   } catch (err) {
     log(`Failed to send control message: ${err.message}`);
+    return false;
   }
 }
 function currentStatus() {

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -13,12 +13,14 @@ export interface DaemonStatus {
 export type ControlClientMessage =
   | { type: "claude_connect" }
   | { type: "claude_disconnect" }
+  | { type: "session_probe_ack"; probeId: string }
   | { type: "claude_to_codex"; requestId: string; message: BridgeMessage; requireReply?: boolean }
   | { type: "status" };
 
 export type ControlServerMessage =
   | { type: "codex_to_claude"; message: BridgeMessage }
   | { type: "claude_to_codex_result"; requestId: string; success: boolean; error?: string }
+  | { type: "session_probe"; probeId: string }
   | { type: "status"; status: DaemonStatus };
 
 /** WebSocket close code sent by the daemon when a newer Claude session replaces the current one. */

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -138,6 +138,9 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
         case "status":
           this.emit("status", message.status);
           return;
+        case "session_probe":
+          this.send({ type: "session_probe_ack", probeId: message.probeId });
+          return;
       }
     };
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -23,6 +23,13 @@ interface ControlSocketData {
   attached: boolean;
 }
 
+interface PendingAttachProbe {
+  probeId: string;
+  incumbent: ServerWebSocket<ControlSocketData>;
+  candidate: ServerWebSocket<ControlSocketData>;
+  timer: ReturnType<typeof setTimeout>;
+}
+
 const stateDir = new StateDirResolver();
 stateDir.ensure();
 const configService = new ConfigService();
@@ -33,6 +40,7 @@ const CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.
 const CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 const TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 const CLAUDE_DISCONNECT_GRACE_MS = 5_000;
+const CLAUDE_ATTACH_PROBE_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_ATTACH_PROBE_MS ?? "1500", 10);
 const MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 const FILTER_MODE: FilterMode =
   (process.env.AGENTBRIDGE_FILTER_MODE as FilterMode) === "full" ? "full" : "filtered";
@@ -59,6 +67,8 @@ let claudeDisconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let claudeOnlineNoticeSent = false;
 let claudeOfflineNoticeShown = false;
 let lastAttachStatusSentTs = 0;
+let pendingAttachProbe: PendingAttachProbe | null = null;
+let nextAttachProbeId = 0;
 const ATTACH_STATUS_COOLDOWN_MS = 30_000; // Don't re-send status on rapid reattach
 
 const bufferedMessages: BridgeMessage[] = [];
@@ -246,6 +256,7 @@ function startControlServer() {
       },
       close: (ws: ServerWebSocket<ControlSocketData>, code: number, reason: string) => {
         log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
+        cancelPendingAttachProbeFor(ws, "frontend socket closed");
         if (attachedClaude === ws) {
           detachClaude(ws, "frontend socket closed");
         }
@@ -272,7 +283,11 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
       attachClaude(ws);
       return;
     case "claude_disconnect":
+      cancelPendingAttachProbeFor(ws, "frontend requested disconnect");
       detachClaude(ws, "frontend requested disconnect");
+      return;
+    case "session_probe_ack":
+      handleAttachProbeAck(ws, message.probeId);
       return;
     case "status":
       sendStatus(ws);
@@ -334,15 +349,19 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
 
 function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
   if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
-    // Reject the new connection — don't disrupt the existing active session.
-    // Check !== CLOSED (not === OPEN) so that CLOSING state is also treated as
-    // "slot occupied", preventing a race where a new session slips in before
-    // the old one finishes its close handshake.
-    log(`Rejecting Claude frontend #${ws.data.clientId} — another session (#${attachedClaude.data.clientId}) is already attached (readyState=${attachedClaude.readyState})`);
-    ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+    if (attachedClaude.readyState === WebSocket.OPEN) {
+      probeAttachedClaude(ws);
+      return;
+    }
+
+    replaceAttachedClaude(ws, `previous attached socket state=${attachedClaude.readyState}`);
     return;
   }
 
+  acceptClaude(ws);
+}
+
+function acceptClaude(ws: ServerWebSocket<ControlSocketData>) {
   clearPendingClaudeDisconnect("Claude frontend attached");
   attachedClaude = ws;
   ws.data.attached = true;
@@ -370,6 +389,94 @@ function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
 
   if (tuiConnectionState.canReply() && shouldNotifyCodexClaudeOnline()) {
     notifyCodexClaudeOnline();
+  }
+}
+
+function probeAttachedClaude(candidate: ServerWebSocket<ControlSocketData>) {
+  const incumbent = attachedClaude;
+  if (!incumbent || incumbent === candidate) {
+    acceptClaude(candidate);
+    return;
+  }
+
+  if (pendingAttachProbe) {
+    if (pendingAttachProbe.candidate !== candidate && pendingAttachProbe.candidate.readyState === WebSocket.OPEN) {
+      pendingAttachProbe.candidate.close(CLOSE_CODE_REPLACED, "superseded by a newer Claude attach attempt");
+    }
+    clearTimeout(pendingAttachProbe.timer);
+    pendingAttachProbe = null;
+  }
+
+  const probeId = `attach_probe_${++nextAttachProbeId}_${Date.now()}`;
+  pendingAttachProbe = {
+    probeId,
+    incumbent,
+    candidate,
+    timer: setTimeout(() => {
+      if (!pendingAttachProbe || pendingAttachProbe.probeId !== probeId) return;
+      log(`Claude attach probe timed out (#${incumbent.data.clientId}); accepting candidate #${candidate.data.clientId}`);
+      pendingAttachProbe = null;
+      replaceAttachedClaude(candidate, `attach probe timed out after ${CLAUDE_ATTACH_PROBE_MS}ms`);
+    }, CLAUDE_ATTACH_PROBE_MS),
+  };
+
+  log(`Probing attached Claude frontend #${incumbent.data.clientId} before accepting candidate #${candidate.data.clientId}`);
+  if (!trySendProtocolMessage(incumbent, { type: "session_probe", probeId })) {
+    clearTimeout(pendingAttachProbe.timer);
+    pendingAttachProbe = null;
+    replaceAttachedClaude(candidate, "attach probe send failed");
+  }
+}
+
+function handleAttachProbeAck(ws: ServerWebSocket<ControlSocketData>, probeId: string) {
+  if (!pendingAttachProbe || pendingAttachProbe.probeId !== probeId) return;
+
+  if (pendingAttachProbe.incumbent !== ws) {
+    log(`Ignoring attach probe ack from non-incumbent frontend #${ws.data.clientId}`);
+    return;
+  }
+
+  const candidate = pendingAttachProbe.candidate;
+  clearTimeout(pendingAttachProbe.timer);
+  pendingAttachProbe = null;
+
+  log(`Attached Claude frontend #${ws.data.clientId} responded to probe; rejecting candidate #${candidate.data.clientId}`);
+  if (candidate.readyState === WebSocket.OPEN) {
+    candidate.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+  }
+}
+
+function replaceAttachedClaude(candidate: ServerWebSocket<ControlSocketData>, reason: string) {
+  if (candidate.readyState !== WebSocket.OPEN) {
+    log(`Skipping Claude frontend replacement; candidate #${candidate.data.clientId} is not open (readyState=${candidate.readyState}, reason=${reason})`);
+    return;
+  }
+
+  const incumbent = attachedClaude;
+  if (incumbent && incumbent !== candidate) {
+    log(`Replacing Claude frontend #${incumbent.data.clientId} with #${candidate.data.clientId} (${reason})`);
+    incumbent.data.attached = false;
+    try {
+      incumbent.close(CLOSE_CODE_REPLACED, "replaced by a newer Claude session");
+    } catch {}
+  }
+
+  attachedClaude = null;
+  acceptClaude(candidate);
+}
+
+function cancelPendingAttachProbeFor(ws: ServerWebSocket<ControlSocketData>, reason: string) {
+  if (!pendingAttachProbe) return;
+  if (pendingAttachProbe.incumbent !== ws && pendingAttachProbe.candidate !== ws) return;
+
+  const candidate = pendingAttachProbe.candidate;
+  const incumbent = pendingAttachProbe.incumbent;
+  clearTimeout(pendingAttachProbe.timer);
+  pendingAttachProbe = null;
+  log(`Cancelled Claude attach probe involving frontend #${ws.data.clientId} (${reason})`);
+
+  if (incumbent === ws && candidate !== ws && candidate.readyState === WebSocket.OPEN) {
+    replaceAttachedClaude(candidate, `incumbent closed during attach probe: ${reason}`);
   }
 }
 
@@ -535,10 +642,20 @@ function broadcastStatus() {
 }
 
 function sendProtocolMessage(ws: ServerWebSocket<ControlSocketData>, message: ControlServerMessage) {
+  trySendProtocolMessage(ws, message);
+}
+
+function trySendProtocolMessage(ws: ServerWebSocket<ControlSocketData>, message: ControlServerMessage): boolean {
   try {
-    ws.send(JSON.stringify(message));
+    const result = ws.send(JSON.stringify(message));
+    if (typeof result === "number" && result <= 0) {
+      log(`Control message send returned ${result} (0=dropped, -1=backpressure)`);
+      return false;
+    }
+    return true;
   } catch (err: any) {
     log(`Failed to send control message: ${err.message}`);
+    return false;
   }
 }
 

--- a/src/unit-test/daemon-client.test.ts
+++ b/src/unit-test/daemon-client.test.ts
@@ -286,4 +286,18 @@ describe("DaemonClient", () => {
     const msg = await received;
     expect(msg.type).toBe("claude_connect");
   });
+
+  test("responds to session_probe with session_probe_ack", async () => {
+    const received = new Promise<any>((resolve) => {
+      onServerMessage = (_ws: any, raw: any) => {
+        resolve(JSON.parse(typeof raw === "string" ? raw : raw.toString()));
+      };
+    });
+
+    await client.connect();
+    sendToClient({ type: "session_probe", probeId: "probe-1" });
+
+    const msg = await received;
+    expect(msg).toEqual({ type: "session_probe_ack", probeId: "probe-1" });
+  });
 });


### PR DESCRIPTION
## Summary
- add a session probe/ack handshake before rejecting a competing Claude attach
- replace the incumbent attached frontend when the probe fails, times out, or the incumbent closes during probing
- update plugin bundles and add DaemonClient probe-ack coverage

## Verification
- bun run typecheck
- bun test src\\unit-test\\daemon-client.test.ts
- bun run verify:plugin-sync

## Notes
Full local un test src was not green because the Windows E2E harness had unrelated environment/port issues: port 14502 remained LISTENING under a missing PID, and CLI E2E paths reported Error: The URL must be of scheme file.