### PR TITLE
release v0.1.6 — Codex TUI 可靠性 + push 默认 + 协作初始化

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "agentbridge",
       "description": "Bridge Claude Code and Codex through a shared daemon, push channel delivery, and reply/get_messages tools.",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "author": {
         "name": "AgentBridge Contributors",
         "email": "raysonmeng@qq.com"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ codex-plugin-cc/
 /.mcp.json
 agentbridge-context.md
 V1_PROGRESS.md
+# Added by code-review-graph
+.code-review-graph/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,93 @@
-# AgentBridge — Project Rules
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+Runtime is **Bun** — do not change the local Bun version.
+
+| Task | Command |
+|------|---------|
+| Install deps | `bun install` |
+| Type check | `bun run typecheck` (= `tsc --noEmit`) |
+| Run all tests | `bun test src` |
+| Run a single test file | `bun test src/unit-test/<name>.test.ts` |
+| Run a single test by name | `bun test src -t "<test name pattern>"` |
+| Full pre-commit check | `bun run check` (typecheck + tests + plugin sync + plugin versions) |
+| Build CLI binary | `bun run build:cli` → `dist/cli.js` |
+| Build plugin bundle | `bun run build:plugin` → `plugins/agentbridge/server/{bridge-server,daemon}.js` |
+| Verify plugin sync | `bun run verify:plugin-sync` |
+| Validate plugin manifest | `bun run validate:plugin` (requires `claude` CLI) |
+| Local dev link | `bun link` then `agentbridge dev` (registers local marketplace + installs plugin) |
+| Start session | `agentbridge claude` (one terminal) + `agentbridge codex` (another) |
+| Stop everything | `agentbridge kill` |
+
+**Before committing**: run `bun run typecheck && bun test src`.
+
+**After modifying `src/`**: run `bun run build:plugin` before end-to-end testing. The installed plugin loads the bundled JS under `plugins/agentbridge/server/`, not the raw TS — forgetting to rebuild means you are testing the old code.
+
+## Architecture
+
+AgentBridge is a **two-process** local bridge between Claude Code and Codex.
+
+```
+Claude Code ── MCP stdio ──▶ bridge.ts (foreground)
+                                 │ control WS :4502
+                                 ▼
+                             daemon.ts (persistent background)
+                                 │ ws proxy :4501
+                                 ▼
+                             Codex app-server :4500
+```
+
+- **`src/bridge.ts`** — foreground MCP server registered as a Claude Code plugin channel. Exits when Claude Code closes.
+- **`src/daemon.ts`** — long-lived background process; owns the Codex app-server proxy and the single source of truth for bridge state. Survives Claude Code restarts; `bridge.ts` reconnects with exponential backoff.
+- **`src/control-protocol.ts`** — message schema for the control WebSocket between foreground and daemon.
+- **`src/claude-adapter.ts`** — MCP tool surface exposed to Claude (`reply`, `get_messages`). Emits `notifications/claude/channel` on inbound messages (push mode).
+- **`src/codex-adapter.ts`** — WebSocket proxy in front of Codex app-server; intercepts `agentMessage` items and injects turns via `turn/start`.
+- **`src/message-filter.ts`** — collapses noisy intermediate events so only meaningful `agentMessage` payloads reach Claude.
+- **`src/daemon-lifecycle.ts`** — shared `ensureRunning` / `kill` / startup-lock logic; both the CLI and `bridge.ts` call into this.
+- **`src/daemon-client.ts`** — typed WS client used by `bridge.ts` to talk to the daemon control port.
+- **`src/config-service.ts`** + **`src/state-dir.ts`** — read/write `.agentbridge/config.json` and resolve the platform state dir (`daemon.pid`, `status.json`, `agentbridge.log`, `killed` sentinel, `startup.lock`).
+- **`src/cli.ts` + `src/cli/*.ts`** — `abg` / `agentbridge` command router (`init`, `claude`, `codex`, `kill`, `dev`).
+- **`src/marker-section.ts` + `src/collaboration-content.ts`** — idempotent marker-based injection of the `<!-- AgentBridge:start/end -->` block into `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `.cursorrules` / `.windsurfrules` / `.kiro/` / `.cursor/` etc. during `abg init`.
+- **`src/bridge-disabled-state.ts` + `src/tui-connection-state.ts`** — disabled-reason and TUI-connect state machines used by the kickoff + reconnect UX.
+
+### Data flow invariants
+
+- Every `BridgeMessage` carries a `source: "claude" | "codex"` — the bridge **never forwards a message back to its origin** (loop prevention).
+- Delivery mode is env-controlled by `AGENTBRIDGE_MODE` (`push` for channel notifications, `pull` for `get_messages`). Default is `push`.
+- Ports are fixed: `CODEX_WS_PORT=4500`, `CODEX_PROXY_PORT=4501`, `AGENTBRIDGE_CONTROL_PORT=4502`. One AgentBridge instance per machine (multi-project support is post-v1).
+- All state lives in the platform state dir (`AGENTBRIDGE_STATE_DIR`, default `~/Library/Application Support/AgentBridge/` on macOS, `$XDG_STATE_HOME/agentbridge/` on Linux). The daemon uses `startup.lock` + `killed` sentinel to coordinate startup and explicit-kill-don't-restart semantics.
+
+### Tests
+
+- Unit tests: `src/unit-test/*.test.ts` (one file per module, e.g. `daemon-lifecycle.test.ts`, `codex-adapter.test.ts`, `marker-section.test.ts`).
+- CLI integration: `src/e2e-cli.test.ts` + `src/unit-test/cli.test.ts`.
+- Reconnect E2E: `src/unit-test/e2e-reconnect.test.ts` and `src/unit-test/e2e/`.
+- `dual-mode.test.ts` covers push vs. pull delivery.
+- Every PR must ship both unit tests and an E2E test plan before merge.
 
 ## Git Workflow
 
 - **永远不要直接推送到 master 分支！** 所有改动必须通过 feature/fix 分支 + PR 合并。
-- 分支命名：`feat/xxx`（功能）、`fix/xxx`（修复）、`docs/xxx`（文档）
-- PR 必须交叉 review：Claude 写的 Codex review，Codex 写的 Claude review
-- 合并使用 squash merge
+- 分支命名：`feat/xxx`（功能）、`fix/xxx`（修复）、`docs/xxx`（文档）。
+- PR 必须交叉 review：Claude 写的由 Codex review，Codex 写的由 Claude review。
+- 合并使用 squash merge。
+- 提交信息与 release note **双语**（中文 + English）。
 
 ## Codex 协作
 
-- Codex 的 sandbox 禁止写 `.git` 目录 —— 所有 git 操作（commit/push/PR）由 Claude 代劳
-- Codex 在主目录 `/Users/raysonmeng/agent_bridge` 工作，Claude 用 worktree
-- 不要在 Codex active turn 期间发 reply —— busy guard 会拒绝
-- Codex TUI 的 resume 功能有已知 bug（GitHub #14470、#12382），建议开新会话
-- 连接 Codex TUI 使用 `agentbridge codex` 命令（通过 `bun link` 安装）
-- **测试某个 PR 时，必须切换到该 PR 对应的分支/worktree 下工作和测试**，不要在其他分支上测试。worktree 路径通常为 `/Users/raysonmeng/agent_bridge_wt_<PR号>`
-
-## 开发规范
-
-- 运行时：Bun（不要修改本地 Bun 版本）
-- 测试：`bun test src/` — 所有改动必须测试通过
-- 类型检查：`bun run typecheck` — 必须通过
-- 提交前必须跑 `bun run typecheck && bun test src/`
-- 环境变量有默认值，不需要 .env 文件
+- Codex sandbox 禁止写 `.git` —— 所有 git 操作（commit/push/PR）由 Claude 代劳。
+- Codex 在主目录 `/Users/raysonmeng/agent_bridge` 工作，Claude 使用 worktree（`/Users/raysonmeng/agent_bridge_wt_<PR号>`）。
+- 不要在 Codex active turn 期间发 `reply` —— busy guard 会拒绝。看到 `⏳ Codex is working` 时等 `✅ Codex finished` 再回复。
+- Codex TUI 的 resume 有已知 bug（GitHub #14470、#12382），建议开新会话。
+- 连接 Codex TUI 用 `agentbridge codex`（通过 `bun link` 安装）。
+- **测试 PR 时必须切到该 PR 对应的分支/worktree** — 不要在别的分支上测。
 
 ## 进度跟踪
 
-- `V1_PROGRESS.md`（本地文件，不提交到 git）记录 v1 任务进度
-- 每完成一个功能更新 Status 和 Progress Timeline
+- `V1_PROGRESS.md`（本地文件，不提交到 git）记录 v1 任务进度；每完成一个功能更新 Status 和 Progress Timeline。
 
 <!-- AgentBridge:start -->
 ## AgentBridge — Multi-Agent Collaboration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,70 @@
 
 - `V1_PROGRESS.md`（本地文件，不提交到 git）记录 v1 任务进度
 - 每完成一个功能更新 Status 和 Progress Timeline
+
+<!-- AgentBridge:start -->
+## AgentBridge — Multi-Agent Collaboration
+
+You are working in a **multi-agent environment** powered by AgentBridge.
+Another AI agent (Codex, by OpenAI) is available in a parallel session on this machine.
+
+### When to collaborate vs. work solo
+- **Collaborate** when the task benefits from a second perspective, parallel execution, or capabilities you lack (e.g., sandboxed code execution, independent verification).
+- **Work solo** for simple, self-contained tasks where the coordination overhead isn't worth it.
+- When in doubt, **propose a task split** to Codex rather than doing everything yourself.
+
+### Capability comparison
+| Capability | Claude (you) | Codex |
+|---|---|---|
+| Architecture & planning | Strong | Moderate |
+| Code review & analysis | Strong | Strong |
+| Sandboxed code execution | No | Yes |
+| File editing & refactoring | Yes (via tools) | Yes (via sandbox) |
+| Web search & docs | Yes | Limited |
+| Independent verification | Cross-review | Reproduce & test |
+
+### How to start collaborating
+1. When you receive a complex task, **proactively propose a division of labor** to Codex via the reply tool.
+2. State what you'll handle and what you'd like Codex to take on.
+3. Ask for Codex's agreement or counter-proposal before proceeding.
+4. After task completion, **cross-review** each other's work.
+<!-- AgentBridge:end -->
+
+<!-- code-review-graph MCP tools -->
+## MCP Tools: code-review-graph
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+|------|----------|
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.

--- a/docs/issues-2026-04-24-codex-not-initialized-after-silent-reconnect.md
+++ b/docs/issues-2026-04-24-codex-not-initialized-after-silent-reconnect.md
@@ -1,0 +1,237 @@
+# Codex TUI 静默闪退(第三种路径)——unintentional reconnect 后 stale session 触发 "Not initialized"
+
+> Date: 2026-04-24
+> Status: analysis complete, phase 2 fix pending
+> Author: Claude(现场诊断) / 请 Codex review 结论和修法
+> Related commit: `f8698b8` on branch `fix/codex-exit-diagnostics`
+> Related logs:
+> - `~/Library/Application Support/AgentBridge/codex-wrapper.log`
+> - `~/Library/Application Support/AgentBridge/agentbridge.log`
+
+## TL;DR
+
+我们上轮通过 `f8698b8` 加的 wrapper + adapter 日志,**第一次现场复现就抓到一个之前没覆盖的根因**。
+
+**不是** FatalExitRequest(Codex 之前 PTY 实验里的场景 A/B),
+**不是** ThreadClosed → ExitMode::Immediate(场景 C),
+**是**:**我们自己的 `handleAppServerClose` 在非主动 upstream 重连时没恢复 `initialize` 状态,TUI 继续用 stale session,后续请求触发 app-server 返回 `"Not initialized"`,TUI 从 `main()` 返 `Err`,exit(1)**。
+
+## 现场证据
+
+### 1. codex-wrapper.log —— TUI 侧退出
+
+```
+[2026-04-24T11:00:26.116Z] spawn: codex --enable tui_app_server --remote ws://127.0.0.1:4501 --yolo
+[2026-04-24T11:00:26.117Z] child pid=62380
+[2026-04-24T11:36:31.833Z] exit: code=1 signal=null runtime_ms=2165717 pid=62380 classification=nonzero_exit:1
+--- last stderr (377 bytes) ---
+Error: turn/steer failed: Not initialized
+
+Stack backtrace:
+   0: __mh_execute_header
+   1: __ZN4absl22internal_any_invocable19LocalManagerTrivialENS0_14FunctionToCallEPNS0_15TypeErasedStateES3_
+   2-8: __mh_execute_header
+--- end stderr ---
+```
+
+关键数据:
+- runtime **36 分钟**
+- exit code **1**,无 signal
+- classification `nonzero_exit:1`(不是 `fatal_exit`,因为 stderr 前缀不是 `ERROR: remote app server` 而是 `Error: turn/steer failed`)
+- stack backtrace 全 `__mh_execute_header` 是 release 构建 strip 后符号未解析的正常现象(即便 `RUST_BACKTRACE=full` 也无能为力)
+
+### 2. agentbridge.log —— 上游重连时序
+
+```
+11:00:26.177  Detected initialize — reconnecting app-server for fresh session
+11:00:26.178  App-server reconnected for new TUI session — replaying buffered messages
+11:00:26.179  TUI → app-server: initialize
+11:00:26.179  TUI → app-server: initialized
+
+... 33 分钟正常使用 ...
+
+11:33:34.444  App-server connection closed (intentional=false, tuiConnected=true, turnInProgress=true)  ← ⚠️ upstream 自己掉,还在 turn 中
+11:33:35.446  Reconnected to app-server                                                                  ← 1 秒后重连成功
+11:33:35.447  App-server reconnect successful
+
+...           TUI 对此毫不知情,继续在 stale session 上工作 3 分钟 ...
+
+11:36:31.806  TUI → app-server: turn/steer                                                               ← 用户按 ESC 取消 turn
+11:36:31.811  TUI disconnected (appServerOpen=true, turnInProgress=false, ...)                           ← 5ms 内 TUI 死
+```
+
+关键字段:
+- `intentional=false` → 这不是我们主动触发的 reconnect,是 upstream 自己掉
+- `turnInProgress=true` → 掉的时候还在处理一个 turn
+- `appServerOpen=true`(TUI 死的时候) → 证明死的原因不是"上游又掉了",而是 TUI 主动退出
+- 时间差 3 分钟 → 排除"立即死"路径
+
+## 为什么 Codex 之前的 PTY 实验没测到
+
+Codex 的三个场景:
+- A: `server close 1000` → 立即 FatalExit(stderr: `ERROR: remote app server ... disconnected: connection closed`)
+- B: `server close 1011` → 同 A,reason 不同
+- C: `thread/closed` notification → 立即 ExitMode::Immediate,空 stderr
+
+**没测**:"server close → 我们立即 reconnect → TUI 继续用 session 若干分钟 → TUI 发请求 → app-server 返回错误 → TUI 退出"
+
+这条链路依赖 **TUI 认为 session 还活着但实际 app-server 已经是全新 uninitialized 的**,需要时间差才能复现。PTY 实验一板一眼断 + 关,没打出来。
+
+## 根因 —— 在我们自己的代码里
+
+`src/codex-adapter.ts`:
+
+```
+handleAppServerClose()          ← upstream 非主动掉时触发
+  ├─ this.appServerWs = null
+  ├─ clearResponseTrackingState()
+  └─ scheduleReconnect()        ← 指数退避重连
+       └─ connectToAppServer(true)
+            └─ onopen: this.appServerWs = appWs  ← 直接设新 socket,没 replay initialize
+```
+
+对比主动触发的 reconnect(TUI 发 `initialize` 触发):
+
+```
+reconnectAppServerForNewSession(tuiWs)
+  ├─ buffer TUI 消息
+  ├─ 关旧 appServerWs
+  ├─ connectToAppServer(false)
+  └─ replay buffered messages   ← 这里重发 initialize + initialized
+```
+
+**区别是**:主动重连有 replay 机制,非主动重连没有。
+新 app-server session 是 uninitialized 的,任何需要 initialized state 的请求都会返回 `{error: "Not initialized"}`,TUI 视为 fatal,exit(1)。
+
+## 为什么 `outageQueue`(phase 1 的修复)救不了
+
+`outageQueue` 只 buffer **outage 期间 TUI 发的消息**。这个 case 的事件序列:
+
+1. 11:33:34 upstream close
+2. 11:33:35 我们重连(1 秒,快于 5 秒 timeout)
+3. 这 1 秒内 TUI **没发任何消息** → queue 是空的
+4. 等到 TUI 在 3 分钟后发 `turn/steer` 时,`appServerWs` 已经 OPEN,直接走 forward 分支
+5. forward 到新 session → 新 session 说 "Not initialized" → TUI 死
+
+**outageQueue 防的是"TUI 发的消息丢"的问题,不防"session 状态丢"的问题。这是两个不同的 failure mode。**
+
+## Phase 2 修法:缓存 + replay initialize(用户选了 A)
+
+### A.1 捕获阶段
+
+在 `onTuiMessage` 里,**在 id-rewriting 之前**,识别并缓存:
+- `initialize` 请求的原始 JSON(含 params)
+- `initialized` notification 的原始 JSON
+- 当前 `thread/start` 或 `thread/resume` 的 threadId(我们已经有 `this.threadId` 字段了)
+
+存在新字段上,例如:
+```typescript
+private lastInitializeRaw: string | null = null;
+private lastInitializedRaw: string | null = null;
+// this.threadId 已存在
+```
+
+### A.2 replay 阶段
+
+`scheduleReconnect` 成功 onopen 后(非主动重连路径),自动:
+
+1. 若 `lastInitializeRaw` 存在,发给新 app-server
+   - 用新的 proxy id,注意 rewrite
+   - 等 response 确认才继续(需要 awaitable send helper,或基于 id 挂钩)
+2. 若 `lastInitializedRaw` 存在,发过去(notification 无需等 response)
+3. 若 `this.threadId` 存在,发 `thread/resume {threadId}`
+4. 全部成功 → 照常服务 TUI,TUI 无感
+5. 任何一步失败 → 降级成方案 B(close TUI 1011,让 codex-rs FatalExit,用户重启)
+
+伪码:
+```typescript
+private async restoreSessionAfterUnintentionalReconnect() {
+  if (!this.lastInitializeRaw) return true; // nothing to replay
+
+  try {
+    await this.sendAndAwait(this.lastInitializeRaw, "initialize");
+    if (this.lastInitializedRaw) this.appServerWs.send(this.lastInitializedRaw);
+    if (this.threadId) {
+      await this.sendAndAwait(JSON.stringify({
+        jsonrpc: "2.0",
+        id: ...,
+        method: "thread/resume",
+        params: { threadId: this.threadId },
+      }), "thread/resume");
+    }
+    this.log(`DIAGNOSTIC: session restored after unintentional reconnect (threadId=${this.threadId})`);
+    return true;
+  } catch (e) {
+    this.log(`ERROR: session restore failed: ${e.message} — closing TUI 1011`);
+    this.tuiWs?.close(1011, "agentbridge: session restore failed after app-server reconnect");
+    return false;
+  }
+}
+```
+
+挂在 `connectToAppServer` 的 `onopen` 里,仅在 `isReconnect === true` 时触发(跳过首次连接)。
+
+### A.3 边界情况
+
+- **TUI 还没发过 initialize** → 没缓存 → reconnect 后直接走老路(可能后续也没事,可能 TUI 还会主动重新 initialize)
+- **app-server 明确拒绝 replay 后的 initialize**(schema 不兼容、seq 校验等) → 降级关 TUI 1011
+- **replay 期间 TUI 又发了新消息** → 复用 `pendingTuiMessages` + `reconnectingForNewSession` 已有机制,buffer 后 flush
+- **`this.threadId` 为 null** 但 initialize 已发(TUI 还没进 thread) → 只 replay initialize + initialized,不发 thread/resume
+- **`clearResponseTrackingState` 和 cache 的互斥**:replay 的消息不应当受 clearResponseTrackingState 影响 —— cache 字段要独立存活
+
+### A.4 风险点(需要 Codex 从 codex-rs 源码确认)
+
+**请 Codex 下次 session 重点查**:
+
+1. **`initialize` handler 对重复调用的行为**
+   - 若 idempotent,replay 安全
+   - 若返回 error(如 "already initialized"),replay 要先 close-then-open
+2. **`thread/resume` 能否在 fresh session 上直接用**
+   - 还是必须先重新 `initialize` 再 `thread/resume`
+   - 还是需要额外的 `thread/attach` 或 `session/attach` 语义
+3. **`initialize` 的 params 里有没有 session-unique 字段**
+   - 比如 client nonce、challenge token、timestamp 校验
+   - 如果有,直接 replay 会被 app-server 拒
+4. **TUI 启动时有没有除了 initialize 以外的"session bootstrap"请求**
+   - 比如 `account/read`、`skills/list` 等(我们日志里看到过)
+   - 这些是幂等的还是 session-dependent,影响要不要也一起 replay
+
+**如果 codex-rs 源码显示 initialize 不可重放**,那方案 A 不可行,回退到方案 B(直接关 TUI 1011,让用户感知到断连)。
+
+### A.5 测试策略
+
+- 单测:构造一个 mock app-server,先正常 handshake,然后主动 close,再接受新连接,验证 adapter 自动发了 initialize + (optional) thread/resume
+- 集成测:模拟上游 1s 短断,观察 `codex-wrapper.log` 里没有"闪退"记录,TUI 继续可用
+- E2E:用户实际跑一次 `abg codex`,人为杀掉 daemon 里的 app-server 连接(需要暴露一个测试端口或 SIGUSR1),看 TUI 是否无感续用
+
+## 分类 regex 建议同步扩
+
+当前 `src/cli/codex.ts` 的启发式分类:
+```typescript
+if (/ERROR: remote app server/.test(tail)) classification = "fatal_exit";
+else if (signal) classification = `signal:${signal}`;
+else if (typeof code === "number" && code !== 0) classification = `nonzero_exit:${code}`;
+else if (code === 0 && tail.trim().length === 0) classification = "exit_0_empty_stderr";
+```
+
+**新增规则**(Claude 这轮 phase 2 会一起加上):
+```typescript
+else if (/Error: .* failed: Not initialized/.test(tail)) classification = "not_initialized_after_reconnect";
+else if (/Error: .* failed:/.test(tail)) classification = "rpc_error_exit";
+```
+
+这样以后再出类似闪退,wrapper log 的 classification 字段直接就能告诉人是不是这个 bug 或类似 bug。
+
+## 当前状态
+
+- `f8698b8` 已 push 到 `fix/codex-exit-diagnostics`(远程)
+- phase 1(诊断基建)工作如预期 —— 这次闪退**全程 on record**,可复盘
+- phase 2(replay initialize)Claude 这轮继续做,Codex 下次上线请先 review 本文档再动工
+- 用户未开 PR,等本 bug 也修完一并开
+
+## 给 Codex 的明确问题清单
+
+1. 同意"真正根因是非主动 reconnect 没 replay initialize"这个判断吗?有没有更简单的解释我们漏了?
+2. 对 A.4 的 4 个风险点,codex-rs 源码侧答案是什么?
+3. 如果 A 不可行,降级到 B(立即关 TUI 强制重启)你觉得用户能接受吗?还是要做 C(replay 后若失败再降级 B)?
+4. A 方案的 `sendAndAwait` helper 要不要抽成公共工具,后续别的 replay 场景也能用?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raysonmeng/agentbridge",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Bridge between Claude Code and Codex — bidirectional agent communication via MCP Channel + JSON-RPC",
   "type": "module",
   "bin": {

--- a/plugins/agentbridge/.claude-plugin/plugin.json
+++ b/plugins/agentbridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentbridge",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Bridge Claude Code and Codex with a shared daemon, push channel delivery, and bidirectional reply tooling.",
   "author": {
     "name": "AgentBridge Contributors",

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13804,8 +13804,8 @@ class ClaudeAdapter extends EventEmitter {
       this.resolvedMode = this.configuredMode;
       this.log(`Delivery mode set by AGENTBRIDGE_MODE: ${this.resolvedMode}`);
     } else {
-      this.resolvedMode = "pull";
-      this.log("Delivery mode defaulting to pull (set AGENTBRIDGE_MODE=push to opt into channel delivery)");
+      this.resolvedMode = "push";
+      this.log("Delivery mode defaulting to push (set AGENTBRIDGE_MODE=pull to use polling instead)");
     }
   }
   async pushNotification(message) {
@@ -14518,6 +14518,8 @@ var daemonClient = new DaemonClient(CONTROL_WS_URL);
 var shuttingDown = false;
 var daemonDisabled = false;
 var daemonDisabledReason = null;
+var hasSeenTuiConnect = false;
+var previousTuiConnected = false;
 var RECONNECT_NOTIFY_COOLDOWN_MS = 30000;
 var DISABLED_RECOVERY_INTERVAL_MS = 5000;
 var lastDisconnectNotifyTs = 0;
@@ -14542,6 +14544,18 @@ daemonClient.on("codexMessage", (message) => {
 });
 daemonClient.on("status", (status) => {
   log(`Daemon status: ready=${status.bridgeReady} tui=${status.tuiConnected} thread=${status.threadId ?? "none"} queued=${status.queuedMessageCount}`);
+  if (!hasSeenTuiConnect && status.tuiConnected && !previousTuiConnected) {
+    hasSeenTuiConnect = true;
+    log("First TUI connect detected \u2014 sending kickoff message to Claude");
+    claude.pushNotification(systemMessage("system_tui_kickoff", [
+      "\uD83E\uDD1D Codex has connected via AgentBridge.",
+      "You are now in a multi-agent collaboration session.",
+      "When you receive a complex task, propose a division of labor to Codex.",
+      "Use `reply` to send messages and `get_messages` to check for responses."
+    ].join(`
+`)));
+  }
+  previousTuiConnected = status.tuiConnected;
 });
 daemonClient.on("disconnect", () => {
   if (shuttingDown || daemonDisabled)

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13708,6 +13708,9 @@ class StateDirResolver {
   get logFile() {
     return join(this.stateDir, "agentbridge.log");
   }
+  get codexWrapperLogFile() {
+    return join(this.stateDir, "codex-wrapper.log");
+  }
   get killedFile() {
     return join(this.stateDir, "killed");
   }

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1656,6 +1656,7 @@ var idleShutdownTimer = null;
 var claudeDisconnectTimer = null;
 var claudeOnlineNoticeSent = false;
 var claudeOfflineNoticeShown = false;
+var codexCollaborationKickoffSent = false;
 var lastAttachStatusSentTs = 0;
 var ATTACH_STATUS_COOLDOWN_MS = 30000;
 var bufferedMessages = [];
@@ -2056,7 +2057,19 @@ function currentReadyMessage() {
 function notifyCodexClaudeOnline() {
   claudeOnlineNoticeSent = true;
   claudeOfflineNoticeShown = false;
-  codex.injectMessage("\u2705 AgentBridge connected to Claude Code.");
+  if (!codexCollaborationKickoffSent) {
+    codexCollaborationKickoffSent = true;
+    codex.injectMessage([
+      "\uD83E\uDD1D Claude Code has connected via AgentBridge.",
+      "You are now in a multi-agent collaboration session.",
+      "When you receive a complex task, propose a division of labor to Claude.",
+      "Claude can send you messages \u2014 they will appear as injected user messages.",
+      "Respond naturally and Claude will receive your output via AgentBridge."
+    ].join(`
+`));
+  } else {
+    codex.injectMessage("\u2705 AgentBridge connected to Claude Code.");
+  }
 }
 function shouldNotifyCodexClaudeOnline() {
   return !claudeOnlineNoticeSent || claudeOfflineNoticeShown;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -54,6 +54,9 @@ class StateDirResolver {
   get logFile() {
     return join(this.stateDir, "agentbridge.log");
   }
+  get codexWrapperLogFile() {
+    return join(this.stateDir, "codex-wrapper.log");
+  }
   get killedFile() {
     return join(this.stateDir, "killed");
   }
@@ -133,6 +136,10 @@ class CodexAdapter extends EventEmitter {
   reconnectingForNewSession = false;
   replayingBufferedMessages = false;
   appServerGeneration = 0;
+  outageQueue = [];
+  outageTimer = null;
+  static OUTAGE_QUEUE_MAX = 64;
+  static OUTAGE_TIMEOUT_MS = 5000;
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
     this.appPort = appPort;
@@ -172,6 +179,8 @@ class CodexAdapter extends EventEmitter {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+    this.outageQueue = [];
+    this.clearOutageTimer();
     this.appServerWs?.close();
     this.appServerWs = null;
     for (const [id, sec] of this.secondaryConnections) {
@@ -253,6 +262,7 @@ class CodexAdapter extends EventEmitter {
         this.reconnectAttempts = 0;
         this.log(isReconnect ? "Reconnected to app-server" : "Connected to app-server");
         this.flushPendingServerResponses();
+        this.drainOutageQueue();
         resolve();
       };
       appWs.onmessage = (event) => {
@@ -351,13 +361,82 @@ class CodexAdapter extends EventEmitter {
     }, delay);
   }
   handleAppServerClose() {
-    this.log("App-server connection closed");
+    const intentional = this.intentionalDisconnect;
+    const tuiConnected = this.tuiWs !== null;
+    this.log(`App-server connection closed (intentional=${intentional}, tuiConnected=${tuiConnected}, turnInProgress=${this.turnInProgress})`);
     this.appServerWs = null;
     this.clearResponseTrackingState();
     this.activeTurnIds.clear();
     this.turnInProgress = false;
-    if (!this.intentionalDisconnect) {
+    if (!intentional) {
       this.scheduleReconnect();
+    }
+  }
+  bufferDuringOutage(ws, raw) {
+    if (this.outageQueue.length >= CodexAdapter.OUTAGE_QUEUE_MAX) {
+      this.log(`ERROR: outage queue overflow (${this.outageQueue.length}/${CodexAdapter.OUTAGE_QUEUE_MAX}) \u2014 closing TUI with 1011`);
+      this.outageQueue = [];
+      this.clearOutageTimer();
+      if (this.tuiWs && this.tuiWs === ws) {
+        try {
+          ws.close(1011, "agentbridge: app-server unavailable; pending TUI queue overflow");
+        } catch (e) {
+          this.log(`Failed to close TUI WS after outage queue overflow: ${e.message}`);
+        }
+      }
+      return;
+    }
+    this.outageQueue.push({ raw, connId: ws.data.connId });
+    this.log(`DIAGNOSTIC: buffered TUI message while app-server unavailable (queue size=${this.outageQueue.length}/${CodexAdapter.OUTAGE_QUEUE_MAX})`);
+    this.ensureOutageTimer();
+  }
+  ensureOutageTimer() {
+    if (this.outageTimer !== null)
+      return;
+    this.outageTimer = setTimeout(() => {
+      this.outageTimer = null;
+      const buffered = this.outageQueue.length;
+      this.outageQueue = [];
+      this.log(`ERROR: app-server did not return within ${CodexAdapter.OUTAGE_TIMEOUT_MS}ms (buffered=${buffered}) \u2014 closing TUI with 1011`);
+      const ws = this.tuiWs;
+      if (ws) {
+        try {
+          ws.close(1011, `agentbridge: app-server unavailable after ${CodexAdapter.OUTAGE_TIMEOUT_MS}ms; buffered=${buffered}`);
+        } catch (e) {
+          this.log(`Failed to close TUI WS on outage timeout: ${e.message}`);
+        }
+      }
+    }, CodexAdapter.OUTAGE_TIMEOUT_MS);
+  }
+  clearOutageTimer() {
+    if (this.outageTimer !== null) {
+      clearTimeout(this.outageTimer);
+      this.outageTimer = null;
+    }
+  }
+  drainOutageQueue() {
+    if (this.outageQueue.length === 0) {
+      this.clearOutageTimer();
+      return;
+    }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN)
+      return;
+    const ws = this.tuiWs;
+    if (!ws) {
+      this.outageQueue = [];
+      this.clearOutageTimer();
+      return;
+    }
+    const messages = this.outageQueue;
+    this.outageQueue = [];
+    this.clearOutageTimer();
+    this.log(`DIAGNOSTIC: replaying ${messages.length} buffered TUI messages after app-server reconnect`);
+    for (const msg of messages) {
+      try {
+        this.onTuiMessage(ws, msg.raw);
+      } catch (e) {
+        this.log(`Failed to replay buffered TUI message (conn #${msg.connId}): ${e.message}`);
+      }
     }
   }
   startProxy() {
@@ -505,12 +584,18 @@ class CodexAdapter extends EventEmitter {
       return;
     }
     if (this.tuiWs === ws) {
-      this.log(`TUI disconnected (conn #${connId})`);
+      const appServerOpen = this.appServerWs?.readyState === WebSocket.OPEN;
+      this.log(`TUI disconnected (conn #${connId}, appServerOpen=${appServerOpen}, turnInProgress=${this.turnInProgress}, pendingTuiMessages=${this.pendingTuiMessages.length}, outageQueue=${this.outageQueue.length}, reconnectingForNewSession=${this.reconnectingForNewSession})`);
       this.tuiWs = null;
       if (this.reconnectingForNewSession) {
         this.log("Clearing pending TUI message buffer (TUI disconnected during app-server reconnect)");
         this.pendingTuiMessages = [];
         this.reconnectingForNewSession = false;
+      }
+      if (this.outageQueue.length > 0 || this.outageTimer !== null) {
+        this.log(`Clearing outage queue on TUI disconnect (buffered=${this.outageQueue.length})`);
+        this.outageQueue = [];
+        this.clearOutageTimer();
       }
       this.emit("tuiDisconnected", connId);
     } else {
@@ -585,6 +670,14 @@ class CodexAdapter extends EventEmitter {
         return;
       }
     }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      if (this.tuiWs && this.tuiWs === ws) {
+        this.bufferDuringOutage(ws, data);
+      } else {
+        this.log(`WARNING: non-primary TUI attempted to send while app-server down \u2014 dropped (connId=${connId})`);
+      }
+      return;
+    }
     let forwarded = data;
     try {
       const parsed = JSON.parse(data);
@@ -605,7 +698,7 @@ class CodexAdapter extends EventEmitter {
     if (this.appServerWs?.readyState === WebSocket.OPEN) {
       this.appServerWs.send(forwarded);
     } else {
-      this.log(`WARNING: app-server not connected, dropping message`);
+      this.log(`WARNING: app-server closed between OPEN check and send \u2014 message lost (connId=${ws.data.connId})`);
     }
   }
   handleAppServerPayload(raw) {
@@ -613,6 +706,11 @@ class CodexAdapter extends EventEmitter {
       const parsed = JSON.parse(raw);
       if (isAppServerNotification(parsed) || typeof parsed === "object" && parsed !== null && !("id" in parsed)) {
         const notificationLike = parsed;
+        if (notificationLike.method === "thread/closed") {
+          const params = notificationLike.params;
+          const threadId = typeof params?.threadId === "string" ? params.threadId : "unknown";
+          this.log(`DIAGNOSTIC: app-server emitted thread/closed (threadId=${threadId}) \u2014 TUI will exit(0) silently`);
+        }
         const forwarded = this.patchResponse(notificationLike, raw);
         this.interceptServerMessage(notificationLike);
         return forwarded;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -140,6 +140,11 @@ class CodexAdapter extends EventEmitter {
   outageTimer = null;
   static OUTAGE_QUEUE_MAX = 64;
   static OUTAGE_TIMEOUT_MS = 5000;
+  lastInitializeRaw = null;
+  lastInitializedRaw = null;
+  sessionRestoreInProgress = false;
+  replayPending = new Map;
+  static SESSION_REPLAY_TIMEOUT_MS = 5000;
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
     this.appPort = appPort;
@@ -262,7 +267,14 @@ class CodexAdapter extends EventEmitter {
         this.reconnectAttempts = 0;
         this.log(isReconnect ? "Reconnected to app-server" : "Connected to app-server");
         this.flushPendingServerResponses();
-        this.drainOutageQueue();
+        if (isReconnect) {
+          this.handleSessionRestoreAfterReconnect().finally(() => this.drainOutageQueue()).catch((e) => {
+            const m = e instanceof Error ? e.message : String(e);
+            this.log(`session restore unexpected error: ${m}`);
+          });
+        } else {
+          this.drainOutageQueue();
+        }
         resolve();
       };
       appWs.onmessage = (event) => {
@@ -413,6 +425,97 @@ class CodexAdapter extends EventEmitter {
       clearTimeout(this.outageTimer);
       this.outageTimer = null;
     }
+  }
+  async handleSessionRestoreAfterReconnect() {
+    if (!this.lastInitializeRaw) {
+      this.log("DIAGNOSTIC: no cached initialize to replay after unintentional reconnect");
+      return;
+    }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      this.log("DIAGNOSTIC: app-server not open at session restore start \u2014 skipping");
+      return;
+    }
+    this.sessionRestoreInProgress = true;
+    try {
+      this.log(`DIAGNOSTIC: replaying cached initialize to restore session (threadId=${this.threadId ?? "none"})`);
+      await this.sendReplayAndAwait(this.lastInitializeRaw, "initialize");
+      if (this.lastInitializedRaw && this.appServerWs.readyState === WebSocket.OPEN) {
+        this.appServerWs.send(this.lastInitializedRaw);
+      }
+      if (this.threadId && this.appServerWs.readyState === WebSocket.OPEN) {
+        const replayId = `agentbridge-replay-thread-resume-${Date.now()}`;
+        const resumeRaw = JSON.stringify({
+          jsonrpc: "2.0",
+          id: replayId,
+          method: "thread/resume",
+          params: { threadId: this.threadId }
+        });
+        await this.sendReplayAndAwait(resumeRaw, "thread/resume");
+      }
+      this.log(`DIAGNOSTIC: session restored after unintentional reconnect (threadId=${this.threadId ?? "none"})`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log(`ERROR: session restore failed (${msg}) \u2014 closing TUI with 1011`);
+      const tuiWs = this.tuiWs;
+      if (tuiWs) {
+        try {
+          tuiWs.close(1011, `agentbridge: session restore failed: ${msg}`);
+        } catch (closeErr) {
+          const cm = closeErr instanceof Error ? closeErr.message : String(closeErr);
+          this.log(`Failed to close TUI after session restore failure: ${cm}`);
+        }
+      }
+    } finally {
+      this.sessionRestoreInProgress = false;
+    }
+  }
+  sendReplayAndAwait(raw, method) {
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("app-server not open"));
+    }
+    let id;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed.id === undefined) {
+        return Promise.reject(new Error(`replay payload for ${method} has no id`));
+      }
+      id = parsed.id;
+    } catch (e) {
+      const m = e instanceof Error ? e.message : String(e);
+      return Promise.reject(new Error(`replay parse failed for ${method}: ${m}`));
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.replayPending.delete(id);
+        reject(new Error(`replay timeout (${CodexAdapter.SESSION_REPLAY_TIMEOUT_MS}ms) for ${method} id=${JSON.stringify(id)}`));
+      }, CodexAdapter.SESSION_REPLAY_TIMEOUT_MS);
+      this.replayPending.set(id, { method, resolve, reject, timer });
+      try {
+        this.appServerWs.send(raw);
+      } catch (e) {
+        clearTimeout(timer);
+        this.replayPending.delete(id);
+        const m = e instanceof Error ? e.message : String(e);
+        reject(new Error(`replay send failed for ${method}: ${m}`));
+      }
+    });
+  }
+  tryConsumeReplayResponse(payload) {
+    const id = payload.id;
+    if (id === undefined)
+      return false;
+    const pending = this.replayPending.get(id);
+    if (!pending)
+      return false;
+    clearTimeout(pending.timer);
+    this.replayPending.delete(id);
+    if (payload.error !== undefined) {
+      const errMsg = typeof payload.error === "object" && payload.error !== null && "message" in payload.error ? String(payload.error.message ?? "unknown") : JSON.stringify(payload.error);
+      pending.reject(new Error(`${pending.method} rejected: ${errMsg}`));
+    } else {
+      pending.resolve(payload);
+    }
+    return true;
   }
   drainOutageQueue() {
     if (this.outageQueue.length === 0) {
@@ -659,6 +762,7 @@ class CodexAdapter extends EventEmitter {
     } catch {}
     if (!this.replayingBufferedMessages) {
       if (detectedMethod === "initialize") {
+        this.lastInitializeRaw = data;
         this.log("Detected initialize \u2014 reconnecting app-server for fresh session");
         this.reconnectingForNewSession = true;
         this.pendingTuiMessages = [data];
@@ -670,7 +774,10 @@ class CodexAdapter extends EventEmitter {
         return;
       }
     }
-    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+    if (detectedMethod === "initialized") {
+      this.lastInitializedRaw = data;
+    }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN || this.sessionRestoreInProgress) {
       if (this.tuiWs && this.tuiWs === ws) {
         this.bufferDuringOutage(ws, data);
       } else {
@@ -704,6 +811,11 @@ class CodexAdapter extends EventEmitter {
   handleAppServerPayload(raw) {
     try {
       const parsed = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null && "id" in parsed) {
+        if (this.tryConsumeReplayResponse(parsed)) {
+          return null;
+        }
+      }
       if (isAppServerNotification(parsed) || typeof parsed === "object" && parsed !== null && !("id" in parsed)) {
         const notificationLike = parsed;
         if (notificationLike.method === "thread/closed") {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1723,6 +1723,9 @@ codex.on("turnCompleted", () => {
   replyReceivedDuringTurn = false;
   emitToClaude(systemMessage("system_turn_completed", "\u2705 Codex finished the current turn. You can reply now if needed."));
   startAttentionWindow();
+  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
+    notifyCodexClaudeOnline();
+  }
 });
 codex.on("ready", (threadId) => {
   tuiConnectionState.markBridgeReady();
@@ -2055,21 +2058,23 @@ function currentReadyMessage() {
   return `\u2705 Codex TUI connected (${codex.activeThreadId}). Bridge ready.`;
 }
 function notifyCodexClaudeOnline() {
+  const message = !codexCollaborationKickoffSent ? [
+    "\uD83E\uDD1D Claude Code has connected via AgentBridge.",
+    "You are now in a multi-agent collaboration session.",
+    "When you receive a complex task, propose a division of labor to Claude.",
+    "Claude can send you messages \u2014 they will appear as injected user messages.",
+    "Respond naturally and Claude will receive your output via AgentBridge."
+  ].join(`
+`) : "\u2705 AgentBridge connected to Claude Code.";
+  const delivered = codex.injectMessage(message);
+  if (!delivered) {
+    log("Deferred Claude-online notice to Codex \u2014 will retry after current turn completes");
+    return false;
+  }
   claudeOnlineNoticeSent = true;
   claudeOfflineNoticeShown = false;
-  if (!codexCollaborationKickoffSent) {
-    codexCollaborationKickoffSent = true;
-    codex.injectMessage([
-      "\uD83E\uDD1D Claude Code has connected via AgentBridge.",
-      "You are now in a multi-agent collaboration session.",
-      "When you receive a complex task, propose a division of labor to Claude.",
-      "Claude can send you messages \u2014 they will appear as injected user messages.",
-      "Respond naturally and Claude will receive your output via AgentBridge."
-    ].join(`
-`));
-  } else {
-    codex.injectMessage("\u2705 AgentBridge connected to Claude Code.");
-  }
+  codexCollaborationKickoffSent = true;
+  return true;
 }
 function shouldNotifyCodexClaudeOnline() {
   return !claudeOnlineNoticeSent || claudeOfflineNoticeShown;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1008,10 +1008,15 @@ class CodexAdapter extends EventEmitter {
     this.serverRequestToProxy.clear();
     this.pendingServerResponses.clear();
   }
+  static buildPortListenLsofCommand(port) {
+    return `lsof -ti tcp:${port} -sTCP:LISTEN`;
+  }
   async checkPorts() {
     for (const port of [this.appPort, this.proxyPort]) {
       try {
-        const pids = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
+        const pids = execSync(CodexAdapter.buildPortListenLsofCommand(port), {
+          encoding: "utf-8"
+        }).trim();
         if (!pids)
           continue;
         const pidList = pids.split(`
@@ -1041,7 +1046,9 @@ class CodexAdapter extends EventEmitter {
           throw new Error(`Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
         }
         try {
-          const remaining = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
+          const remaining = execSync(CodexAdapter.buildPortListenLsofCommand(port), {
+            encoding: "utf-8"
+          }).trim();
           if (remaining) {
             throw new Error(`Port ${port} is still occupied (PID(s): ${remaining.replace(/\n/g, ", ")}) after cleanup. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
           }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -25,6 +25,10 @@ let shuttingDown = false;
 let daemonDisabled = false;
 let daemonDisabledReason: BridgeDisabledReason | null = null;
 
+// --- TUI kickoff tracking ---
+let hasSeenTuiConnect = false;
+let previousTuiConnected = false;
+
 // --- Notification throttling for reconnect loops ---
 const RECONNECT_NOTIFY_COOLDOWN_MS = 30_000; // Only notify once per 30s window
 const DISABLED_RECOVERY_INTERVAL_MS = 5_000;
@@ -57,6 +61,22 @@ daemonClient.on("status", (status) => {
   log(
     `Daemon status: ready=${status.bridgeReady} tui=${status.tuiConnected} thread=${status.threadId ?? "none"} queued=${status.queuedMessageCount}`,
   );
+
+  // Kickoff message on first TUI connect transition (not reconnects)
+  if (!hasSeenTuiConnect && status.tuiConnected && !previousTuiConnected) {
+    hasSeenTuiConnect = true;
+    log("First TUI connect detected — sending kickoff message to Claude");
+    void claude.pushNotification(systemMessage(
+      "system_tui_kickoff",
+      [
+        "🤝 Codex has connected via AgentBridge.",
+        "You are now in a multi-agent collaboration session.",
+        "When you receive a complex task, propose a division of labor to Codex.",
+        "Use `reply` to send messages and `get_messages` to check for responses.",
+      ].join("\n"),
+    ));
+  }
+  previousTuiConnected = status.tuiConnected;
 });
 
 daemonClient.on("disconnect", () => {

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -5,7 +5,7 @@
  *   - Push mode (OAuth): real-time via notifications/claude/channel
  *   - Pull mode (API key): message queue + get_messages tool
  *
- * Mode defaults to pull in auto mode, or set explicitly via AGENTBRIDGE_MODE env var.
+ * Mode defaults to push in auto mode, or set explicitly via AGENTBRIDGE_MODE env var.
  *
  * Emits:
  *   - "ready"   ()                   — MCP connected, mode resolved
@@ -137,12 +137,12 @@ export class ClaudeAdapter extends EventEmitter {
       this.resolvedMode = this.configuredMode;
       this.log(`Delivery mode set by AGENTBRIDGE_MODE: ${this.resolvedMode}`);
     } else {
-      // Default to pull — Claude Code doesn't declare channel support in
-      // client capabilities, so we can't reliably detect whether channel
-      // delivery is actually working. Users can opt into push explicitly with
-      // AGENTBRIDGE_MODE=push when their setup is known to support it.
-      this.resolvedMode = "pull";
-      this.log("Delivery mode defaulting to pull (set AGENTBRIDGE_MODE=push to opt into channel delivery)");
+      // Default to push — AgentBridge always runs as a Claude Code plugin
+      // with --dangerously-load-development-channels, so channel delivery
+      // is available. If push fails, pushViaChannel already falls back to
+      // queueForPull per-message.
+      this.resolvedMode = "push";
+      this.log("Delivery mode defaulting to push (set AGENTBRIDGE_MODE=pull to use polling instead)");
     }
   }
 

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -1,9 +1,54 @@
 import { spawn, execSync } from "node:child_process";
-import { openSync, writeSync, closeSync, writeFileSync, unlinkSync } from "node:fs";
+import {
+  openSync,
+  writeSync,
+  closeSync,
+  writeFileSync,
+  unlinkSync,
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";
+import { dirname } from "node:path";
 import { StateDirResolver } from "../state-dir";
 import { ConfigService } from "../config-service";
 import { DaemonLifecycle } from "../daemon-lifecycle";
+import { StderrRingBuffer } from "../stderr-ring-buffer";
 import { checkOwnedFlagConflicts } from "./claude";
+
+/**
+ * Write a timestamped entry to the codex wrapper log.
+ *
+ * Silent on IO failure — logging must never break the wrapper itself.
+ */
+function appendWrapperLog(path: string, entry: string): void {
+  try {
+    const dir = dirname(path);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    appendFileSync(path, `[${new Date().toISOString()}] ${entry}\n`, "utf-8");
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Build the child env for codex.
+ *
+ * Enables Rust tracing + full backtrace so that the next "silent exit" shows
+ * up in `~/.codex/log/codex-tui.log` and on stderr (which we also tee).
+ * User-provided values take precedence — we only set defaults.
+ */
+function buildChildEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    RUST_BACKTRACE: process.env.RUST_BACKTRACE ?? "full",
+    RUST_LOG:
+      process.env.RUST_LOG ??
+      "info,codex_core=debug,codex_tui=debug,codex_app_server=debug",
+  };
+}
 
 /** Flags that AgentBridge owns for codex command. */
 const OWNED_FLAGS = ["--remote"];
@@ -129,13 +174,40 @@ export async function runCodex(args: string[]) {
     ...args,
   ];
 
+  // Capture the last 64KB of child stderr so the "ERROR: ..." line from
+  // codex-rs on ExitReason::Fatal survives even when stdio is inherited by
+  // a terminal that clears on exit. See codex-rs/cli/src/main.rs:553.
+  const stderrTail = new StderrRingBuffer();
+  const wrapperLogPath = stateDir.codexWrapperLogFile;
+  const startedAt = Date.now();
+
+  stateDir.ensure();
+  appendWrapperLog(
+    wrapperLogPath,
+    `spawn: codex ${fullArgs.map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}`,
+  );
+
   const child = spawn("codex", fullArgs, {
-    stdio: "inherit",
-    env: process.env,
+    // inherit stdin + stdout (TUI needs raw TTY), pipe stderr so we can tee.
+    stdio: ["inherit", "inherit", "pipe"],
+    env: buildChildEnv(),
   });
 
   if (typeof child.pid === "number") {
     writeFileSync(stateDir.tuiPidFile, `${child.pid}\n`, "utf-8");
+    appendWrapperLog(wrapperLogPath, `child pid=${child.pid}`);
+  }
+
+  // Tee stderr: pass through to user's terminal, tail into ring buffer.
+  if (child.stderr) {
+    child.stderr.on("data", (chunk: Buffer) => {
+      try {
+        process.stderr.write(chunk);
+      } catch {
+        /* stderr may be closed during shutdown */
+      }
+      stderrTail.append(chunk);
+    });
   }
 
   let cleanedTuiPid = false;
@@ -151,13 +223,47 @@ export async function runCodex(args: string[]) {
   process.on("SIGINT", () => { restoreTerminal(); cleanupTuiPidFile(); process.exit(130); });
   process.on("SIGTERM", () => { restoreTerminal(); cleanupTuiPidFile(); process.exit(143); });
 
-  child.on("exit", (code) => {
+  child.on("exit", (code, signal) => {
     cleanupTuiPidFile();
+
+    const runtimeMs = Date.now() - startedAt;
+    const tail = stderrTail.toString();
+    const tailLines = tail.length === 0
+      ? "(no stderr captured)"
+      : tail;
+    // Heuristic classification for quick scanning of the wrapper log.
+    //
+    // Source-of-truth from codex-rs (verified via Codex's PTY experiment):
+    //   - "ERROR: remote app server ... disconnected: ..." → exit code 1
+    //     (comes from codex-rs/cli/src/main.rs:553 on ExitReason::Fatal,
+    //      triggered by app-server WS close regardless of close code)
+    //   - "thread/closed" ServerNotification → exit code 0, EMPTY stderr
+    //     (ExitMode::Immediate, invisible in wrapper logs alone —
+    //      correlate with agentbridge.log where the adapter sniffs it)
+    //   - Plain Ctrl+C → signal:SIGINT
+    //   - Other non-zero → likely upstream bug
+    let classification = "normal";
+    if (/ERROR: remote app server/.test(tail)) classification = "fatal_exit";
+    else if (signal) classification = `signal:${signal}`;
+    else if (typeof code === "number" && code !== 0) classification = `nonzero_exit:${code}`;
+    else if (code === 0 && tail.trim().length === 0) classification = "exit_0_empty_stderr";
+
+    appendWrapperLog(
+      wrapperLogPath,
+      [
+        `exit: code=${code ?? "null"} signal=${signal ?? "null"} runtime_ms=${runtimeMs} pid=${child.pid ?? "unknown"} classification=${classification}`,
+        `--- last stderr (${stderrTail.byteLength} bytes) ---`,
+        tailLines,
+        `--- end stderr ---`,
+      ].join("\n"),
+    );
+
     process.exit(code ?? 0);
   });
 
   child.on("error", (err) => {
     cleanupTuiPidFile();
+    appendWrapperLog(wrapperLogPath, `spawn error: ${err.message}`);
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       console.error("Error: codex not found in PATH.");
       console.error("Install Codex: https://github.com/openai/codex");

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -244,6 +244,8 @@ export async function runCodex(args: string[]) {
     //   - Other non-zero → likely upstream bug
     let classification = "normal";
     if (/ERROR: remote app server/.test(tail)) classification = "fatal_exit";
+    else if (/Error: .* failed: Not initialized/.test(tail)) classification = "not_initialized_after_reconnect";
+    else if (/Error: .* failed:/.test(tail)) classification = "rpc_error_exit";
     else if (signal) classification = `signal:${signal}`;
     else if (typeof code === "number" && code !== 0) classification = `nonzero_exit:${code}`;
     else if (code === 0 && tail.trim().length === 0) classification = "exit_0_empty_stderr";

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,7 +1,15 @@
 import { execSync, execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { ConfigService } from "../config-service";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { findPackageRoot, registerMarketplace } from "./pkg-root";
+import { upsertMarkedSection } from "../marker-section";
+import {
+  MARKER_ID,
+  CLAUDE_MD_SECTION,
+  AGENTS_MD_SECTION,
+} from "../collaboration-content";
 
 const MIN_CLAUDE_VERSION = "2.1.80";
 
@@ -29,7 +37,16 @@ export async function runInit() {
   }
   console.log("");
 
-  // Step 3: Register marketplace + install plugin (best-effort)
+  // Step 3: Write collaboration sections to CLAUDE.md and AGENTS.md
+  console.log("Writing collaboration sections...");
+  const projectRoot = process.cwd();
+  const collabResults = writeCollaborationSections(projectRoot);
+  for (const result of collabResults) {
+    console.log(`  ${result}`);
+  }
+  console.log("");
+
+  // Step 4: Register marketplace + install plugin (best-effort)
   console.log("Installing AgentBridge plugin...");
   try {
     registerMarketplace(findPackageRoot());
@@ -44,7 +61,7 @@ export async function runInit() {
   }
   console.log("");
 
-  // Step 4: Done
+  // Step 5: Done
   console.log("Setup complete!\n");
   console.log("Next steps:");
   console.log("  1. If Claude Code is already running, execute /reload-plugins in your session");
@@ -109,6 +126,46 @@ function compareVersions(a: string, b: string): number {
     if (va > vb) return 1;
   }
   return 0;
+}
+
+/**
+ * Write or update AgentBridge collaboration sections in CLAUDE.md and AGENTS.md.
+ * Returns human-readable status lines for each file.
+ */
+export function writeCollaborationSections(projectRoot: string): string[] {
+  const results: string[] = [];
+
+  const files: Array<{ name: string; path: string; section: string }> = [
+    { name: "CLAUDE.md", path: join(projectRoot, "CLAUDE.md"), section: CLAUDE_MD_SECTION },
+    { name: "AGENTS.md", path: join(projectRoot, "AGENTS.md"), section: AGENTS_MD_SECTION },
+  ];
+
+  for (const { name, path, section } of files) {
+    let existing = "";
+    try {
+      existing = readFileSync(path, "utf-8");
+    } catch {
+      // File doesn't exist — will be created
+    }
+
+    const updated = upsertMarkedSection(existing, MARKER_ID, section);
+
+    if (updated === existing) {
+      results.push(`${name}: unchanged (section already up to date)`);
+      continue;
+    }
+
+    writeFileSync(path, updated, "utf-8");
+    if (existing === "") {
+      results.push(`${name}: created with collaboration section`);
+    } else if (existing.includes(`<!-- ${MARKER_ID}:start -->`)) {
+      results.push(`${name}: updated collaboration section`);
+    } else {
+      results.push(`${name}: appended collaboration section`);
+    }
+  }
+
+  return results;
 }
 
 export { compareVersions };

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -148,7 +148,14 @@ export function writeCollaborationSections(projectRoot: string): string[] {
       // File doesn't exist — will be created
     }
 
-    const updated = upsertMarkedSection(existing, MARKER_ID, section);
+    let updated: string;
+    try {
+      updated = upsertMarkedSection(existing, MARKER_ID, section);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      results.push(`${name}: skipped — ${msg}`);
+      continue;
+    }
 
     if (updated === existing) {
       results.push(`${name}: unchanged (section already up to date)`);

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -117,6 +117,29 @@ export class CodexAdapter extends EventEmitter {
   private static readonly OUTAGE_QUEUE_MAX = 64;
   private static readonly OUTAGE_TIMEOUT_MS = 5000;
 
+  // Session-state capture for unintentional-reconnect replay.
+  //
+  // When the upstream app-server drops unexpectedly and we silently
+  // reconnect, the new session has no knowledge of initialize/thread
+  // state. The TUI doesn't know the reconnect happened and continues
+  // using its stale session. The first request that requires
+  // initialized state (e.g. turn/steer) gets `"Not initialized"`,
+  // codex-rs exits with `Error: turn/steer failed: Not initialized`.
+  //
+  // To avoid that, we capture the TUI's initialize/initialized payloads
+  // and replay them against the fresh app-server session on
+  // unintentional reconnect. See handleSessionRestoreAfterReconnect.
+  private lastInitializeRaw: string | null = null;
+  private lastInitializedRaw: string | null = null;
+  private sessionRestoreInProgress = false;
+  private replayPending = new Map<number | string, {
+    method: string;
+    resolve: (response: unknown) => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }>();
+  private static readonly SESSION_REPLAY_TIMEOUT_MS = 5000;
+
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
     this.appPort = appPort;
@@ -259,8 +282,20 @@ export class CodexAdapter extends EventEmitter {
         this.reconnectAttempts = 0;
         this.log(isReconnect ? "Reconnected to app-server" : "Connected to app-server");
         this.flushPendingServerResponses();
-        // Drain outage-buffered TUI messages that arrived while upstream was down.
-        this.drainOutageQueue();
+        // On unintentional reconnect, restore session state (cached
+        // initialize / thread/resume) BEFORE draining any TUI messages
+        // that might require an initialized session. On first connect,
+        // there's no state to restore so drain immediately.
+        if (isReconnect) {
+          this.handleSessionRestoreAfterReconnect()
+            .finally(() => this.drainOutageQueue())
+            .catch((e: unknown) => {
+              const m = e instanceof Error ? e.message : String(e);
+              this.log(`session restore unexpected error: ${m}`);
+            });
+        } else {
+          this.drainOutageQueue();
+        }
         resolve();
       };
 
@@ -463,6 +498,151 @@ export class CodexAdapter extends EventEmitter {
       clearTimeout(this.outageTimer);
       this.outageTimer = null;
     }
+  }
+
+  // ── Session restore after unintentional reconnect ────────────
+
+  /**
+   * Restore codex-rs session state on the fresh app-server WS.
+   *
+   * Flow:
+   *   1. If no cached initialize, bail (no-op, usually because the
+   *      reconnect happened before the TUI's initial handshake).
+   *   2. Send cached initialize, await response by id.
+   *   3. Send cached `initialized` notification (fire-and-forget).
+   *   4. If we know an active threadId, send `thread/resume` and await.
+   *   5. On any failure, close the TUI with 1011 so codex-rs surfaces a
+   *      visible FatalExitRequest instead of deadlocking on the next
+   *      `"Not initialized"` response.
+   *
+   * Open questions for Codex source review:
+   *   - Is `initialize` idempotent in codex app-server?
+   *   - Does `thread/resume` work against a fresh session, or must it
+   *     follow a session handshake specific to the thread's creator?
+   *   - Are there session-unique fields in initialize that would cause
+   *     replay to be rejected?
+   * See docs/issues-2026-04-24-codex-not-initialized-after-silent-reconnect.md.
+   */
+  private async handleSessionRestoreAfterReconnect(): Promise<void> {
+    if (!this.lastInitializeRaw) {
+      this.log("DIAGNOSTIC: no cached initialize to replay after unintentional reconnect");
+      return;
+    }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      this.log("DIAGNOSTIC: app-server not open at session restore start — skipping");
+      return;
+    }
+
+    this.sessionRestoreInProgress = true;
+    try {
+      this.log(
+        `DIAGNOSTIC: replaying cached initialize to restore session (threadId=${this.threadId ?? "none"})`,
+      );
+      await this.sendReplayAndAwait(this.lastInitializeRaw, "initialize");
+
+      if (this.lastInitializedRaw && this.appServerWs.readyState === WebSocket.OPEN) {
+        this.appServerWs.send(this.lastInitializedRaw);
+      }
+
+      if (this.threadId && this.appServerWs.readyState === WebSocket.OPEN) {
+        const replayId = `agentbridge-replay-thread-resume-${Date.now()}`;
+        const resumeRaw = JSON.stringify({
+          jsonrpc: "2.0",
+          id: replayId,
+          method: "thread/resume",
+          params: { threadId: this.threadId },
+        });
+        await this.sendReplayAndAwait(resumeRaw, "thread/resume");
+      }
+
+      this.log(
+        `DIAGNOSTIC: session restored after unintentional reconnect (threadId=${this.threadId ?? "none"})`,
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log(
+        `ERROR: session restore failed (${msg}) — closing TUI with 1011`,
+      );
+      const tuiWs = this.tuiWs;
+      if (tuiWs) {
+        try {
+          tuiWs.close(1011, `agentbridge: session restore failed: ${msg}`);
+        } catch (closeErr: unknown) {
+          const cm = closeErr instanceof Error ? closeErr.message : String(closeErr);
+          this.log(`Failed to close TUI after session restore failure: ${cm}`);
+        }
+      }
+    } finally {
+      this.sessionRestoreInProgress = false;
+    }
+  }
+
+  /**
+   * Send a raw JSON-RPC payload to app-server and await the response by id.
+   *
+   * Short-circuits the normal response handler via `replayPending`, so the
+   * response is captured here and NOT forwarded to the TUI (which would
+   * confuse it — the TUI didn't send this request). Rejects on timeout
+   * or if the response carries an `error` field.
+   */
+  private sendReplayAndAwait(raw: string, method: string): Promise<unknown> {
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("app-server not open"));
+    }
+    let id: number | string;
+    try {
+      const parsed = JSON.parse(raw) as { id?: number | string };
+      if (parsed.id === undefined) {
+        return Promise.reject(new Error(`replay payload for ${method} has no id`));
+      }
+      id = parsed.id;
+    } catch (e: unknown) {
+      const m = e instanceof Error ? e.message : String(e);
+      return Promise.reject(new Error(`replay parse failed for ${method}: ${m}`));
+    }
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.replayPending.delete(id);
+        reject(new Error(`replay timeout (${CodexAdapter.SESSION_REPLAY_TIMEOUT_MS}ms) for ${method} id=${JSON.stringify(id)}`));
+      }, CodexAdapter.SESSION_REPLAY_TIMEOUT_MS);
+
+      this.replayPending.set(id, { method, resolve, reject, timer });
+      try {
+        this.appServerWs!.send(raw);
+      } catch (e: unknown) {
+        clearTimeout(timer);
+        this.replayPending.delete(id);
+        const m = e instanceof Error ? e.message : String(e);
+        reject(new Error(`replay send failed for ${method}: ${m}`));
+      }
+    });
+  }
+
+  /**
+   * Intercept an app-server response that matches a pending replay.
+   *
+   * Returns true if the response was consumed (and should NOT be forwarded
+   * to TUI). Returns false if no replay is awaiting this id.
+   */
+  private tryConsumeReplayResponse(payload: Record<string, unknown>): boolean {
+    const id = payload.id;
+    if (id === undefined) return false;
+    const pending = this.replayPending.get(id as number | string);
+    if (!pending) return false;
+
+    clearTimeout(pending.timer);
+    this.replayPending.delete(id as number | string);
+
+    if (payload.error !== undefined) {
+      const errMsg = typeof payload.error === "object" && payload.error !== null && "message" in payload.error
+        ? String((payload.error as { message?: unknown }).message ?? "unknown")
+        : JSON.stringify(payload.error);
+      pending.reject(new Error(`${pending.method} rejected: ${errMsg}`));
+    } else {
+      pending.resolve(payload);
+    }
+    return true;
   }
 
   /**
@@ -786,6 +966,10 @@ export class CodexAdapter extends EventEmitter {
     // Skip this check during replay to avoid infinite recursion.
     if (!this.replayingBufferedMessages) {
       if (detectedMethod === "initialize") {
+        // Cache the raw payload for use by unintentional-reconnect replay.
+        // Replays use the TUI's original id as-is — safe because the new
+        // app-server session has no prior mapping for it.
+        this.lastInitializeRaw = data;
         this.log("Detected initialize — reconnecting app-server for fresh session");
         this.reconnectingForNewSession = true;
         this.pendingTuiMessages = [data];
@@ -800,13 +984,28 @@ export class CodexAdapter extends EventEmitter {
       }
     }
 
+    // Cache `initialized` notification raw payload — used by
+    // handleSessionRestoreAfterReconnect to recover session state after
+    // an unintentional upstream reconnect.
+    if (detectedMethod === "initialized") {
+      this.lastInitializedRaw = data;
+    }
+
     // Outage-path early return: buffer RAW before any id-rewriting or
     // upstreamToClient/serverRequestToProxy mutation. This avoids a
     // response-tracking race where `handleAppServerClose` clears mappings
     // that our buffered `forwarded` bytes would then point to. On drain
     // we re-enter this method with the raw bytes and do a fresh rewrite
     // against the new app-server session.
-    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+    //
+    // We also treat `sessionRestoreInProgress` as an outage — while we're
+    // replaying cached initialize / thread/resume, we must not let TUI
+    // requests leak onto the still-uninitialized session.
+    if (
+      !this.appServerWs
+      || this.appServerWs.readyState !== WebSocket.OPEN
+      || this.sessionRestoreInProgress
+    ) {
       if (this.tuiWs && this.tuiWs === ws) {
         this.bufferDuringOutage(ws, data);
       } else {
@@ -854,6 +1053,14 @@ export class CodexAdapter extends EventEmitter {
   private handleAppServerPayload(raw: string): string | null {
     try {
       const parsed: unknown = JSON.parse(raw);
+      // Short-circuit: response carries an id that matches a pending
+      // session-restore replay? Consume it and suppress forwarding to
+      // the TUI (which didn't send the request and would be confused).
+      if (typeof parsed === "object" && parsed !== null && "id" in parsed) {
+        if (this.tryConsumeReplayResponse(parsed as Record<string, unknown>)) {
+          return null;
+        }
+      }
       if (isAppServerNotification(parsed) || (typeof parsed === "object" && parsed !== null && !("id" in parsed))) {
         const notificationLike = parsed as Record<string, unknown>;
         // Sniff thread/closed → the ONLY signal that correlates with a

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -107,6 +107,16 @@ export class CodexAdapter extends EventEmitter {
   // Generation counter to prevent stale app-server close handlers from interfering
   private appServerGeneration = 0;
 
+  // Outage recovery window — when app-server is unintentionally down, buffer
+  // outbound TUI messages briefly so short upstream blips don't kill the TUI.
+  // If the outage runs past OUTAGE_TIMEOUT_MS or the queue overflows, we
+  // fail-fast by closing the TUI WS with code 1011 so codex-rs raises a
+  // visible FatalExitRequest rather than hanging silently.
+  private outageQueue: Array<{ raw: string; connId: number }> = [];
+  private outageTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly OUTAGE_QUEUE_MAX = 64;
+  private static readonly OUTAGE_TIMEOUT_MS = 5000;
+
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
     this.appPort = appPort;
@@ -154,6 +164,10 @@ export class CodexAdapter extends EventEmitter {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+
+    // Cancel any outage recovery in flight
+    this.outageQueue = [];
+    this.clearOutageTimer();
 
     this.appServerWs?.close();
     this.appServerWs = null;
@@ -245,6 +259,8 @@ export class CodexAdapter extends EventEmitter {
         this.reconnectAttempts = 0;
         this.log(isReconnect ? "Reconnected to app-server" : "Connected to app-server");
         this.flushPendingServerResponses();
+        // Drain outage-buffered TUI messages that arrived while upstream was down.
+        this.drainOutageQueue();
         resolve();
       };
 
@@ -365,15 +381,127 @@ export class CodexAdapter extends EventEmitter {
   }
 
   private handleAppServerClose() {
-    this.log("App-server connection closed");
+    // Extra detail helps diagnose the "TUI silent exit" path: if app-server
+    // closes first (upstream-side failure) and TUI sends anything afterwards,
+    // the outage queue absorbs the blow for up to OUTAGE_TIMEOUT_MS; after
+    // that we close the TUI with 1011 so codex-rs raises a visible
+    // FatalExitRequest. The timestamp here pairs with codex-wrapper.log.
+    const intentional = this.intentionalDisconnect;
+    const tuiConnected = this.tuiWs !== null;
+    this.log(
+      `App-server connection closed (intentional=${intentional}, tuiConnected=${tuiConnected}, turnInProgress=${this.turnInProgress})`,
+    );
     this.appServerWs = null;
     // Approval request/response ids are scoped to the current app-server session.
     // If the socket reconnects, replaying old approval state would forward stale ids.
     this.clearResponseTrackingState();
     this.activeTurnIds.clear();
     this.turnInProgress = false;
-    if (!this.intentionalDisconnect) {
+    if (!intentional) {
       this.scheduleReconnect();
+    }
+  }
+
+  // ── Outage recovery queue ─────────────────────────────────────
+
+  /**
+   * Buffer a TUI → app-server message during an upstream outage.
+   *
+   * Called when `onTuiMessage` would otherwise silently drop the message.
+   * Starts a fail-fast timer on first use; overflows close the TUI with
+   * 1011. The buffer is drained in-order when app-server reconnects.
+   */
+  private bufferDuringOutage(ws: ServerWebSocket<TuiSocketData>, raw: string): void {
+    if (this.outageQueue.length >= CodexAdapter.OUTAGE_QUEUE_MAX) {
+      this.log(
+        `ERROR: outage queue overflow (${this.outageQueue.length}/${CodexAdapter.OUTAGE_QUEUE_MAX}) — closing TUI with 1011`,
+      );
+      this.outageQueue = [];
+      this.clearOutageTimer();
+      if (this.tuiWs && this.tuiWs === ws) {
+        try {
+          ws.close(1011, "agentbridge: app-server unavailable; pending TUI queue overflow");
+        } catch (e: any) {
+          this.log(`Failed to close TUI WS after outage queue overflow: ${e.message}`);
+        }
+      }
+      return;
+    }
+
+    this.outageQueue.push({ raw, connId: ws.data.connId });
+    this.log(
+      `DIAGNOSTIC: buffered TUI message while app-server unavailable (queue size=${this.outageQueue.length}/${CodexAdapter.OUTAGE_QUEUE_MAX})`,
+    );
+    this.ensureOutageTimer();
+  }
+
+  private ensureOutageTimer(): void {
+    if (this.outageTimer !== null) return;
+    this.outageTimer = setTimeout(() => {
+      this.outageTimer = null;
+      const buffered = this.outageQueue.length;
+      this.outageQueue = [];
+      this.log(
+        `ERROR: app-server did not return within ${CodexAdapter.OUTAGE_TIMEOUT_MS}ms (buffered=${buffered}) — closing TUI with 1011`,
+      );
+      const ws = this.tuiWs;
+      if (ws) {
+        try {
+          ws.close(
+            1011,
+            `agentbridge: app-server unavailable after ${CodexAdapter.OUTAGE_TIMEOUT_MS}ms; buffered=${buffered}`,
+          );
+        } catch (e: any) {
+          this.log(`Failed to close TUI WS on outage timeout: ${e.message}`);
+        }
+      }
+    }, CodexAdapter.OUTAGE_TIMEOUT_MS);
+  }
+
+  private clearOutageTimer(): void {
+    if (this.outageTimer !== null) {
+      clearTimeout(this.outageTimer);
+      this.outageTimer = null;
+    }
+  }
+
+  /**
+   * Replay the outage queue after app-server reconnects.
+   *
+   * Messages are replayed in original order. We stored RAW TUI bytes
+   * (pre-rewrite), so re-entering `onTuiMessage` produces a fresh proxy id
+   * and a fresh `upstreamToClient` mapping against the new app-server
+   * session — avoiding the response-tracking race where the original
+   * mapping was wiped by `clearResponseTrackingState` on close.
+   */
+  private drainOutageQueue(): void {
+    if (this.outageQueue.length === 0) {
+      this.clearOutageTimer();
+      return;
+    }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) return;
+    const ws = this.tuiWs;
+    if (!ws) {
+      // TUI disconnected between buffer and drain — safe to discard.
+      this.outageQueue = [];
+      this.clearOutageTimer();
+      return;
+    }
+
+    const messages = this.outageQueue;
+    this.outageQueue = [];
+    this.clearOutageTimer();
+    this.log(
+      `DIAGNOSTIC: replaying ${messages.length} buffered TUI messages after app-server reconnect`,
+    );
+    for (const msg of messages) {
+      try {
+        // Re-enter the full TUI message pipeline so rewriting and tracking
+        // run against the fresh app-server session.
+        this.onTuiMessage(ws, msg.raw);
+      } catch (e: any) {
+        this.log(`Failed to replay buffered TUI message (conn #${msg.connId}): ${e.message}`);
+      }
     }
   }
 
@@ -559,13 +687,29 @@ export class CodexAdapter extends EventEmitter {
 
     // Only clear tuiWs if this is still the current connection
     if (this.tuiWs === ws) {
-      this.log(`TUI disconnected (conn #${connId})`);
+      // Capture app-server state at the moment TUI disconnects — critical
+      // for diagnosing "silent exit": did the TUI drop before or after we
+      // lost app-server? This timestamp lines up with codex-wrapper.log's
+      // exit line so we can reconstruct the sequence.
+      const appServerOpen = this.appServerWs?.readyState === WebSocket.OPEN;
+      this.log(
+        `TUI disconnected (conn #${connId}, appServerOpen=${appServerOpen}, turnInProgress=${this.turnInProgress}, pendingTuiMessages=${this.pendingTuiMessages.length}, outageQueue=${this.outageQueue.length}, reconnectingForNewSession=${this.reconnectingForNewSession})`,
+      );
       this.tuiWs = null;
       // Clear any pending reconnection state
       if (this.reconnectingForNewSession) {
         this.log("Clearing pending TUI message buffer (TUI disconnected during app-server reconnect)");
         this.pendingTuiMessages = [];
         this.reconnectingForNewSession = false;
+      }
+      // Clear outage buffer and timer — no TUI to replay to, and stale
+      // messages would be wrong for whatever TUI reconnects next.
+      if (this.outageQueue.length > 0 || this.outageTimer !== null) {
+        this.log(
+          `Clearing outage queue on TUI disconnect (buffered=${this.outageQueue.length})`,
+        );
+        this.outageQueue = [];
+        this.clearOutageTimer();
       }
       this.emit("tuiDisconnected", connId);
     } else {
@@ -656,6 +800,23 @@ export class CodexAdapter extends EventEmitter {
       }
     }
 
+    // Outage-path early return: buffer RAW before any id-rewriting or
+    // upstreamToClient/serverRequestToProxy mutation. This avoids a
+    // response-tracking race where `handleAppServerClose` clears mappings
+    // that our buffered `forwarded` bytes would then point to. On drain
+    // we re-enter this method with the raw bytes and do a fresh rewrite
+    // against the new app-server session.
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      if (this.tuiWs && this.tuiWs === ws) {
+        this.bufferDuringOutage(ws, data);
+      } else {
+        this.log(
+          `WARNING: non-primary TUI attempted to send while app-server down — dropped (connId=${connId})`,
+        );
+      }
+      return;
+    }
+
     let forwarded = data;
     try {
       const parsed = JSON.parse(data);
@@ -676,11 +837,15 @@ export class CodexAdapter extends EventEmitter {
       this.log(`TUI → app-server: (unparseable)`);
     }
 
-    // Forward to app-server
+    // Forward to app-server. The OPEN check above guarantees readyState was
+    // OPEN when we started processing; the narrow race where upstream closes
+    // between that check and here is handled here as a best-effort warning.
     if (this.appServerWs?.readyState === WebSocket.OPEN) {
       this.appServerWs.send(forwarded);
     } else {
-      this.log(`WARNING: app-server not connected, dropping message`);
+      this.log(
+        `WARNING: app-server closed between OPEN check and send — message lost (connId=${ws.data.connId})`,
+      );
     }
   }
 
@@ -691,6 +856,19 @@ export class CodexAdapter extends EventEmitter {
       const parsed: unknown = JSON.parse(raw);
       if (isAppServerNotification(parsed) || (typeof parsed === "object" && parsed !== null && !("id" in parsed))) {
         const notificationLike = parsed as Record<string, unknown>;
+        // Sniff thread/closed → the ONLY signal that correlates with a
+        // silent TUI exit (code 0, empty stderr, no ERROR line). Verified
+        // via Codex's PTY reproduction: server emitting this notification
+        // causes TUI to run ExitMode::Immediate with no output. We log a
+        // high-signal line so codex-wrapper.log's `exit_0_empty_stderr`
+        // classification can be paired up by timestamp with this event.
+        if (notificationLike.method === "thread/closed") {
+          const params = notificationLike.params as Record<string, unknown> | undefined;
+          const threadId = typeof params?.threadId === "string" ? params.threadId : "unknown";
+          this.log(
+            `DIAGNOSTIC: app-server emitted thread/closed (threadId=${threadId}) — TUI will exit(0) silently`,
+          );
+        }
         const forwarded = this.patchResponse(notificationLike, raw);
         this.interceptServerMessage(notificationLike);
         return forwarded;

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -1173,6 +1173,19 @@ export class CodexAdapter extends EventEmitter {
   }
 
   /**
+   * Build the lsof command used to find LISTENing processes on a TCP port.
+   *
+   * Restricting to `-sTCP:LISTEN` is critical: a bare `lsof -ti :PORT` also
+   * returns processes that merely have an outbound (client) FD to that port,
+   * including stale CLOSED connections from crashed clients. Those false
+   * positives caused `abg claude` to refuse startup whenever a previous
+   * Codex TUI process lingered with a half-closed connection to port 4501.
+   */
+  static buildPortListenLsofCommand(port: number): string {
+    return `lsof -ti tcp:${port} -sTCP:LISTEN`;
+  }
+
+  /**
    * Clean up stale ports before starting.
    * Only kills `codex app-server` processes (our own spawns). If the port is
    * occupied by something else, throws with a clear message.
@@ -1180,7 +1193,9 @@ export class CodexAdapter extends EventEmitter {
   private async checkPorts() {
     for (const port of [this.appPort, this.proxyPort]) {
       try {
-        const pids = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
+        const pids = execSync(CodexAdapter.buildPortListenLsofCommand(port), {
+          encoding: "utf-8",
+        }).trim();
         if (!pids) continue;
 
         // Check if the occupying process is a codex app-server (our own stale spawn)
@@ -1220,7 +1235,9 @@ export class CodexAdapter extends EventEmitter {
 
         // Verify port is now free
         try {
-          const remaining = execSync(`lsof -ti :${port}`, { encoding: "utf-8" }).trim();
+          const remaining = execSync(CodexAdapter.buildPortListenLsofCommand(port), {
+            encoding: "utf-8",
+          }).trim();
           if (remaining) {
             throw new Error(
               `Port ${port} is still occupied (PID(s): ${remaining.replace(/\n/g, ", ")}) after cleanup. ` +

--- a/src/collaboration-content.ts
+++ b/src/collaboration-content.ts
@@ -1,0 +1,67 @@
+/**
+ * Collaboration section content for CLAUDE.md and AGENTS.md.
+ *
+ * These are injected by `abg init` into project-level instruction files
+ * so that agents auto-discover the multi-agent collaboration setup.
+ *
+ * Content must be generic (not project-specific) and under ~30 lines each.
+ * Tool usage details are already covered by MCP server instructions —
+ * these sections focus on *when* and *why* to collaborate.
+ */
+
+export const MARKER_ID = "AgentBridge";
+
+export const CLAUDE_MD_SECTION = `\
+## AgentBridge — Multi-Agent Collaboration
+
+You are working in a **multi-agent environment** powered by AgentBridge.
+Another AI agent (Codex, by OpenAI) is available in a parallel session on this machine.
+
+### When to collaborate vs. work solo
+- **Collaborate** when the task benefits from a second perspective, parallel execution, or capabilities you lack (e.g., sandboxed code execution, independent verification).
+- **Work solo** for simple, self-contained tasks where the coordination overhead isn't worth it.
+- When in doubt, **propose a task split** to Codex rather than doing everything yourself.
+
+### Capability comparison
+| Capability | Claude (you) | Codex |
+|---|---|---|
+| Architecture & planning | Strong | Moderate |
+| Code review & analysis | Strong | Strong |
+| Sandboxed code execution | No | Yes |
+| File editing & refactoring | Yes (via tools) | Yes (via sandbox) |
+| Web search & docs | Yes | Limited |
+| Independent verification | Cross-review | Reproduce & test |
+
+### How to start collaborating
+1. When you receive a complex task, **proactively propose a division of labor** to Codex via the reply tool.
+2. State what you'll handle and what you'd like Codex to take on.
+3. Ask for Codex's agreement or counter-proposal before proceeding.
+4. After task completion, **cross-review** each other's work.`;
+
+export const AGENTS_MD_SECTION = `\
+## AgentBridge — Multi-Agent Collaboration
+
+You are working in a **multi-agent environment** powered by AgentBridge.
+Another AI agent (Claude, by Anthropic) is available in a parallel session on this machine.
+Communication happens via AgentBridge MCP tools — Claude has \`reply\` and \`get_messages\` tools.
+
+### When to collaborate vs. work solo
+- **Collaborate** when the task benefits from a second perspective, parallel execution, or capabilities the other agent has.
+- **Work solo** for simple, self-contained tasks where the coordination overhead isn't worth it.
+- When in doubt, **propose a task split** to Claude rather than doing everything yourself.
+
+### Capability comparison
+| Capability | Codex (you) | Claude |
+|---|---|---|
+| Sandboxed code execution | Yes | No |
+| Reproduce & verify bugs | Strong | Limited |
+| Architecture & planning | Moderate | Strong |
+| Code review & analysis | Strong | Strong |
+| Web search & docs | Limited | Yes |
+| File editing & refactoring | Yes (via sandbox) | Yes (via tools) |
+
+### How to start collaborating
+1. When you receive a complex task, **proactively propose a division of labor**.
+2. State what you'll handle and what you'd like Claude to take on.
+3. Ask for Claude's agreement or counter-proposal before proceeding.
+4. After task completion, **cross-review** each other's work.`;

--- a/src/collaboration-content.ts
+++ b/src/collaboration-content.ts
@@ -17,6 +17,11 @@ export const CLAUDE_MD_SECTION = `\
 You are working in a **multi-agent environment** powered by AgentBridge.
 Another AI agent (Codex, by OpenAI) is available in a parallel session on this machine.
 
+### Communication mechanism
+- **Claude → Codex**: Use the AgentBridge MCP tools (\`reply\` / \`get_messages\`) — these are yours only.
+- **Codex → Claude**: Codex has no symmetric tool. The bridge transparently intercepts Codex's normal output and forwards it to you. Messages arrive as push notifications (or via \`get_messages\` in pull mode).
+- If Codex ever complains it can't find a "send-to-Claude" API, remind it that its side is transparent — it just writes a reply and you'll see it.
+
 ### When to collaborate vs. work solo
 - **Collaborate** when the task benefits from a second perspective, parallel execution, or capabilities you lack (e.g., sandboxed code execution, independent verification).
 - **Work solo** for simple, self-contained tasks where the coordination overhead isn't worth it.
@@ -43,7 +48,14 @@ export const AGENTS_MD_SECTION = `\
 
 You are working in a **multi-agent environment** powered by AgentBridge.
 Another AI agent (Claude, by Anthropic) is available in a parallel session on this machine.
-Communication happens via AgentBridge MCP tools — Claude has \`reply\` and \`get_messages\` tools.
+
+### Communication mechanism (read this first)
+AgentBridge is a **transparent proxy** on your side. You do **not** have a tool to "send a message to Claude".
+
+- **Codex → Claude**: Just write your normal response. The bridge intercepts your \`agentMessage\` output and forwards it to Claude automatically. No tool call needed.
+- **Claude → Codex**: Claude uses its own MCP tools (\`reply\` / \`get_messages\`). Those messages arrive in your session as new user turns — you'll see them like any other user input.
+
+**Do not** search the AgentBridge source for a Codex-side "send" / "reply" / "sendToClaude" API — it does not exist, and looking for it wastes turns. If you catch yourself thinking "I need to find how to message Claude", stop and just write your reply as normal text.
 
 ### When to collaborate vs. work solo
 - **Collaborate** when the task benefits from a second perspective, parallel execution, or capabilities the other agent has.
@@ -61,7 +73,7 @@ Communication happens via AgentBridge MCP tools — Claude has \`reply\` and \`g
 | File editing & refactoring | Yes (via sandbox) | Yes (via tools) |
 
 ### How to start collaborating
-1. When you receive a complex task, **proactively propose a division of labor**.
+1. When you receive a complex task, **proactively propose a division of labor** in your response (Claude will receive it).
 2. State what you'll handle and what you'd like Claude to take on.
 3. Ask for Claude's agreement or counter-proposal before proceeding.
 4. After task completion, **cross-review** each other's work.`;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -58,6 +58,7 @@ let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
 let claudeDisconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let claudeOnlineNoticeSent = false;
 let claudeOfflineNoticeShown = false;
+let codexCollaborationKickoffSent = false;
 let lastAttachStatusSentTs = 0;
 const ATTACH_STATUS_COOLDOWN_MS = 30_000; // Don't re-send status on rapid reattach
 
@@ -566,7 +567,21 @@ function currentReadyMessage() {
 function notifyCodexClaudeOnline() {
   claudeOnlineNoticeSent = true;
   claudeOfflineNoticeShown = false;
-  codex.injectMessage("✅ AgentBridge connected to Claude Code.");
+
+  if (!codexCollaborationKickoffSent) {
+    codexCollaborationKickoffSent = true;
+    codex.injectMessage(
+      [
+        "🤝 Claude Code has connected via AgentBridge.",
+        "You are now in a multi-agent collaboration session.",
+        "When you receive a complex task, propose a division of labor to Claude.",
+        "Claude can send you messages — they will appear as injected user messages.",
+        "Respond naturally and Claude will receive your output via AgentBridge.",
+      ].join("\n"),
+    );
+  } else {
+    codex.injectMessage("✅ AgentBridge connected to Claude Code.");
+  }
 }
 
 function shouldNotifyCodexClaudeOnline() {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -166,6 +166,11 @@ codex.on("turnCompleted", () => {
     ),
   );
   startAttentionWindow();
+
+  // Retry Claude-online notice if it was deferred while the turn was in progress.
+  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
+    notifyCodexClaudeOnline();
+  }
 });
 
 codex.on("ready", (threadId: string) => {
@@ -564,24 +569,27 @@ function currentReadyMessage() {
   return `✅ Codex TUI connected (${codex.activeThreadId}). Bridge ready.`;
 }
 
-function notifyCodexClaudeOnline() {
-  claudeOnlineNoticeSent = true;
-  claudeOfflineNoticeShown = false;
-
-  if (!codexCollaborationKickoffSent) {
-    codexCollaborationKickoffSent = true;
-    codex.injectMessage(
-      [
+function notifyCodexClaudeOnline(): boolean {
+  const message = !codexCollaborationKickoffSent
+    ? [
         "🤝 Claude Code has connected via AgentBridge.",
         "You are now in a multi-agent collaboration session.",
         "When you receive a complex task, propose a division of labor to Claude.",
         "Claude can send you messages — they will appear as injected user messages.",
         "Respond naturally and Claude will receive your output via AgentBridge.",
-      ].join("\n"),
-    );
-  } else {
-    codex.injectMessage("✅ AgentBridge connected to Claude Code.");
+      ].join("\n")
+    : "✅ AgentBridge connected to Claude Code.";
+
+  const delivered = codex.injectMessage(message);
+  if (!delivered) {
+    log("Deferred Claude-online notice to Codex — will retry after current turn completes");
+    return false;
   }
+
+  claudeOnlineNoticeSent = true;
+  claudeOfflineNoticeShown = false;
+  codexCollaborationKickoffSent = true;
+  return true;
 }
 
 function shouldNotifyCodexClaudeOnline() {

--- a/src/marker-section.ts
+++ b/src/marker-section.ts
@@ -1,0 +1,48 @@
+/**
+ * Idempotent marker-based section injection for markdown files.
+ *
+ * Supports three cases:
+ *   1. Empty/no content → return markers + section
+ *   2. Content exists, no markers → append markers + section
+ *   3. Content exists, markers present → replace between markers
+ */
+
+const MARKER_START = (id: string) => `<!-- ${id}:start -->`;
+const MARKER_END = (id: string) => `<!-- ${id}:end -->`;
+
+/**
+ * Insert or replace a marked section in a markdown string.
+ *
+ * @param content  - Existing file content (empty string if file doesn't exist)
+ * @param sectionId - Unique marker identifier (e.g. "AgentBridge")
+ * @param section  - The new content to place between markers (no trailing newline needed)
+ * @returns Updated content string
+ */
+export function upsertMarkedSection(
+  content: string,
+  sectionId: string,
+  section: string,
+): string {
+  const startMarker = MARKER_START(sectionId);
+  const endMarker = MARKER_END(sectionId);
+  const block = `${startMarker}\n${section}\n${endMarker}`;
+
+  const startIdx = content.indexOf(startMarker);
+  const endIdx = content.indexOf(endMarker);
+
+  // Case 3: markers exist → replace between them
+  if (startIdx !== -1 && endIdx !== -1) {
+    const before = content.slice(0, startIdx);
+    const after = content.slice(endIdx + endMarker.length);
+    return before + block + after;
+  }
+
+  // Case 1: empty content → just the block
+  if (content.trim() === "") {
+    return block + "\n";
+  }
+
+  // Case 2: content exists but no markers → append
+  const trimmed = content.endsWith("\n") ? content : content + "\n";
+  return trimmed + "\n" + block + "\n";
+}

--- a/src/marker-section.ts
+++ b/src/marker-section.ts
@@ -29,12 +29,24 @@ export function upsertMarkedSection(
 
   const startIdx = content.indexOf(startMarker);
   const endIdx = content.indexOf(endMarker);
+  const hasStart = startIdx !== -1;
+  const hasEnd = endIdx !== -1;
 
-  // Case 3: markers exist → replace between them
-  if (startIdx !== -1 && endIdx !== -1) {
+  // Case 3: well-formed marker pair → replace between them.
+  if (hasStart && hasEnd && startIdx < endIdx) {
     const before = content.slice(0, startIdx);
     const after = content.slice(endIdx + endMarker.length);
     return before + block + after;
+  }
+
+  // Malformed: one marker without its pair, or end marker before start. Refuse
+  // to write — silently appending a second block would cause the next call to
+  // splice out user content between the stray marker and the new block.
+  if (hasStart || hasEnd) {
+    throw new Error(
+      `Malformed ${sectionId} markers in file (start=${startIdx}, end=${endIdx}). ` +
+        `Please repair the file manually — remove the stray marker(s) or restore the pair.`,
+    );
   }
 
   // Case 1: empty content → just the block

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -62,6 +62,19 @@ export class StateDirResolver {
     return join(this.stateDir, "agentbridge.log");
   }
 
+  /**
+   * Dedicated log for `agentbridge codex` wrapper.
+   *
+   * Separate from agentbridge.log so we can see the child codex TUI's
+   * exit code, signal, runtime, args, and the last 64KB of its stderr
+   * without it being drowned in daemon noise. Critical for diagnosing
+   * silent exits (FatalExitRequest / ThreadClosed) where the TUI's
+   * "ERROR:" line on stderr is normally lost to stdio inherit.
+   */
+  get codexWrapperLogFile(): string {
+    return join(this.stateDir, "codex-wrapper.log");
+  }
+
   get killedFile(): string {
     return join(this.stateDir, "killed");
   }

--- a/src/stderr-ring-buffer.ts
+++ b/src/stderr-ring-buffer.ts
@@ -1,0 +1,59 @@
+/**
+ * Bounded ring buffer for tailing a child process's stderr.
+ *
+ * The wrapper around `codex` needs to surface the last N bytes the child
+ * printed to stderr before exiting — in particular the `ERROR: ...` line
+ * emitted by codex-rs/cli/src/main.rs on `ExitReason::Fatal`, which would
+ * otherwise be lost when the TUI clears the screen on exit.
+ */
+
+const DEFAULT_MAX_BYTES = 64 * 1024;
+
+export class StderrRingBuffer {
+  private chunks: Buffer[] = [];
+  private bytes = 0;
+
+  constructor(private readonly maxBytes: number = DEFAULT_MAX_BYTES) {
+    if (maxBytes <= 0) {
+      throw new Error("StderrRingBuffer maxBytes must be positive");
+    }
+  }
+
+  append(chunk: Buffer): void {
+    if (chunk.length === 0) return;
+
+    // If the incoming chunk alone exceeds capacity, keep only its tail.
+    if (chunk.length >= this.maxBytes) {
+      this.chunks = [chunk.subarray(chunk.length - this.maxBytes)];
+      this.bytes = this.maxBytes;
+      return;
+    }
+
+    this.chunks.push(chunk);
+    this.bytes += chunk.length;
+
+    while (this.bytes > this.maxBytes && this.chunks.length > 0) {
+      const head = this.chunks[0];
+      const overflow = this.bytes - this.maxBytes;
+      if (head.length <= overflow) {
+        this.chunks.shift();
+        this.bytes -= head.length;
+      } else {
+        this.chunks[0] = head.subarray(overflow);
+        this.bytes -= overflow;
+      }
+    }
+  }
+
+  snapshot(): Buffer {
+    return Buffer.concat(this.chunks, this.bytes);
+  }
+
+  toString(encoding: BufferEncoding = "utf-8"): string {
+    return this.snapshot().toString(encoding);
+  }
+
+  get byteLength(): number {
+    return this.bytes;
+  }
+}

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -1114,3 +1114,235 @@ describe("CodexAdapter port precheck — LISTEN-only filter", () => {
     }
   });
 });
+
+describe("CodexAdapter TUI outage recovery", () => {
+  type FakeSocket = {
+    data: { connId: number };
+    closed: Array<{ code: number; reason: string }>;
+    sent: string[];
+    close: (code: number, reason: string) => void;
+    send: (data: string) => void;
+  };
+
+  function makeFakeSocket(connId: number): FakeSocket {
+    const closed: Array<{ code: number; reason: string }> = [];
+    const sent: string[] = [];
+    return {
+      data: { connId },
+      closed,
+      sent,
+      close(code: number, reason: string) {
+        closed.push({ code, reason });
+      },
+      send(data: string) {
+        sent.push(data);
+      },
+    };
+  }
+
+  function setupAdapterWithTui(connId = 1) {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.log = (msg: string) => logs.push(msg);
+    const ws = makeFakeSocket(connId);
+    adapter.tuiConnId = connId;
+    adapter.tuiWs = ws;
+    adapter.appServerWs = null;
+    return { adapter, ws, logs };
+  }
+
+  test("buffers TUI message when app-server is not connected (does not close)", () => {
+    const { adapter, ws, logs } = setupAdapterWithTui();
+
+    adapter.onTuiMessage(ws, JSON.stringify({
+      jsonrpc: "2.0",
+      id: 42,
+      method: "test",
+      params: {},
+    }));
+
+    expect(ws.closed.length).toBe(0);
+    expect(adapter.outageQueue.length).toBe(1);
+    expect(adapter.outageTimer).not.toBeNull();
+    expect(logs.some((l) => l.startsWith("DIAGNOSTIC: buffered TUI message"))).toBe(true);
+
+    // Cleanup timer to not leak into other tests.
+    clearTimeout(adapter.outageTimer);
+    adapter.outageTimer = null;
+  });
+
+  test("overflows with 1011 when queue fills past OUTAGE_QUEUE_MAX", () => {
+    const { adapter, ws, logs } = setupAdapterWithTui();
+    const max = (adapter.constructor as any).OUTAGE_QUEUE_MAX;
+    expect(typeof max).toBe("number");
+
+    // Fill to capacity.
+    for (let i = 0; i < max; i++) {
+      adapter.onTuiMessage(ws, JSON.stringify({ jsonrpc: "2.0", id: i, method: "m", params: {} }));
+    }
+    expect(adapter.outageQueue.length).toBe(max);
+    expect(ws.closed.length).toBe(0);
+
+    // One more triggers overflow and close.
+    adapter.onTuiMessage(ws, JSON.stringify({ jsonrpc: "2.0", id: max, method: "m", params: {} }));
+
+    expect(ws.closed.length).toBe(1);
+    expect(ws.closed[0].code).toBe(1011);
+    expect(ws.closed[0].reason).toMatch(/queue overflow/);
+    expect(adapter.outageQueue.length).toBe(0);
+    expect(adapter.outageTimer).toBeNull();
+    expect(logs.some((l) => l.includes("outage queue overflow"))).toBe(true);
+  });
+
+  test("drains queued messages in order when app-server reconnects (notifications)", () => {
+    const { adapter, ws } = setupAdapterWithTui();
+    // Notifications (no id) don't trigger id-rewriting, so we can compare
+    // raw bytes exactly. The key property under test is order + count.
+    adapter.outageQueue = [
+      { raw: '{"jsonrpc":"2.0","method":"a"}', connId: 1 },
+      { raw: '{"jsonrpc":"2.0","method":"b"}', connId: 1 },
+      { raw: '{"jsonrpc":"2.0","method":"c"}', connId: 1 },
+    ];
+    adapter.outageTimer = setTimeout(() => {}, 60_000);
+
+    const sent: string[] = [];
+    adapter.appServerWs = {
+      readyState: 1 /* WebSocket.OPEN */,
+      send: (data: string) => sent.push(data),
+    };
+
+    adapter.drainOutageQueue();
+
+    expect(sent).toEqual([
+      '{"jsonrpc":"2.0","method":"a"}',
+      '{"jsonrpc":"2.0","method":"b"}',
+      '{"jsonrpc":"2.0","method":"c"}',
+    ]);
+    expect(adapter.outageQueue.length).toBe(0);
+    expect(adapter.outageTimer).toBeNull();
+    expect(ws.closed.length).toBe(0);
+  });
+
+  test("drain re-assigns fresh proxy ids for requests (no stale mapping race)", () => {
+    const { adapter, ws } = setupAdapterWithTui();
+    // A TUI → app-server REQUEST (has both id and method). On outage we
+    // store RAW, so the replay goes through onTuiMessage's rewriting path
+    // against the fresh app-server session. This prevents the race Codex
+    // flagged where handleAppServerClose() would wipe upstreamToClient
+    // and strand forwarded bytes pointing at a dead mapping.
+    adapter.outageQueue = [
+      { raw: '{"jsonrpc":"2.0","id":"client-42","method":"thread/start","params":{}}', connId: 1 },
+    ];
+    adapter.outageTimer = setTimeout(() => {}, 60_000);
+
+    const sent: string[] = [];
+    adapter.appServerWs = {
+      readyState: 1 /* WebSocket.OPEN */,
+      send: (data: string) => sent.push(data),
+    };
+    // Observe the upstreamToClient map before and after.
+    expect(adapter.upstreamToClient.size).toBe(0);
+
+    adapter.drainOutageQueue();
+
+    expect(sent.length).toBe(1);
+    const forwarded = JSON.parse(sent[0]);
+    expect(forwarded.method).toBe("thread/start");
+    expect(typeof forwarded.id).toBe("number"); // proxy id is numeric
+    expect(forwarded.id).not.toBe("client-42"); // was rewritten
+
+    // Mapping for the new proxy id was registered on the fresh session.
+    expect(adapter.upstreamToClient.size).toBe(1);
+    const mapping = adapter.upstreamToClient.get(forwarded.id);
+    expect(mapping).toEqual({ connId: 1, clientId: "client-42" });
+
+    expect(ws.closed.length).toBe(0);
+  });
+
+  test("closes TUI with 1011 when outage timer fires", async () => {
+    const { adapter, ws, logs } = setupAdapterWithTui();
+    // Shrink timeout for the test via monkey-patching the static value.
+    (adapter.constructor as any).OUTAGE_TIMEOUT_MS = 20;
+
+    adapter.onTuiMessage(ws, JSON.stringify({ jsonrpc: "2.0", id: 1, method: "x", params: {} }));
+    expect(adapter.outageQueue.length).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(ws.closed.length).toBe(1);
+    expect(ws.closed[0].code).toBe(1011);
+    expect(ws.closed[0].reason).toMatch(/after \d+ms/);
+    expect(adapter.outageQueue.length).toBe(0);
+    expect(adapter.outageTimer).toBeNull();
+    expect(logs.some((l) => l.includes("did not return within"))).toBe(true);
+
+    // Restore default.
+    (adapter.constructor as any).OUTAGE_TIMEOUT_MS = 5000;
+  });
+
+  test("drops non-primary outage sends with WARNING log (no close)", () => {
+    const { adapter, logs } = setupAdapterWithTui(2);
+    const stale = makeFakeSocket(1);
+
+    adapter.onTuiMessage(stale, JSON.stringify({ jsonrpc: "2.0", id: 1, method: "x", params: {} }));
+
+    // Stale connection messages are filtered earlier by the tuiConnId guard,
+    // so we don't even reach the forward path. Verify nothing was buffered.
+    expect(adapter.outageQueue.length).toBe(0);
+    expect(adapter.outageTimer).toBeNull();
+    expect(stale.closed.length).toBe(0);
+    // The higher-layer "Dropping message from stale TUI conn" log fires instead.
+    expect(logs.some((l) => l.includes("stale TUI"))).toBe(true);
+  });
+});
+
+describe("CodexAdapter thread/closed diagnostic sniffer", () => {
+  test("logs DIAGNOSTIC line when app-server emits thread/closed", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.log = (msg: string) => logs.push(msg);
+    adapter.interceptServerMessage = () => {};
+
+    adapter.handleAppServerPayload(JSON.stringify({
+      jsonrpc: "2.0",
+      method: "thread/closed",
+      params: { threadId: "abc-123" },
+    }));
+
+    const diag = logs.filter((l) => l.startsWith("DIAGNOSTIC: app-server emitted thread/closed"));
+    expect(diag.length).toBe(1);
+    expect(diag[0]).toContain("threadId=abc-123");
+  });
+
+  test("handles thread/closed with missing params gracefully", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.log = (msg: string) => logs.push(msg);
+    adapter.interceptServerMessage = () => {};
+
+    adapter.handleAppServerPayload(JSON.stringify({
+      jsonrpc: "2.0",
+      method: "thread/closed",
+    }));
+
+    const diag = logs.filter((l) => l.startsWith("DIAGNOSTIC: app-server emitted thread/closed"));
+    expect(diag.length).toBe(1);
+    expect(diag[0]).toContain("threadId=unknown");
+  });
+
+  test("does not log DIAGNOSTIC for other notifications", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.log = (msg: string) => logs.push(msg);
+    adapter.interceptServerMessage = () => {};
+
+    adapter.handleAppServerPayload(JSON.stringify({
+      jsonrpc: "2.0",
+      method: "thread/started",
+      params: { threadId: "abc-123" },
+    }));
+
+    const diag = logs.filter((l) => l.startsWith("DIAGNOSTIC:"));
+    expect(diag.length).toBe(0);
+  });
+});

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -1296,6 +1296,268 @@ describe("CodexAdapter TUI outage recovery", () => {
   });
 });
 
+describe("CodexAdapter session restore after unintentional reconnect", () => {
+  type FakeSocket = {
+    data: { connId: number };
+    closed: Array<{ code: number; reason: string }>;
+    close: (code: number, reason: string) => void;
+    send: (data: string) => void;
+  };
+
+  function makeFakeSocket(connId: number): FakeSocket {
+    const closed: Array<{ code: number; reason: string }> = [];
+    return {
+      data: { connId },
+      closed,
+      close(code: number, reason: string) {
+        closed.push({ code, reason });
+      },
+      send() {},
+    };
+  }
+
+  function makeFakeAppServerWs() {
+    const sent: string[] = [];
+    return {
+      readyState: 1 /* WebSocket.OPEN */,
+      sent,
+      send: function (data: string) {
+        sent.push(data);
+      },
+    };
+  }
+
+  test("sendReplayAndAwait resolves when app-server responds with matching id (no error)", async () => {
+    const adapter = createAdapter();
+    adapter.log = () => {};
+
+    const server = makeFakeAppServerWs();
+    adapter.appServerWs = server;
+
+    const promise = adapter.sendReplayAndAwait(
+      JSON.stringify({ jsonrpc: "2.0", id: "replay-1", method: "initialize" }),
+      "initialize",
+    );
+
+    // Simulate app-server response arriving via handleAppServerPayload.
+    setTimeout(() => {
+      const consumed = adapter.handleAppServerPayload(JSON.stringify({
+        id: "replay-1",
+        result: { capabilities: {} },
+      }));
+      // Response should have been swallowed (not forwarded to TUI).
+      expect(consumed).toBeNull();
+    }, 5);
+
+    const response = await promise;
+    expect(response).toEqual({ id: "replay-1", result: { capabilities: {} } });
+  });
+
+  test("sendReplayAndAwait rejects when app-server responds with error field", async () => {
+    const adapter = createAdapter();
+    adapter.log = () => {};
+
+    adapter.appServerWs = makeFakeAppServerWs();
+
+    const promise = adapter.sendReplayAndAwait(
+      JSON.stringify({ jsonrpc: "2.0", id: "replay-err", method: "initialize" }),
+      "initialize",
+    );
+
+    setTimeout(() => {
+      adapter.handleAppServerPayload(JSON.stringify({
+        id: "replay-err",
+        error: { message: "already initialized" },
+      }));
+    }, 5);
+
+    await expect(promise).rejects.toThrow(/initialize rejected: already initialized/);
+  });
+
+  test("sendReplayAndAwait rejects on timeout", async () => {
+    const adapter = createAdapter();
+    adapter.log = () => {};
+    (adapter.constructor as any).SESSION_REPLAY_TIMEOUT_MS = 30;
+    adapter.appServerWs = makeFakeAppServerWs();
+
+    const promise = adapter.sendReplayAndAwait(
+      JSON.stringify({ jsonrpc: "2.0", id: "replay-timeout", method: "initialize" }),
+      "initialize",
+    );
+
+    await expect(promise).rejects.toThrow(/replay timeout/);
+    (adapter.constructor as any).SESSION_REPLAY_TIMEOUT_MS = 5000;
+  });
+
+  test("handleSessionRestoreAfterReconnect bails when no cached initialize", async () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.log = (m: string) => logs.push(m);
+
+    adapter.appServerWs = makeFakeAppServerWs();
+    adapter.lastInitializeRaw = null;
+
+    await adapter.handleSessionRestoreAfterReconnect();
+
+    expect(logs.some((l) => l.includes("no cached initialize"))).toBe(true);
+  });
+
+  test("handleSessionRestoreAfterReconnect closes TUI 1011 on initialize failure", async () => {
+    const adapter = createAdapter();
+    adapter.log = () => {};
+
+    const ws = makeFakeSocket(1);
+    adapter.tuiConnId = 1;
+    adapter.tuiWs = ws;
+
+    const server = makeFakeAppServerWs();
+    adapter.appServerWs = server;
+
+    adapter.lastInitializeRaw = JSON.stringify({
+      jsonrpc: "2.0",
+      id: "init-will-fail",
+      method: "initialize",
+      params: {},
+    });
+
+    const restorePromise = adapter.handleSessionRestoreAfterReconnect();
+
+    // Simulate app-server rejecting the replayed initialize.
+    setTimeout(() => {
+      adapter.handleAppServerPayload(JSON.stringify({
+        id: "init-will-fail",
+        error: { message: "schema mismatch" },
+      }));
+    }, 5);
+
+    await restorePromise;
+
+    expect(ws.closed.length).toBe(1);
+    expect(ws.closed[0].code).toBe(1011);
+    expect(ws.closed[0].reason).toMatch(/initialize rejected: schema mismatch/);
+  });
+
+  test("handleSessionRestoreAfterReconnect sends initialize + initialized + thread/resume when happy path", async () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.log = (m: string) => logs.push(m);
+
+    const ws = makeFakeSocket(1);
+    adapter.tuiConnId = 1;
+    adapter.tuiWs = ws;
+
+    const server = makeFakeAppServerWs();
+    adapter.appServerWs = server;
+
+    adapter.lastInitializeRaw = JSON.stringify({
+      jsonrpc: "2.0",
+      id: "replay-init",
+      method: "initialize",
+      params: {},
+    });
+    adapter.lastInitializedRaw = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "initialized",
+    });
+    adapter.threadId = "thread-xyz";
+
+    const restorePromise = adapter.handleSessionRestoreAfterReconnect();
+
+    // Respond to each replayed request in order.
+    await new Promise((r) => setTimeout(r, 2));
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: "replay-init",
+      result: { ok: true },
+    }));
+
+    // Give the initialize promise a chance to resolve before responding
+    // to thread/resume.
+    await new Promise((r) => setTimeout(r, 2));
+    // The thread/resume id is generated dynamically — inspect what was
+    // sent to find it.
+    const resumeSent = server.sent.find((s: string) => s.includes("thread/resume"));
+    expect(resumeSent).toBeDefined();
+    const resumeId = JSON.parse(resumeSent!).id;
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: resumeId,
+      result: { thread: { id: "thread-xyz" } },
+    }));
+
+    await restorePromise;
+
+    // Expected 3 sends: initialize, initialized, thread/resume.
+    expect(server.sent.length).toBe(3);
+    expect(JSON.parse(server.sent[0]).method).toBe("initialize");
+    expect(JSON.parse(server.sent[1]).method).toBe("initialized");
+    expect(JSON.parse(server.sent[2]).method).toBe("thread/resume");
+    expect(JSON.parse(server.sent[2]).params).toEqual({ threadId: "thread-xyz" });
+
+    expect(ws.closed.length).toBe(0);
+    expect(logs.some((l) => l.includes("session restored"))).toBe(true);
+  });
+
+  test("onTuiMessage buffers during sessionRestoreInProgress (no leak to uninitialized session)", () => {
+    const adapter = createAdapter();
+    adapter.log = () => {};
+
+    const ws = makeFakeSocket(1);
+    adapter.tuiConnId = 1;
+    adapter.tuiWs = ws;
+    adapter.appServerWs = makeFakeAppServerWs();
+    adapter.sessionRestoreInProgress = true;
+
+    adapter.onTuiMessage(ws, JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "turn/steer",
+      params: {},
+    }));
+
+    // Message should have been pushed onto the outage queue, not sent to
+    // app-server, because restore was in progress.
+    expect(adapter.outageQueue.length).toBe(1);
+    expect(adapter.appServerWs.sent.length).toBe(0);
+
+    // Cleanup timer to avoid leaking into other tests.
+    if (adapter.outageTimer) {
+      clearTimeout(adapter.outageTimer);
+      adapter.outageTimer = null;
+    }
+  });
+
+  test("onTuiMessage caches initialize and initialized raw payloads", () => {
+    const adapter = createAdapter();
+    adapter.log = () => {};
+
+    const ws = makeFakeSocket(1);
+    adapter.tuiConnId = 1;
+    adapter.tuiWs = ws;
+    adapter.appServerWs = makeFakeAppServerWs();
+
+    // The `initialize` request triggers reconnectAppServerForNewSession
+    // which caches the raw payload.
+    const initRaw = JSON.stringify({
+      jsonrpc: "2.0",
+      id: "init-1",
+      method: "initialize",
+      params: { foo: "bar" },
+    });
+    // Stub out the reconnect to avoid real network activity.
+    adapter.reconnectAppServerForNewSession = async () => {};
+    adapter.onTuiMessage(ws, initRaw);
+    expect(adapter.lastInitializeRaw).toBe(initRaw);
+
+    // `initialized` notification is captured in the normal forward path.
+    const initedRaw = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "initialized",
+    });
+    adapter.reconnectingForNewSession = false;
+    adapter.onTuiMessage(ws, initedRaw);
+    expect(adapter.lastInitializedRaw).toBe(initedRaw);
+  });
+});
+
 describe("CodexAdapter thread/closed diagnostic sniffer", () => {
   test("logs DIAGNOSTIC line when app-server emits thread/closed", () => {
     const adapter = createAdapter();

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { createServer, Socket, type Server } from "node:net";
 import { CodexAdapter } from "../codex-adapter";
 
 function createAdapter() {
@@ -1054,5 +1056,61 @@ describe("CodexAdapter initialize reconnect", () => {
 
     expect(adapter.threadId).toBeNull();
     expect(adapter.injectMessage("hello")).toBe(false);
+  });
+});
+
+describe("CodexAdapter port precheck — LISTEN-only filter", () => {
+  function runLsof(args: string): string[] {
+    try {
+      return execSync(`lsof ${args}`, {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .trim()
+        .split("\n")
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  test("buildPortListenLsofCommand restricts to LISTEN sockets", () => {
+    expect(CodexAdapter.buildPortListenLsofCommand(4501)).toBe(
+      "lsof -ti tcp:4501 -sTCP:LISTEN",
+    );
+  });
+
+  test("LISTEN filter ignores stale outbound FDs after listener dies", async () => {
+    const port = 40000 + Math.floor(Math.random() * 10000);
+
+    const server: Server = await new Promise((resolve, reject) => {
+      const s = createServer();
+      s.once("error", reject);
+      s.listen(port, "127.0.0.1", () => resolve(s));
+    });
+
+    const client: Socket = await new Promise((resolve, reject) => {
+      const c = new Socket();
+      c.once("error", reject);
+      c.connect(port, "127.0.0.1", () => resolve(c));
+    });
+
+    try {
+      // Sanity check: while listener is alive, LISTEN filter finds this process.
+      const withListener = runLsof(CodexAdapter.buildPortListenLsofCommand(port).slice(5));
+      expect(withListener).toContain(String(process.pid));
+
+      // Close the listener; the established outbound client FD lingers in this process.
+      await new Promise<void>((r) => server.close(() => r()));
+
+      // OLD impl `lsof -ti :PORT` (no LISTEN filter) would still find this process
+      // via the lingering outbound FD — the false positive that broke `abg claude`.
+      // NEW impl correctly returns no PIDs because nothing is LISTENING anymore.
+      const afterClose = runLsof(CodexAdapter.buildPortListenLsofCommand(port).slice(5));
+      expect(afterClose).toEqual([]);
+    } finally {
+      client.destroy();
+      if (server.listening) server.close();
+    }
   });
 });

--- a/src/unit-test/collaboration-init.test.ts
+++ b/src/unit-test/collaboration-init.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { writeCollaborationSections } from "../cli/init";
+import { MARKER_ID } from "../collaboration-content";
+
+const START = `<!-- ${MARKER_ID}:start -->`;
+const END = `<!-- ${MARKER_ID}:end -->`;
+
+describe("writeCollaborationSections", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "agentbridge-collab-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("creates CLAUDE.md and AGENTS.md when they don't exist", () => {
+    const results = writeCollaborationSections(tempDir);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toContain("CLAUDE.md: created");
+    expect(results[1]).toContain("AGENTS.md: created");
+
+    const claude = readFileSync(join(tempDir, "CLAUDE.md"), "utf-8");
+    expect(claude).toContain(START);
+    expect(claude).toContain(END);
+    expect(claude).toContain("Multi-Agent Collaboration");
+    expect(claude).toContain("Codex");
+
+    const agents = readFileSync(join(tempDir, "AGENTS.md"), "utf-8");
+    expect(agents).toContain(START);
+    expect(agents).toContain(END);
+    expect(agents).toContain("Multi-Agent Collaboration");
+    expect(agents).toContain("Claude");
+  });
+
+  test("appends to existing CLAUDE.md without markers", () => {
+    const existingContent = "# My Project Rules\n\nDo not break things.\n";
+    writeFileSync(join(tempDir, "CLAUDE.md"), existingContent, "utf-8");
+
+    const results = writeCollaborationSections(tempDir);
+
+    expect(results[0]).toContain("CLAUDE.md: appended");
+
+    const claude = readFileSync(join(tempDir, "CLAUDE.md"), "utf-8");
+    // Original content preserved
+    expect(claude).toContain("# My Project Rules");
+    expect(claude).toContain("Do not break things.");
+    // New section appended
+    expect(claude).toContain(START);
+    expect(claude).toContain("Multi-Agent Collaboration");
+  });
+
+  test("replaces existing markers on re-run", () => {
+    // First run
+    writeCollaborationSections(tempDir);
+    const firstRun = readFileSync(join(tempDir, "CLAUDE.md"), "utf-8");
+    expect(firstRun).toContain(START);
+
+    // Second run (idempotent replace)
+    const results = writeCollaborationSections(tempDir);
+    expect(results[0]).toContain("unchanged");
+
+    const secondRun = readFileSync(join(tempDir, "CLAUDE.md"), "utf-8");
+    expect(secondRun).toBe(firstRun);
+  });
+
+  test("preserves pre-existing content when appending", () => {
+    const projectRules = [
+      "# Project CLAUDE.md",
+      "",
+      "## Git Rules",
+      "- Always use feature branches",
+      "- Squash merge only",
+      "",
+    ].join("\n");
+    writeFileSync(join(tempDir, "CLAUDE.md"), projectRules, "utf-8");
+
+    writeCollaborationSections(tempDir);
+
+    const result = readFileSync(join(tempDir, "CLAUDE.md"), "utf-8");
+    // All original content preserved
+    expect(result).toContain("# Project CLAUDE.md");
+    expect(result).toContain("## Git Rules");
+    expect(result).toContain("Always use feature branches");
+    expect(result).toContain("Squash merge only");
+    // Collaboration section added
+    expect(result).toContain("Multi-Agent Collaboration");
+  });
+
+  test("updates when section content changes between versions", () => {
+    // Simulate an older version's markers with different content
+    const oldContent = `# Project\n\n${START}\nOLD COLLABORATION CONTENT\n${END}\n`;
+    writeFileSync(join(tempDir, "CLAUDE.md"), oldContent, "utf-8");
+
+    const results = writeCollaborationSections(tempDir);
+    expect(results[0]).toContain("CLAUDE.md: updated");
+
+    const updated = readFileSync(join(tempDir, "CLAUDE.md"), "utf-8");
+    expect(updated).not.toContain("OLD COLLABORATION CONTENT");
+    expect(updated).toContain("Multi-Agent Collaboration");
+    expect(updated).toContain("# Project");
+  });
+});

--- a/src/unit-test/collaboration-init.test.ts
+++ b/src/unit-test/collaboration-init.test.ts
@@ -93,6 +93,24 @@ describe("writeCollaborationSections", () => {
     expect(result).toContain("Multi-Agent Collaboration");
   });
 
+  test("skips malformed file instead of corrupting it", () => {
+    // User's CLAUDE.md has an orphan start marker (end deleted manually).
+    // upsertMarkedSection throws; init should skip just this file and keep going.
+    const orphaned = `# My Project\n<!-- ${MARKER_ID}:start -->\nLegacy notes preserved here\n## Other Section\nImportant user content\n`;
+    writeFileSync(join(tempDir, "CLAUDE.md"), orphaned, "utf-8");
+
+    const results = writeCollaborationSections(tempDir);
+
+    expect(results[0]).toContain("CLAUDE.md: skipped");
+    expect(results[0]).toContain("Malformed");
+    // AGENTS.md didn't exist → should still be created.
+    expect(results[1]).toContain("AGENTS.md: created");
+
+    // Critically: CLAUDE.md content is untouched.
+    const unchanged = readFileSync(join(tempDir, "CLAUDE.md"), "utf-8");
+    expect(unchanged).toBe(orphaned);
+  });
+
   test("updates when section content changes between versions", () => {
     // Simulate an older version's markers with different content
     const oldContent = `# Project\n\n${START}\nOLD COLLABORATION CONTENT\n${END}\n`;

--- a/src/unit-test/dual-mode.test.ts
+++ b/src/unit-test/dual-mode.test.ts
@@ -59,11 +59,11 @@ describe("Dual-mode transport: mode resolution", () => {
     expect(adapter.configuredMode).toBe("auto");
   });
 
-  test("auto mode defaults to pull", () => {
+  test("auto mode defaults to push", () => {
     const adapter = createAdapter();
     adapter.resolveMode();
-    expect(adapter.resolvedMode).toBe("pull");
-    expect(adapter.getDeliveryMode()).toBe("pull");
+    expect(adapter.resolvedMode).toBe("push");
+    expect(adapter.getDeliveryMode()).toBe("push");
   });
 
   test("resolveMode sets 'push' when configuredMode is 'push'", () => {

--- a/src/unit-test/marker-section.test.ts
+++ b/src/unit-test/marker-section.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { upsertMarkedSection } from "../marker-section";
+
+const SECTION_ID = "TestSection";
+const START = `<!-- ${SECTION_ID}:start -->`;
+const END = `<!-- ${SECTION_ID}:end -->`;
+
+describe("upsertMarkedSection", () => {
+  test("case 1: empty content → creates block with markers", () => {
+    const result = upsertMarkedSection("", SECTION_ID, "Hello World");
+    expect(result).toBe(`${START}\nHello World\n${END}\n`);
+  });
+
+  test("case 1: whitespace-only content → creates block with markers", () => {
+    const result = upsertMarkedSection("  \n  \n", SECTION_ID, "Hello World");
+    expect(result).toBe(`${START}\nHello World\n${END}\n`);
+  });
+
+  test("case 2: existing content without markers → appends block", () => {
+    const existing = "# My Project\n\nSome content here.\n";
+    const result = upsertMarkedSection(existing, SECTION_ID, "New section");
+    expect(result).toBe(
+      `# My Project\n\nSome content here.\n\n${START}\nNew section\n${END}\n`,
+    );
+  });
+
+  test("case 2: existing content without trailing newline → adds newline before block", () => {
+    const existing = "# My Project\n\nSome content here.";
+    const result = upsertMarkedSection(existing, SECTION_ID, "New section");
+    expect(result).toBe(
+      `# My Project\n\nSome content here.\n\n${START}\nNew section\n${END}\n`,
+    );
+  });
+
+  test("case 3: existing content with markers → replaces between markers", () => {
+    const existing = `# My Project\n\n${START}\nOld content\n${END}\n\n## Footer\n`;
+    const result = upsertMarkedSection(existing, SECTION_ID, "Updated content");
+    expect(result).toBe(
+      `# My Project\n\n${START}\nUpdated content\n${END}\n\n## Footer\n`,
+    );
+  });
+
+  test("case 3: replaces even when section content is identical", () => {
+    const section = "Same content";
+    const existing = `${START}\n${section}\n${END}\n`;
+    const result = upsertMarkedSection(existing, SECTION_ID, section);
+    // Should return identical content (no change)
+    expect(result).toBe(existing);
+  });
+
+  test("preserves content before and after markers", () => {
+    const before = "# Title\n\nParagraph.\n\n";
+    const after = "\n\n## Other Section\n\nMore text.\n";
+    const existing = `${before}${START}\nOLD\n${END}${after}`;
+    const result = upsertMarkedSection(existing, SECTION_ID, "NEW");
+    expect(result).toBe(`${before}${START}\nNEW\n${END}${after}`);
+  });
+
+  test("different section IDs don't interfere", () => {
+    const existing = `<!-- Other:start -->\nKeep this\n<!-- Other:end -->\n`;
+    const result = upsertMarkedSection(existing, SECTION_ID, "New block");
+    // Should append (no matching markers for TestSection)
+    expect(result).toContain("Keep this");
+    expect(result).toContain(START);
+    expect(result).toContain("New block");
+  });
+});

--- a/src/unit-test/marker-section.test.ts
+++ b/src/unit-test/marker-section.test.ts
@@ -64,4 +64,29 @@ describe("upsertMarkedSection", () => {
     expect(result).toContain(START);
     expect(result).toContain("New block");
   });
+
+  test("malformed: orphan start marker → throws instead of silently appending", () => {
+    // User manually deleted the end marker. A naive append would create a second
+    // start marker, and the next call would splice out content in between.
+    const existing = `# Title\n${START}\nOld notes\n## Other Section\nUser content\n`;
+    expect(() => upsertMarkedSection(existing, SECTION_ID, "NEW")).toThrow(
+      /Malformed .* markers/,
+    );
+  });
+
+  test("malformed: orphan end marker → throws", () => {
+    const existing = `# Title\nUser content\n${END}\nMore content\n`;
+    expect(() => upsertMarkedSection(existing, SECTION_ID, "NEW")).toThrow(
+      /Malformed .* markers/,
+    );
+  });
+
+  test("malformed: end marker before start marker → throws", () => {
+    // Pathological case from git merge or manual editing — markers out of order.
+    // Silently splicing here reverses slice direction and destroys content.
+    const existing = `# Title\n${END}\nUser notes\n${START}\nOld block\n`;
+    expect(() => upsertMarkedSection(existing, SECTION_ID, "NEW")).toThrow(
+      /Malformed .* markers/,
+    );
+  });
 });

--- a/src/unit-test/stderr-ring-buffer.test.ts
+++ b/src/unit-test/stderr-ring-buffer.test.ts
@@ -1,0 +1,66 @@
+import { test, expect, describe } from "bun:test";
+import { StderrRingBuffer } from "../stderr-ring-buffer";
+
+describe("StderrRingBuffer", () => {
+  test("rejects non-positive capacity", () => {
+    expect(() => new StderrRingBuffer(0)).toThrow(/positive/);
+    expect(() => new StderrRingBuffer(-1)).toThrow(/positive/);
+  });
+
+  test("ignores empty chunks", () => {
+    const buf = new StderrRingBuffer(16);
+    buf.append(Buffer.alloc(0));
+    expect(buf.byteLength).toBe(0);
+    expect(buf.toString()).toBe("");
+  });
+
+  test("stores chunks under capacity without eviction", () => {
+    const buf = new StderrRingBuffer(1024);
+    buf.append(Buffer.from("hello "));
+    buf.append(Buffer.from("world"));
+    expect(buf.byteLength).toBe(11);
+    expect(buf.toString()).toBe("hello world");
+  });
+
+  test("evicts oldest bytes when capacity exceeded", () => {
+    const buf = new StderrRingBuffer(10);
+    buf.append(Buffer.from("0123456789"));
+    buf.append(Buffer.from("abc"));
+    expect(buf.byteLength).toBe(10);
+    expect(buf.toString()).toBe("3456789abc");
+  });
+
+  test("truncates a single oversized chunk to its tail", () => {
+    const buf = new StderrRingBuffer(5);
+    buf.append(Buffer.from("abcdefghij"));
+    expect(buf.byteLength).toBe(5);
+    expect(buf.toString()).toBe("fghij");
+  });
+
+  test("handles partial eviction of head chunk", () => {
+    const buf = new StderrRingBuffer(6);
+    buf.append(Buffer.from("abcdef"));
+    buf.append(Buffer.from("XY"));
+    // 'abcdefXY' is 8 bytes, overflow 2, drop 'ab' from head.
+    expect(buf.byteLength).toBe(6);
+    expect(buf.toString()).toBe("cdefXY");
+  });
+
+  test("preserves binary data via snapshot()", () => {
+    const buf = new StderrRingBuffer(4);
+    buf.append(Buffer.from([0, 1, 2, 3, 4, 5]));
+    const snap = buf.snapshot();
+    expect(snap.length).toBe(4);
+    expect(Array.from(snap)).toEqual([2, 3, 4, 5]);
+  });
+
+  test("repeated appends near capacity behave stably", () => {
+    const buf = new StderrRingBuffer(4);
+    for (let i = 0; i < 100; i++) {
+      buf.append(Buffer.from(String.fromCharCode(65 + (i % 26))));
+    }
+    expect(buf.byteLength).toBe(4);
+    // Last 4 chars of the A..Z rotation at i=96..99 → indices 96%26=18,19,20,21 = S T U V
+    expect(buf.toString()).toBe("STUV");
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary

15 个 commit 自 v0.1.5,主线是 **Codex TUI 静默崩溃修复**,顺手把协作初始化基础设施和默认投递模式调整一起 ship。

## 关键修复 / Key Fixes

### Codex TUI 可靠性(本 PR 主线)
- **f8698b8** Codex TUI 退出诊断 — stderr tee + 64KB ring buffer + `codex-wrapper.log` 分类(fatal_exit / exit_0_empty_stderr / signal:X);outage queue(64 msg / 5s)让 TUI 扛住 app-server 短断重连
- **416fc21** 非主动断线后重放 initialize — app-server 中途掉线 → 静默 reconnect 到新 session → TUI 不知道继续发 → "Not initialized" → exit 1。现在缓存 TUI 最后的 initialize/initialized payload,重连时按原顺序重放 + 重放 `thread/resume`;restore 期间消息走 outage queue;5s 超时则 close 1011 让 codex-rs 报 visible FatalExitRequest
- **c992797** 端口预检 `lsof -ti :PORT` 被崩溃后残留的 outbound CLOSED FD 误判 → 加 `-sTCP:LISTEN` 只看监听者

### 协作初始化
- **4d42c6e** `abg init` 写入协作段落到 CLAUDE.md / AGENTS.md(marker-section.ts 幂等工具 + collaboration-content.ts 模板)
- **3527f21** 首次双方就绪时给 Codex 注入完整 kickoff(分工 / 通信方式);重连用简短消息
- **bd133d7** 修两个 ultrareview 找出的 bug:① kickoff 被 turn-in-progress 拒绝时 latch 误置 true → 永久丢失;② `upsertMarkedSection` 遇到孤立 / 错序 marker 会静默吞用户笔记

### 投递模式
- **7215f4f** 默认投递模式 pull → push(plugin 始终通过 channel 可达,push 失败已有 per-message fallback;解决"收不到消息"反馈)

### 已合并到 master 但未 release 的(7 个)
- 0130fa1 chore: 同步 plugin bundle + CLAUDE.md
- 1a27d22 fix: 补全 #64 诊断日志盲区
- fc4bb40 refactor: 配置契约清理 + 诊断日志
- dc22866 fix: 日志路径迁移到 StateDirResolver
- 83f6c64 fix: npm install 后自动注册 marketplace
- 72345ce chore: 同步 plugin bundle
- 0d7b348 ci: 合并 PR 自动 tag + release

## 验证 / Verification

- `tsc --noEmit` ✓
- `bun test src` — **219 pass / 0 fail / 620 expect()**
- `bun run verify:plugin-sync` ✓ — bundles in sync with source
- `bun run validate:plugin-versions` ✓ — 3 manifests aligned at 0.1.6
- `bun run check` ✓ — full pipeline

## 影响 / Impact

- 用户场景:Codex 端 reconnect 不再静默崩溃 + 第一次连上就有清晰协作分工;Claude 端收 Codex 消息默认 push(不用 polling)
- 兼容性:wire 不变,channel/JSON-RPC 协议无变化;只是默认值切换和健壮性提升
- 部署:`/plugin update agentbridge@agentbridge` 后生效;npm 端 `npm install -g @raysonmeng/agentbridge@latest`

## Test plan

- [x] tsc + 219 unit tests green locally
- [x] plugin bundle in sync with source(commit verified)
- [x] manifests aligned at 0.1.6
- [ ] reviewer 确认 Auto Release workflow 会在 merge 后正确发 v0.1.6 tag

merge 后 `.github/workflows/auto-release.yml` 触发(检测到 package.json 改动) → 自动建 v0.1.6 tag + GitHub release。