### PR TITLE
fix: clean up stale Codex app-server processes on Windows pre-flight

### DIFF
--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -5,7 +5,7 @@
 import { appendFileSync as appendFileSync2 } from "fs";
 
 // src/codex-adapter.ts
-import { spawn, execSync } from "child_process";
+import { spawn, execFileSync } from "child_process";
 import { createInterface } from "readline";
 import { EventEmitter } from "events";
 import { appendFileSync } from "fs";
@@ -1010,50 +1010,75 @@ class CodexAdapter extends EventEmitter {
   }
   async checkPorts() {
     for (const port of [this.appPort, this.proxyPort]) {
-      try {
-        const pids = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
-        if (!pids)
-          continue;
-        const pidList = pids.split(`
-`).map((p) => p.trim()).filter(Boolean);
-        const staleCodexPids = [];
-        const foreignPids = [];
-        for (const pid of pidList) {
+      const pidList = this.getPortPids(port);
+      if (pidList.length === 0)
+        continue;
+      const staleCodexPids = [];
+      const foreignPids = [];
+      for (const pid of pidList) {
+        try {
+          const cmdline = this.getProcessCommandLine(pid);
+          if (this.isCodexAppServerCommandLine(cmdline)) {
+            staleCodexPids.push(pid);
+          } else {
+            foreignPids.push(pid);
+          }
+        } catch {}
+      }
+      if (staleCodexPids.length > 0) {
+        this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
+        for (const pid of staleCodexPids) {
           try {
-            const cmdline = execSync(`ps -p ${pid} -o args=`, { encoding: "utf-8" }).trim();
-            if (cmdline.includes("codex") && cmdline.includes("app-server")) {
-              staleCodexPids.push(pid);
-            } else {
-              foreignPids.push(pid);
-            }
+            this.killProcess(pid);
           } catch {}
         }
-        if (staleCodexPids.length > 0) {
-          this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
-          for (const pid of staleCodexPids) {
-            try {
-              execSync(`kill ${pid}`, { encoding: "utf-8" });
-            } catch {}
-          }
-          await new Promise((r) => setTimeout(r, 500));
-        }
-        if (foreignPids.length > 0) {
-          throw new Error(`Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
-        }
-        try {
-          const remaining = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
-          if (remaining) {
-            throw new Error(`Port ${port} is still occupied (PID(s): ${remaining.replace(/\n/g, ", ")}) after cleanup. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
-          }
-        } catch (err) {
-          if (err.message?.includes("Port"))
-            throw err;
-        }
-      } catch (err) {
-        if (err.message?.includes("Port") || err.message?.includes("non-Codex"))
-          throw err;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      if (foreignPids.length > 0) {
+        throw new Error(`Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
+      }
+      const remaining = this.getPortPids(port);
+      if (remaining.length > 0) {
+        throw new Error(`Port ${port} is still occupied (PID(s): ${remaining.join(", ")}) after cleanup. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
       }
     }
+  }
+  getPortPids(port) {
+    try {
+      const output = process.platform === "win32" ? execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique`
+      ], { encoding: "utf-8" }) : execFileSync("lsof", ["-ti", `:${port}`], { encoding: "utf-8" });
+      return output.split(/\r?\n/).map((pid) => pid.trim()).filter((pid, index, all) => pid.length > 0 && all.indexOf(pid) === index);
+    } catch {
+      return [];
+    }
+  }
+  getProcessCommandLine(pid) {
+    if (process.platform === "win32") {
+      return execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction SilentlyContinue; if ($p -and $p.CommandLine) { $p.CommandLine }`
+      ], { encoding: "utf-8" }).trim();
+    }
+    return execFileSync("ps", ["-p", pid, "-o", "args="], { encoding: "utf-8" }).trim();
+  }
+  killProcess(pid) {
+    if (process.platform === "win32") {
+      execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `Stop-Process -Id ${pid} -Force -ErrorAction Stop`
+      ], { encoding: "utf-8" });
+      return;
+    }
+    execFileSync("kill", [pid], { encoding: "utf-8" });
+  }
+  isCodexAppServerCommandLine(cmdline) {
+    const normalized = cmdline.toLowerCase();
+    return normalized.includes("codex") && normalized.includes("app-server");
   }
   log(msg) {
     const line = `[${new Date().toISOString()}] [CodexAdapter] ${msg}
@@ -1267,7 +1292,7 @@ class TuiConnectionState {
 }
 
 // src/daemon-lifecycle.ts
-import { spawn as spawn2, execFileSync } from "child_process";
+import { spawn as spawn2, execFileSync as execFileSync2 } from "child_process";
 import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
@@ -1506,7 +1531,7 @@ class DaemonLifecycle {
   }
   isDaemonProcess(pid) {
     try {
-      const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
+      const cmd = execFileSync2("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
       return cmd.includes("daemon") && (cmd.includes("agentbridge") || cmd.includes("agent_bridge"));
     } catch {
       return false;

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -9,7 +9,7 @@
  * disconnect), because TUI rapidly reconnects between bootstrap phases.
  */
 
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, execFileSync, type ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
 import { EventEmitter } from "node:events";
 import { appendFileSync } from "node:fs";
@@ -1179,63 +1179,101 @@ export class CodexAdapter extends EventEmitter {
    */
   private async checkPorts() {
     for (const port of [this.appPort, this.proxyPort]) {
-      try {
-        const pids = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
-        if (!pids) continue;
+      const pidList = this.getPortPids(port);
+      if (pidList.length === 0) continue;
 
-        // Check if the occupying process is a codex app-server (our own stale spawn)
-        const pidList = pids.split("\n").map((p) => p.trim()).filter(Boolean);
-        const staleCodexPids: string[] = [];
-        const foreignPids: string[] = [];
+      // Check if the occupying process is a codex app-server (our own stale spawn)
+      const staleCodexPids: string[] = [];
+      const foreignPids: string[] = [];
 
-        for (const pid of pidList) {
-          try {
-            const cmdline = execSync(`ps -p ${pid} -o args=`, { encoding: "utf-8" }).trim();
-            if (cmdline.includes("codex") && cmdline.includes("app-server")) {
-              staleCodexPids.push(pid);
-            } else {
-              foreignPids.push(pid);
-            }
-          } catch {
-            // Process already gone
-          }
-        }
-
-        // Kill stale codex app-server processes (our own previous spawns)
-        if (staleCodexPids.length > 0) {
-          this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
-          for (const pid of staleCodexPids) {
-            try { execSync(`kill ${pid}`, { encoding: "utf-8" }); } catch {}
-          }
-          await new Promise((r) => setTimeout(r, 500));
-        }
-
-        // If foreign processes still occupy the port, fail with a clear message
-        if (foreignPids.length > 0) {
-          throw new Error(
-            `Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` +
-            `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
-          );
-        }
-
-        // Verify port is now free
+      for (const pid of pidList) {
         try {
-          const remaining = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
-          if (remaining) {
-            throw new Error(
-              `Port ${port} is still occupied (PID(s): ${remaining.replace(/\n/g, ", ")}) after cleanup. ` +
-              `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
-            );
+          const cmdline = this.getProcessCommandLine(pid);
+          if (this.isCodexAppServerCommandLine(cmdline)) {
+            staleCodexPids.push(pid);
+          } else {
+            foreignPids.push(pid);
           }
-        } catch (err: any) {
-          if (err.message?.includes("Port")) throw err;
-          // lsof exit 1 = port free, good
+        } catch {
+          // Process already gone
         }
-      } catch (err: any) {
-        // lsof returns exit code 1 if no match — port is free
-        if (err.message?.includes("Port") || err.message?.includes("non-Codex")) throw err;
+      }
+
+      // Kill stale codex app-server processes (our own previous spawns)
+      if (staleCodexPids.length > 0) {
+        this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
+        for (const pid of staleCodexPids) {
+          try { this.killProcess(pid); } catch {}
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+
+      // If foreign processes still occupy the port, fail with a clear message
+      if (foreignPids.length > 0) {
+        throw new Error(
+          `Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` +
+          `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
+        );
+      }
+
+      // Verify port is now free
+      const remaining = this.getPortPids(port);
+      if (remaining.length > 0) {
+        throw new Error(
+          `Port ${port} is still occupied (PID(s): ${remaining.join(", ")}) after cleanup. ` +
+          `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
+        );
       }
     }
+  }
+
+  private getPortPids(port: number): string[] {
+    try {
+      const output = process.platform === "win32"
+        ? execFileSync("powershell.exe", [
+          "-NoProfile",
+          "-Command",
+          `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique`,
+        ], { encoding: "utf-8" })
+        : execFileSync("lsof", ["-ti", `:${port}`], { encoding: "utf-8" });
+
+      return output
+        .split(/\r?\n/)
+        .map((pid) => pid.trim())
+        .filter((pid, index, all) => pid.length > 0 && all.indexOf(pid) === index);
+    } catch {
+      return [];
+    }
+  }
+
+  private getProcessCommandLine(pid: string): string {
+    if (process.platform === "win32") {
+      return execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction SilentlyContinue; if ($p -and $p.CommandLine) { $p.CommandLine }`,
+      ], { encoding: "utf-8" }).trim();
+    }
+
+    return execFileSync("ps", ["-p", pid, "-o", "args="], { encoding: "utf-8" }).trim();
+  }
+
+  private killProcess(pid: string) {
+    if (process.platform === "win32") {
+      execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `Stop-Process -Id ${pid} -Force -ErrorAction Stop`,
+      ], { encoding: "utf-8" });
+      return;
+    }
+
+    execFileSync("kill", [pid], { encoding: "utf-8" });
+  }
+
+  private isCodexAppServerCommandLine(cmdline: string): boolean {
+    const normalized = cmdline.toLowerCase();
+    return normalized.includes("codex") && normalized.includes("app-server");
   }
 
   private log(msg: string) {

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -1056,3 +1056,36 @@ describe("CodexAdapter initialize reconnect", () => {
     expect(adapter.injectMessage("hello")).toBe(false);
   });
 });
+
+describe("CodexAdapter stale app-server cleanup", () => {
+  test("kills stale codex app-server process occupying the app port", async () => {
+    const adapter = createAdapter();
+    const killed: string[] = [];
+    let appPortChecks = 0;
+
+    adapter.getPortPids = (port: number) => {
+      if (port !== 4510) return [];
+      appPortChecks += 1;
+      return appPortChecks === 1 ? ["1234"] : [];
+    };
+    adapter.getProcessCommandLine = () =>
+      "C:\\Program Files\\nodejs\\codex.exe app-server --listen ws://127.0.0.1:4510";
+    adapter.killProcess = (pid: string) => killed.push(pid);
+
+    await adapter.checkPorts();
+
+    expect(killed).toEqual(["1234"]);
+  });
+
+  test("fails without killing when port is owned by a non-Codex process", async () => {
+    const adapter = createAdapter();
+    const killed: string[] = [];
+
+    adapter.getPortPids = (port: number) => port === 4510 ? ["9876"] : [];
+    adapter.getProcessCommandLine = () => "node unrelated-server.js";
+    adapter.killProcess = (pid: string) => killed.push(pid);
+
+    await expect(adapter.checkPorts()).rejects.toThrow("non-Codex process");
+    expect(killed).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

When the AgentBridge daemon is hard-killed (e.g. `Stop-Process`, `taskkill`, IDE-driven plugin reload), its spawned `codex.exe` child does **not** die with it on Windows. The orphan keeps holding port 4500, so the next daemon startup spawns a fresh `codex.exe` that exits with `os error 10048` (port in use) — surfaced to the user as the recurring "PARTIAL state, codex exit code 66" failure that requires a manual `agentbridge kill` every time.

The existing pre-flight cleanup in `CodexAdapter.start()` was Unix-only (`lsof` / `ps` / `kill`), so on Windows the occupied-port check fell through silently and the spawn proceeded into the `EADDRINUSE` failure.

## Changes

- **`src/codex-adapter.ts`** — replace Unix-only helpers with platform-aware implementations:
  - `getPortPids(port)` — Windows: `Get-NetTCPConnection -LocalPort -State Listen` / Unix: `lsof -ti :PORT`
  - `getProcessCommandLine(pid)` — Windows: `Get-CimInstance Win32_Process` / Unix: `ps -p PID -o args=`
  - `killProcess(pid)` — Windows: `Stop-Process -Force` / Unix: `kill PID`
  - `isCodexAppServerCommandLine(cmdline)` — single source of truth for matching
- **Foreign port owners still fail explicitly** with `Port X is already in use by non-Codex process(es)…` — we never silently kill processes we didn't spawn.
- **`src/unit-test/codex-adapter.test.ts`** — added coverage for the stale-Codex cleanup path and the foreign-process refusal path.
- **`plugins/agentbridge/server/daemon.js`** — rebuilt bundle.

## Caveat

This is **recovery-on-next-startup**, not a Job Object kill-on-daemon-death guarantee. Graceful daemon shutdown already calls `codex.stop()` unchanged. A Win32 Job Object (with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) would be cleaner — OS would kill children at the moment of daemon death — but is a much larger surgery. This patch gets ~90% of the value with ~10% of the risk and unblocks the chronic friction immediately.

## Relation to #75

Independent. #75 fixes **stale Claude attach ownership** at the WebSocket / control-protocol layer (probe + ack). This fixes **stale Codex app-server process ownership** at the OS / port layer. Both can ship independently and address different failure modes that look similar from the outside.

## Verification

- `bun run typecheck` OK
- `bun test src/unit-test/codex-adapter.test.ts` → 44 pass
- `bun run build:plugin` OK
- `bun run verify:plugin-sync` OK
- Reproduced locally on Windows 11 / Bun on company PC — the orphan-codex-on-4500 failure mode hits without this patch on every daemon hard-restart, and is resolved with this patch.

## Test plan

- [ ] Maintainer-side smoke test: hard-kill daemon while codex TUI attached, verify next `agentbridge` startup recovers cleanly without manual `agentbridge kill`.
- [ ] Confirm foreign-process refusal still triggers when port is held by an unrelated PID (e.g. `python -m http.server 4500`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)