### PR TITLE
feat: Phase B + C realtime path (wait_for_messages MCP tool + UserPromptSubmit injection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ When Claude Code closes, the foreground MCP process exits while the background d
 
 | Direction | Path |
 |-----------|------|
-| **Codex -> Claude** | `daemon.ts` captures `agentMessage` -> control WS -> `bridge.ts` -> `notifications/claude/channel` |
+| **Codex -> Claude** | `daemon.ts` captures `agentMessage` -> control WS -> `bridge.ts` -> configured push notification method plus/or persisted pull queue |
 | **Claude -> Codex** | Claude calls the `reply` tool -> `bridge.ts` -> control WS -> `daemon.ts` -> `turn/start` injects into the Codex thread |
 
 ### Loop prevention
@@ -241,6 +241,7 @@ agent_bridge/
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | Control port between bridge.ts and daemon.ts |
 | `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs, persisted pull queue, and audit transcript (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
 | `AGENTBRIDGE_MODE` | `auto` (resolves to `pull`) | Message delivery mode (`push` for channels, `pull` for queue-only delivery, `dual` for channel push plus persisted pull queue) |
+| `AGENTBRIDGE_PUSH_METHOD` | `claude/channel` | Debug push notification method. Use `standard` to send MCP `notifications/message` instead of custom `notifications/claude/channel`. |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |
 
 ### State Directory

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ agent_bridge/
 | `CODEX_WS_PORT` | `4500` | Codex app-server WebSocket port |
 | `CODEX_PROXY_PORT` | `4501` | Bridge proxy port for the Codex TUI |
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | Control port between bridge.ts and daemon.ts |
-| `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
-| `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
+| `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs, persisted pull queue, and audit transcript (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
+| `AGENTBRIDGE_MODE` | `auto` (resolves to `pull`) | Message delivery mode (`push` for channels, `pull` for queue-only delivery, `dual` for channel push plus persisted pull queue) |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |
 
 ### State Directory
@@ -252,7 +252,7 @@ The daemon stores runtime state in a platform-aware directory:
 | macOS | `~/Library/Application Support/agentbridge/` |
 | Linux | `$XDG_STATE_HOME/agentbridge/` (fallback: `~/.local/state/agentbridge/`) |
 
-Contents: `daemon.pid`, `status.json`, `agentbridge.log`, `killed` (sentinel), `startup.lock`
+Contents: `daemon.pid`, `status.json`, `agentbridge.log`, `queue.db`, `transcript.jsonl`, `killed` (sentinel), `startup.lock`
 
 ## Current Limitations
 

--- a/plugins/agentbridge/hooks/hooks.json
+++ b/plugins/agentbridge/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Hint-only health checks for AgentBridge startup. These hooks never orchestrate the daemon.",
+  "description": "Hint-only health checks for AgentBridge startup, plus Phase C UserPromptSubmit injection of pending Codex messages.",
   "hooks": {
     "SessionStart": [
       {
@@ -8,6 +8,17 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/health-check.sh\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/inject-pending-codex.sh\""
           }
         ]
       }

--- a/plugins/agentbridge/scripts/health-check.sh
+++ b/plugins/agentbridge/scripts/health-check.sh
@@ -29,6 +29,28 @@ printf '%s' "$now" >"$stamp_file" 2>/dev/null || true
 
 health_json="$(curl -fsS --max-time 1 "http://127.0.0.1:${port}/healthz" 2>/dev/null || true)"
 
+# Phase C: probe pending unacked Codex messages (non-consuming).
+# Hook should never fail because the peek can't run, so all errors are swallowed.
+pending_suffix=""
+plugin_root="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$(realpath "$0")")")}"
+peek_script="${plugin_root}/scripts/peek_codex_queue.py"
+python_bin="${AGENTBRIDGE_PYTHON:-}"
+if [ -z "$python_bin" ]; then
+  if [ -x "/c/Users/tomin/AppData/Local/Programs/Python/Python312/python.exe" ]; then
+    python_bin="/c/Users/tomin/AppData/Local/Programs/Python/Python312/python.exe"
+  elif command -v python3 >/dev/null 2>&1; then
+    python_bin="python3"
+  elif command -v python >/dev/null 2>&1; then
+    python_bin="python"
+  fi
+fi
+if [ -n "$python_bin" ] && [ -f "$peek_script" ]; then
+  pending_count="$("$python_bin" -X utf8 "$peek_script" --format=count 2>/dev/null || echo 0)"
+  if [ -n "$pending_count" ] && [ "$pending_count" != "0" ]; then
+    pending_suffix=" ${pending_count} unread Codex message(s) pending — they will be injected on your next prompt."
+  fi
+fi
+
 if [ -n "$health_json" ]; then
   tui_connected="false"
   if printf '%s' "$health_json" | grep -q '"tuiConnected":true'; then
@@ -37,11 +59,11 @@ if [ -n "$health_json" ]; then
 
   if [ "$tui_connected" = "true" ]; then
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge is running. Daemon healthy, Codex TUI connected. Bridge is ready for communication."}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge is running. Daemon healthy, Codex TUI connected. Bridge is ready for communication.${pending_suffix}"}}
 EOF
   else
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex"}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex${pending_suffix}"}}
 EOF
   fi
 else

--- a/plugins/agentbridge/scripts/inject-pending-codex.sh
+++ b/plugins/agentbridge/scripts/inject-pending-codex.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Phase C: UserPromptSubmit hook.
+# Injects unacked + undrained Codex messages from the AgentBridge queue
+# into Claude's context as a system-reminder additionalContext block.
+# Non-consuming — ack happens inside the reply tool, drain happens via
+# get_messages / wait_for_messages MCP tools.
+
+set -uo pipefail
+
+# Drain stdin (Claude Code sends a JSON event on stdin to hooks).
+INPUT="$(cat 2>/dev/null || true)"
+unset INPUT  # not used yet; reserved for future filtering
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$(realpath "$0")")")}"
+PEEK_SCRIPT="${PLUGIN_ROOT}/scripts/peek_codex_queue.py"
+
+# Discover Python. Tony's box: explicit Python 3.12 path. Fallback to PATH.
+PYTHON="${AGENTBRIDGE_PYTHON:-}"
+if [ -z "${PYTHON}" ]; then
+  if [ -x "/c/Users/tomin/AppData/Local/Programs/Python/Python312/python.exe" ]; then
+    PYTHON="/c/Users/tomin/AppData/Local/Programs/Python/Python312/python.exe"
+  elif command -v python3 >/dev/null 2>&1; then
+    PYTHON="python3"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON="python"
+  else
+    exit 0  # No Python — silently no-op so hook never blocks user prompts.
+  fi
+fi
+
+if [ ! -f "${PEEK_SCRIPT}" ]; then
+  exit 0
+fi
+
+OUTPUT="$("${PYTHON}" -X utf8 "${PEEK_SCRIPT}" --format=hook --event=UserPromptSubmit 2>/dev/null)"
+if [ -z "${OUTPUT}" ]; then
+  exit 0  # No pending messages → no-op.
+fi
+
+printf '%s\n' "${OUTPUT}"

--- a/plugins/agentbridge/scripts/peek_codex_queue.py
+++ b/plugins/agentbridge/scripts/peek_codex_queue.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Read-only peek into the AgentBridge SQLite message queue.
+
+Used by Claude Code hooks (UserPromptSubmit / SessionStart) to surface
+pending Codex messages as system-reminder additionalContext without
+consuming them from the queue.
+
+Phase C semantics:
+- Returns messages where drained_at IS NULL AND acked_at IS NULL.
+- Does NOT mutate state. Ack happens inside bridge-server.js when the
+  Claude reply tool is called.
+
+Output modes:
+  --format=count     emit the integer count (single line)
+  --format=hook      emit a JSON object suitable for stdin in a hook
+                     (matches Claude Code hookSpecificOutput shape)
+  --format=text      emit human-readable text (debugging)
+  --format=json      emit raw JSON list of message rows (debugging)
+
+Exit codes:
+  0  success
+  2  queue.db missing (daemon never ran on this machine)
+  3  query error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def state_dir() -> Path:
+    """Mirror the StateDirResolver logic from src/state-dir.ts."""
+    override = os.environ.get("AGENTBRIDGE_STATE_DIR")
+    if override:
+        return Path(override)
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "AgentBridge"
+    xdg = os.environ.get("XDG_STATE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "state"
+    return base / "agentbridge"
+
+
+def queue_db_path() -> Path:
+    return state_dir() / "queue.db"
+
+
+def fetch_pending(db: Path, limit: int) -> list[dict[str, Any]]:
+    if not db.is_file():
+        return []
+    # Read-only URI so multiple concurrent readers (hooks + daemon) are safe.
+    uri = f"file:{db.as_posix()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=2.0)
+    try:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute(
+            """
+            SELECT
+              seq,
+              message_id,
+              chat_id,
+              source,
+              content,
+              timestamp,
+              marker,
+              created_at
+            FROM messages
+            WHERE drained_at IS NULL AND acked_at IS NULL
+            ORDER BY seq ASC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+        return [dict(r) for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def format_for_hook(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build the system-reminder additionalContext payload."""
+    if not rows:
+        return {}
+    header = (
+        f"AgentBridge: {len(rows)} unread Codex message(s) pending in the queue. "
+        "Content is included below for context. To clear them, either call "
+        "the reply tool (which auto-acks) or call get_messages (which drains)."
+    )
+    blocks = [header, ""]
+    for r in rows:
+        marker = r.get("marker") or "untagged"
+        chat_id = r.get("chat_id") or "?"
+        msg_id = r.get("message_id") or "?"
+        ts = r.get("timestamp") or 0
+        content = r.get("content") or ""
+        blocks.append(
+            f"--- [{marker}] chat_id={chat_id} message_id={msg_id} ts={ts} ---"
+        )
+        blocks.append(content)
+        blocks.append("")
+    additional = "\n".join(blocks).rstrip()
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": additional,
+        }
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--format", choices=["count", "hook", "text", "json"], default="hook")
+    p.add_argument("--limit", type=int, default=20, help="max messages to return")
+    p.add_argument(
+        "--event",
+        default="UserPromptSubmit",
+        help="hook event name to embed in --format=hook output",
+    )
+    args = p.parse_args()
+
+    db = queue_db_path()
+    if not db.is_file():
+        if args.format == "count":
+            print(0)
+            return 0
+        if args.format == "hook":
+            # Empty output → Claude Code treats hook as no-op.
+            return 0
+        print(f"queue.db not found at {db}", file=sys.stderr)
+        return 2
+
+    try:
+        rows = fetch_pending(db, args.limit)
+    except sqlite3.Error as e:
+        print(f"sqlite error: {e}", file=sys.stderr)
+        return 3
+
+    if args.format == "count":
+        print(len(rows))
+        return 0
+
+    if args.format == "hook":
+        if not rows:
+            return 0
+        payload = format_for_hook(rows)
+        # Allow caller to override the event name (SessionStart vs UserPromptSubmit).
+        if "hookSpecificOutput" in payload:
+            payload["hookSpecificOutput"]["hookEventName"] = args.event
+        print(json.dumps(payload, ensure_ascii=False))
+        return 0
+
+    if args.format == "json":
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+        return 0
+
+    # text
+    if not rows:
+        print("(no pending Codex messages)")
+        return 0
+    print(f"{len(rows)} pending Codex message(s):")
+    for r in rows:
+        print(
+            f"  seq={r['seq']} marker={r['marker']} chat={r['chat_id']} "
+            f"msg={r['message_id']} ts={r['timestamp']}"
+        )
+        preview = (r.get("content") or "").strip().replace("\n", " ")
+        if len(preview) > 120:
+            preview = preview[:120] + "..."
+        print(f"    {preview}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13908,8 +13908,9 @@ var CLAUDE_INSTRUCTIONS = [
   "",
   "## How to interact",
   "- Use the reply tool to send messages back to Codex \u2014 pass chat_id back.",
-  "- Use the get_messages tool to check for pending messages from Codex.",
-  "- After sending a reply, call get_messages to check for responses.",
+  "- Use the get_messages tool to check for pending messages from Codex (non-blocking snapshot).",
+  "- Use the wait_for_messages tool to BLOCK until Codex replies (default 60s). Prefer this over auto-poll when you sent reply(require_reply=true) and want a real-time response \u2014 re-call after each timeout to keep listening, stop only when the user signals so or Codex sends \u2705 finished.",
+  "- After sending a reply, call get_messages or wait_for_messages to receive Codex's response.",
   "- When the user asks about Codex status or progress, call get_messages.",
   "",
   "## Turn coordination",
@@ -13928,6 +13929,7 @@ class ClaudeAdapter extends EventEmitter {
   replySender = null;
   logFile;
   queue;
+  pushMethod;
   configuredMode;
   resolvedMode = null;
   pendingMessages = [];
@@ -13945,10 +13947,13 @@ class ClaudeAdapter extends EventEmitter {
     this.log(`ClaudeAdapter created (instance=${this.instanceId})`);
     const envMode = process.env.AGENTBRIDGE_MODE;
     this.configuredMode = envMode && ["push", "pull", "dual", "auto"].includes(envMode) ? envMode : "auto";
+    const envPushMethod = process.env.AGENTBRIDGE_PUSH_METHOD;
+    this.pushMethod = envPushMethod === "standard" ? "standard" : "claude/channel";
     this.maxBufferedMessages = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
     this.server = new Server({ name: "agentbridge", version: "0.1.0" }, {
       capabilities: {
         experimental: { "claude/channel": {} },
+        logging: {},
         tools: {}
       },
       instructions: CLAUDE_INSTRUCTIONS
@@ -13959,7 +13964,9 @@ class ClaudeAdapter extends EventEmitter {
     const transport = new StdioServerTransport;
     this.resolveMode();
     await this.server.connect(transport);
-    this.log(`MCP server connected (mode: ${this.resolvedMode})`);
+    const clientCapabilities = this.server._clientCapabilities;
+    this.log(`MCP server connected (mode: ${this.resolvedMode}, pushMethod: ${this.pushMethod})`);
+    this.log(`MCP client capabilities: ${JSON.stringify(clientCapabilities ?? null)}`);
     this.emit("ready");
   }
   setReplySender(sender) {
@@ -13983,7 +13990,7 @@ class ClaudeAdapter extends EventEmitter {
     }
   }
   async pushNotification(message) {
-    this.log(`pushNotification (instance=${this.instanceId}, mode=${this.resolvedMode}, msgId=${message.id}, len=${message.content.length})`);
+    this.log(`pushNotification (instance=${this.instanceId}, mode=${this.resolvedMode}, pushMethod=${this.pushMethod}, msgId=${message.id}, len=${message.content.length})`);
     if (this.resolvedMode === "dual") {
       const entry = this.queueForPull(message);
       if (this.lastQueueWasDuplicate) {
@@ -14001,20 +14008,7 @@ class ClaudeAdapter extends EventEmitter {
     const msgId = persistedMessageId ?? this.nextNotificationId();
     const ts = new Date(message.timestamp).toISOString();
     try {
-      await this.server.notification({
-        method: "notifications/claude/channel",
-        params: {
-          content: message.content,
-          meta: {
-            chat_id: this.sessionId,
-            message_id: msgId,
-            user: "Codex",
-            user_id: "codex",
-            ts,
-            source_type: "codex"
-          }
-        }
-      });
+      await this.server.notification(this.buildPushNotification(message, msgId, ts));
       this.log(`Pushed notification: ${msgId}`);
       if (persistedMessageId) {
         this.queue.markPushed(persistedMessageId);
@@ -14038,6 +14032,36 @@ class ClaudeAdapter extends EventEmitter {
         this.queueForPull(message);
       }
     }
+  }
+  buildPushNotification(message, msgId, ts) {
+    const meta2 = {
+      chat_id: this.sessionId,
+      message_id: msgId,
+      user: "Codex",
+      user_id: "codex",
+      ts,
+      source_type: "codex"
+    };
+    if (this.pushMethod === "standard") {
+      return {
+        method: "notifications/message",
+        params: {
+          level: "info",
+          logger: "agentbridge",
+          data: {
+            content: message.content,
+            meta: meta2
+          }
+        }
+      };
+    }
+    return {
+      method: "notifications/claude/channel",
+      params: {
+        content: message.content,
+        meta: meta2
+      }
+    };
   }
   queueForPull(message) {
     if (this.queue.countUndrained() >= this.maxBufferedMessages) {
@@ -14156,10 +14180,24 @@ ${formatted}`
         },
         {
           name: "get_messages",
-          description: "Check for new messages from Codex. Call this after sending a reply or when you expect a response from Codex.",
+          description: "Check for new messages from Codex. Returns immediately with a snapshot (may be empty).",
           inputSchema: {
             type: "object",
             properties: {},
+            required: []
+          }
+        },
+        {
+          name: "wait_for_messages",
+          description: "Block until Codex sends a new message, or until timeout (default 60s, max 60s). Use proactively in a listening loop after reply(require_reply=true): wait_for_messages \u2192 process arrival \u2192 reply \u2192 wait_for_messages again. On arrival, drains the queue exactly like get_messages. On timeout, returns a 'timed_out' sentinel \u2014 re-call to keep listening unless the user told you to stop.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              timeout_s: {
+                type: "number",
+                description: "How long to block in seconds (default 60, max 60, min 1)."
+              }
+            },
             required: []
           }
         }
@@ -14173,11 +14211,44 @@ ${formatted}`
       if (name === "get_messages") {
         return this.drainMessages();
       }
+      if (name === "wait_for_messages") {
+        return this.waitForMessages(args);
+      }
       return {
         content: [{ type: "text", text: `Unknown tool: ${name}` }],
         isError: true
       };
     });
+  }
+  async waitForMessages(args) {
+    const requested = Number(args?.timeout_s ?? 60);
+    const timeoutS = Math.min(Math.max(Number.isFinite(requested) ? requested : 60, 1), 60);
+    const deadline = Date.now() + timeoutS * 1000;
+    const pollIntervalMs = 500;
+    this.log(`wait_for_messages start (instance=${this.instanceId}, timeout_s=${timeoutS}, pending=${this.queue.countUndrained()})`);
+    while (Date.now() < deadline) {
+      if (this.queue.countUndrained() > 0) {
+        this.log(`wait_for_messages woke (instance=${this.instanceId}, pending=${this.queue.countUndrained()})`);
+        return this.drainMessages();
+      }
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+    }
+    this.log(`wait_for_messages timed out (instance=${this.instanceId}, timeout_s=${timeoutS})`);
+    this.queue.audit({
+      event: "wait_for_messages_timeout",
+      direction: "internal",
+      sender: "claude",
+      chatId: this.sessionId,
+      deliveryMode: this.getDeliveryMode()
+    });
+    return {
+      content: [
+        {
+          type: "text",
+          text: `[wait_for_messages] timed_out after ${timeoutS}s \u2014 no new Codex messages. Call wait_for_messages again to keep listening, or stop if the user signaled to stop.`
+        }
+      ]
+    };
   }
   async handleReply(args) {
     const text = args?.text;

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13693,15 +13693,21 @@ class PersistentMessageQueue {
         pushed_at INTEGER,
         push_error TEXT,
         drained_at INTEGER,
+        acked_at INTEGER,
         created_at INTEGER NOT NULL
       )
     `);
+    const cols = this.db.query("PRAGMA table_info(messages)").all();
+    if (!cols.some((c) => c.name === "acked_at")) {
+      this.db.exec("ALTER TABLE messages ADD COLUMN acked_at INTEGER");
+    }
     this.db.exec(`
       CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_undrained_dedupe
       ON messages(chat_id, content_hash)
       WHERE drained_at IS NULL
     `);
     this.db.exec("CREATE INDEX IF NOT EXISTS idx_messages_undrained_seq ON messages(drained_at, seq)");
+    this.db.exec("CREATE INDEX IF NOT EXISTS idx_messages_unacked_undrained ON messages(acked_at, drained_at, seq)");
   }
   enqueue(input) {
     const contentHash = hashContent(input.message.content);
@@ -13733,11 +13739,37 @@ class PersistentMessageQueue {
         pushed_at AS pushedAt,
         push_error AS pushError,
         drained_at AS drainedAt,
+        acked_at AS ackedAt,
         created_at AS createdAt
       FROM messages
       WHERE drained_at IS NULL
       ORDER BY seq ASC
     `).all();
+  }
+  listUnackedUndrained() {
+    return this.db.query(`
+      SELECT
+        seq,
+        message_id AS messageId,
+        chat_id AS chatId,
+        source,
+        content,
+        timestamp,
+        marker,
+        content_hash AS contentHash,
+        pushed_at AS pushedAt,
+        push_error AS pushError,
+        drained_at AS drainedAt,
+        acked_at AS ackedAt,
+        created_at AS createdAt
+      FROM messages
+      WHERE drained_at IS NULL AND acked_at IS NULL
+      ORDER BY seq ASC
+    `).all();
+  }
+  countUnackedUndrained() {
+    const row = this.db.query("SELECT COUNT(*) AS count FROM messages WHERE drained_at IS NULL AND acked_at IS NULL").get();
+    return row.count;
   }
   countUndrained() {
     const row = this.db.query("SELECT COUNT(*) AS count FROM messages WHERE drained_at IS NULL").get();
@@ -13759,6 +13791,10 @@ class PersistentMessageQueue {
     });
     transaction(messageIds);
   }
+  ackByChatId(chatId, ackedAt = Date.now()) {
+    const result = this.db.query("UPDATE messages SET acked_at = ? WHERE chat_id = ? AND drained_at IS NULL AND acked_at IS NULL").run(ackedAt, chatId);
+    return Number(result.changes ?? 0);
+  }
   markOldestUndrainedDropped(droppedAt = Date.now()) {
     const entry = this.db.query(`
       SELECT
@@ -13773,6 +13809,7 @@ class PersistentMessageQueue {
         pushed_at AS pushedAt,
         push_error AS pushError,
         drained_at AS drainedAt,
+        acked_at AS ackedAt,
         created_at AS createdAt
       FROM messages
       WHERE drained_at IS NULL
@@ -13808,6 +13845,7 @@ class PersistentMessageQueue {
         pushed_at AS pushedAt,
         push_error AS pushError,
         drained_at AS drainedAt,
+        acked_at AS ackedAt,
         created_at AS createdAt
       FROM messages
       WHERE chat_id = ? AND content_hash = ? AND drained_at IS NULL
@@ -14282,6 +14320,13 @@ ${formatted}`
       };
     }
     this.auditReply("reply_sent", bridgeMsg, requireReply);
+    const replyChatId = args?.chat_id;
+    if (replyChatId) {
+      const ackedCount = this.queue.ackByChatId(replyChatId);
+      if (ackedCount > 0) {
+        this.log(`reply acked ${ackedCount} message(s) on chat ${replyChatId}`);
+      }
+    }
     const pending = this.getPendingMessageCount();
     let responseText = "Reply sent to Codex.";
     if (pending > 0) {

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -6518,7 +6518,7 @@ var require_dist = __commonJS((exports, module) => {
 });
 
 // src/bridge.ts
-import { appendFileSync as appendFileSync2 } from "fs";
+import { appendFileSync as appendFileSync3 } from "fs";
 
 // node_modules/zod/v4/core/core.js
 var NEVER = Object.freeze({
@@ -13662,10 +13662,174 @@ class StdioServerTransport {
 // src/claude-adapter.ts
 import { EventEmitter } from "events";
 import { randomUUID } from "crypto";
-import { appendFileSync } from "fs";
+import { appendFileSync as appendFileSync2 } from "fs";
+import { dirname as dirname2, join as join2 } from "path";
+
+// src/message-queue.ts
+import { Database } from "bun:sqlite";
+import { appendFileSync, mkdirSync } from "fs";
+import { createHash } from "crypto";
+import { dirname } from "path";
+
+class PersistentMessageQueue {
+  db;
+  auditFile;
+  constructor(dbFile, auditFile) {
+    mkdirSync(dirname(dbFile), { recursive: true });
+    this.auditFile = auditFile;
+    this.db = new Database(dbFile);
+    this.db.exec("PRAGMA journal_mode = WAL");
+    this.db.exec("PRAGMA synchronous = NORMAL");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS messages (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        message_id TEXT NOT NULL UNIQUE,
+        chat_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        content TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        marker TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        pushed_at INTEGER,
+        push_error TEXT,
+        drained_at INTEGER,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    this.db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_undrained_dedupe
+      ON messages(chat_id, content_hash)
+      WHERE drained_at IS NULL
+    `);
+    this.db.exec("CREATE INDEX IF NOT EXISTS idx_messages_undrained_seq ON messages(drained_at, seq)");
+  }
+  enqueue(input) {
+    const contentHash = hashContent(input.message.content);
+    const marker = extractMarker(input.message.content);
+    const createdAt = Date.now();
+    const insert = this.db.query(`
+      INSERT OR IGNORE INTO messages (
+        message_id, chat_id, source, content, timestamp, marker, content_hash, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    insert.run(input.messageId, input.chatId, input.message.source, input.message.content, input.message.timestamp, marker, contentHash, createdAt);
+    const entry = this.findUndrainedByChatAndHash(input.chatId, contentHash);
+    if (!entry) {
+      throw new Error("Failed to persist AgentBridge message queue entry.");
+    }
+    return entry;
+  }
+  listUndrained() {
+    return this.db.query(`
+      SELECT
+        seq,
+        message_id AS messageId,
+        chat_id AS chatId,
+        source,
+        content,
+        timestamp,
+        marker,
+        content_hash AS contentHash,
+        pushed_at AS pushedAt,
+        push_error AS pushError,
+        drained_at AS drainedAt,
+        created_at AS createdAt
+      FROM messages
+      WHERE drained_at IS NULL
+      ORDER BY seq ASC
+    `).all();
+  }
+  countUndrained() {
+    const row = this.db.query("SELECT COUNT(*) AS count FROM messages WHERE drained_at IS NULL").get();
+    return row.count;
+  }
+  markPushed(messageId, pushedAt = Date.now()) {
+    this.db.query("UPDATE messages SET pushed_at = ?, push_error = NULL WHERE message_id = ?").run(pushedAt, messageId);
+  }
+  markPushFailed(messageId, error2) {
+    this.db.query("UPDATE messages SET push_error = ? WHERE message_id = ?").run(error2, messageId);
+  }
+  markDrained(messageIds, drainedAt = Date.now()) {
+    if (messageIds.length === 0)
+      return;
+    const update = this.db.query("UPDATE messages SET drained_at = ? WHERE message_id = ? AND drained_at IS NULL");
+    const transaction = this.db.transaction((ids) => {
+      for (const id of ids)
+        update.run(drainedAt, id);
+    });
+    transaction(messageIds);
+  }
+  markOldestUndrainedDropped(droppedAt = Date.now()) {
+    const entry = this.db.query(`
+      SELECT
+        seq,
+        message_id AS messageId,
+        chat_id AS chatId,
+        source,
+        content,
+        timestamp,
+        marker,
+        content_hash AS contentHash,
+        pushed_at AS pushedAt,
+        push_error AS pushError,
+        drained_at AS drainedAt,
+        created_at AS createdAt
+      FROM messages
+      WHERE drained_at IS NULL
+      ORDER BY seq ASC
+      LIMIT 1
+    `).get();
+    if (!entry)
+      return null;
+    this.db.query("UPDATE messages SET drained_at = ? WHERE message_id = ? AND drained_at IS NULL").run(droppedAt, entry.messageId);
+    return entry;
+  }
+  audit(event) {
+    try {
+      mkdirSync(dirname(this.auditFile), { recursive: true });
+      appendFileSync(this.auditFile, JSON.stringify({ ts: Date.now(), ...event }) + `
+`, "utf-8");
+    } catch {}
+  }
+  close() {
+    this.db.close();
+  }
+  findUndrainedByChatAndHash(chatId, contentHash) {
+    return this.db.query(`
+      SELECT
+        seq,
+        message_id AS messageId,
+        chat_id AS chatId,
+        source,
+        content,
+        timestamp,
+        marker,
+        content_hash AS contentHash,
+        pushed_at AS pushedAt,
+        push_error AS pushError,
+        drained_at AS drainedAt,
+        created_at AS createdAt
+      FROM messages
+      WHERE chat_id = ? AND content_hash = ? AND drained_at IS NULL
+      ORDER BY seq ASC
+      LIMIT 1
+    `).get(chatId, contentHash);
+  }
+}
+function hashContent(content) {
+  return createHash("sha256").update(content).digest("hex");
+}
+function extractMarker(content) {
+  const match = content.match(/^\[(IMPORTANT|STATUS|FYI)\]/);
+  return match?.[1] ?? "untagged";
+}
+function previewContent(content, maxLength = 160) {
+  const compact = content.replace(/\s+/g, " ").trim();
+  return compact.length > maxLength ? `${compact.slice(0, maxLength)}...` : compact;
+}
 
 // src/state-dir.ts
-import { mkdirSync, existsSync } from "fs";
+import { mkdirSync as mkdirSync2, existsSync } from "fs";
 import { join } from "path";
 import { homedir, platform } from "os";
 
@@ -13684,7 +13848,7 @@ class StateDirResolver {
   }
   ensure() {
     if (!existsSync(this.stateDir)) {
-      mkdirSync(this.stateDir, { recursive: true });
+      mkdirSync2(this.stateDir, { recursive: true });
     }
   }
   get dir() {
@@ -13707,6 +13871,12 @@ class StateDirResolver {
   }
   get logFile() {
     return join(this.stateDir, "agentbridge.log");
+  }
+  get queueDbFile() {
+    return join(this.stateDir, "queue.db");
+  }
+  get transcriptFile() {
+    return join(this.stateDir, "transcript.jsonl");
   }
   get killedFile() {
     return join(this.stateDir, "killed");
@@ -13757,20 +13927,24 @@ class ClaudeAdapter extends EventEmitter {
   instanceId;
   replySender = null;
   logFile;
+  queue;
   configuredMode;
   resolvedMode = null;
   pendingMessages = [];
   maxBufferedMessages;
   droppedMessageCount = 0;
-  constructor(logFile = new StateDirResolver().logFile) {
+  lastQueueWasDuplicate = false;
+  constructor(logFile = new StateDirResolver().logFile, queue) {
     super();
     this.logFile = logFile;
+    const stateDir = dirname2(logFile);
+    this.queue = queue ?? new PersistentMessageQueue(join2(stateDir, "queue.db"), join2(stateDir, "transcript.jsonl"));
     this.instanceId = randomUUID().slice(0, 8);
     this.sessionId = `codex_${Date.now()}`;
     this.notificationIdPrefix = randomUUID().replace(/-/g, "").slice(0, 12);
     this.log(`ClaudeAdapter created (instance=${this.instanceId})`);
     const envMode = process.env.AGENTBRIDGE_MODE;
-    this.configuredMode = envMode && ["push", "pull", "auto"].includes(envMode) ? envMode : "auto";
+    this.configuredMode = envMode && ["push", "pull", "dual", "auto"].includes(envMode) ? envMode : "auto";
     this.maxBufferedMessages = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
     this.server = new Server({ name: "agentbridge", version: "0.1.0" }, {
       capabilities: {
@@ -13795,12 +13969,12 @@ class ClaudeAdapter extends EventEmitter {
     return this.resolvedMode ?? "pull";
   }
   getPendingMessageCount() {
-    return this.pendingMessages.length;
+    return this.queue.countUndrained();
   }
   resolveMode() {
     if (this.resolvedMode)
       return;
-    if (this.configuredMode === "push" || this.configuredMode === "pull") {
+    if (this.configuredMode === "push" || this.configuredMode === "pull" || this.configuredMode === "dual") {
       this.resolvedMode = this.configuredMode;
       this.log(`Delivery mode set by AGENTBRIDGE_MODE: ${this.resolvedMode}`);
     } else {
@@ -13810,14 +13984,21 @@ class ClaudeAdapter extends EventEmitter {
   }
   async pushNotification(message) {
     this.log(`pushNotification (instance=${this.instanceId}, mode=${this.resolvedMode}, msgId=${message.id}, len=${message.content.length})`);
-    if (this.resolvedMode === "push") {
+    if (this.resolvedMode === "dual") {
+      const entry = this.queueForPull(message);
+      if (this.lastQueueWasDuplicate) {
+        this.log(`Skipping duplicate dual push for message ${entry.messageId}`);
+        return;
+      }
+      await this.pushViaChannel(message, entry.messageId);
+    } else if (this.resolvedMode === "push") {
       await this.pushViaChannel(message);
     } else {
       this.queueForPull(message);
     }
   }
-  async pushViaChannel(message) {
-    const msgId = `codex_msg_${this.notificationIdPrefix}_${++this.notificationSeq}`;
+  async pushViaChannel(message, persistedMessageId) {
+    const msgId = persistedMessageId ?? this.nextNotificationId();
     const ts = new Date(message.timestamp).toISOString();
     try {
       await this.server.notification({
@@ -13835,28 +14016,78 @@ class ClaudeAdapter extends EventEmitter {
         }
       });
       this.log(`Pushed notification: ${msgId}`);
+      if (persistedMessageId) {
+        this.queue.markPushed(persistedMessageId);
+        this.auditMessage("message_pushed", message, {
+          messageId: persistedMessageId,
+          queued: true,
+          pushed: true
+        });
+      }
     } catch (e) {
       this.log(`Push notification failed: ${e.message}`);
-      this.queueForPull(message);
+      if (persistedMessageId) {
+        this.queue.markPushFailed(persistedMessageId, e.message);
+        this.auditMessage("message_push_failed", message, {
+          messageId: persistedMessageId,
+          queued: true,
+          pushed: false,
+          pushError: e.message
+        });
+      } else {
+        this.queueForPull(message);
+      }
     }
   }
   queueForPull(message) {
-    if (this.pendingMessages.length >= this.maxBufferedMessages) {
-      this.pendingMessages.shift();
+    if (this.queue.countUndrained() >= this.maxBufferedMessages) {
+      const dropped = this.queue.markOldestUndrainedDropped();
       this.droppedMessageCount++;
+      if (dropped) {
+        this.queue.audit({
+          event: "message_dropped",
+          direction: "codex_to_claude",
+          sender: "codex",
+          chatId: dropped.chatId,
+          messageId: dropped.messageId,
+          marker: dropped.marker,
+          contentLen: dropped.content.length,
+          contentHash: dropped.contentHash,
+          preview: previewContent(dropped.content),
+          deliveryMode: this.getDeliveryMode(),
+          queued: false,
+          drained: true
+        });
+      }
       this.log(`Message queue full, dropped oldest message (total dropped: ${this.droppedMessageCount})`);
     }
-    this.pendingMessages.push(message);
-    this.log(`Queued message for pull (${this.pendingMessages.length} pending, instance=${this.instanceId})`);
+    const messageId = this.nextNotificationId();
+    const entry = this.queue.enqueue({
+      message,
+      chatId: this.sessionId,
+      messageId
+    });
+    this.lastQueueWasDuplicate = entry.messageId !== messageId;
+    this.pendingMessages = this.entriesToBridgeMessages(this.queue.listUndrained());
+    this.auditMessage("message_queued", message, {
+      messageId: entry.messageId,
+      queued: true,
+      pushed: entry.pushedAt !== null,
+      pushError: entry.pushError
+    });
+    this.log(`Queued message for pull (${this.queue.countUndrained()} pending, instance=${this.instanceId})`);
+    return entry;
   }
   drainMessages() {
-    this.log(`get_messages called (instance=${this.instanceId}, pending=${this.pendingMessages.length}, dropped=${this.droppedMessageCount})`);
-    if (this.pendingMessages.length === 0 && this.droppedMessageCount === 0) {
+    const entries = this.queue.listUndrained();
+    this.pendingMessages = this.entriesToBridgeMessages(entries);
+    this.log(`get_messages called (instance=${this.instanceId}, pending=${entries.length}, dropped=${this.droppedMessageCount})`);
+    if (entries.length === 0 && this.droppedMessageCount === 0) {
       return {
         content: [{ type: "text", text: "No new messages from Codex." }]
       };
     }
-    const messages = this.pendingMessages;
+    const messages = entries;
     this.pendingMessages = [];
     const dropped = this.droppedMessageCount;
     this.droppedMessageCount = 0;
@@ -13871,10 +14102,21 @@ chat_id: ${this.sessionId}`;
       const ts = new Date(msg.timestamp).toISOString();
       return `---
 [${i + 1}] ${ts}
+message_id: ${msg.messageId}
 Codex: ${msg.content}`;
     }).join(`
 
 `);
+    this.queue.markDrained(messages.map((msg) => msg.messageId));
+    this.queue.audit({
+      event: "messages_drained",
+      direction: "codex_to_claude",
+      sender: "claude",
+      chatId: this.sessionId,
+      deliveryMode: this.getDeliveryMode(),
+      count,
+      drained: true
+    });
     this.log(`get_messages returning ${count} message(s) (instance=${this.instanceId}, dropped=${dropped})`);
     return {
       content: [
@@ -13962,12 +14204,14 @@ ${formatted}`
     const result = await this.replySender(bridgeMsg, requireReply);
     if (!result.success) {
       this.log(`Reply delivery failed: ${result.error}`);
+      this.auditReply("reply_failed", bridgeMsg, requireReply, result.error);
       return {
         content: [{ type: "text", text: `Error: ${result.error}` }],
         isError: true
       };
     }
-    const pending = this.pendingMessages.length;
+    this.auditReply("reply_sent", bridgeMsg, requireReply);
+    const pending = this.getPendingMessageCount();
     let responseText = "Reply sent to Codex.";
     if (pending > 0) {
       responseText += ` Note: ${pending} unread Codex message${pending > 1 ? "s" : ""} already waiting \u2014 call get_messages to read them.`;
@@ -13981,8 +14225,54 @@ ${formatted}`
 `;
     process.stderr.write(line);
     try {
-      appendFileSync(this.logFile, line);
+      appendFileSync2(this.logFile, line);
     } catch {}
+  }
+  nextNotificationId() {
+    return `codex_msg_${this.notificationIdPrefix}_${++this.notificationSeq}`;
+  }
+  entriesToBridgeMessages(entries) {
+    return entries.map((entry) => ({
+      id: entry.messageId,
+      source: entry.source,
+      content: entry.content,
+      timestamp: entry.timestamp
+    }));
+  }
+  auditMessage(event, message, opts) {
+    this.queue.audit({
+      event,
+      direction: "codex_to_claude",
+      sender: "codex",
+      chatId: this.sessionId,
+      messageId: opts.messageId,
+      marker: message.content.match(/^\[(IMPORTANT|STATUS|FYI)\]/)?.[1] ?? "untagged",
+      contentLen: message.content.length,
+      contentHash: hashContent(message.content),
+      preview: previewContent(message.content),
+      deliveryMode: this.getDeliveryMode(),
+      queued: opts.queued,
+      pushed: opts.pushed,
+      pushError: opts.pushError
+    });
+  }
+  auditReply(event, message, requireReply, error2) {
+    this.queue.audit({
+      event,
+      direction: "claude_to_codex",
+      sender: "claude",
+      chatId: message.id,
+      messageId: message.id,
+      marker: message.content.match(/^\[(IMPORTANT|STATUS|FYI)\]/)?.[1] ?? "untagged",
+      contentLen: message.content.length,
+      contentHash: hashContent(message.content),
+      preview: previewContent(message.content),
+      deliveryMode: this.getDeliveryMode(),
+      queued: false,
+      pushed: false,
+      requireReply,
+      error: error2 ?? null
+    });
   }
 }
 
@@ -14401,8 +14691,8 @@ function isProcessAlive(pid) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, existsSync as existsSync3 } from "fs";
-import { join as join2 } from "path";
+import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, existsSync as existsSync3 } from "fs";
+import { join as join3 } from "path";
 var DEFAULT_CONFIG = {
   version: "1.0",
   codex: {
@@ -14454,8 +14744,8 @@ class ConfigService {
   configPath;
   constructor(projectRoot) {
     const root = projectRoot ?? process.cwd();
-    this.configDir = join2(root, CONFIG_DIR);
-    this.configPath = join2(this.configDir, CONFIG_FILE);
+    this.configDir = join3(root, CONFIG_DIR);
+    this.configPath = join3(this.configDir, CONFIG_FILE);
   }
   hasConfig() {
     return existsSync3(this.configPath);
@@ -14490,7 +14780,7 @@ class ConfigService {
   }
   ensureConfigDir() {
     if (!existsSync3(this.configDir)) {
-      mkdirSync2(this.configDir, { recursive: true });
+      mkdirSync3(this.configDir, { recursive: true });
     }
   }
 }
@@ -14742,7 +15032,7 @@ function log(msg) {
 `;
   process.stderr.write(line);
   try {
-    appendFileSync2(stateDir.logFile, line);
+    appendFileSync3(stateDir.logFile, line);
   } catch {}
 }
 log(`Starting AgentBridge frontend (daemon ws ${CONTROL_WS_URL})`);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -5,7 +5,7 @@
 import { appendFileSync as appendFileSync2 } from "fs";
 
 // src/codex-adapter.ts
-import { spawn, execSync } from "child_process";
+import { spawn, execFileSync } from "child_process";
 import { createInterface } from "readline";
 import { EventEmitter } from "events";
 import { appendFileSync } from "fs";
@@ -1016,50 +1016,75 @@ class CodexAdapter extends EventEmitter {
   }
   async checkPorts() {
     for (const port of [this.appPort, this.proxyPort]) {
-      try {
-        const pids = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
-        if (!pids)
-          continue;
-        const pidList = pids.split(`
-`).map((p) => p.trim()).filter(Boolean);
-        const staleCodexPids = [];
-        const foreignPids = [];
-        for (const pid of pidList) {
+      const pidList = this.getPortPids(port);
+      if (pidList.length === 0)
+        continue;
+      const staleCodexPids = [];
+      const foreignPids = [];
+      for (const pid of pidList) {
+        try {
+          const cmdline = this.getProcessCommandLine(pid);
+          if (this.isCodexAppServerCommandLine(cmdline)) {
+            staleCodexPids.push(pid);
+          } else {
+            foreignPids.push(pid);
+          }
+        } catch {}
+      }
+      if (staleCodexPids.length > 0) {
+        this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
+        for (const pid of staleCodexPids) {
           try {
-            const cmdline = execSync(`ps -p ${pid} -o args=`, { encoding: "utf-8" }).trim();
-            if (cmdline.includes("codex") && cmdline.includes("app-server")) {
-              staleCodexPids.push(pid);
-            } else {
-              foreignPids.push(pid);
-            }
+            this.killProcess(pid);
           } catch {}
         }
-        if (staleCodexPids.length > 0) {
-          this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
-          for (const pid of staleCodexPids) {
-            try {
-              execSync(`kill ${pid}`, { encoding: "utf-8" });
-            } catch {}
-          }
-          await new Promise((r) => setTimeout(r, 500));
-        }
-        if (foreignPids.length > 0) {
-          throw new Error(`Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
-        }
-        try {
-          const remaining = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
-          if (remaining) {
-            throw new Error(`Port ${port} is still occupied (PID(s): ${remaining.replace(/\n/g, ", ")}) after cleanup. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
-          }
-        } catch (err) {
-          if (err.message?.includes("Port"))
-            throw err;
-        }
-      } catch (err) {
-        if (err.message?.includes("Port") || err.message?.includes("non-Codex"))
-          throw err;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      if (foreignPids.length > 0) {
+        throw new Error(`Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
+      }
+      const remaining = this.getPortPids(port);
+      if (remaining.length > 0) {
+        throw new Error(`Port ${port} is still occupied (PID(s): ${remaining.join(", ")}) after cleanup. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
       }
     }
+  }
+  getPortPids(port) {
+    try {
+      const output = process.platform === "win32" ? execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique`
+      ], { encoding: "utf-8" }) : execFileSync("lsof", ["-ti", `:${port}`], { encoding: "utf-8" });
+      return output.split(/\r?\n/).map((pid) => pid.trim()).filter((pid, index, all) => pid.length > 0 && all.indexOf(pid) === index);
+    } catch {
+      return [];
+    }
+  }
+  getProcessCommandLine(pid) {
+    if (process.platform === "win32") {
+      return execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction SilentlyContinue; if ($p -and $p.CommandLine) { $p.CommandLine }`
+      ], { encoding: "utf-8" }).trim();
+    }
+    return execFileSync("ps", ["-p", pid, "-o", "args="], { encoding: "utf-8" }).trim();
+  }
+  killProcess(pid) {
+    if (process.platform === "win32") {
+      execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `Stop-Process -Id ${pid} -Force -ErrorAction Stop`
+      ], { encoding: "utf-8" });
+      return;
+    }
+    execFileSync("kill", [pid], { encoding: "utf-8" });
+  }
+  isCodexAppServerCommandLine(cmdline) {
+    const normalized = cmdline.toLowerCase();
+    return normalized.includes("codex") && normalized.includes("app-server");
   }
   log(msg) {
     const line = `[${new Date().toISOString()}] [CodexAdapter] ${msg}
@@ -1273,7 +1298,7 @@ class TuiConnectionState {
 }
 
 // src/daemon-lifecycle.ts
-import { spawn as spawn2, execFileSync } from "child_process";
+import { spawn as spawn2, execFileSync as execFileSync2 } from "child_process";
 import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
@@ -1512,7 +1537,7 @@ class DaemonLifecycle {
   }
   isDaemonProcess(pid) {
     try {
-      const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
+      const cmd = execFileSync2("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
       return cmd.includes("daemon") && (cmd.includes("agentbridge") || cmd.includes("agent_bridge"));
     } catch {
       return false;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -54,6 +54,12 @@ class StateDirResolver {
   get logFile() {
     return join(this.stateDir, "agentbridge.log");
   }
+  get queueDbFile() {
+    return join(this.stateDir, "queue.db");
+  }
+  get transcriptFile() {
+    return join(this.stateDir, "transcript.jsonl");
+  }
   get killedFile() {
     return join(this.stateDir, "killed");
   }

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -492,6 +492,18 @@ export class ClaudeAdapter extends EventEmitter {
 
     this.auditReply("reply_sent", bridgeMsg, requireReply);
 
+    // Phase C: ack messages on the chat we just replied to so the
+    // UserPromptSubmit hook stops re-injecting them on later turns.
+    // Skip when chat_id was synthesized (reply_<ts>) \u2014 that's a fresh
+    // conversation, no inbound messages exist on it yet.
+    const replyChatId = args?.chat_id as string | undefined;
+    if (replyChatId) {
+      const ackedCount = this.queue.ackByChatId(replyChatId);
+      if (ackedCount > 0) {
+        this.log(`reply acked ${ackedCount} message(s) on chat ${replyChatId}`);
+      }
+    }
+
     // Include pending message hint
     const pending = this.getPendingMessageCount();
     let responseText = "Reply sent to Codex.";

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -21,11 +21,18 @@ import {
 import { EventEmitter } from "node:events";
 import { randomUUID } from "node:crypto";
 import { appendFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  PersistentMessageQueue,
+  hashContent,
+  previewContent,
+  type QueueEntry,
+} from "./message-queue";
 import { StateDirResolver } from "./state-dir";
 import type { BridgeMessage } from "./types";
 
 export type ReplySender = (msg: BridgeMessage, requireReply?: boolean) => Promise<{ success: boolean; error?: string }>;
-export type DeliveryMode = "push" | "pull" | "auto";
+export type DeliveryMode = "push" | "pull" | "dual" | "auto";
 
 export const CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
@@ -69,24 +76,28 @@ export class ClaudeAdapter extends EventEmitter {
   private readonly instanceId: string;
   private replySender: ReplySender | null = null;
   private readonly logFile: string;
+  private readonly queue: PersistentMessageQueue;
 
   // Dual-mode transport
   private readonly configuredMode: DeliveryMode;
-  private resolvedMode: "push" | "pull" | null = null;
+  private resolvedMode: "push" | "pull" | "dual" | null = null;
   private pendingMessages: BridgeMessage[] = [];
   private readonly maxBufferedMessages: number;
   private droppedMessageCount = 0;
+  private lastQueueWasDuplicate = false;
 
-  constructor(logFile = new StateDirResolver().logFile) {
+  constructor(logFile = new StateDirResolver().logFile, queue?: PersistentMessageQueue) {
     super();
     this.logFile = logFile;
+    const stateDir = dirname(logFile);
+    this.queue = queue ?? new PersistentMessageQueue(join(stateDir, "queue.db"), join(stateDir, "transcript.jsonl"));
     this.instanceId = randomUUID().slice(0, 8);
     this.sessionId = `codex_${Date.now()}`;
     this.notificationIdPrefix = randomUUID().replace(/-/g, "").slice(0, 12);
     this.log(`ClaudeAdapter created (instance=${this.instanceId})`);
 
     const envMode = process.env.AGENTBRIDGE_MODE as DeliveryMode | undefined;
-    this.configuredMode = envMode && ["push", "pull", "auto"].includes(envMode) ? envMode : "auto";
+    this.configuredMode = envMode && ["push", "pull", "dual", "auto"].includes(envMode) ? envMode : "auto";
     this.maxBufferedMessages = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 
     this.server = new Server(
@@ -119,13 +130,13 @@ export class ClaudeAdapter extends EventEmitter {
   }
 
   /** Returns the resolved delivery mode. */
-  getDeliveryMode(): "push" | "pull" {
+  getDeliveryMode(): "push" | "pull" | "dual" {
     return this.resolvedMode ?? "pull";
   }
 
   /** Returns the number of messages waiting in the pull queue. */
   getPendingMessageCount(): number {
-    return this.pendingMessages.length;
+    return this.queue.countUndrained();
   }
 
   // ── Mode Detection ─────────────────────────────────────────
@@ -133,7 +144,7 @@ export class ClaudeAdapter extends EventEmitter {
   private resolveMode(): void {
     if (this.resolvedMode) return;
 
-    if (this.configuredMode === "push" || this.configuredMode === "pull") {
+    if (this.configuredMode === "push" || this.configuredMode === "pull" || this.configuredMode === "dual") {
       this.resolvedMode = this.configuredMode;
       this.log(`Delivery mode set by AGENTBRIDGE_MODE: ${this.resolvedMode}`);
     } else {
@@ -150,15 +161,22 @@ export class ClaudeAdapter extends EventEmitter {
 
   async pushNotification(message: BridgeMessage) {
     this.log(`pushNotification (instance=${this.instanceId}, mode=${this.resolvedMode}, msgId=${message.id}, len=${message.content.length})`);
-    if (this.resolvedMode === "push") {
+    if (this.resolvedMode === "dual") {
+      const entry = this.queueForPull(message);
+      if (this.lastQueueWasDuplicate) {
+        this.log(`Skipping duplicate dual push for message ${entry.messageId}`);
+        return;
+      }
+      await this.pushViaChannel(message, entry.messageId);
+    } else if (this.resolvedMode === "push") {
       await this.pushViaChannel(message);
     } else {
       this.queueForPull(message);
     }
   }
 
-  private async pushViaChannel(message: BridgeMessage) {
-    const msgId = `codex_msg_${this.notificationIdPrefix}_${++this.notificationSeq}`;
+  private async pushViaChannel(message: BridgeMessage, persistedMessageId?: string) {
+    const msgId = persistedMessageId ?? this.nextNotificationId();
     const ts = new Date(message.timestamp).toISOString();
 
     try {
@@ -177,34 +195,85 @@ export class ClaudeAdapter extends EventEmitter {
         },
       });
       this.log(`Pushed notification: ${msgId}`);
+      if (persistedMessageId) {
+        this.queue.markPushed(persistedMessageId);
+        this.auditMessage("message_pushed", message, {
+          messageId: persistedMessageId,
+          queued: true,
+          pushed: true,
+        });
+      }
     } catch (e: any) {
       this.log(`Push notification failed: ${e.message}`);
-      this.queueForPull(message);
+      if (persistedMessageId) {
+        this.queue.markPushFailed(persistedMessageId, e.message);
+        this.auditMessage("message_push_failed", message, {
+          messageId: persistedMessageId,
+          queued: true,
+          pushed: false,
+          pushError: e.message,
+        });
+      } else {
+        this.queueForPull(message);
+      }
     }
   }
 
-  private queueForPull(message: BridgeMessage) {
-    if (this.pendingMessages.length >= this.maxBufferedMessages) {
-      this.pendingMessages.shift();
+  private queueForPull(message: BridgeMessage): QueueEntry {
+    if (this.queue.countUndrained() >= this.maxBufferedMessages) {
+      const dropped = this.queue.markOldestUndrainedDropped();
       this.droppedMessageCount++;
+      if (dropped) {
+        this.queue.audit({
+          event: "message_dropped",
+          direction: "codex_to_claude",
+          sender: "codex",
+          chatId: dropped.chatId,
+          messageId: dropped.messageId,
+          marker: dropped.marker,
+          contentLen: dropped.content.length,
+          contentHash: dropped.contentHash,
+          preview: previewContent(dropped.content),
+          deliveryMode: this.getDeliveryMode(),
+          queued: false,
+          drained: true,
+        });
+      }
       this.log(`Message queue full, dropped oldest message (total dropped: ${this.droppedMessageCount})`);
     }
-    this.pendingMessages.push(message);
-    this.log(`Queued message for pull (${this.pendingMessages.length} pending, instance=${this.instanceId})`);
+
+    const messageId = this.nextNotificationId();
+    const entry = this.queue.enqueue({
+      message,
+      chatId: this.sessionId,
+      messageId,
+    });
+    this.lastQueueWasDuplicate = entry.messageId !== messageId;
+    this.pendingMessages = this.entriesToBridgeMessages(this.queue.listUndrained());
+    this.auditMessage("message_queued", message, {
+      messageId: entry.messageId,
+      queued: true,
+      pushed: entry.pushedAt !== null,
+      pushError: entry.pushError,
+    });
+    this.log(`Queued message for pull (${this.queue.countUndrained()} pending, instance=${this.instanceId})`);
+    return entry;
   }
 
   // ── get_messages ───────────────────────────────────────────
 
   private drainMessages(): { content: Array<{ type: "text"; text: string }> } {
-    this.log(`get_messages called (instance=${this.instanceId}, pending=${this.pendingMessages.length}, dropped=${this.droppedMessageCount})`);
-    if (this.pendingMessages.length === 0 && this.droppedMessageCount === 0) {
+    const entries = this.queue.listUndrained();
+    this.pendingMessages = this.entriesToBridgeMessages(entries);
+    this.log(`get_messages called (instance=${this.instanceId}, pending=${entries.length}, dropped=${this.droppedMessageCount})`);
+    if (entries.length === 0 && this.droppedMessageCount === 0) {
       return {
         content: [{ type: "text" as const, text: "No new messages from Codex." }],
       };
     }
 
-    // Snapshot and clear atomically to avoid issues with concurrent writes
-    const messages = this.pendingMessages;
+    // Snapshot and mark drained after formatting so restart replay is preserved until get_messages succeeds.
+    const messages = entries;
     this.pendingMessages = [];
     const dropped = this.droppedMessageCount;
     this.droppedMessageCount = 0;
@@ -219,9 +288,20 @@ export class ClaudeAdapter extends EventEmitter {
     const formatted = messages
       .map((msg, i) => {
         const ts = new Date(msg.timestamp).toISOString();
-        return `---\n[${i + 1}] ${ts}\nCodex: ${msg.content}`;
+        return `---\n[${i + 1}] ${ts}\nmessage_id: ${msg.messageId}\nCodex: ${msg.content}`;
       })
       .join("\n\n");
+
+    this.queue.markDrained(messages.map((msg) => msg.messageId));
+    this.queue.audit({
+      event: "messages_drained",
+      direction: "codex_to_claude",
+      sender: "claude",
+      chatId: this.sessionId,
+      deliveryMode: this.getDeliveryMode(),
+      count,
+      drained: true,
+    });
 
     this.log(`get_messages returning ${count} message(s) (instance=${this.instanceId}, dropped=${dropped})`);
     return {
@@ -322,14 +402,17 @@ export class ClaudeAdapter extends EventEmitter {
     const result = await this.replySender(bridgeMsg, requireReply);
     if (!result.success) {
       this.log(`Reply delivery failed: ${result.error}`);
+      this.auditReply("reply_failed", bridgeMsg, requireReply, result.error);
       return {
         content: [{ type: "text" as const, text: `Error: ${result.error}` }],
         isError: true,
       };
     }
 
+    this.auditReply("reply_sent", bridgeMsg, requireReply);
+
     // Include pending message hint
-    const pending = this.pendingMessages.length;
+    const pending = this.getPendingMessageCount();
     let responseText = "Reply sent to Codex.";
     if (pending > 0) {
       responseText += ` Note: ${pending} unread Codex message${pending > 1 ? "s" : ""} already waiting \u2014 call get_messages to read them.`;
@@ -346,5 +429,64 @@ export class ClaudeAdapter extends EventEmitter {
     try {
       appendFileSync(this.logFile, line);
     } catch {}
+  }
+
+  private nextNotificationId(): string {
+    return `codex_msg_${this.notificationIdPrefix}_${++this.notificationSeq}`;
+  }
+
+  private entriesToBridgeMessages(entries: QueueEntry[]): BridgeMessage[] {
+    return entries.map((entry) => ({
+      id: entry.messageId,
+      source: entry.source,
+      content: entry.content,
+      timestamp: entry.timestamp,
+    }));
+  }
+
+  private auditMessage(
+    event: string,
+    message: BridgeMessage,
+    opts: {
+      messageId: string;
+      queued: boolean;
+      pushed?: boolean;
+      pushError?: string | null;
+    },
+  ) {
+    this.queue.audit({
+      event,
+      direction: "codex_to_claude",
+      sender: "codex",
+      chatId: this.sessionId,
+      messageId: opts.messageId,
+      marker: message.content.match(/^\[(IMPORTANT|STATUS|FYI)\]/)?.[1] ?? "untagged",
+      contentLen: message.content.length,
+      contentHash: hashContent(message.content),
+      preview: previewContent(message.content),
+      deliveryMode: this.getDeliveryMode(),
+      queued: opts.queued,
+      pushed: opts.pushed,
+      pushError: opts.pushError,
+    });
+  }
+
+  private auditReply(event: string, message: BridgeMessage, requireReply: boolean, error?: string) {
+    this.queue.audit({
+      event,
+      direction: "claude_to_codex",
+      sender: "claude",
+      chatId: message.id,
+      messageId: message.id,
+      marker: message.content.match(/^\[(IMPORTANT|STATUS|FYI)\]/)?.[1] ?? "untagged",
+      contentLen: message.content.length,
+      contentHash: hashContent(message.content),
+      preview: previewContent(message.content),
+      deliveryMode: this.getDeliveryMode(),
+      queued: false,
+      pushed: false,
+      requireReply,
+      error: error ?? null,
+    });
   }
 }

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -33,6 +33,7 @@ import type { BridgeMessage } from "./types";
 
 export type ReplySender = (msg: BridgeMessage, requireReply?: boolean) => Promise<{ success: boolean; error?: string }>;
 export type DeliveryMode = "push" | "pull" | "dual" | "auto";
+export type PushMethod = "claude/channel" | "standard";
 
 export const CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
@@ -58,8 +59,9 @@ export const CLAUDE_INSTRUCTIONS = [
   "",
   "## How to interact",
   "- Use the reply tool to send messages back to Codex — pass chat_id back.",
-  "- Use the get_messages tool to check for pending messages from Codex.",
-  "- After sending a reply, call get_messages to check for responses.",
+  "- Use the get_messages tool to check for pending messages from Codex (non-blocking snapshot).",
+  "- Use the wait_for_messages tool to BLOCK until Codex replies (default 60s). Prefer this over auto-poll when you sent reply(require_reply=true) and want a real-time response — re-call after each timeout to keep listening, stop only when the user signals so or Codex sends ✅ finished.",
+  "- After sending a reply, call get_messages or wait_for_messages to receive Codex's response.",
   "- When the user asks about Codex status or progress, call get_messages.",
   "",
   "## Turn coordination",
@@ -77,6 +79,7 @@ export class ClaudeAdapter extends EventEmitter {
   private replySender: ReplySender | null = null;
   private readonly logFile: string;
   private readonly queue: PersistentMessageQueue;
+  private readonly pushMethod: PushMethod;
 
   // Dual-mode transport
   private readonly configuredMode: DeliveryMode;
@@ -98,6 +101,8 @@ export class ClaudeAdapter extends EventEmitter {
 
     const envMode = process.env.AGENTBRIDGE_MODE as DeliveryMode | undefined;
     this.configuredMode = envMode && ["push", "pull", "dual", "auto"].includes(envMode) ? envMode : "auto";
+    const envPushMethod = process.env.AGENTBRIDGE_PUSH_METHOD;
+    this.pushMethod = envPushMethod === "standard" ? "standard" : "claude/channel";
     this.maxBufferedMessages = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 
     this.server = new Server(
@@ -105,6 +110,7 @@ export class ClaudeAdapter extends EventEmitter {
       {
         capabilities: {
           experimental: { "claude/channel": {} },
+          logging: {},
           tools: {},
         },
         instructions: CLAUDE_INSTRUCTIONS,
@@ -120,7 +126,9 @@ export class ClaudeAdapter extends EventEmitter {
     const transport = new StdioServerTransport();
     this.resolveMode();
     await this.server.connect(transport);
-    this.log(`MCP server connected (mode: ${this.resolvedMode})`);
+    const clientCapabilities = (this.server as any)._clientCapabilities;
+    this.log(`MCP server connected (mode: ${this.resolvedMode}, pushMethod: ${this.pushMethod})`);
+    this.log(`MCP client capabilities: ${JSON.stringify(clientCapabilities ?? null)}`);
     this.emit("ready");
   }
 
@@ -160,7 +168,7 @@ export class ClaudeAdapter extends EventEmitter {
   // ── Message Delivery ───────────────────────────────────────
 
   async pushNotification(message: BridgeMessage) {
-    this.log(`pushNotification (instance=${this.instanceId}, mode=${this.resolvedMode}, msgId=${message.id}, len=${message.content.length})`);
+    this.log(`pushNotification (instance=${this.instanceId}, mode=${this.resolvedMode}, pushMethod=${this.pushMethod}, msgId=${message.id}, len=${message.content.length})`);
     if (this.resolvedMode === "dual") {
       const entry = this.queueForPull(message);
       if (this.lastQueueWasDuplicate) {
@@ -180,20 +188,7 @@ export class ClaudeAdapter extends EventEmitter {
     const ts = new Date(message.timestamp).toISOString();
 
     try {
-      await this.server.notification({
-        method: "notifications/claude/channel",
-        params: {
-          content: message.content,
-          meta: {
-            chat_id: this.sessionId,
-            message_id: msgId,
-            user: "Codex",
-            user_id: "codex",
-            ts,
-            source_type: "codex",
-          },
-        },
-      });
+      await this.server.notification(this.buildPushNotification(message, msgId, ts) as any);
       this.log(`Pushed notification: ${msgId}`);
       if (persistedMessageId) {
         this.queue.markPushed(persistedMessageId);
@@ -217,6 +212,39 @@ export class ClaudeAdapter extends EventEmitter {
         this.queueForPull(message);
       }
     }
+  }
+
+  private buildPushNotification(message: BridgeMessage, msgId: string, ts: string) {
+    const meta = {
+      chat_id: this.sessionId,
+      message_id: msgId,
+      user: "Codex",
+      user_id: "codex",
+      ts,
+      source_type: "codex",
+    };
+
+    if (this.pushMethod === "standard") {
+      return {
+        method: "notifications/message",
+        params: {
+          level: "info",
+          logger: "agentbridge",
+          data: {
+            content: message.content,
+            meta,
+          },
+        },
+      };
+    }
+
+    return {
+      method: "notifications/claude/channel",
+      params: {
+        content: message.content,
+        meta,
+      },
+    };
   }
 
   private queueForPull(message: BridgeMessage): QueueEntry {
@@ -345,10 +373,25 @@ export class ClaudeAdapter extends EventEmitter {
         {
           name: "get_messages",
           description:
-            "Check for new messages from Codex. Call this after sending a reply or when you expect a response from Codex.",
+            "Check for new messages from Codex. Returns immediately with a snapshot (may be empty).",
           inputSchema: {
             type: "object" as const,
             properties: {},
+            required: [],
+          },
+        },
+        {
+          name: "wait_for_messages",
+          description:
+            "Block until Codex sends a new message, or until timeout (default 60s, max 60s). Use proactively in a listening loop after reply(require_reply=true): wait_for_messages → process arrival → reply → wait_for_messages again. On arrival, drains the queue exactly like get_messages. On timeout, returns a 'timed_out' sentinel — re-call to keep listening unless the user told you to stop.",
+          inputSchema: {
+            type: "object" as const,
+            properties: {
+              timeout_s: {
+                type: "number",
+                description: "How long to block in seconds (default 60, max 60, min 1).",
+              },
+            },
             required: [],
           },
         },
@@ -366,11 +409,49 @@ export class ClaudeAdapter extends EventEmitter {
         return this.drainMessages();
       }
 
+      if (name === "wait_for_messages") {
+        return this.waitForMessages(args as Record<string, unknown>);
+      }
+
       return {
         content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
         isError: true,
       };
     });
+  }
+
+  private async waitForMessages(args: Record<string, unknown>) {
+    const requested = Number(args?.timeout_s ?? 60);
+    const timeoutS = Math.min(Math.max(Number.isFinite(requested) ? requested : 60, 1), 60);
+    const deadline = Date.now() + timeoutS * 1000;
+    const pollIntervalMs = 500;
+
+    this.log(`wait_for_messages start (instance=${this.instanceId}, timeout_s=${timeoutS}, pending=${this.queue.countUndrained()})`);
+
+    while (Date.now() < deadline) {
+      if (this.queue.countUndrained() > 0) {
+        this.log(`wait_for_messages woke (instance=${this.instanceId}, pending=${this.queue.countUndrained()})`);
+        return this.drainMessages();
+      }
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+    }
+
+    this.log(`wait_for_messages timed out (instance=${this.instanceId}, timeout_s=${timeoutS})`);
+    this.queue.audit({
+      event: "wait_for_messages_timeout",
+      direction: "internal",
+      sender: "claude",
+      chatId: this.sessionId,
+      deliveryMode: this.getDeliveryMode(),
+    });
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `[wait_for_messages] timed_out after ${timeoutS}s — no new Codex messages. Call wait_for_messages again to keep listening, or stop if the user signaled to stop.`,
+        },
+      ],
+    };
   }
 
   private async handleReply(args: Record<string, unknown>) {

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -9,7 +9,7 @@
  * disconnect), because TUI rapidly reconnects between bootstrap phases.
  */
 
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, execFileSync, type ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
 import { EventEmitter } from "node:events";
 import { appendFileSync } from "node:fs";
@@ -1179,63 +1179,101 @@ export class CodexAdapter extends EventEmitter {
    */
   private async checkPorts() {
     for (const port of [this.appPort, this.proxyPort]) {
-      try {
-        const pids = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
-        if (!pids) continue;
+      const pidList = this.getPortPids(port);
+      if (pidList.length === 0) continue;
 
-        // Check if the occupying process is a codex app-server (our own stale spawn)
-        const pidList = pids.split("\n").map((p) => p.trim()).filter(Boolean);
-        const staleCodexPids: string[] = [];
-        const foreignPids: string[] = [];
+      // Check if the occupying process is a codex app-server (our own stale spawn)
+      const staleCodexPids: string[] = [];
+      const foreignPids: string[] = [];
 
-        for (const pid of pidList) {
-          try {
-            const cmdline = execSync(`ps -p ${pid} -o args=`, { encoding: "utf-8" }).trim();
-            if (cmdline.includes("codex") && cmdline.includes("app-server")) {
-              staleCodexPids.push(pid);
-            } else {
-              foreignPids.push(pid);
-            }
-          } catch {
-            // Process already gone
-          }
-        }
-
-        // Kill stale codex app-server processes (our own previous spawns)
-        if (staleCodexPids.length > 0) {
-          this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
-          for (const pid of staleCodexPids) {
-            try { execSync(`kill ${pid}`, { encoding: "utf-8" }); } catch {}
-          }
-          await new Promise((r) => setTimeout(r, 500));
-        }
-
-        // If foreign processes still occupy the port, fail with a clear message
-        if (foreignPids.length > 0) {
-          throw new Error(
-            `Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` +
-            `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
-          );
-        }
-
-        // Verify port is now free
+      for (const pid of pidList) {
         try {
-          const remaining = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
-          if (remaining) {
-            throw new Error(
-              `Port ${port} is still occupied (PID(s): ${remaining.replace(/\n/g, ", ")}) after cleanup. ` +
-              `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
-            );
+          const cmdline = this.getProcessCommandLine(pid);
+          if (this.isCodexAppServerCommandLine(cmdline)) {
+            staleCodexPids.push(pid);
+          } else {
+            foreignPids.push(pid);
           }
-        } catch (err: any) {
-          if (err.message?.includes("Port")) throw err;
-          // lsof exit 1 = port free, good
+        } catch {
+          // Process already gone
         }
-      } catch (err: any) {
-        // lsof returns exit code 1 if no match — port is free
-        if (err.message?.includes("Port") || err.message?.includes("non-Codex")) throw err;
+      }
+
+      // Kill stale codex app-server processes (our own previous spawns)
+      if (staleCodexPids.length > 0) {
+        this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
+        for (const pid of staleCodexPids) {
+          try { this.killProcess(pid); } catch {}
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+
+      // If foreign processes still occupy the port, fail with a clear message
+      if (foreignPids.length > 0) {
+        throw new Error(
+          `Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` +
+          `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
+        );
+      }
+
+      // Verify port is now free
+      const remaining = this.getPortPids(port);
+      if (remaining.length > 0) {
+        throw new Error(
+          `Port ${port} is still occupied (PID(s): ${remaining.join(", ")}) after cleanup. ` +
+          `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
+        );
       }
     }
+  }
+
+  private getPortPids(port: number): string[] {
+    try {
+      const output = process.platform === "win32"
+        ? execFileSync("powershell.exe", [
+          "-NoProfile",
+          "-Command",
+          `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique`,
+        ], { encoding: "utf-8" })
+        : execFileSync("lsof", ["-ti", `:${port}`], { encoding: "utf-8" });
+
+      return output
+        .split(/\r?\n/)
+        .map((pid) => pid.trim())
+        .filter((pid, index, all) => pid.length > 0 && all.indexOf(pid) === index);
+    } catch {
+      return [];
+    }
+  }
+
+  private getProcessCommandLine(pid: string): string {
+    if (process.platform === "win32") {
+      return execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction SilentlyContinue; if ($p -and $p.CommandLine) { $p.CommandLine }`,
+      ], { encoding: "utf-8" }).trim();
+    }
+
+    return execFileSync("ps", ["-p", pid, "-o", "args="], { encoding: "utf-8" }).trim();
+  }
+
+  private killProcess(pid: string) {
+    if (process.platform === "win32") {
+      execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `Stop-Process -Id ${pid} -Force -ErrorAction Stop`,
+      ], { encoding: "utf-8" });
+      return;
+    }
+
+    execFileSync("kill", [pid], { encoding: "utf-8" });
+  }
+
+  private isCodexAppServerCommandLine(cmdline: string): boolean {
+    const normalized = cmdline.toLowerCase();
+    return normalized.includes("codex") && normalized.includes("app-server");
   }
 
   private log(msg: string) {

--- a/src/message-queue.ts
+++ b/src/message-queue.ts
@@ -16,6 +16,7 @@ export interface QueueEntry {
   pushedAt: number | null;
   pushError: string | null;
   drainedAt: number | null;
+  ackedAt: number | null;
   createdAt: number;
 }
 
@@ -68,15 +69,22 @@ export class PersistentMessageQueue {
         pushed_at INTEGER,
         push_error TEXT,
         drained_at INTEGER,
+        acked_at INTEGER,
         created_at INTEGER NOT NULL
       )
     `);
+    // Phase C migration: add acked_at column if missing on pre-existing DBs.
+    const cols = this.db.query("PRAGMA table_info(messages)").all() as { name: string }[];
+    if (!cols.some((c) => c.name === "acked_at")) {
+      this.db.exec("ALTER TABLE messages ADD COLUMN acked_at INTEGER");
+    }
     this.db.exec(`
       CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_undrained_dedupe
       ON messages(chat_id, content_hash)
       WHERE drained_at IS NULL
     `);
     this.db.exec("CREATE INDEX IF NOT EXISTS idx_messages_undrained_seq ON messages(drained_at, seq)");
+    this.db.exec("CREATE INDEX IF NOT EXISTS idx_messages_unacked_undrained ON messages(acked_at, drained_at, seq)");
   }
 
   enqueue(input: EnqueueInput): QueueEntry {
@@ -122,11 +130,45 @@ export class PersistentMessageQueue {
         pushed_at AS pushedAt,
         push_error AS pushError,
         drained_at AS drainedAt,
+        acked_at AS ackedAt,
         created_at AS createdAt
       FROM messages
       WHERE drained_at IS NULL
       ORDER BY seq ASC
     `).all() as QueueEntry[];
+  }
+
+  /**
+   * Phase C: messages eligible for hook injection — undrained AND unacked.
+   * Non-consuming read; callers must not mutate state on this query alone.
+   */
+  listUnackedUndrained(): QueueEntry[] {
+    return this.db.query(`
+      SELECT
+        seq,
+        message_id AS messageId,
+        chat_id AS chatId,
+        source,
+        content,
+        timestamp,
+        marker,
+        content_hash AS contentHash,
+        pushed_at AS pushedAt,
+        push_error AS pushError,
+        drained_at AS drainedAt,
+        acked_at AS ackedAt,
+        created_at AS createdAt
+      FROM messages
+      WHERE drained_at IS NULL AND acked_at IS NULL
+      ORDER BY seq ASC
+    `).all() as QueueEntry[];
+  }
+
+  countUnackedUndrained(): number {
+    const row = this.db.query(
+      "SELECT COUNT(*) AS count FROM messages WHERE drained_at IS NULL AND acked_at IS NULL"
+    ).get() as { count: number };
+    return row.count;
   }
 
   countUndrained(): number {
@@ -151,6 +193,21 @@ export class PersistentMessageQueue {
     transaction(messageIds);
   }
 
+  /**
+   * Phase C: mark all undrained messages on a chat as acked.
+   * Called when Claude replies to that chat — signals the hook layer
+   * to stop re-injecting these on subsequent UserPromptSubmit events.
+   * Non-destructive to drained_at; get_messages can still consume.
+   * Returns the number of rows actually flipped (zero is a no-op).
+   */
+  ackByChatId(chatId: string, ackedAt = Date.now()): number {
+    const result = this.db
+      .query("UPDATE messages SET acked_at = ? WHERE chat_id = ? AND drained_at IS NULL AND acked_at IS NULL")
+      .run(ackedAt, chatId);
+    // bun:sqlite returns { changes, lastInsertRowid }
+    return Number((result as { changes?: number }).changes ?? 0);
+  }
+
   markOldestUndrainedDropped(droppedAt = Date.now()): QueueEntry | null {
     const entry = this.db.query(`
       SELECT
@@ -165,6 +222,7 @@ export class PersistentMessageQueue {
         pushed_at AS pushedAt,
         push_error AS pushError,
         drained_at AS drainedAt,
+        acked_at AS ackedAt,
         created_at AS createdAt
       FROM messages
       WHERE drained_at IS NULL
@@ -204,6 +262,7 @@ export class PersistentMessageQueue {
         pushed_at AS pushedAt,
         push_error AS pushError,
         drained_at AS drainedAt,
+        acked_at AS ackedAt,
         created_at AS createdAt
       FROM messages
       WHERE chat_id = ? AND content_hash = ? AND drained_at IS NULL

--- a/src/message-queue.ts
+++ b/src/message-queue.ts
@@ -1,0 +1,228 @@
+import { Database } from "bun:sqlite";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { dirname } from "node:path";
+import type { BridgeMessage } from "./types";
+
+export interface QueueEntry {
+  seq: number;
+  messageId: string;
+  chatId: string;
+  source: BridgeMessage["source"];
+  content: string;
+  timestamp: number;
+  marker: string;
+  contentHash: string;
+  pushedAt: number | null;
+  pushError: string | null;
+  drainedAt: number | null;
+  createdAt: number;
+}
+
+export interface EnqueueInput {
+  message: BridgeMessage;
+  chatId: string;
+  messageId: string;
+}
+
+export interface AuditEvent {
+  event: string;
+  direction: "codex_to_claude" | "claude_to_codex" | "internal";
+  sender: string;
+  chatId: string;
+  messageId?: string;
+  marker?: string;
+  contentLen?: number;
+  contentHash?: string;
+  preview?: string;
+  deliveryMode?: string;
+  queued?: boolean;
+  pushed?: boolean;
+  drained?: boolean;
+  requireReply?: boolean;
+  error?: string | null;
+  pushError?: string | null;
+  count?: number;
+}
+
+export class PersistentMessageQueue {
+  private readonly db: Database;
+  private readonly auditFile: string;
+
+  constructor(dbFile: string, auditFile: string) {
+    mkdirSync(dirname(dbFile), { recursive: true });
+    this.auditFile = auditFile;
+    this.db = new Database(dbFile);
+    this.db.exec("PRAGMA journal_mode = WAL");
+    this.db.exec("PRAGMA synchronous = NORMAL");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS messages (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        message_id TEXT NOT NULL UNIQUE,
+        chat_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        content TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        marker TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        pushed_at INTEGER,
+        push_error TEXT,
+        drained_at INTEGER,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    this.db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_undrained_dedupe
+      ON messages(chat_id, content_hash)
+      WHERE drained_at IS NULL
+    `);
+    this.db.exec("CREATE INDEX IF NOT EXISTS idx_messages_undrained_seq ON messages(drained_at, seq)");
+  }
+
+  enqueue(input: EnqueueInput): QueueEntry {
+    const contentHash = hashContent(input.message.content);
+    const marker = extractMarker(input.message.content);
+    const createdAt = Date.now();
+
+    const insert = this.db.query(`
+      INSERT OR IGNORE INTO messages (
+        message_id, chat_id, source, content, timestamp, marker, content_hash, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    insert.run(
+      input.messageId,
+      input.chatId,
+      input.message.source,
+      input.message.content,
+      input.message.timestamp,
+      marker,
+      contentHash,
+      createdAt,
+    );
+
+    const entry = this.findUndrainedByChatAndHash(input.chatId, contentHash);
+    if (!entry) {
+      throw new Error("Failed to persist AgentBridge message queue entry.");
+    }
+    return entry;
+  }
+
+  listUndrained(): QueueEntry[] {
+    return this.db.query(`
+      SELECT
+        seq,
+        message_id AS messageId,
+        chat_id AS chatId,
+        source,
+        content,
+        timestamp,
+        marker,
+        content_hash AS contentHash,
+        pushed_at AS pushedAt,
+        push_error AS pushError,
+        drained_at AS drainedAt,
+        created_at AS createdAt
+      FROM messages
+      WHERE drained_at IS NULL
+      ORDER BY seq ASC
+    `).all() as QueueEntry[];
+  }
+
+  countUndrained(): number {
+    const row = this.db.query("SELECT COUNT(*) AS count FROM messages WHERE drained_at IS NULL").get() as { count: number };
+    return row.count;
+  }
+
+  markPushed(messageId: string, pushedAt = Date.now()) {
+    this.db.query("UPDATE messages SET pushed_at = ?, push_error = NULL WHERE message_id = ?").run(pushedAt, messageId);
+  }
+
+  markPushFailed(messageId: string, error: string) {
+    this.db.query("UPDATE messages SET push_error = ? WHERE message_id = ?").run(error, messageId);
+  }
+
+  markDrained(messageIds: string[], drainedAt = Date.now()) {
+    if (messageIds.length === 0) return;
+    const update = this.db.query("UPDATE messages SET drained_at = ? WHERE message_id = ? AND drained_at IS NULL");
+    const transaction = this.db.transaction((ids: string[]) => {
+      for (const id of ids) update.run(drainedAt, id);
+    });
+    transaction(messageIds);
+  }
+
+  markOldestUndrainedDropped(droppedAt = Date.now()): QueueEntry | null {
+    const entry = this.db.query(`
+      SELECT
+        seq,
+        message_id AS messageId,
+        chat_id AS chatId,
+        source,
+        content,
+        timestamp,
+        marker,
+        content_hash AS contentHash,
+        pushed_at AS pushedAt,
+        push_error AS pushError,
+        drained_at AS drainedAt,
+        created_at AS createdAt
+      FROM messages
+      WHERE drained_at IS NULL
+      ORDER BY seq ASC
+      LIMIT 1
+    `).get() as QueueEntry | null;
+
+    if (!entry) return null;
+    this.db.query("UPDATE messages SET drained_at = ? WHERE message_id = ? AND drained_at IS NULL").run(droppedAt, entry.messageId);
+    return entry;
+  }
+
+  audit(event: AuditEvent) {
+    try {
+      mkdirSync(dirname(this.auditFile), { recursive: true });
+      appendFileSync(this.auditFile, JSON.stringify({ ts: Date.now(), ...event }) + "\n", "utf-8");
+    } catch {
+      // Audit is diagnostic only; it must never block message delivery.
+    }
+  }
+
+  close() {
+    this.db.close();
+  }
+
+  private findUndrainedByChatAndHash(chatId: string, contentHash: string): QueueEntry | null {
+    return this.db.query(`
+      SELECT
+        seq,
+        message_id AS messageId,
+        chat_id AS chatId,
+        source,
+        content,
+        timestamp,
+        marker,
+        content_hash AS contentHash,
+        pushed_at AS pushedAt,
+        push_error AS pushError,
+        drained_at AS drainedAt,
+        created_at AS createdAt
+      FROM messages
+      WHERE chat_id = ? AND content_hash = ? AND drained_at IS NULL
+      ORDER BY seq ASC
+      LIMIT 1
+    `).get(chatId, contentHash) as QueueEntry | null;
+  }
+}
+
+export function hashContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function extractMarker(content: string): string {
+  const match = content.match(/^\[(IMPORTANT|STATUS|FYI)\]/);
+  return match?.[1] ?? "untagged";
+}
+
+export function previewContent(content: string, maxLength = 160): string {
+  const compact = content.replace(/\s+/g, " ").trim();
+  return compact.length > maxLength ? `${compact.slice(0, maxLength)}...` : compact;
+}

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -62,6 +62,14 @@ export class StateDirResolver {
     return join(this.stateDir, "agentbridge.log");
   }
 
+  get queueDbFile(): string {
+    return join(this.stateDir, "queue.db");
+  }
+
+  get transcriptFile(): string {
+    return join(this.stateDir, "transcript.jsonl");
+  }
+
   get killedFile(): string {
     return join(this.stateDir, "killed");
   }

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -1056,3 +1056,36 @@ describe("CodexAdapter initialize reconnect", () => {
     expect(adapter.injectMessage("hello")).toBe(false);
   });
 });
+
+describe("CodexAdapter stale app-server cleanup", () => {
+  test("kills stale codex app-server process occupying the app port", async () => {
+    const adapter = createAdapter();
+    const killed: string[] = [];
+    let appPortChecks = 0;
+
+    adapter.getPortPids = (port: number) => {
+      if (port !== 4510) return [];
+      appPortChecks += 1;
+      return appPortChecks === 1 ? ["1234"] : [];
+    };
+    adapter.getProcessCommandLine = () =>
+      "C:\\Program Files\\nodejs\\codex.exe app-server --listen ws://127.0.0.1:4510";
+    adapter.killProcess = (pid: string) => killed.push(pid);
+
+    await adapter.checkPorts();
+
+    expect(killed).toEqual(["1234"]);
+  });
+
+  test("fails without killing when port is owned by a non-Codex process", async () => {
+    const adapter = createAdapter();
+    const killed: string[] = [];
+
+    adapter.getPortPids = (port: number) => port === 4510 ? ["9876"] : [];
+    adapter.getProcessCommandLine = () => "node unrelated-server.js";
+    adapter.killProcess = (pid: string) => killed.push(pid);
+
+    await expect(adapter.checkPorts()).rejects.toThrow("non-Codex process");
+    expect(killed).toEqual([]);
+  });
+});

--- a/src/unit-test/dual-mode.test.ts
+++ b/src/unit-test/dual-mode.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { ClaudeAdapter } from "../claude-adapter";
+import { PersistentMessageQueue } from "../message-queue";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let tempDirs: string[] = [];
 
 // Access internals for testing
-function createAdapter(envMode?: string): any {
+function createAdapter(envMode?: string, stateDir?: string): any {
   const origMode = process.env.AGENTBRIDGE_MODE;
   const origMax = process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES;
+  const dir = stateDir ?? mkdtempSync(join(tmpdir(), "agentbridge-dual-test-"));
+  if (!stateDir) tempDirs.push(dir);
 
   if (envMode !== undefined) {
     process.env.AGENTBRIDGE_MODE = envMode;
@@ -12,7 +20,10 @@ function createAdapter(envMode?: string): any {
     delete process.env.AGENTBRIDGE_MODE;
   }
 
-  const adapter = new ClaudeAdapter() as any;
+  const queue = new PersistentMessageQueue(join(dir, "queue.db"), join(dir, "transcript.jsonl"));
+  const adapter = new ClaudeAdapter(join(dir, "agentbridge.log"), queue) as any;
+  adapter.__testStateDir = dir;
+  adapter.__testQueue = queue;
 
   // Restore env immediately after construction reads it
   if (origMode !== undefined) {
@@ -79,6 +90,13 @@ describe("Dual-mode transport: mode resolution", () => {
     expect(adapter.resolvedMode).toBe("pull");
     expect(adapter.getDeliveryMode()).toBe("pull");
   });
+
+  test("resolveMode sets 'dual' when configuredMode is 'dual'", () => {
+    const adapter = createAdapter("dual");
+    adapter.resolveMode();
+    expect(adapter.resolvedMode).toBe("dual");
+    expect(adapter.getDeliveryMode()).toBe("dual");
+  });
 });
 
 describe("Dual-mode transport: pull mode message queue", () => {
@@ -89,9 +107,8 @@ describe("Dual-mode transport: pull mode message queue", () => {
     const msg = makeBridgeMessage("hello from codex");
     adapter.queueForPull(msg);
 
-    expect(adapter.pendingMessages).toHaveLength(1);
-    expect(adapter.pendingMessages[0].content).toBe("hello from codex");
     expect(adapter.getPendingMessageCount()).toBe(1);
+    expect(adapter.queue.listUndrained()[0].content).toBe("hello from codex");
   });
 
   test("queueForPull drops oldest when queue is full", () => {
@@ -107,9 +124,10 @@ describe("Dual-mode transport: pull mode message queue", () => {
     adapter.queueForPull(makeBridgeMessage("msg3"));
     adapter.queueForPull(makeBridgeMessage("msg4"));
 
-    expect(adapter.pendingMessages).toHaveLength(3);
-    expect(adapter.pendingMessages[0].content).toBe("msg2");
-    expect(adapter.pendingMessages[2].content).toBe("msg4");
+    const pending = adapter.queue.listUndrained();
+    expect(pending).toHaveLength(3);
+    expect(pending[0].content).toBe("msg2");
+    expect(pending[2].content).toBe("msg4");
     expect(adapter.droppedMessageCount).toBe(1);
   });
 
@@ -117,8 +135,8 @@ describe("Dual-mode transport: pull mode message queue", () => {
     const adapter = createAdapter("pull");
     adapter.resolveMode();
     await adapter.pushNotification(makeBridgeMessage("pull msg"));
-    expect(adapter.pendingMessages).toHaveLength(1);
-    expect(adapter.pendingMessages[0].content).toBe("pull msg");
+    expect(adapter.getPendingMessageCount()).toBe(1);
+    expect(adapter.queue.listUndrained()[0].content).toBe("pull msg");
   });
 
   test("push mode message ids include a session-unique prefix", async () => {
@@ -158,8 +176,74 @@ describe("Dual-mode transport: pull mode message queue", () => {
 
     await adapter.pushNotification(makeBridgeMessage("fallback msg"));
 
-    expect(adapter.pendingMessages).toHaveLength(1);
-    expect(adapter.pendingMessages[0].content).toBe("fallback msg");
+    expect(adapter.getPendingMessageCount()).toBe(1);
+    expect(adapter.queue.listUndrained()[0].content).toBe("fallback msg");
+  });
+
+  test("dual mode persists first and pushes with the same message id", async () => {
+    const adapter = createAdapter("dual");
+    adapter.resolveMode();
+
+    const notifications: any[] = [];
+    adapter.server = {
+      notification: async (payload: any) => notifications.push(payload),
+    };
+
+    await adapter.pushNotification(makeBridgeMessage("dual msg", 1705312200000));
+
+    expect(notifications).toHaveLength(1);
+    expect(adapter.getPendingMessageCount()).toBe(1);
+    const entry = adapter.queue.listUndrained()[0];
+    expect(entry.content).toBe("dual msg");
+    expect(entry.pushedAt).toBeNumber();
+    expect(notifications[0].params.meta.message_id).toBe(entry.messageId);
+  });
+
+  test("dual mode keeps persisted message when channel push throws", async () => {
+    const adapter = createAdapter("dual");
+    adapter.resolveMode();
+    adapter.server = {
+      notification: async () => {
+        throw new Error("channel unavailable");
+      },
+    };
+
+    await adapter.pushNotification(makeBridgeMessage("dual fallback"));
+
+    const entry = adapter.queue.listUndrained()[0];
+    expect(entry.content).toBe("dual fallback");
+    expect(entry.pushError).toBe("channel unavailable");
+  });
+
+  test("dedupes undrained messages by chat_id and content_hash", async () => {
+    const adapter = createAdapter("dual");
+    adapter.resolveMode();
+    const notifications: any[] = [];
+    adapter.server = { notification: async (payload: any) => notifications.push(payload) };
+
+    await adapter.pushNotification(makeBridgeMessage("same content", 1705312200000));
+    await adapter.pushNotification(makeBridgeMessage("same content", 1705312205000));
+
+    expect(adapter.queue.listUndrained()).toHaveLength(1);
+    expect(notifications).toHaveLength(1);
+  });
+
+  test("writes audit JSONL without using it as replay source", async () => {
+    const adapter = createAdapter("dual");
+    adapter.resolveMode();
+    adapter.server = { notification: async () => {} };
+
+    await adapter.pushNotification(makeBridgeMessage("[IMPORTANT] audited message", 1705312200000));
+
+    const audit = readFileSync(join(adapter.__testStateDir, "transcript.jsonl"), "utf-8")
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+
+    expect(audit.some((entry) => entry.event === "message_queued")).toBe(true);
+    expect(audit.some((entry) => entry.event === "message_pushed")).toBe(true);
+    expect(audit[0].contentHash).toBeString();
+    expect(audit[0].preview).toContain("audited message");
   });
 });
 
@@ -191,7 +275,6 @@ describe("Dual-mode transport: drainMessages (get_messages)", () => {
     expect(text).toContain("second message");
 
     // Queue should be cleared
-    expect(adapter.pendingMessages).toHaveLength(0);
     expect(adapter.getPendingMessageCount()).toBe(0);
   });
 
@@ -221,6 +304,48 @@ describe("Dual-mode transport: drainMessages (get_messages)", () => {
 
     const result = adapter.drainMessages();
     expect(result.content[0].text).toContain("[1 new message from Codex]");
+  });
+
+  test("persists undrained messages across adapter restart", () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "agentbridge-dual-restart-"));
+    tempDirs.push(stateDir);
+
+    const first = createAdapter("dual", stateDir);
+    first.resolveMode();
+    first.queueForPull(makeBridgeMessage("survives restart", 1705312200000));
+    first.__testQueue.close();
+
+    const second = createAdapter("pull", stateDir);
+    second.resolveMode();
+
+    const result = second.drainMessages();
+    expect(result.content[0].text).toContain("survives restart");
+    expect(second.getPendingMessageCount()).toBe(0);
+  });
+
+  test("restart before push attempt still replays persisted message", () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "agentbridge-dual-crash-"));
+    tempDirs.push(stateDir);
+
+    const first = createAdapter("dual", stateDir);
+    first.resolveMode();
+    first.queueForPull(makeBridgeMessage("persisted before crash", 1705312200000));
+    first.__testQueue.close();
+
+    const second = createAdapter("pull", stateDir);
+    second.resolveMode();
+
+    const result = second.drainMessages();
+    expect(result.content[0].text).toContain("persisted before crash");
+  });
+
+  test("second drain does not replay already drained rows", () => {
+    const adapter = createAdapter("pull");
+    adapter.resolveMode();
+    adapter.queueForPull(makeBridgeMessage("drain once"));
+
+    expect(adapter.drainMessages().content[0].text).toContain("drain once");
+    expect(adapter.drainMessages().content[0].text).toBe("No new messages from Codex.");
   });
 });
 
@@ -268,4 +393,11 @@ describe("Dual-mode transport: reply pending hint", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("bridge not initialized");
   });
+});
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
+  tempDirs = [];
 });

--- a/src/unit-test/dual-mode.test.ts
+++ b/src/unit-test/dual-mode.test.ts
@@ -8,9 +8,10 @@ import { tmpdir } from "node:os";
 let tempDirs: string[] = [];
 
 // Access internals for testing
-function createAdapter(envMode?: string, stateDir?: string): any {
+function createAdapter(envMode?: string, stateDir?: string, pushMethod?: string): any {
   const origMode = process.env.AGENTBRIDGE_MODE;
   const origMax = process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES;
+  const origPushMethod = process.env.AGENTBRIDGE_PUSH_METHOD;
   const dir = stateDir ?? mkdtempSync(join(tmpdir(), "agentbridge-dual-test-"));
   if (!stateDir) tempDirs.push(dir);
 
@@ -18,6 +19,11 @@ function createAdapter(envMode?: string, stateDir?: string): any {
     process.env.AGENTBRIDGE_MODE = envMode;
   } else {
     delete process.env.AGENTBRIDGE_MODE;
+  }
+  if (pushMethod !== undefined) {
+    process.env.AGENTBRIDGE_PUSH_METHOD = pushMethod;
+  } else {
+    delete process.env.AGENTBRIDGE_PUSH_METHOD;
   }
 
   const queue = new PersistentMessageQueue(join(dir, "queue.db"), join(dir, "transcript.jsonl"));
@@ -35,6 +41,11 @@ function createAdapter(envMode?: string, stateDir?: string): any {
     process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES = origMax;
   } else {
     delete process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES;
+  }
+  if (origPushMethod !== undefined) {
+    process.env.AGENTBRIDGE_PUSH_METHOD = origPushMethod;
+  } else {
+    delete process.env.AGENTBRIDGE_PUSH_METHOD;
   }
 
   return adapter;
@@ -68,6 +79,16 @@ describe("Dual-mode transport: mode resolution", () => {
   test("invalid AGENTBRIDGE_MODE falls back to 'auto'", () => {
     const adapter = createAdapter("invalid");
     expect(adapter.configuredMode).toBe("auto");
+  });
+
+  test("pushMethod defaults to custom claude/channel notification", () => {
+    const adapter = createAdapter("push");
+    expect(adapter.pushMethod).toBe("claude/channel");
+  });
+
+  test("pushMethod can use standard notifications/message for debugging", () => {
+    const adapter = createAdapter("push", undefined, "standard");
+    expect(adapter.pushMethod).toBe("standard");
   });
 
   test("auto mode defaults to pull", () => {
@@ -178,6 +199,25 @@ describe("Dual-mode transport: pull mode message queue", () => {
 
     expect(adapter.getPendingMessageCount()).toBe(1);
     expect(adapter.queue.listUndrained()[0].content).toBe("fallback msg");
+  });
+
+  test("standard push method sends MCP logging notifications", async () => {
+    const adapter = createAdapter("push", undefined, "standard");
+    adapter.resolveMode();
+
+    const notifications: any[] = [];
+    adapter.server = {
+      notification: async (payload: any) => notifications.push(payload),
+    };
+
+    await adapter.pushNotification(makeBridgeMessage("standard push", 1705312200000));
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].method).toBe("notifications/message");
+    expect(notifications[0].params.level).toBe("info");
+    expect(notifications[0].params.logger).toBe("agentbridge");
+    expect(notifications[0].params.data.content).toBe("standard push");
+    expect(notifications[0].params.data.meta.message_id).toMatch(/^codex_msg_[a-f0-9]{12}_1$/);
   });
 
   test("dual mode persists first and pushes with the same message id", async () => {
@@ -392,6 +432,63 @@ describe("Dual-mode transport: reply pending hint", () => {
     const result = await adapter.handleReply({ text: "hello" });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("bridge not initialized");
+  });
+});
+
+describe("Dual-mode transport: wait_for_messages (Phase B)", () => {
+  test("returns immediately when queue already has messages", async () => {
+    const adapter = createAdapter("pull");
+    adapter.resolveMode();
+    adapter.queueForPull({ id: "x", source: "codex", content: "hello", timestamp: Date.now() });
+
+    const start = Date.now();
+    const result = await adapter.waitForMessages({ timeout_s: 5 });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(1000);
+    expect(result.content[0].text).toContain("[1 new message from Codex]");
+    expect(result.content[0].text).toContain("hello");
+  });
+
+  test("times out cleanly when queue stays empty", async () => {
+    const adapter = createAdapter("pull");
+    adapter.resolveMode();
+
+    const start = Date.now();
+    const result = await adapter.waitForMessages({ timeout_s: 1 });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(1000);
+    expect(elapsed).toBeLessThan(2000);
+    expect(result.content[0].text).toContain("timed_out");
+  });
+
+  test("wakes when a message arrives mid-wait", async () => {
+    const adapter = createAdapter("pull");
+    adapter.resolveMode();
+
+    // Schedule a message to arrive ~600ms later
+    setTimeout(() => {
+      adapter.queueForPull({ id: "y", source: "codex", content: "wakeup", timestamp: Date.now() });
+    }, 600);
+
+    const start = Date.now();
+    const result = await adapter.waitForMessages({ timeout_s: 5 });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(500);
+    expect(elapsed).toBeLessThan(2000);
+    expect(result.content[0].text).toContain("wakeup");
+  });
+
+  test("clamps timeout above 60s to 60s and below 1s to 1s", async () => {
+    const adapter = createAdapter("pull");
+    adapter.resolveMode();
+
+    // Use a number > 60 — internal clamp should still proceed; we verify by giving it a queued msg so it returns fast
+    adapter.queueForPull({ id: "z", source: "codex", content: "clamped", timestamp: Date.now() });
+    const result = await adapter.waitForMessages({ timeout_s: 9999 });
+    expect(result.content[0].text).toContain("clamped");
   });
 });
 

--- a/src/unit-test/message-queue.test.ts
+++ b/src/unit-test/message-queue.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PersistentMessageQueue } from "../message-queue";
+import type { BridgeMessage } from "../types";
+
+const tempDirs: string[] = [];
+
+function newQueue(): { queue: PersistentMessageQueue; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), "agentbridge-queue-test-"));
+  tempDirs.push(dir);
+  return {
+    queue: new PersistentMessageQueue(
+      join(dir, "queue.db"),
+      join(dir, "transcript.jsonl"),
+    ),
+    dir,
+  };
+}
+
+function makeMsg(content: string): BridgeMessage {
+  return {
+    id: `test_${Math.random().toString(36).slice(2)}`,
+    source: "codex",
+    content,
+    timestamp: Date.now(),
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Phase C: acked_at column + ackByChatId", () => {
+  test("acked_at column exists after construction (fresh DB)", () => {
+    const { queue } = newQueue();
+    // listUnackedUndrained must work even with no rows; it would throw if column was missing.
+    expect(queue.listUnackedUndrained()).toEqual([]);
+    expect(queue.countUnackedUndrained()).toBe(0);
+    queue.close();
+  });
+
+  test("freshly enqueued message has ackedAt = null and shows up in unacked list", () => {
+    const { queue } = newQueue();
+    queue.enqueue({
+      message: makeMsg("hello A"),
+      chatId: "chat-1",
+      messageId: "m-1",
+    });
+    const list = queue.listUnackedUndrained();
+    expect(list).toHaveLength(1);
+    expect(list[0].ackedAt).toBeNull();
+    expect(list[0].drainedAt).toBeNull();
+    expect(queue.countUnackedUndrained()).toBe(1);
+    queue.close();
+  });
+
+  test("ackByChatId flips acked_at and removes from unacked list (non-consuming for drain)", () => {
+    const { queue } = newQueue();
+    queue.enqueue({ message: makeMsg("a"), chatId: "chat-1", messageId: "m-1" });
+    queue.enqueue({ message: makeMsg("b"), chatId: "chat-1", messageId: "m-2" });
+    queue.enqueue({ message: makeMsg("c"), chatId: "chat-2", messageId: "m-3" });
+
+    const flipped = queue.ackByChatId("chat-1");
+    expect(flipped).toBe(2);
+
+    // Unacked list should now only contain chat-2
+    const unacked = queue.listUnackedUndrained();
+    expect(unacked).toHaveLength(1);
+    expect(unacked[0].chatId).toBe("chat-2");
+    expect(queue.countUnackedUndrained()).toBe(1);
+
+    // But undrained list (used by get_messages) still sees all 3 — ack does NOT consume.
+    const undrained = queue.listUndrained();
+    expect(undrained).toHaveLength(3);
+    queue.close();
+  });
+
+  test("ackByChatId is idempotent (second call returns 0 changes)", () => {
+    const { queue } = newQueue();
+    queue.enqueue({ message: makeMsg("x"), chatId: "chat-1", messageId: "m-1" });
+    expect(queue.ackByChatId("chat-1")).toBe(1);
+    expect(queue.ackByChatId("chat-1")).toBe(0);
+    queue.close();
+  });
+
+  test("ackByChatId on unknown chat is no-op", () => {
+    const { queue } = newQueue();
+    queue.enqueue({ message: makeMsg("x"), chatId: "chat-1", messageId: "m-1" });
+    expect(queue.ackByChatId("never-seen")).toBe(0);
+    expect(queue.countUnackedUndrained()).toBe(1);
+    queue.close();
+  });
+
+  test("draining a message removes it from unacked list even if not yet acked", () => {
+    const { queue } = newQueue();
+    queue.enqueue({ message: makeMsg("d"), chatId: "chat-1", messageId: "m-1" });
+    expect(queue.countUnackedUndrained()).toBe(1);
+    queue.markDrained(["m-1"]);
+    expect(queue.countUnackedUndrained()).toBe(0);
+    queue.close();
+  });
+
+  test("migration: existing DB without acked_at column is upgraded on open", () => {
+    // Create a queue, close it, then re-open with the same path.
+    // The second constructor must run the ALTER TABLE migration safely.
+    const dir = mkdtempSync(join(tmpdir(), "agentbridge-queue-migrate-"));
+    tempDirs.push(dir);
+    const dbFile = join(dir, "queue.db");
+    const auditFile = join(dir, "transcript.jsonl");
+
+    const q1 = new PersistentMessageQueue(dbFile, auditFile);
+    q1.enqueue({ message: makeMsg("pre"), chatId: "chat-1", messageId: "m-1" });
+    q1.close();
+
+    const q2 = new PersistentMessageQueue(dbFile, auditFile);
+    const list = q2.listUnackedUndrained();
+    expect(list).toHaveLength(1);
+    expect(list[0].ackedAt).toBeNull();
+    expect(q2.ackByChatId("chat-1")).toBe(1);
+    q2.close();
+  });
+});

--- a/src/unit-test/state-dir.test.ts
+++ b/src/unit-test/state-dir.test.ts
@@ -28,6 +28,8 @@ describe("StateDirResolver", () => {
     expect(resolver.statusFile).toBe(join(tempDir, "status.json"));
     expect(resolver.portsFile).toBe(join(tempDir, "ports.json"));
     expect(resolver.logFile).toBe(join(tempDir, "agentbridge.log"));
+    expect(resolver.queueDbFile).toBe(join(tempDir, "queue.db"));
+    expect(resolver.transcriptFile).toBe(join(tempDir, "transcript.jsonl"));
   });
 
   test("ensure() creates directory if it does not exist", () => {


### PR DESCRIPTION
## Summary

Two stacked commits adding both halves of the Codex↔Claude realtime path:

1. **Phase B** — `wait_for_messages(timeout_s)` MCP tool (long-poll on the SQLite pull queue from PR #77).
2. **Phase C** — UserPromptSubmit hook injection of pending Codex messages into Claude's context as `system-reminder additionalContext` when the Claude session is between turns. Non-consuming peek; ack happens inside `reply()` via `ackByChatId()`. Idle-side counterpart to Phase B's active-listening loop.

Together: Codex push → daemon queue → (active) `wait_for_messages` wake or (idle) next user prompt → injected context → Claude → `reply` (auto-acks) or `get_messages` (drains).

## Phase B (commit 1)

`wait_for_messages` registered alongside `get_messages` and `reply`. Polls `queue.countUndrained()` every 500ms; on hit, returns the same payload `get_messages` would return; on miss, returns a `[wait_for_messages] timed_out after Ns ...` block. Timeout clamped to `[1, 60]`. CLAUDE_INSTRUCTIONS updated to prefer this after `reply(require_reply=true)`.

## Phase C (commit 2)

**Schema**
- Add `acked_at INTEGER` column to `messages` table with `ALTER TABLE` migration for pre-existing DBs.
- New index `idx_messages_unacked_undrained`.

**API**
- `PersistentMessageQueue.ackByChatId(chatId)` flips `acked_at` for undrained+unacked rows on a chat. Idempotent.
- `listUnackedUndrained()` / `countUnackedUndrained()` for hook reads (non-mutating).
- `ClaudeAdapter.handleReply` calls `queue.ackByChatId(chat_id)` after successful send when chat_id is provided.

**Hooks**
- `scripts/peek_codex_queue.py` — read-only SQLite peek (`mode=ro` URI, safe under WAL). Emits `hookSpecificOutput` JSON, count, text, or raw JSON.
- `scripts/inject-pending-codex.sh` — UserPromptSubmit hook; calls peek and emits the `system-reminder` block.
- `scripts/health-check.sh` — SessionStart hook now appends pending count to the existing AgentBridge ready notice.
- `hooks/hooks.json` — registers UserPromptSubmit alongside SessionStart.

## Tests

- Phase B: `bun test src/unit-test/dual-mode.test.ts` — **35/35 pass** (4 new cases for immediate return, clean timeout, mid-wait wake, timeout clamping).
- Phase C: `bun test src/unit-test/message-queue.test.ts` — **7/7 pass** (migration safety, ackByChatId semantics, idempotency, ack-vs-drain independence, unacked listing).
- Full non-e2e: `bun test src` excluding `e2e-cli.test.ts` — **108/108 pass**.
- Pre-existing `e2e-cli.test.ts` failures on Windows are unrelated (test harness can't locate Claude binary; "URL must be of scheme file"). Not introduced by this PR.

## Stack context

Builds on (still open against `master`):
- #75 — recover stale Claude attach sessions (sticky lock)
- #76 — clean up stale Codex app-server processes on Windows pre-flight (orphan cleanup)
- #77 — `AGENTBRIDGE_MODE=dual` durable inbound persistence + diagnostic push

Phase C is logically independent of Phase B (hook reads SQLite directly, doesn't depend on the new MCP tool), but the commits live on the same branch for easier review. Happy to split into two PRs on request.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test src` (108/108 non-e2e)
- [x] `bun run build:plugin`
- [x] Phase B end-to-end: real Claude Code session — `reply(require_reply=true)` + `wait_for_messages` returned Codex pong in ~1s
- [ ] Phase C end-to-end: requires session restart to pick up rebuilt bridge-server.js — pending verification