### PR TITLE
feat: multi-Claude + multi-TUI parallel agent support

### DIFF
--- a/docs/shared-thread-mode-spec.md
+++ b/docs/shared-thread-mode-spec.md
@@ -1,0 +1,464 @@
+# Shared Thread Mode — Design Spec (v2.2)
+
+**Status:** Final — Codex go-with-edits (codex_msg_34d65b44c51d_25) applied. Ready for implementation.
+**Branch:** `feat/shared-thread-mode`
+**Author:** Claude (Opus 4.7), with design input from Codex
+**Date:** 2026-05-15
+
+## 0. v1 → v2 → v2.1 → v2.2 changelog
+
+v1 proposed `ClaudeThread + thread/resume(tuiThreadId)` as the sharing mechanism. Codex's independent review found this **blocked by codex-rs**: `thread/resume` rejects unmaterialized threads (`no rollout found for thread id`), confirmed by source test `thread_resume_rejects_unmaterialized_thread` and reproduced locally on codex-cli 0.130.0.
+
+v2 adopted Codex's counter-proposal: **paired Claude uses CodexAdapter as shared transport** (the v1 mechanism from this project's earliest version), no thread/resume needed. ClaudeThread + thread/start path is kept for **unpaired (isolated) Claudes only**, preserving multi-Claude isolation.
+
+v2.2 applies Codex's go-with-edits final review:
+- **§4.3 protocol fix**: `error` is a top-level notification (`params.error`), NOT a `ThreadItem` variant. `thread/closed` likewise. Update protocol allowlist.
+- **§4.3 + ClaudeAdapter rule**: `turnStarted` system message MUST NOT satisfy `requireReply`. Only `agentMessage`, `error`, `threadClosed`, or `turnCompleted-without-agentMessage` releases it. Otherwise no-output failures get masked by the start message.
+- **§4.5 race fix**: implement content-hash echo dedup alongside turnId, narrowly scoped to the pre-response window (~5s). turnId stays the 60s primary mechanism.
+- **R3 confirmed**: `AGENTBRIDGE_PAIR_REAP_MS = 30000` (separate from CLAUDE_REAP_MS).
+- **Wording**: "restoring shared Codex TUI session, retry shortly" for app-server reconnect window (vs "provisioning" for first-time bootstrap).
+- **Consistency fixes**: §5.1 default reconciled to `PAIR_RACE_MS=0`; P6 uses `source:"codex"` with prefix; E1 references §4.6.
+
+v2.1 refined v2 with Codex's second review:
+- **Echo prevention**: turnId dedup (not content-hash) as primary mechanism
+- **Whitelist expansion**: control-plane events (`turn/started`, `turn/completed`, `error`, `thread/closed`) MUST forward, otherwise paired Claude's `requireReply` hangs silently on failures
+- **Source-type encoding**: keep `BridgeMessage.source` as `"claude"|"codex"`. User-typed text forwarded as `source:"codex"` with explicit prefix
+- **§8 E7 correction**: `injectMessage` returns `false` when turn-in-progress, no queue. Paired Claude gets a `busy, retry` error
+- **New paired state**: `paired-but-not-ready` — pairing happens on TUI WS connect, but injection requires `thread/started` first. `reply` returns provisioning error during this window
+- **Token discrimination transport**: implementation uses Codex's native `--remote-auth-token-env` Authorization header path. Current `codex-cli 0.130.0` rejects query strings in `--remote` (`ws://host:port` only). The proxy still accepts legacy `abg_token` query values for probes/backcompat.
+
+## 1. Motivation
+
+(unchanged from v1) User wants the right-pane Codex TUI to show Claude↔Codex activity in real time AND accept user typing as a third voice, while keeping multi-Claude parallelism. Restore v1 UX of this project, conditional on a single paired (Claude, TUI) pair.
+
+## 2. Goals & non-goals
+
+### Goals
+- Designated "paired" (Claude, TUI) duo shares a single Codex thread (the TUI's thread).
+- Paired Claude's turn/start is **injected through the TUI's WS** (via `CodexAdapter.injectMessage`), so:
+  - The TUI sees the turn natively (it's a normal turn on its own thread).
+  - The TUI sees responses normally.
+- User-typed messages in the TUI route back to the paired Claude (so Claude has full conversation context).
+- Multi-Claude isolation preserved: a second Claude attaches as an isolated ClaudeThread, untouched.
+- Pairing opt-in via `--via-proxy` on the TUI; default `agentbridge codex` stays direct.
+
+### Non-goals
+- Multiple `--via-proxy` TUIs simultaneously. The first wins; subsequent are rejected at WS handshake.
+- Multiple paired Claudes sharing one TUI. The first Claude wins; subsequent Claudes go isolated.
+- Mirroring multiple Claude threads into one TUI.
+- Standalone observability dashboard for N-Claude scenarios (separate effort).
+- Daemon-crash recovery for paired sessions. If daemon dies, both sides must restart (document the limit).
+- `thread/resume` semantics. Not used by this design.
+
+## 3. Architecture overview
+
+```
+                    ┌────────────────────────────┐
+                    │   Codex app-server :4500   │
+                    │   (thread T_proxy lives)   │
+                    └────────────┬───────────────┘
+                                 │  WS (proxy intercepts)
+              ┌──────────────────┴────────────────┐
+              │   CodexAdapter (in daemon)        │
+              │   - tuiWs ──── shared transport   │
+              │   - pairedChatId: "claude_abc"    │
+              │   - injectMessage(text) for paired│
+              │   - emits item/userMessage  ─┐    │
+              │   - emits item/agentMessage ─┤    │
+              └────────┬──────────────────┬──┴────┘
+                       │ WS :4501         │ control plane
+                       │                  │
+                ┌──────▼──────┐    ┌──────▼──────────────────────┐
+                │  Proxy TUI  │    │  Daemon (chats map)         │
+                │  (right     │    │  - paired Claude: chat_abc  │
+                │   pane)     │    │  - isolated Claude(s):      │
+                │             │    │    chat_xyz → ClaudeThread  │
+                └─────────────┘    └─────────────────────────────┘
+                                          │
+                  ┌───────────────────────┼──────────────────┐
+                  │                       │                  │
+            ┌─────▼────┐            ┌─────▼─────┐      ┌─────▼─────┐
+            │ Paired   │            │ Isolated  │      │ Isolated  │
+            │ Claude   │            │ Claude #2 │      │ Claude #N │
+            │ (reply → │            │ (own      │      │ (own      │
+            │ inject) │             │  thread)  │      │  thread)  │
+            └──────────┘            └───────────┘      └───────────┘
+```
+
+**Key invariants:**
+1. At most one `tuiWs` (paired TUI) per daemon. Second WS connection that's not the paired TUI's own secondary picker is rejected.
+2. At most one `pairedChatId`. Set when first eligible Claude attaches while `tuiWs != null`.
+3. Paired Claude has **no ClaudeThread**. Its reply/turn flows entirely through CodexAdapter.
+4. Isolated Claudes (chatId ≠ pairedChatId) use ClaudeThread normally — unchanged.
+
+## 4. CodexAdapter changes
+
+### 4.1 Paired-chat ownership
+
+Add to `CodexAdapter`:
+
+```ts
+private pairedChatId: string | null = null;
+
+setPairedChat(chatId: string | null): void {
+  this.pairedChatId = chatId;
+  this.logger(`[CodexAdapter] paired chat set to: ${chatId ?? "<none>"}`);
+}
+
+isPaired(chatId: string): boolean {
+  return this.pairedChatId === chatId;
+}
+```
+
+Daemon calls `setPairedChat()` exactly once per pairing event. Cleared on Claude detach (after grace) OR on proxy TUI disconnect (full clear).
+
+### 4.2 Inbound: Claude → injectMessage → tuiWs
+
+`injectMessage(text: string): boolean` already exists at line 225. No signature change. Daemon's per-chat routing decides which transport to use:
+
+- If `chatId === codexAdapter.pairedChatId`: call `codexAdapter.injectMessage(text)`. The text becomes a `turn/start` injected on the TUI's WS, so codex-rs treats it as if the TUI's user typed it.
+- Otherwise: existing ClaudeThread path (`thread/start` + own thread).
+
+### 4.3 Outbound: items routed to paired Claude
+
+Without a ClaudeThread, paired Claude has no native turn-tracking. The CodexAdapter must emit enough signals so paired Claude's `requireReply` doesn't hang on errors. Items routed:
+
+**Transcript items** (rendered as conversation):
+- `item/completed` with `item.type === "agentMessage"` — Codex's response → forwarded as `BridgeMessage{ source: "codex", content }` (unchanged from existing)
+- `item/completed` with `item.type === "userMessage"` AND `params.turnId NOT in injectedTurnIds` — user typed in TUI → forwarded as `BridgeMessage{ source: "codex", content: "[IMPORTANT] Human typed in the paired Codex TUI:\n${text}" }`
+
+**Control-plane events** (forwarded as system messages so paired Claude knows turn state):
+- `turn/started` (notification) — emit system message `{ source: "codex", content: "[system] Codex turn started", satisfiesRequireReply: false }`. **Diagnostic only, MUST NOT satisfy `requireReply`** — otherwise no-output failures get masked by the start message.
+- `turn/completed` (notification) — emit system message `{ source: "codex", content: "[system] Codex turn completed", satisfiesRequireReply: true (only if no agentMessage came in this turn) }`. Used as the "no-output failure" signal: if a turn started and completed without an agentMessage, this is the only signal paired Claude has that something went wrong.
+- `error` (top-level notification, NOT a ThreadItem) — codex-rs emits this as `{ method: "error", params: { error: { code, message } } }`. Emit system message `{ source: "codex", content: "[error] ${params.error.message}", satisfiesRequireReply: true }`.
+- `thread/closed` (top-level notification, NOT a ThreadItem) — emit system message `{ source: "codex", content: "[system] Shared Codex thread closed — pair is being torn down", satisfiesRequireReply: true }`. Triggers daemon's TUI-disconnect-equivalent transition (§5).
+
+**Protocol allowlist update** (`src/app-server-protocol.ts`): the `AppServerNotification` union must include `"error"` and `"thread/closed"` so `isAppServerNotification()` recognizes them. Currently the union only lists `turn/started`, `turn/completed`, `item/started`, `item/completed`, `item/agentMessage/delta`. Add:
+```ts
+| { jsonrpc?: "2.0"; id?: undefined; method: "error"; params?: { error?: { code?: number; message?: string; data?: unknown } } }
+| { jsonrpc?: "2.0"; id?: undefined; method: "thread/closed"; params?: { threadId?: string } }
+```
+
+**`requireReply` release rule** (enforced in ClaudeAdapter or daemon's per-chat outbound path):
+- Messages flagged `satisfiesRequireReply: true` release any outstanding `require_reply` wait.
+- `turnStarted` (false) does not release.
+- `agentMessage`, `error`, `threadClosed`: release.
+- `turnCompleted`: release ONLY if no `agentMessage` was emitted earlier in this same turnId — tracks "turn finished with no output" failure mode. (Daemon keeps a per-turnId `sawAgentMessage` bool.)
+- `userMessage` (after echo dedup): release. The human just spoke in the TUI, that counts as a response Claude should react to.
+
+**Source-type encoding rationale**: `BridgeMessage.source` is `"claude" | "codex"` today (`src/types.ts`). v2.2 keeps the type unchanged. User-typed text and system messages are encoded as `source: "codex"` with explicit text prefixes. This avoids invasive type widening across `claude-adapter`, `daemon-client`, control-protocol, and formatting paths.
+
+### 4.4 What does NOT go to paired Claude (whitelist exclusion)
+
+To avoid Claude's context being polluted with internal Codex execution noise:
+
+- `toolCall`, `shellCommand`, `fileChange` items: NOT forwarded. These are Codex's own internal actions; Claude doesn't need them as conversation context. (TUI shows them natively.)
+- Approval requests (`item/permissions/requestApproval`, `item/fileChange/requestApproval`, `item/commandExecution/requestApproval`): NOT forwarded to Claude. The user (via TUI) approves, not Claude.
+- `reasoning`, `plan`, raw `response` items: NOT forwarded.
+- `item/agentMessage/delta` (streaming chunks): NOT forwarded individually — only the final `item/completed` is emitted, as today.
+
+### 4.5 Echo prevention: turnId dedup
+
+When daemon routes a paired Claude's reply through `CodexAdapter.injectMessage(text)`, codex-rs will subsequently emit `item/completed{ item.type: "userMessage", params.turnId: T }` for the very same text. Without dedup, this would echo back to the paired Claude as a user message.
+
+**Mechanism (primary):**
+
+```ts
+// In CodexAdapter
+private injectedTurnIds = new Map<string, number>();  // turnId → expiresAt
+private readonly ECHO_DEDUP_TTL_MS = 60_000;
+
+injectMessage(text: string): boolean {
+  // existing turn-in-progress check ...
+  const reqId = nextProxyId();
+  const turnStart = { jsonrpc: "2.0", id: reqId, method: "turn/start", params: { /* ... */ } };
+  this.appServerWs.send(JSON.stringify(turnStart));
+  this.pendingInjects.set(reqId, { text, sentAt: Date.now() });
+  return true;
+}
+
+// On turn/start response:
+private handleInjectionTurnStartResponse(response: AppServerResponse<TurnStartResponse>) {
+  const turnId = response.result?.turn?.id;
+  if (turnId) {
+    this.injectedTurnIds.set(turnId, Date.now() + this.ECHO_DEDUP_TTL_MS);
+  }
+  // existing logic ...
+}
+
+// In item/completed handler for userMessage:
+const turnId = params?.turnId;
+if (typeof turnId === "string" && this.isInjectedTurn(turnId)) {
+  return;  // suppress echo
+}
+
+private isInjectedTurn(turnId: string): boolean {
+  const expiresAt = this.injectedTurnIds.get(turnId);
+  if (!expiresAt) return false;
+  if (Date.now() > expiresAt) {
+    this.injectedTurnIds.delete(turnId);
+    return false;
+  }
+  return true;
+}
+```
+
+**Race protection (content-hash, also implemented)**: Even when turnId is present, a `userMessage` notification could arrive **before** the `turn/start` response populates `injectedTurnIds`. The window is tiny but non-zero. Mitigation: a parallel `pendingInjectionHashes: Map<contentHash, expiresAt>` with 5s TTL.
+
+```ts
+private pendingInjectionHashes = new Map<string, number>();
+private readonly PENDING_HASH_TTL_MS = 5_000;
+
+injectMessage(text: string): boolean {
+  // existing turn-in-progress check ...
+  const hash = sha1(text).slice(0, 16);
+  this.pendingInjectionHashes.set(hash, Date.now() + this.PENDING_HASH_TTL_MS);
+  // ... send turn/start, etc.
+}
+
+// In item/completed handler for userMessage:
+private isEchoOfInjection(text: string, turnId: string | undefined): boolean {
+  if (turnId && this.isInjectedTurn(turnId)) return true;        // primary: turnId match
+  const hash = sha1(text).slice(0, 16);
+  const expires = this.pendingInjectionHashes.get(hash);
+  if (expires && Date.now() <= expires) {
+    this.pendingInjectionHashes.delete(hash);                    // consume; one-shot
+    return true;
+  }
+  return false;
+}
+```
+
+The hash map is one-shot (delete on match) to avoid suppressing a legitimate user-typed message that happens to match an earlier injection's text. TTL 5s is well under realistic typing latency for a duplicate.
+
+Metadata-marker approach is rejected — codex-rs's `ThreadItem` does not preserve arbitrary fields on round-trip.
+
+### 4.6 Secondary-picker discrimination
+
+Rejecting any second proxy WS would break codex-rs's own secondary "resume picker" connection (current adapter intentionally supports these via `secondaryConnections` Map at line 83).
+
+**Mechanism: Authorization bearer token.**
+
+- `agentbridge codex --via-proxy` generates a random 16-char token at startup, sets `AGENTBRIDGE_PROXY_TOKEN=<token>`, and starts codex with `--remote ws://127.0.0.1:4501 --remote-auth-token-env AGENTBRIDGE_PROXY_TOKEN`.
+- Codex-rs applies this as `Authorization: Bearer <token>` on each remote app-server WebSocket connection. This path is required because current `codex-cli 0.130.0` rejects query strings in `--remote` and only accepts `ws://host:port` / `wss://host:port`.
+- Daemon proxy at WS upgrade reads `Authorization: Bearer <token>` as canonical input. It also accepts legacy `?abg_token=<token>` for probe/backcompat coverage.
+- Accept/reject logic:
+  - If token absent: reject (foreign WS or stale picker from a dead session).
+  - If token matches the existing `proxyTuiSlot.token`: allow as secondary picker (route via existing `secondaryConnections` path).
+  - If token differs from existing `proxyTuiSlot.token`: reject with WS close 4002 + reason `"another --via-proxy TUI is already connected"`.
+
+If no `proxyTuiSlot` yet (first connect): accept and store `proxyTuiSlot.token = token`.
+
+## 5. Daemon pairing state machine
+
+```ts
+type PairReadiness = "not-ready" | "ready";
+
+type ProxyTuiSlot = {
+  ws: ServerWebSocket;
+  token: string;
+  pairedChatId: string | null;
+  readiness: PairReadiness;        // becomes "ready" when CodexAdapter has activeThreadId
+  attachedAt: number;
+};
+
+class Daemon {
+  private proxyTuiSlot: ProxyTuiSlot | null = null;
+}
+```
+
+**`readiness` state lifecycle:**
+- TUI WS opens → `readiness = "not-ready"`. Pairing CAN happen (a Claude attaches) but `reply` returns "thread provisioning, retry in a moment" until ready.
+- CodexAdapter observes `thread/started` (existing event path) → daemon flips `readiness = "ready"`. Now `injectMessage` will succeed.
+- App-server reconnect / session restore → readiness may flip back to "not-ready" momentarily during `handleSessionRestoreAfterReconnect`. Same provisioning error returned.
+
+**Transitions:**
+
+| Event | Effect |
+|---|---|
+| Proxy TUI connects with new token | `proxyTuiSlot = {ws, token, pairedChatId: null, readiness: "not-ready", attachedAt: now}`. Notify CodexAdapter via `setProxyTui()`. |
+| CodexAdapter emits `thread-ready` (after observing `thread/started` on TUI WS) | `proxyTuiSlot.readiness = "ready"`. If a paired Claude was already attached waiting, no action needed — its next `reply` will succeed. |
+| Claude attaches (chat created) | If `proxyTuiSlot && !proxyTuiSlot.pairedChatId` → pair (regardless of readiness): `proxyTuiSlot.pairedChatId = chatId`; call `codexAdapter.setPairedChat(chatId)`; **skip ClaudeThread construction** for this chat. Else: construct ClaudeThread normally (isolated). |
+| Paired Claude calls `reply` while `readiness === "not-ready"` | Return error to Claude: `"Shared Codex TUI thread is still provisioning. Retry shortly."` Do NOT inject. Do not hang. |
+| Paired Claude calls `reply` while `readiness === "ready"` | Daemon calls `codexAdapter.injectMessage(text)`. If `injectMessage` returns `false` (turn-in-progress, see §8 E7), return error `"Shared Codex TUI is busy with another turn. Retry."` Same surface, different reason. |
+| Paired Claude WS detaches | Start grace timer (default `AGENTBRIDGE_PAIR_REAP_MS = 30000`). On expiry, clear `proxyTuiSlot.pairedChatId` and call `codexAdapter.setPairedChat(null)`. Within grace, same chatId reconnect re-pairs immediately. |
+| Same Claude reconnects within grace | Cancel grace timer. Pair preserved. No state change in CodexAdapter. |
+| Proxy TUI WS disconnects | Clear `proxyTuiSlot = null`. Call `codexAdapter.setPairedChat(null)`. **If a paired Claude was still attached: send Claude a system notice (§4.3 control-plane event), then transition that Claude to isolated mode** — daemon now constructs a fresh ClaudeThread for this chatId (new `thread/start`, new threadId, no replay of TUI conversation context). The system notice content: `"[system] Shared Codex TUI thread is gone. Future replies will use a fresh isolated Codex thread (no prior context carried over)."` |
+| Paired Claude receives `thread/closed` notification (forwarded as system message per §4.3) | Same as "Proxy TUI WS disconnects" — pair torn down, transition to isolated, system notice sent. |
+| Second proxy TUI connect (foreign token) | Reject at WS upgrade. Daemon does not touch `proxyTuiSlot`. |
+| Second proxy TUI connect (same token) | Treat as secondary picker. Route via CodexAdapter's existing `secondaryConnections` path. |
+
+### 5.1 Race window (Claude vs TUI startup order)
+
+- **No grace window.** If Claude attaches and `proxyTuiSlot == null`, it goes straight to isolated. No waiting.
+- `AGENTBRIDGE_PAIR_RACE_MS` env var exists for future opt-in but **default is `0`** (no race window). Resolved per Codex review Q4 — predictability over race tolerance.
+
+If user starts TUI after Claude, they must restart Claude to enable pairing. This is documented in the kickoff message:
+> "Shared Codex TUI mode is opt-in via `agentbridge codex --via-proxy`. To use it, start the TUI before attaching Claude. If Claude is already attached when you open the TUI, only future Claude sessions can pair."
+
+## 6. ClaudeAdapter / ClaudeThread changes
+
+- `ClaudeAdapter`: unchanged. Its public API (`reply`, `get_messages`) is the same for both paired and isolated chats. The routing decision happens in daemon.
+- `ClaudeThread`: unchanged. Just not constructed for the paired chat.
+- `Daemon.handleClaudeAttach`: branch on "paired or isolated", construct ClaudeThread only for isolated.
+
+Inbound (Claude → Codex) routing in daemon:
+```ts
+async onClaudeMessage(chatId: string, text: string): Promise<ReplyResult> {
+  if (codexAdapter.isPaired(chatId)) {
+    if (proxyTuiSlot.readiness !== "ready") {
+      return { ok: false, error: "Shared Codex TUI thread is still provisioning. Retry shortly." };
+    }
+    const accepted = codexAdapter.injectMessage(text);
+    if (!accepted) {
+      return { ok: false, error: "Shared Codex TUI is busy with another turn. Retry." };
+    }
+    return { ok: true };
+  }
+  // isolated path:
+  chats.get(chatId).claudeThread.injectTurn(text);
+  return { ok: true };
+}
+```
+
+Outbound (Codex → Claude) routing — all encoded as `source: "codex"` with explicit prefixes:
+```ts
+codexAdapter.on("agentMessage", ({ content }) => {
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, { source: "codex", content });
+  }
+});
+
+codexAdapter.on("userMessage", ({ content, turnId }) => {
+  // §4.5 echo dedup already applied inside CodexAdapter; this event only fires for genuine user typing
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, {
+      source: "codex",
+      content: `[IMPORTANT] Human typed in the paired Codex TUI:\n${content}`,
+    });
+  }
+});
+
+codexAdapter.on("turnStarted", () => {
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, { source: "codex", content: "[system] Codex turn started" });
+  }
+});
+
+codexAdapter.on("turnCompleted", () => {
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, { source: "codex", content: "[system] Codex turn completed" });
+  }
+});
+
+codexAdapter.on("errorItem", ({ detail }) => {
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, { source: "codex", content: `[error] ${detail}` });
+  }
+});
+
+codexAdapter.on("threadClosed", () => {
+  // also drives §5 transition
+  daemon.handleSharedThreadClosed();
+});
+```
+
+Isolated Claudes get their messages from their own ClaudeThread's existing event flow — unchanged.
+
+## 7. CLI changes (`src/cli/codex.ts`)
+
+- When `--via-proxy`: generate `abgToken = crypto.randomBytes(8).toString("hex")`; spawn codex with the bare proxy URL plus `--remote-auth-token-env AGENTBRIDGE_PROXY_TOKEN`, setting that env var to the token.
+- **Pre-flight check**: before spawning codex-rs, hit daemon's `/status` endpoint to check `proxyTuiConnected`. If true: exit(1) with `error: another --via-proxy TUI is already running. Close it first, or use 'agentbridge codex' (direct mode) for parallel.`
+- Daemon's `DaemonStatus` adds `proxyTuiConnected: boolean`.
+
+## 8. Edge cases (Codex's review items addressed)
+
+| # | Edge case | Resolution |
+|---|---|---|
+| E1 | Second `--via-proxy` TUI conflated with codex-rs picker | Token discrimination (§4.6). Same token = picker. New token = reject. |
+| E2 | Claude-first, TUI-later | Goes isolated. User must restart Claude to pair. Document in kickoff. |
+| E3 | User-typed TUI text not visible to Claude | New `userMessage` event emission (§4.3). |
+| E4 | Daemon crash recovery | Out of scope. Both clients restart. Documented. |
+| E5 | Transient paired-Claude disconnect race | 30s grace window (§5). Same chatId reconnect resumes pair. |
+| E6 | Tool/approval/system noise leaking into Claude context | Strict whitelist in §4.3 (forward agentMessage + userMessage + control-plane events) and §4.4 (block tool/approval/reasoning items). |
+| E7 | Turn-arbitration: Claude tries to inject while TUI mid-turn | **Corrected:** `CodexAdapter.injectMessage()` returns `false` when `turnInProgress` — it does not queue. Daemon surfaces `"Shared Codex TUI is busy with another turn. Retry."` to paired Claude. No internal queue in v1. |
+| E8 | App-server restart mid-pair | Existing `handleSessionRestoreAfterReconnect` (codex-adapter.ts:566) handles TUI; paired Claude has no separate session to restore. Pair survives, but during restore window `readiness` flips back to `"not-ready"` and `reply` returns provisioning error. |
+| E9 | Paired Claude sends `reply` before `thread/started` lands | `readiness === "not-ready"` → daemon returns provisioning error. Paired Claude retries; once `thread/started` arrives, readiness flips to `"ready"` and injection proceeds. |
+| E10 | Echo loop: paired Claude's injected text comes back as userMessage | `injectedTurnIds` Set (§4.5). When `item/completed{type: userMessage, params.turnId in set}` arrives, suppress forwarding. Content-hash fallback if turnId absent. |
+| E11 | Paired Claude `requireReply` hanging silently on Codex error | Control-plane events (`turn/completed`, `error`, `thread/closed`) forwarded as system messages (§4.3). `requireReply` releases on first forwarded message; error path is observable. |
+
+## 9. Test matrix
+
+Probe scripts (real WS clients) in `probes/shared-thread/`:
+
+| # | Scenario | Asserts |
+|---|---|---|
+| P1 | TUI (with token) first, Claude second | Claude reply via CodexAdapter; TUI receives turn/started + agentMessage events; both clients see same threadId |
+| P2 | Claude first, TUI second | Claude is isolated (own threadId); TUI is unpaired (own threadId); they don't interact |
+| P3 | TUI + 2 Claudes | First Claude pairs; second goes isolated. Both Claudes can converse independently. Pair-Claude's turn shows in TUI; isolated-Claude's turn does not. |
+| P4 | 2 `--via-proxy` TUIs (different tokens) | Second rejected with 4002 at WS upgrade. CLI exits 1 with clear message. First TUI keeps running. |
+| P5 | 1 `--via-proxy` TUI + its secondary picker (same token) | Both accepted. Routing through existing `secondaryConnections`. Pair still works. |
+| P6 | TUI sends `userMessage`, paired Claude attached | Claude receives a BridgeMessage with `source: "codex"` and content prefixed `[IMPORTANT] Human typed in the paired Codex TUI:\n...`. Verifies §4.3 encoding + §4.5 echo dedup (the TUI-originated message must reach Claude, while Claude-originated injection echoes must not). |
+| P7 | Paired Claude WS disconnects, reconnects within 30s | Pair preserved; CodexAdapter.pairedChatId unchanged. |
+| P8 | Paired Claude WS disconnects, doesn't reconnect within 30s | After grace: `pairedChatId = null`. Next attaching Claude can re-pair. |
+| P9 | Proxy TUI disconnects (paired Claude still attached) | Pair cleared. Claude transitions to isolated mode (new ClaudeThread). Verify continuity from Claude's side (no message loss). |
+| P10 | Approval request from TUI thread mid-pair | Approval goes only to TUI. Paired Claude does NOT see approval-request items. |
+| P11 | Tool/shellCommand items mid-pair | Not forwarded to paired Claude (whitelist enforcement). |
+| P12 | Paired Claude `reply` with `requireReply=true`, Codex turn completes without an `agentMessage` | Paired Claude's wait releases on `turn/completed` (the "no-output failure" signal). Without this, `requireReply` would hang. |
+| P13 | Paired Claude `reply` with `requireReply=true`, codex-rs emits `error` notification (e.g. permission denied) | Paired Claude's wait releases on error system message. Content prefix `[error] ...` visible. |
+| P14 | Echo race: paired Claude calls `injectMessage`; `userMessage` notification arrives BEFORE `turn/start` response | Content-hash fallback suppresses echo. Verifies §4.5 race protection. |
+
+Unit tests:
+- `codex-adapter.test.ts`: setPairedChat/isPaired; userMessage emission; whitelist (no toolCall/approval leakage); token-based secondary discrimination.
+- `daemon.test.ts`: pairing FIFO; grace window; race-protection window; isolation-on-TUI-disconnect transition.
+- `cli/codex.test.ts`: token generation; pre-flight status check; `--via-proxy` error path.
+
+## 10. Open questions — status
+
+Questions from v2's first review pass (Codex msg #21), resolved in v2.1:
+
+| Q | Topic | Resolution |
+|---|---|---|
+| Q1 | Whitelist completeness | **Resolved**: control-plane events (turn/started, turn/completed, error, thread/closed) added (§4.3). Internal noise (tool/approval/reasoning) explicitly blocked (§4.4). |
+| Q2 | Token propagation | **Resolved**: implementation uses Codex's `--remote-auth-token-env` bearer header path because `codex-cli 0.130.0` rejects query strings in `--remote`. P5 validates same-token/foreign-token behavior through the proxy. |
+| Q3 | TUI-disconnect → isolated transition | **Resolved per Codex**: transition to fresh isolated (new conversation, no replay), with explicit system notice to Claude (§5). |
+| Q4 | Race window default | **Resolved**: `PAIR_RACE_MS = 0` (no race window). Document "start TUI first" in kickoff. |
+| Q5 | Echo loop | **Resolved**: `injectedTurnIds` Set with TTL keyed on `params.turnId` from `turn/start` response (§4.5). Content-hash fallback documented but not implemented unless P6 reveals turnId missing. |
+
+Open items remaining (resolved by Codex final review):
+
+- **R1**: Token discrimination transport (§4.6). **Status**: resolved to Authorization header via `--remote-auth-token-env`; proxy keeps legacy query parsing only for probes/backcompat.
+- **R2**: Content-hash race protection. **Status**: Codex recommended implementing now alongside turnId (§4.5 updated). Both mechanisms ship together; turnId primary (60s TTL), content-hash race-protection (5s TTL, one-shot).
+- **R3**: `AGENTBRIDGE_PAIR_REAP_MS` default. **Status**: confirmed `30000` (separate constant from CLAUDE_REAP_MS=600000).
+
+## 11. Implementation order
+
+1. **Spec v2.1 final sign-off from Codex** — confirm R1/R2/R3 in §10 don't block; agree on P5 as the gating empirical test before merging.
+2. **CodexAdapter §4 changes**: pairedChatId state, item event emission (agentMessage/userMessage/turnStarted/turnCompleted/errorItem/threadClosed), §4.4 exclusion whitelist enforcement, §4.5 injectedTurnIds dedup, §4.6 token-based secondary discrimination, §5 readiness signaling.
+3. **Daemon §5 state machine**: pairing transitions, readiness state, grace window, isolation transition on TUI disconnect with system notice.
+4. **ClaudeAdapter routing in daemon §6**: branch on isPaired with paired-not-ready and busy error returns.
+5. **CLI §7 changes**: token generation, pre-flight status check, kickoff message documenting "start TUI first".
+6. **Unit tests** (§9): codex-adapter, daemon, cli/codex.
+7. **Probes P1–P11** (Codex's deliverable, my/user-side execution). **P5 must run** to lock §4.6 path.
+8. **Manual cross-test**: left Claude + right `abg codex --via-proxy`, observe 3-way chat; second `abg codex` (direct) in third terminal stays parallel.
+9. **Bilingual release notes** + sync `plugins/agentbridge/server/{bridge-server,daemon}.js` bundle via `bun run build:plugin`.
+
+## 12. Division of labor
+
+- **Claude (me)**: §4 CodexAdapter changes, §5 daemon state machine, §6 routing, §7 CLI. Unit tests for each. Spec maintenance.
+- **Codex**: Probes P1–P11 in `probes/shared-thread/`. Empirical verification of P5 (token discriminator path). Cross-review of state machine for races I missed. Cross-review of implementation PRs.
+- **Both**: `bun run check` before every commit. Bilingual release notes are bilateral.
+
+Sandbox note: Codex's environment cannot bind local listeners (`Bun.serve({port:0})` and `codex app-server --listen ws://...` both fail with `Operation not permitted`). Probes can be written there but final live execution must run on my side or user-side terminals.
+
+---
+
+**Status**: v2.2 has Codex's go-with-edits sign-off. All 4 final-review edits applied. Implementation begins next.
+
+**Implementation kickoff order**:
+1. Sync state: `bun run typecheck && bun test src` (baseline green check).
+2. Branch off `feat/shared-thread-mode` is current. Start with `app-server-protocol.ts` (§4.3 protocol allowlist) — small, foundational, unblocks CodexAdapter changes.
+3. CodexAdapter changes incrementally (each behind a unit test).
+4. Daemon state machine.
+5. CLI.
+6. Probes (Codex's deliverable; P5 first to lock §4.6 path; P14 last as the trickiest race test).

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13758,6 +13758,7 @@ class ClaudeAdapter extends EventEmitter {
   sessionId;
   notificationIdPrefix;
   instanceId;
+  chatId;
   replySender = null;
   logFile;
   configuredMode;
@@ -13769,7 +13770,8 @@ class ClaudeAdapter extends EventEmitter {
     super();
     this.logFile = logFile;
     this.instanceId = randomUUID().slice(0, 8);
-    this.sessionId = `codex_${Date.now()}`;
+    this.sessionId = `codex_${Date.now()}_${this.instanceId}`;
+    this.chatId = this.sessionId;
     this.notificationIdPrefix = randomUUID().replace(/-/g, "").slice(0, 12);
     this.log(`ClaudeAdapter created (instance=${this.instanceId})`);
     const envMode = process.env.AGENTBRIDGE_MODE;
@@ -14004,9 +14006,14 @@ class DaemonClient extends EventEmitter2 {
   wsId = 0;
   nextRequestId = 1;
   pendingReplies = new Map;
-  constructor(url) {
+  chatId;
+  constructor(url, opts) {
     super();
     this.url = url;
+    this.chatId = opts?.chatId;
+  }
+  setChatId(chatId) {
+    this.chatId = chatId;
   }
   async connect() {
     if (this.ws?.readyState === WebSocket.OPEN) {
@@ -14048,13 +14055,13 @@ class DaemonClient extends EventEmitter2 {
     });
   }
   attachClaude() {
-    this.send({ type: "claude_connect" });
+    this.send({ type: "claude_connect", chatId: this.chatId });
   }
   async disconnect() {
     if (!this.ws)
       return;
     try {
-      this.send({ type: "claude_disconnect" });
+      this.send({ type: "claude_disconnect", chatId: this.chatId });
     } catch {}
     try {
       this.ws.close();
@@ -14076,6 +14083,7 @@ class DaemonClient extends EventEmitter2 {
       this.send({
         type: "claude_to_codex",
         requestId,
+        chatId: this.chatId,
         message,
         ...requireReply ? { requireReply: true } : {}
       });
@@ -14517,7 +14525,7 @@ var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 var claude = new ClaudeAdapter(stateDir.logFile);
-var daemonClient = new DaemonClient(CONTROL_WS_URL);
+var daemonClient = new DaemonClient(CONTROL_WS_URL, { chatId: claude.chatId });
 var shuttingDown = false;
 var daemonDisabled = false;
 var daemonDisabledReason = null;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2404,8 +2404,8 @@ codex.on("turnCompleted", () => {
   const paired = getPairedChatState();
   if (!paired)
     return;
-  if (!paired.pairedTurnSawAgentMessage) {
-    log(`[${paired.chatId}] Codex turn completed with no agentMessage \u2014 surfacing as failure signal`);
+  if (!paired.pairedTurnSawAgentMessage && paired.replyRequired) {
+    log(`[${paired.chatId}] Codex turn completed with no agentMessage while replyRequired \u2014 surfacing as failure signal`);
     paired.replyReceivedDuringTurn = true;
     emitToChat(paired, systemMessage("system_codex_turn_completed_no_output", "[system] Codex turn completed without any agentMessage \u2014 likely a failure or empty response."));
   } else {
@@ -2420,7 +2420,9 @@ codex.on("errorItem", (payload) => {
     return;
   paired.replyReceivedDuringTurn = true;
   emitToChat(paired, systemMessage("system_codex_error", `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
+  paired.pairedTurnSawAgentMessage = true;
   paired.replyRequired = false;
+  paired.replyReceivedDuringTurn = false;
 });
 codex.on("sessionRestoreStart", () => {
   if (!proxyTuiSlot)
@@ -2480,8 +2482,64 @@ function pairChat(state) {
     emitToChat(state, systemMessage("system_paired_provisioning", "\u2705 This Claude session is paired with the right-pane Codex TUI. Waiting for the shared thread to finish provisioning before replies can flow."));
   }
 }
+var ISOLATED_BOOTSTRAP_MAX_ATTEMPTS = parseInt(process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_MAX_ATTEMPTS ?? "2", 10);
+var ISOLATED_BOOTSTRAP_RETRY_DELAY_MS = parseInt(process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_RETRY_DELAY_MS ?? "2000", 10);
+function bootstrapIsolatedThread(state, attempt = 1) {
+  state.thread.bootstrap().then((threadId) => {
+    state.ready = true;
+    emitToChat(state, systemMessage("system_isolated_ready", `\u2705 Fresh isolated Codex thread ready (threadId=${threadId}).`));
+  }).catch((err) => {
+    const errMsg = err?.message ?? String(err);
+    log(`[${state.chatId}] Isolated bootstrap attempt ${attempt}/${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS} failed: ${errMsg}`);
+    if (attempt < ISOLATED_BOOTSTRAP_MAX_ATTEMPTS) {
+      emitToChat(state, systemMessage("system_isolated_retry", `\u26A0\uFE0F Bootstrap of isolated Codex thread failed (attempt ${attempt}/${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS}): ${errMsg}. Retrying in ${ISOLATED_BOOTSTRAP_RETRY_DELAY_MS}ms.`));
+      setTimeout(() => {
+        try {
+          state.thread.close();
+        } catch {}
+        state.thread = new ClaudeThread({
+          appServerUrl: codex.appServerUrl,
+          chatId: state.chatId,
+          logFile: stateDir.logFile,
+          cwd: process.cwd()
+        });
+        wireClaudeThreadEvents(state);
+        bootstrapIsolatedThread(state, attempt + 1);
+      }, ISOLATED_BOOTSTRAP_RETRY_DELAY_MS);
+    } else {
+      emitToChat(state, systemMessage("system_isolated_failed", `\u274C Failed to bootstrap isolated Codex thread after ${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS} attempts: ${errMsg}. Closing this chat \u2014 please reconnect Claude (close the window and re-attach) to start a fresh attempt.`));
+      reapChatState(state, "isolated bootstrap exhausted");
+    }
+  });
+}
+function reapChatState(state, reason) {
+  log(`Reaping chat state: chatId=${state.chatId} (${reason})`);
+  if (state.ws) {
+    try {
+      state.ws.close(1011, `chat reaped: ${reason}`);
+    } catch {}
+    state.ws = null;
+  }
+  if (state.attentionWindowTimer)
+    clearTimeout(state.attentionWindowTimer);
+  if (state.disconnectTimer)
+    clearTimeout(state.disconnectTimer);
+  if (state.reaperTimer)
+    clearTimeout(state.reaperTimer);
+  try {
+    state.statusBuffer.dispose();
+  } catch {}
+  try {
+    state.thread.close();
+  } catch {}
+  chats.delete(state.chatId);
+  broadcastStatus();
+}
 function transitionToIsolated(state, reason) {
   state.paired = false;
+  state.replyRequired = false;
+  state.replyReceivedDuringTurn = false;
+  state.pairedTurnSawAgentMessage = false;
   emitToChat(state, systemMessage("system_pair_torn_down", `[system] ${reason}. Future replies will use a fresh isolated Codex thread (no prior shared-TUI context carried over).`));
   state.thread = new ClaudeThread({
     appServerUrl: codex.appServerUrl,
@@ -2491,12 +2549,7 @@ function transitionToIsolated(state, reason) {
   });
   state.ready = false;
   wireClaudeThreadEvents(state);
-  state.thread.bootstrap().then((threadId) => {
-    state.ready = true;
-    emitToChat(state, systemMessage("system_isolated_ready", `\u2705 Fresh isolated Codex thread ready (threadId=${threadId}).`));
-  }).catch((err) => {
-    emitToChat(state, systemMessage("system_isolated_failed", `\u274C Failed to bootstrap isolated Codex thread: ${err?.message ?? err}.`));
-  });
+  bootstrapIsolatedThread(state);
 }
 codex.on("error", (err) => {
   log(`Codex error: ${err.message}`);
@@ -3082,10 +3135,68 @@ function log(msg) {
     appendFileSync3(stateDir.logFile, line);
   } catch {}
 }
-if (daemonLifecycle.wasKilled()) {
-  log("Killed sentinel found \u2014 daemon was intentionally stopped. Exiting immediately.");
-  process.exit(0);
+function startDaemon() {
+  if (daemonLifecycle.wasKilled()) {
+    log("Killed sentinel found \u2014 daemon was intentionally stopped. Exiting immediately.");
+    process.exit(0);
+  }
+  writePidFile();
+  startControlServer();
+  bootCodex();
 }
-writePidFile();
-startControlServer();
-bootCodex();
+if (import.meta.main) {
+  startDaemon();
+}
+var __testing = {
+  get proxyTuiSlot() {
+    return proxyTuiSlot;
+  },
+  setProxyTuiSlot(next) {
+    proxyTuiSlot = next;
+  },
+  chats,
+  codex,
+  fns: {
+    pairChat,
+    transitionToIsolated,
+    bootstrapIsolatedThread,
+    getPairedChatState,
+    createChatState,
+    detachClaudeWs,
+    emitToChat
+  },
+  config: {
+    PAIR_REAP_MS,
+    CLAUDE_REAP_AFTER_MS,
+    ISOLATED_BOOTSTRAP_MAX_ATTEMPTS,
+    ISOLATED_BOOTSTRAP_RETRY_DELAY_MS
+  },
+  reset() {
+    if (proxyTuiSlot?.pairReapTimer) {
+      clearTimeout(proxyTuiSlot.pairReapTimer);
+    }
+    for (const state of chats.values()) {
+      if (state.attentionWindowTimer)
+        clearTimeout(state.attentionWindowTimer);
+      if (state.disconnectTimer)
+        clearTimeout(state.disconnectTimer);
+      if (state.reaperTimer)
+        clearTimeout(state.reaperTimer);
+      try {
+        state.statusBuffer.dispose();
+      } catch {}
+      try {
+        state.thread.close();
+      } catch {}
+    }
+    chats.clear();
+    proxyTuiSlot = null;
+    try {
+      codex.setPairedChat(null);
+    } catch {}
+  },
+  reapChatState
+};
+export {
+  __testing
+};

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -9,6 +9,7 @@ import { spawn, execSync } from "child_process";
 import { createInterface } from "readline";
 import { EventEmitter } from "events";
 import { appendFileSync } from "fs";
+import { createHash } from "crypto";
 
 // src/state-dir.ts
 import { mkdirSync, existsSync } from "fs";
@@ -78,7 +79,9 @@ var APP_SERVER_NOTIFICATION_METHODS = [
   "turn/completed",
   "item/started",
   "item/agentMessage/delta",
-  "item/completed"
+  "item/completed",
+  "error",
+  "thread/closed"
 ];
 var TRACKED_REQUEST_METHOD_SET = new Set(APP_SERVER_TRACKED_REQUEST_METHODS);
 var SERVER_REQUEST_METHOD_SET = new Set(APP_SERVER_SERVER_REQUEST_METHODS);
@@ -145,6 +148,12 @@ class CodexAdapter extends EventEmitter {
   sessionRestoreInProgress = false;
   replayPending = new Map;
   static SESSION_REPLAY_TIMEOUT_MS = 5000;
+  pairedChatId = null;
+  injectedTurnIds = new Map;
+  pendingInjectionHashes = new Map;
+  pendingInjectionByReqId = new Map;
+  static ECHO_DEDUP_TTL_MS = 60000;
+  static PENDING_HASH_TTL_MS = 5000;
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
     this.appPort = appPort;
@@ -222,6 +231,10 @@ class CodexAdapter extends EventEmitter {
       this.log("Cannot inject: app-server WebSocket not connected");
       return false;
     }
+    if (this.sessionRestoreInProgress) {
+      this.log(`Rejected injection: shared Codex TUI session restore in progress`);
+      return false;
+    }
     if (this.turnInProgress) {
       this.log(`Rejected injection: Codex turn is in progress (thread ${this.threadId})`);
       return false;
@@ -229,6 +242,9 @@ class CodexAdapter extends EventEmitter {
     this.log(`Injecting message into Codex (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
     this.trackBridgeRequestId(requestId);
+    const contentHash = this.hashInjectionContent(text);
+    this.pendingInjectionHashes.set(contentHash, Date.now() + CodexAdapter.PENDING_HASH_TTL_MS);
+    this.pendingInjectionByReqId.set(requestId, contentHash);
     try {
       this.appServerWs.send(JSON.stringify({
         method: "turn/start",
@@ -238,9 +254,49 @@ class CodexAdapter extends EventEmitter {
       return true;
     } catch (err) {
       this.untrackBridgeRequestId(requestId);
+      this.pendingInjectionByReqId.delete(requestId);
+      this.pendingInjectionHashes.delete(contentHash);
       this.log(`Injection send failed: ${err.message}`);
       return false;
     }
+  }
+  setPairedChat(chatId) {
+    this.pairedChatId = chatId;
+    this.log(`Paired chat set to: ${chatId ?? "<none>"}`);
+  }
+  isPaired(chatId) {
+    return this.pairedChatId !== null && this.pairedChatId === chatId;
+  }
+  get currentPairedChatId() {
+    return this.pairedChatId;
+  }
+  hashInjectionContent(text) {
+    return createHash("sha1").update(text).digest("hex").slice(0, 16);
+  }
+  isEchoOfInjection(content, turnId) {
+    if (typeof turnId === "string" && turnId.length > 0) {
+      const expiresAt = this.injectedTurnIds.get(turnId);
+      if (expiresAt !== undefined) {
+        if (Date.now() <= expiresAt)
+          return true;
+        this.injectedTurnIds.delete(turnId);
+      }
+    }
+    const hash = this.hashInjectionContent(content);
+    const hashExpiresAt = this.pendingInjectionHashes.get(hash);
+    if (hashExpiresAt !== undefined) {
+      if (Date.now() <= hashExpiresAt) {
+        this.pendingInjectionHashes.delete(hash);
+        return true;
+      }
+      this.pendingInjectionHashes.delete(hash);
+    }
+    return false;
+  }
+  recordInjectedTurnId(turnId, contentHash) {
+    this.injectedTurnIds.set(turnId, Date.now() + CodexAdapter.ECHO_DEDUP_TTL_MS);
+    if (contentHash)
+      this.pendingInjectionHashes.delete(contentHash);
   }
   async waitForHealthy(maxRetries = 20, delayMs = 500) {
     for (let i = 0;i < maxRetries; i++) {
@@ -436,6 +492,8 @@ class CodexAdapter extends EventEmitter {
       return;
     }
     this.sessionRestoreInProgress = true;
+    this.emit("sessionRestoreStart", { threadId: this.threadId });
+    let restoreSucceeded = false;
     try {
       this.log(`DIAGNOSTIC: replaying cached initialize to restore session (threadId=${this.threadId ?? "none"})`);
       await this.sendReplayAndAwait(this.lastInitializeRaw, "initialize");
@@ -453,6 +511,7 @@ class CodexAdapter extends EventEmitter {
         await this.sendReplayAndAwait(resumeRaw, "thread/resume");
       }
       this.log(`DIAGNOSTIC: session restored after unintentional reconnect (threadId=${this.threadId ?? "none"})`);
+      restoreSucceeded = true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log(`ERROR: session restore failed (${msg}) \u2014 closing TUI with 1011`);
@@ -467,7 +526,11 @@ class CodexAdapter extends EventEmitter {
       }
     } finally {
       this.sessionRestoreInProgress = false;
+      this.emit("sessionRestoreEnd", { threadId: this.threadId, ok: restoreSucceeded });
     }
+  }
+  get isSessionRestoreInProgress() {
+    return this.sessionRestoreInProgress;
   }
   sendReplayAndAwait(raw, method) {
     if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
@@ -550,11 +613,16 @@ class CodexAdapter extends EventEmitter {
       fetch(req, server) {
         const url = new URL(req.url);
         const isUpgrade = req.headers.get("upgrade")?.toLowerCase() === "websocket";
-        self.log(`HTTP ${req.method} ${url.pathname} (upgrade=${isUpgrade})`);
+        const queryToken = url.searchParams.get("abg_token") ?? "";
+        const authHeader = req.headers.get("authorization") ?? "";
+        const bearerToken = authHeader.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? "";
+        const token = bearerToken || queryToken;
+        const tokenSource = bearerToken ? "authorization" : queryToken ? "query" : "none";
+        self.log(`HTTP ${req.method} ${url.pathname} (upgrade=${isUpgrade}, token=${token ? token.slice(0, 8) + "\u2026" : "<none>"}, tokenSource=${tokenSource})`);
         if (url.pathname === "/healthz" || url.pathname === "/readyz") {
           return fetch(`http://127.0.0.1:${self.appPort}${url.pathname}`);
         }
-        if (server.upgrade(req, { data: { connId: 0 } }))
+        if (server.upgrade(req, { data: { connId: 0, token } }))
           return;
         self.log(`WARNING: non-upgrade HTTP request not handled: ${req.method} ${url.pathname}`);
         return new Response("AgentBridge Codex Proxy");
@@ -573,7 +641,18 @@ class CodexAdapter extends EventEmitter {
     const connId = ++this.connIdCounter;
     ws.data.connId = connId;
     if (this.tuiWs) {
-      this.log(`Secondary TUI connected (conn #${connId}, primary is #${this.tuiConnId})`);
+      const primaryToken = this.tuiWs.data.token;
+      const newToken = ws.data.token;
+      if (primaryToken !== newToken) {
+        this.log(`Rejecting second proxy TUI: token mismatch (primary conn #${this.tuiConnId} token=${primaryToken ? primaryToken.slice(0, 8) + "\u2026" : "<none>"}, new conn #${connId} token=${newToken ? newToken.slice(0, 8) + "\u2026" : "<none>"})`);
+        try {
+          ws.close(4002, "another --via-proxy TUI is already connected");
+        } catch (err) {
+          this.log(`Failed to close rejected second TUI cleanly: ${err.message}`);
+        }
+        return;
+      }
+      this.log(`Secondary TUI connected (conn #${connId}, primary is #${this.tuiConnId}, token matches)`);
       this.setupSecondaryConnection(ws, connId);
       return;
     }
@@ -581,8 +660,8 @@ class CodexAdapter extends EventEmitter {
     this.tuiConnId = connId;
     this.tuiWs = ws;
     this.threadId = null;
-    this.log(`TUI connected (conn #${this.tuiConnId})`);
-    this.emit("tuiConnected", this.tuiConnId);
+    this.log(`TUI connected (conn #${this.tuiConnId}, token=${ws.data.token ? ws.data.token.slice(0, 8) + "\u2026" : "<none>"})`);
+    this.emit("tuiConnected", this.tuiConnId, ws.data.token);
     if (previousConnId !== null) {
       this.retireConnectionState(previousConnId);
     }
@@ -924,8 +1003,22 @@ class CodexAdapter extends EventEmitter {
     if (!isNaN(numericId) && this.consumeBridgeRequestId(numericId)) {
       if (parsed.error) {
         this.log(`Bridge-originated request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
+        const contentHash = this.pendingInjectionByReqId.get(numericId);
+        if (contentHash) {
+          this.pendingInjectionHashes.delete(contentHash);
+          this.pendingInjectionByReqId.delete(numericId);
+        }
       } else {
-        this.log(`Bridge-originated request completed (id ${responseId})`);
+        const result = parsed.result ?? {};
+        const turnId = result.turn?.id;
+        const contentHash = this.pendingInjectionByReqId.get(numericId);
+        this.pendingInjectionByReqId.delete(numericId);
+        if (typeof turnId === "string" && turnId.length > 0) {
+          this.recordInjectedTurnId(turnId, contentHash);
+          this.log(`Bridge-originated request completed (id ${responseId}, turnId=${turnId} dedup)`);
+        } else {
+          this.log(`Bridge-originated request completed (id ${responseId}, no turnId \u2014 falling back to content-hash dedup)`);
+        }
       }
       return null;
     }
@@ -968,9 +1061,10 @@ class CodexAdapter extends EventEmitter {
   handleServerNotification(msg) {
     const { method, params } = msg;
     switch (method) {
-      case "turn/started":
+      case "turn/started": {
         this.markTurnStarted(params?.turn?.id);
         break;
+      }
       case "item/started": {
         const item = params?.item;
         if (item?.type === "agentMessage")
@@ -1000,15 +1094,46 @@ class CodexAdapter extends EventEmitter {
               timestamp: Date.now()
             });
           }
+        } else if (item?.type === "userMessage") {
+          const content = this.extractContent(item);
+          if (content) {
+            const turnIdFromParams = typeof params?.turnId === "string" ? params.turnId : undefined;
+            if (this.isEchoOfInjection(content, turnIdFromParams)) {
+              this.log(`Suppressed userMessage echo (item ${item.id}, ${content.length} chars)`);
+            } else {
+              this.log(`User message from TUI (${content.length} chars)`);
+              this.emit("userMessage", {
+                id: item.id,
+                source: "codex",
+                content,
+                timestamp: Date.now(),
+                turnId: turnIdFromParams
+              });
+            }
+          }
         }
         break;
       }
       case "turn/completed": {
         const wasInProgress = this.turnInProgress;
-        this.markTurnCompleted(params?.turn?.id);
+        const turnId = params?.turn?.id;
+        this.markTurnCompleted(turnId);
         if (wasInProgress && !this.turnInProgress) {
-          this.emit("turnCompleted");
+          this.emit("turnCompleted", { turnId });
         }
+        break;
+      }
+      case "error": {
+        const errorParams = params ?? {};
+        const detail = errorParams.error?.message ?? "(no error message)";
+        const code = errorParams.error?.code;
+        this.log(`App-server error notification: ${detail}${code !== undefined ? ` (code ${code})` : ""}`);
+        this.emit("errorItem", { code, message: detail, data: errorParams.error?.data });
+        break;
+      }
+      case "thread/closed": {
+        const closedThreadId = params ?? {};
+        this.emit("threadClosed", { threadId: closedThreadId.threadId });
         break;
       }
     }
@@ -1108,7 +1233,7 @@ class CodexAdapter extends EventEmitter {
     }
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
-      this.emit("turnStarted");
+      this.emit("turnStarted", { turnId });
     }
   }
   markTurnCompleted(turnId) {
@@ -2168,6 +2293,7 @@ var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 var CLAUDE_DISCONNECT_GRACE_MS = 5000;
 var CLAUDE_REAP_AFTER_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_REAP_MS ?? "600000", 10);
+var PAIR_REAP_MS = parseInt(process.env.AGENTBRIDGE_PAIR_REAP_MS ?? "30000", 10);
 var MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 var FILTER_MODE = process.env.AGENTBRIDGE_FILTER_MODE === "full" ? "full" : "filtered";
 var IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
@@ -2181,6 +2307,7 @@ var codexBootstrapped = false;
 var shuttingDown = false;
 var idleShutdownTimer = null;
 var chats = new Map;
+var proxyTuiSlot = null;
 var tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
   log,
@@ -2194,19 +2321,183 @@ var tuiConnectionState = new TuiConnectionState({
 codex.on("ready", (threadId) => {
   tuiConnectionState.markBridgeReady();
   log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
+  if (proxyTuiSlot) {
+    proxyTuiSlot.readiness = "ready";
+    if (proxyTuiSlot.pairedChatId) {
+      const state = chats.get(proxyTuiSlot.pairedChatId);
+      if (state && !state.ready) {
+        state.ready = true;
+        emitToChat(state, systemMessage("system_pair_ready", `\u2705 Shared Codex TUI thread is now ready (threadId=${threadId}). Replies sent via the reply tool will appear in the right pane's TUI.`));
+      }
+    }
+  }
 });
-codex.on("tuiConnected", (connId) => {
+codex.on("tuiConnected", (connId, token = "") => {
   tuiConnectionState.handleTuiConnected(connId);
   cancelIdleShutdown();
-  log(`Codex TUI connected (conn #${connId})`);
+  log(`Codex TUI connected (conn #${connId}, token=${token ? token.slice(0, 8) + "\u2026" : "<none>"})`);
+  if (token && !proxyTuiSlot) {
+    proxyTuiSlot = {
+      token,
+      pairedChatId: null,
+      readiness: "not-ready",
+      attachedAt: Date.now(),
+      pairReapTimer: null
+    };
+    log(`Proxy TUI slot allocated (token=${token.slice(0, 8)}\u2026)`);
+  }
   broadcastStatus();
 });
 codex.on("tuiDisconnected", (connId) => {
   tuiConnectionState.handleTuiDisconnected(connId);
   log(`Codex TUI disconnected (conn #${connId})`);
+  if (proxyTuiSlot) {
+    const wasPairedChat = proxyTuiSlot.pairedChatId;
+    if (proxyTuiSlot.pairReapTimer)
+      clearTimeout(proxyTuiSlot.pairReapTimer);
+    proxyTuiSlot = null;
+    codex.setPairedChat(null);
+    if (wasPairedChat) {
+      const state = chats.get(wasPairedChat);
+      if (state) {
+        log(`Transitioning paired chat ${wasPairedChat} to isolated (TUI disconnect)`);
+        transitionToIsolated(state, "Shared Codex TUI thread is gone");
+      }
+    }
+  }
   broadcastStatus();
   scheduleIdleShutdown();
 });
+codex.on("agentMessage", (msg) => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  log(`[${paired.chatId}] CodexAdapter \u2192 paired Claude (agentMessage, ${msg.content.length} chars)`);
+  paired.pairedTurnSawAgentMessage = true;
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, msg);
+});
+codex.on("userMessage", (payload) => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  if (!payload.content)
+    return;
+  log(`[${paired.chatId}] CodexAdapter \u2192 paired Claude (userMessage from TUI, ${payload.content.length} chars)`);
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, {
+    id: payload.id ?? `tui_user_${Date.now()}`,
+    source: "codex",
+    content: `[IMPORTANT] Human typed in the paired Codex TUI:
+${payload.content}`,
+    timestamp: Date.now()
+  });
+});
+codex.on("turnStarted", () => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  paired.pairedTurnSawAgentMessage = false;
+  emitToChat(paired, systemMessage("system_codex_turn_started", "[system] Codex turn started"));
+});
+codex.on("turnCompleted", () => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  if (!paired.pairedTurnSawAgentMessage) {
+    log(`[${paired.chatId}] Codex turn completed with no agentMessage \u2014 surfacing as failure signal`);
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, systemMessage("system_codex_turn_completed_no_output", "[system] Codex turn completed without any agentMessage \u2014 likely a failure or empty response."));
+  } else {
+    emitToChat(paired, systemMessage("system_codex_turn_completed", "[system] Codex turn completed"));
+  }
+  paired.replyRequired = false;
+  paired.replyReceivedDuringTurn = false;
+});
+codex.on("errorItem", (payload) => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, systemMessage("system_codex_error", `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
+  paired.replyRequired = false;
+});
+codex.on("sessionRestoreStart", () => {
+  if (!proxyTuiSlot)
+    return;
+  log(`Shared Codex session restore started \u2014 flipping paired readiness to not-ready`);
+  proxyTuiSlot.readiness = "not-ready";
+  const paired = getPairedChatState();
+  if (paired)
+    paired.ready = false;
+});
+codex.on("sessionRestoreEnd", (payload = {}) => {
+  if (!proxyTuiSlot)
+    return;
+  if (payload.ok === false) {
+    log(`Shared Codex session restore FAILED \u2014 keeping paired readiness=not-ready, awaiting TUI tear-down`);
+    return;
+  }
+  log(`Shared Codex session restore succeeded \u2014 flipping paired readiness back to ready`);
+  proxyTuiSlot.readiness = "ready";
+  const paired = getPairedChatState();
+  if (paired) {
+    paired.ready = true;
+    emitToChat(paired, systemMessage("system_pair_restored", "\u2705 Shared Codex TUI session restored. Replies can flow again."));
+  }
+});
+codex.on("threadClosed", () => {
+  const paired = getPairedChatState();
+  log(`Codex emitted thread/closed`);
+  if (proxyTuiSlot) {
+    const wasPairedChat = proxyTuiSlot.pairedChatId;
+    proxyTuiSlot = null;
+    codex.setPairedChat(null);
+    if (wasPairedChat && paired) {
+      log(`Transitioning paired chat ${wasPairedChat} to isolated (thread/closed)`);
+      transitionToIsolated(paired, "Shared Codex thread closed");
+    }
+  }
+});
+function getPairedChatState() {
+  if (!proxyTuiSlot?.pairedChatId)
+    return null;
+  return chats.get(proxyTuiSlot.pairedChatId) ?? null;
+}
+function pairChat(state) {
+  if (!proxyTuiSlot)
+    return;
+  if (proxyTuiSlot.pairedChatId)
+    return;
+  proxyTuiSlot.pairedChatId = state.chatId;
+  state.paired = true;
+  codex.setPairedChat(state.chatId);
+  state.ready = proxyTuiSlot.readiness === "ready";
+  log(`Paired chat ${state.chatId} with proxy TUI (readiness=${proxyTuiSlot.readiness})`);
+  if (state.ready) {
+    emitToChat(state, systemMessage("system_paired_ready", "\u2705 This Claude session is paired with the right-pane Codex TUI. Replies will appear there; user typing in the TUI will be forwarded to you with an [IMPORTANT] prefix."));
+  } else {
+    emitToChat(state, systemMessage("system_paired_provisioning", "\u2705 This Claude session is paired with the right-pane Codex TUI. Waiting for the shared thread to finish provisioning before replies can flow."));
+  }
+}
+function transitionToIsolated(state, reason) {
+  state.paired = false;
+  emitToChat(state, systemMessage("system_pair_torn_down", `[system] ${reason}. Future replies will use a fresh isolated Codex thread (no prior shared-TUI context carried over).`));
+  state.thread = new ClaudeThread({
+    appServerUrl: codex.appServerUrl,
+    chatId: state.chatId,
+    logFile: stateDir.logFile,
+    cwd: process.cwd()
+  });
+  state.ready = false;
+  wireClaudeThreadEvents(state);
+  state.thread.bootstrap().then((threadId) => {
+    state.ready = true;
+    emitToChat(state, systemMessage("system_isolated_ready", `\u2705 Fresh isolated Codex thread ready (threadId=${threadId}).`));
+  }).catch((err) => {
+    emitToChat(state, systemMessage("system_isolated_failed", `\u274C Failed to bootstrap isolated Codex thread: ${err?.message ?? err}.`));
+  });
+}
 codex.on("error", (err) => {
   log(`Codex error: ${err.message}`);
 });
@@ -2321,6 +2612,12 @@ async function attachClaude(ws, requestedChatId) {
   cancelIdleShutdown();
   log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
   sendStatus(ws);
+  if (proxyTuiSlot && proxyTuiSlot.pairedChatId === null) {
+    emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Pairing with the right-pane Codex TUI for shared-thread mode..."));
+    pairChat(state);
+    broadcastStatus();
+    return;
+  }
   emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
   try {
     const threadId = await state.thread.bootstrap();
@@ -2344,6 +2641,8 @@ function createChatState(chatId) {
       cwd: process.cwd()
     }),
     ready: false,
+    paired: false,
+    pairedTurnSawAgentMessage: false,
     inAttentionWindow: false,
     attentionWindowTimer: null,
     replyRequired: false,
@@ -2357,6 +2656,11 @@ function createChatState(chatId) {
     nextSystemMessageId: 0
   };
   state.statusBuffer = new StatusBuffer((summary) => emitToChat(state, summary));
+  wireClaudeThreadEvents(state);
+  return state;
+}
+function wireClaudeThreadEvents(state) {
+  const chatId = state.chatId;
   state.thread.on("agentMessage", (msg) => {
     if (msg.source !== "codex")
       return;
@@ -2415,15 +2719,45 @@ function createChatState(chatId) {
   state.thread.on("error", (err) => {
     log(`[${chatId}] ClaudeThread error: ${err?.message ?? err}`);
   });
-  return state;
 }
 function detachClaudeWs(state, reason) {
   if (!state.ws)
     return;
-  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason})`);
+  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason}, paired=${state.paired})`);
   state.ws = null;
   scheduleDisconnectTimer(state);
   scheduleReaperTimer(state);
+  if (state.paired && proxyTuiSlot && proxyTuiSlot.pairedChatId === state.chatId) {
+    if (proxyTuiSlot.pairReapTimer)
+      clearTimeout(proxyTuiSlot.pairReapTimer);
+    proxyTuiSlot.pairReapTimer = setTimeout(() => {
+      if (!proxyTuiSlot)
+        return;
+      const currentState = chats.get(state.chatId);
+      if (currentState?.ws) {
+        log(`Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
+        return;
+      }
+      log(`Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms \u2014 clearing pair slot and reaping chat state`);
+      proxyTuiSlot.pairedChatId = null;
+      proxyTuiSlot.pairReapTimer = null;
+      codex.setPairedChat(null);
+      if (currentState) {
+        try {
+          currentState.thread.close();
+        } catch {}
+        currentState.statusBuffer.dispose();
+        if (currentState.attentionWindowTimer)
+          clearTimeout(currentState.attentionWindowTimer);
+        if (currentState.disconnectTimer)
+          clearTimeout(currentState.disconnectTimer);
+        if (currentState.reaperTimer)
+          clearTimeout(currentState.reaperTimer);
+        chats.delete(state.chatId);
+        broadcastStatus();
+      }
+    }, PAIR_REAP_MS);
+  }
   scheduleIdleShutdown();
 }
 function scheduleReaperTimer(state) {
@@ -2495,11 +2829,23 @@ function handleClaudeToCodex(ws, message) {
     });
   }
   if (!state.ready) {
+    let errorMsg;
+    if (state.paired) {
+      if (codex.isSessionRestoreInProgress) {
+        errorMsg = "Restoring shared Codex TUI session, retry shortly.";
+      } else if (proxyTuiSlot) {
+        errorMsg = "Shared Codex TUI thread is still provisioning. Retry shortly.";
+      } else {
+        errorMsg = "Shared Codex TUI is no longer connected. Wait for transition to isolated mode.";
+      }
+    } else {
+      errorMsg = "Your Codex thread is still provisioning. Wait for system_thread_ready.";
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,
       success: false,
-      error: "Your Codex thread is still provisioning. Wait for system_thread_ready."
+      error: errorMsg
     });
   }
   const requireReply = !!message.requireReply;
@@ -2512,10 +2858,13 @@ function handleClaudeToCodex(ws, message) {
     state.replyReceivedDuringTurn = false;
     log(`[${chatId}] Reply required flag set`);
   }
-  log(`[${chatId}] Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-  const injected = state.thread.injectMessage(contentWithReminder);
+  log(`[${chatId}] Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply}, paired=${state.paired})`);
+  const injected = state.paired ? codex.injectMessage(contentWithReminder) : state.thread.injectMessage(contentWithReminder);
   if (!injected) {
-    const reason = state.thread.isTurnInProgress ? "Codex is busy executing a turn on your thread. Wait for it to finish." : "Injection failed: thread WS not connected.";
+    const reason = state.paired ? "Shared Codex TUI is busy with another turn. Retry." : state.thread.isTurnInProgress ? "Codex is busy executing a turn on your thread. Wait for it to finish." : "Injection failed: thread WS not connected.";
+    if (requireReply) {
+      state.replyRequired = false;
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,
@@ -2621,7 +2970,8 @@ function currentStatus() {
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
     pid: process.pid,
-    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length
+    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length,
+    proxyTuiConnected: proxyTuiSlot !== null
   };
 }
 function systemMessage(idPrefix, content) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1324,7 +1324,7 @@ class ClaudeThread extends EventEmitter2 {
       clientInfo: { name: "agentbridge-claude-thread", version: "0.1.0" },
       capabilities: { experimentalApi: false }
     });
-    const params = {};
+    const params = { approvalPolicy: "never" };
     if (this.cwd)
       params.cwd = this.cwd;
     const startRes = await this.callRpc("thread/start", params);
@@ -1449,13 +1449,7 @@ class ClaudeThread extends EventEmitter2 {
       const tid = parsed.params?.threadId;
       if (tid && this.threadId && tid !== this.threadId)
         return;
-      try {
-        this.ws?.send(JSON.stringify({
-          jsonrpc: "2.0",
-          id: parsed.id,
-          error: { code: -32601, message: "auto-denied by ClaudeThread (no UI to approve)" }
-        }));
-      } catch {}
+      this.respondToServerRequest(parsed.id, parsed.method, parsed.params);
       return;
     }
     if (typeof parsed.method === "string" && parsed.id === undefined) {
@@ -1552,6 +1546,46 @@ class ClaudeThread extends EventEmitter2 {
         reject(err);
       }
     });
+  }
+  respondToServerRequest(id, method, _params) {
+    let result;
+    let error;
+    switch (method) {
+      case "item/commandExecution/requestApproval":
+        result = { decision: "accept" };
+        this.log(`auto-accepted ${method} (id=${id})`);
+        break;
+      case "item/fileChange/requestApproval":
+        result = { decision: "accept" };
+        this.log(`auto-accepted ${method} (id=${id})`);
+        break;
+      case "applyPatchApproval":
+      case "execCommandApproval":
+        result = { decision: "approved" };
+        this.log(`auto-approved ${method} (id=${id})`);
+        break;
+      case "item/permissions/requestApproval":
+        result = { permissions: {} };
+        this.log(`auto-denied permission widening for ${method} (id=${id})`);
+        break;
+      default:
+        error = {
+          code: -32601,
+          message: `ClaudeThread received unknown server request method '${method}' with no handler`
+        };
+        this.log(`unknown server request method: ${method} (id=${id}) \u2014 replying -32601`);
+        break;
+    }
+    const payload = { jsonrpc: "2.0", id };
+    if (result !== undefined)
+      payload.result = result;
+    if (error !== undefined)
+      payload.error = error;
+    try {
+      this.ws?.send(JSON.stringify(payload));
+    } catch (err) {
+      this.log(`failed to send server-request response: ${err?.message ?? err}`);
+    }
   }
   log(s) {
     const line = `[${new Date().toISOString()}] [ClaudeThread:${this.chatId}] ${s}

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2,7 +2,7 @@
 // @bun
 
 // src/daemon.ts
-import { appendFileSync as appendFileSync2 } from "fs";
+import { appendFileSync as appendFileSync3 } from "fs";
 
 // src/codex-adapter.ts
 import { spawn, execSync } from "child_process";
@@ -1282,6 +1282,287 @@ class CodexAdapter extends EventEmitter {
   }
 }
 
+// src/claude-thread.ts
+import { EventEmitter as EventEmitter2 } from "events";
+import { appendFileSync as appendFileSync2 } from "fs";
+var RPC_TIMEOUT_MS = 30000;
+
+class ClaudeThread extends EventEmitter2 {
+  chatId;
+  appServerUrl;
+  logFile;
+  cwd;
+  ws = null;
+  threadId = null;
+  nextId = 1;
+  pending = new Map;
+  turnInProgress = false;
+  agentMessageBuffers = new Map;
+  bootstrapped = false;
+  closed = false;
+  constructor(opts) {
+    super();
+    this.chatId = opts.chatId;
+    this.appServerUrl = opts.appServerUrl;
+    this.logFile = opts.logFile;
+    this.cwd = opts.cwd;
+  }
+  get activeThreadId() {
+    return this.threadId;
+  }
+  get isTurnInProgress() {
+    return this.turnInProgress;
+  }
+  get isReady() {
+    return this.bootstrapped && this.threadId !== null;
+  }
+  async bootstrap() {
+    if (this.bootstrapped && this.threadId)
+      return this.threadId;
+    await this.openSocket();
+    await this.callRpc("initialize", {
+      clientInfo: { name: "agentbridge-claude-thread", version: "0.1.0" },
+      capabilities: { experimentalApi: false }
+    });
+    const params = {};
+    if (this.cwd)
+      params.cwd = this.cwd;
+    const startRes = await this.callRpc("thread/start", params);
+    const tid = startRes?.thread?.id ?? startRes?.threadId ?? null;
+    if (typeof tid !== "string" || tid.length === 0) {
+      throw new Error("thread/start did not return a threadId");
+    }
+    this.threadId = tid;
+    this.bootstrapped = true;
+    this.log(`bootstrap ok threadId=${tid}`);
+    this.emit("ready", tid);
+    return tid;
+  }
+  injectMessage(text) {
+    if (!this.threadId) {
+      this.log("inject rejected: not bootstrapped");
+      return false;
+    }
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.log("inject rejected: ws not open");
+      return false;
+    }
+    if (this.turnInProgress) {
+      this.log(`inject rejected: turn already in progress`);
+      return false;
+    }
+    const id = this.nextId++;
+    const msg = {
+      jsonrpc: "2.0",
+      id,
+      method: "turn/start",
+      params: {
+        threadId: this.threadId,
+        input: [{ type: "text", text }]
+      }
+    };
+    try {
+      this.ws.send(JSON.stringify(msg));
+      return true;
+    } catch (err) {
+      this.log(`inject send failed: ${err.message}`);
+      return false;
+    }
+  }
+  close() {
+    if (this.closed)
+      return;
+    this.closed = true;
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {}
+      this.ws = null;
+    }
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(new Error("ClaudeThread closed"));
+    }
+    this.pending.clear();
+  }
+  openSocket() {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.appServerUrl);
+      let settled = false;
+      ws.onopen = () => {
+        if (settled)
+          return;
+        settled = true;
+        this.ws = ws;
+        this.attachHandlers(ws);
+        resolve();
+      };
+      ws.onerror = (e) => {
+        if (settled)
+          return;
+        settled = true;
+        reject(new Error(`ws connect failed: ${e?.message ?? "unknown"}`));
+      };
+      ws.onclose = (e) => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(`ws closed during handshake (code=${e?.code})`));
+          return;
+        }
+      };
+    });
+  }
+  attachHandlers(ws) {
+    ws.onmessage = (event) => {
+      const raw = typeof event.data === "string" ? event.data : event.data.toString();
+      this.handlePayload(raw);
+    };
+    ws.onclose = () => {
+      this.log(`ws closed (chatId=${this.chatId}, threadId=${this.threadId})`);
+      this.ws = null;
+      this.emit("close");
+    };
+    ws.onerror = (e) => {
+      this.log(`ws error: ${e?.message ?? "unknown"}`);
+      this.emit("error", e);
+    };
+  }
+  handlePayload(raw) {
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (typeof parsed.id === "number" && this.pending.has(parsed.id) && (parsed.result !== undefined || parsed.error !== undefined)) {
+      const pending = this.pending.get(parsed.id);
+      this.pending.delete(parsed.id);
+      clearTimeout(pending.timer);
+      if (parsed.error) {
+        pending.reject(new Error(`${pending.method} failed: ${JSON.stringify(parsed.error).slice(0, 200)}`));
+      } else {
+        pending.resolve(parsed.result);
+      }
+      return;
+    }
+    if (parsed.id !== undefined && typeof parsed.method === "string") {
+      const tid = parsed.params?.threadId;
+      if (tid && this.threadId && tid !== this.threadId)
+        return;
+      try {
+        this.ws?.send(JSON.stringify({
+          jsonrpc: "2.0",
+          id: parsed.id,
+          error: { code: -32601, message: "auto-denied by ClaudeThread (no UI to approve)" }
+        }));
+      } catch {}
+      return;
+    }
+    if (typeof parsed.method === "string" && parsed.id === undefined) {
+      const tid = parsed.params?.threadId;
+      if (tid && this.threadId && tid !== this.threadId) {
+        return;
+      }
+      this.handleNotification(parsed.method, parsed.params ?? {});
+    }
+  }
+  handleNotification(method, params) {
+    switch (method) {
+      case "turn/started": {
+        if (!this.turnInProgress) {
+          this.turnInProgress = true;
+          this.emit("turnStarted");
+        }
+        break;
+      }
+      case "item/started": {
+        const item = params?.item;
+        if (item?.type === "agentMessage")
+          this.agentMessageBuffers.set(item.id, []);
+        break;
+      }
+      case "item/agentMessage/delta": {
+        const itemId = params?.itemId;
+        const delta = params?.delta;
+        if (typeof itemId === "string") {
+          const buf = this.agentMessageBuffers.get(itemId);
+          if (buf && typeof delta === "string")
+            buf.push(delta);
+        }
+        break;
+      }
+      case "item/completed": {
+        const item = params?.item;
+        if (item?.type === "agentMessage") {
+          const content = this.extractContent(item);
+          this.agentMessageBuffers.delete(item.id);
+          if (content) {
+            const bridgeMsg = {
+              id: item.id,
+              source: "codex",
+              content,
+              timestamp: Date.now()
+            };
+            this.emit("agentMessage", bridgeMsg);
+          }
+        }
+        break;
+      }
+      case "turn/completed": {
+        if (this.turnInProgress) {
+          this.turnInProgress = false;
+          this.emit("turnCompleted");
+        }
+        break;
+      }
+      case "turn/failed": {
+        if (this.turnInProgress) {
+          this.turnInProgress = false;
+          this.emit("turnCompleted");
+        }
+        this.emit("turnFailed", params);
+        break;
+      }
+    }
+  }
+  extractContent(item) {
+    if (item.content?.length) {
+      return item.content.filter((c) => c.type === "text" && c.text).map((c) => c.text).join("");
+    }
+    return this.agentMessageBuffers.get(item.id)?.join("") ?? "";
+  }
+  callRpc(method, params) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("callRpc: ws not open"));
+    }
+    const id = this.nextId++;
+    const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(new Error(`${method} timed out after ${RPC_TIMEOUT_MS}ms`));
+        }
+      }, RPC_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, method, timer });
+      try {
+        this.ws.send(msg);
+      } catch (err) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+  log(s) {
+    const line = `[${new Date().toISOString()}] [ClaudeThread:${this.chatId}] ${s}
+`;
+    process.stderr.write(line);
+    try {
+      appendFileSync2(this.logFile, line);
+    } catch {}
+  }
+}
+
 // src/message-filter.ts
 var MARKER_REGEX = /^\s*\[(IMPORTANT|STATUS|FYI)\]\s*/i;
 function parseMarker(content) {
@@ -1852,6 +2133,7 @@ var CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.co
 var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 var CLAUDE_DISCONNECT_GRACE_MS = 5000;
+var CLAUDE_REAP_AFTER_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_REAP_MS ?? "600000", 10);
 var MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 var FILTER_MODE = process.env.AGENTBRIDGE_FILTER_MODE === "full" ? "full" : "filtered";
 var IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
@@ -1860,98 +2142,24 @@ var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT,
 var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
 var attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 var controlServer = null;
-var attachedClaude = null;
 var nextControlClientId = 0;
-var nextSystemMessageId = 0;
 var codexBootstrapped = false;
-var attentionWindowTimer = null;
-var inAttentionWindow = false;
-var replyRequired = false;
-var replyReceivedDuringTurn = false;
 var shuttingDown = false;
 var idleShutdownTimer = null;
-var claudeDisconnectTimer = null;
-var claudeOnlineNoticeSent = false;
-var claudeOfflineNoticeShown = false;
-var codexCollaborationKickoffSent = false;
-var lastAttachStatusSentTs = 0;
-var ATTACH_STATUS_COOLDOWN_MS = 30000;
-var bufferedMessages = [];
+var chats = new Map;
 var tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
   log,
   onDisconnectPersisted: (connId) => {
-    emitToClaude(systemMessage("system_tui_disconnected", `\u26A0\uFE0F Codex TUI disconnected (conn #${connId}). Codex is still running in the background \u2014 reconnect the TUI to resume.`));
+    broadcastToAllClaudes(systemMessage("system_tui_disconnected", `\u26A0\uFE0F Codex TUI disconnected (conn #${connId}). Codex is still running in the background \u2014 reconnect the TUI to resume.`));
   },
   onReconnectAfterNotice: (connId) => {
-    emitToClaude(systemMessage("system_tui_reconnected", `\u2705 Codex TUI reconnected (conn #${connId}). Bridge restored, communication can continue.`));
-    codex.injectMessage("\u2705 Claude Code is still online, bridge restored. Bidirectional communication can continue.");
-  }
-});
-var statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
-codex.on("turnStarted", () => {
-  log("Codex turn started");
-  emitToClaude(systemMessage("system_turn_started", "\u23F3 Codex is working on the current task. Wait for completion before sending a reply."));
-});
-codex.on("agentMessage", (msg) => {
-  if (msg.source !== "codex")
-    return;
-  const result = classifyMessage(msg.content, FILTER_MODE);
-  if (replyRequired) {
-    log(`Codex \u2192 Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
-    replyReceivedDuringTurn = true;
-    if (statusBuffer.size > 0) {
-      statusBuffer.flush("reply-required message arrived");
-    }
-    emitToClaude(msg);
-    return;
-  }
-  if (inAttentionWindow && result.marker === "status") {
-    log(`Codex \u2192 Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
-    statusBuffer.add(msg);
-    return;
-  }
-  log(`Codex \u2192 Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
-  switch (result.action) {
-    case "forward":
-      if (result.marker === "important" && statusBuffer.size > 0) {
-        statusBuffer.flush("important message arrived");
-      }
-      emitToClaude(msg);
-      if (result.marker === "important") {
-        startAttentionWindow();
-      }
-      break;
-    case "buffer":
-      statusBuffer.add(msg);
-      break;
-    case "drop":
-      break;
-  }
-});
-codex.on("turnCompleted", () => {
-  log("Codex turn completed");
-  statusBuffer.flush("turn completed");
-  if (replyRequired && !replyReceivedDuringTurn) {
-    log("\u26A0\uFE0F Reply was required but Codex did not send any agentMessage");
-    emitToClaude(systemMessage("system_reply_missing", "\u26A0\uFE0F Codex completed the turn without sending a reply (require_reply was set). Codex may not have generated an agentMessage. You may want to retry or rephrase."));
-  }
-  replyRequired = false;
-  replyReceivedDuringTurn = false;
-  emitToClaude(systemMessage("system_turn_completed", "\u2705 Codex finished the current turn. You can reply now if needed."));
-  startAttentionWindow();
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
+    broadcastToAllClaudes(systemMessage("system_tui_reconnected", `\u2705 Codex TUI reconnected (conn #${connId}). Bridge restored.`));
   }
 });
 codex.on("ready", (threadId) => {
   tuiConnectionState.markBridgeReady();
-  log(`Codex ready \u2014 thread ${threadId}`);
-  log("Bridge fully operational");
-  emitToClaude(systemMessage("system_ready", currentReadyMessage()));
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
+  log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
 });
 codex.on("tuiConnected", (connId) => {
   tuiConnectionState.handleTuiConnected(connId);
@@ -1969,14 +2177,16 @@ codex.on("error", (err) => {
   log(`Codex error: ${err.message}`);
 });
 codex.on("exit", (code) => {
-  log(`Codex process exited (code ${code})`);
+  log(`Codex app-server process exited (code ${code})`);
   codexBootstrapped = false;
-  statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
-  clearPendingClaudeDisconnect("Codex process exited");
-  claudeOnlineNoticeSent = false;
-  claudeOfflineNoticeShown = false;
-  emitToClaude(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running, but the Codex side needs to be restarted.`));
+  broadcastToAllClaudes(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`));
+  for (const state of chats.values()) {
+    try {
+      state.thread.close();
+    } catch {}
+    state.ready = false;
+  }
   broadcastStatus();
 });
 function startControlServer() {
@@ -1985,13 +2195,12 @@ function startControlServer() {
     hostname: "127.0.0.1",
     fetch(req, server) {
       const url = new URL(req.url);
-      if (url.pathname === "/healthz") {
+      if (url.pathname === "/healthz")
         return Response.json(currentStatus());
-      }
       if (url.pathname === "/readyz") {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false } })) {
+      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, chatId: null } })) {
         return;
       }
       return new Response("AgentBridge daemon");
@@ -2004,9 +2213,13 @@ function startControlServer() {
         log(`Frontend socket opened (#${ws.data.clientId})`);
       },
       close: (ws, code, reason) => {
-        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
-        if (attachedClaude === ws) {
-          detachClaude(ws, "frontend socket closed");
+        const chatId = ws.data.chatId;
+        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, chatId=${chatId ?? "-"})`);
+        if (chatId) {
+          const state = chats.get(chatId);
+          if (state && state.ws === ws) {
+            detachClaudeWs(state, "frontend socket closed");
+          }
         }
       },
       message: (ws, raw) => {
@@ -2026,195 +2239,301 @@ function handleControlMessage(ws, raw) {
   }
   switch (message.type) {
     case "claude_connect":
-      attachClaude(ws);
+      attachClaude(ws, message.chatId);
       return;
-    case "claude_disconnect":
-      detachClaude(ws, "frontend requested disconnect");
+    case "claude_disconnect": {
+      const chatId = message.chatId ?? ws.data.chatId;
+      if (!chatId)
+        return;
+      const state = chats.get(chatId);
+      if (state)
+        detachClaudeWs(state, "frontend requested disconnect");
       return;
+    }
     case "status":
       sendStatus(ws);
       return;
-    case "claude_to_codex": {
-      if (message.message.source !== "claude") {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Invalid message source"
-        });
-        return;
-      }
-      if (!tuiConnectionState.canReply()) {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Codex is not ready. Wait for TUI to connect and create a thread."
-        });
-        return;
-      }
-      const requireReply = !!message.requireReply;
-      let contentWithReminder = message.message.content + `
-
-` + BRIDGE_CONTRACT_REMINDER;
-      if (requireReply) {
-        contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
-        replyRequired = true;
-        replyReceivedDuringTurn = false;
-        log(`Reply required flag set for this message`);
-      }
-      log(`Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-      const injected = codex.injectMessage(contentWithReminder);
-      if (!injected) {
-        const reason = codex.turnInProgress ? "Codex is busy executing a turn. Wait for it to finish before sending another message." : "Injection failed: no active thread or WebSocket not connected.";
-        log(`Injection rejected: ${reason}`);
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: reason
-        });
-        return;
-      }
-      clearAttentionWindow();
-      sendProtocolMessage(ws, {
-        type: "claude_to_codex_result",
-        requestId: message.requestId,
-        success: true
-      });
+    case "claude_to_codex":
+      handleClaudeToCodex(ws, message);
       return;
-    }
   }
 }
-function attachClaude(ws) {
-  if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
-    log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 another session (#${attachedClaude.data.clientId}) is already attached (readyState=${attachedClaude.readyState})`);
-    ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+async function attachClaude(ws, requestedChatId) {
+  const chatId = requestedChatId ?? `auto_${ws.data.clientId}_${Date.now()}`;
+  ws.data.chatId = chatId;
+  let state = chats.get(chatId);
+  if (state) {
+    if (state.ws && state.ws !== ws && state.ws.readyState !== WebSocket.CLOSED) {
+      log(`Replacing prior WS for chatId=${chatId} (#${state.ws.data.clientId} \u2192 #${ws.data.clientId})`);
+      try {
+        state.ws.close(CLOSE_CODE_REPLACED, "replaced by newer connection for same chatId");
+      } catch {}
+    }
+    state.ws = ws;
+    ws.data.attached = true;
+    clearDisconnectTimer(state, "claude resumed");
+    clearReaperTimer(state, "claude resumed");
+    cancelIdleShutdown();
+    log(`Claude resumed chatId=${chatId} (#${ws.data.clientId})`);
+    statusBufferFlushIfPaused(state, "claude resumed");
+    flushBufferedMessages(state);
+    sendStatus(ws);
     return;
   }
-  clearPendingClaudeDisconnect("Claude frontend attached");
-  attachedClaude = ws;
+  state = createChatState(chatId);
+  chats.set(chatId, state);
+  state.ws = ws;
   ws.data.attached = true;
   cancelIdleShutdown();
-  log(`Claude frontend attached (#${ws.data.clientId})`);
-  statusBuffer.flush("claude reconnected");
+  log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
   sendStatus(ws);
-  const now = Date.now();
-  const isRapidReattach = now - lastAttachStatusSentTs < ATTACH_STATUS_COOLDOWN_MS;
-  if (bufferedMessages.length > 0) {
-    flushBufferedMessages(ws);
-  } else if (!isRapidReattach) {
-    if (tuiConnectionState.canReply()) {
-      sendBridgeMessage(ws, systemMessage("system_ready", currentReadyMessage()));
-    } else if (codexBootstrapped) {
-      sendBridgeMessage(ws, systemMessage("system_waiting", currentWaitingMessage()));
-    }
-  }
-  lastAttachStatusSentTs = now;
-  if (tuiConnectionState.canReply() && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
+  emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
+  try {
+    const threadId = await state.thread.bootstrap();
+    state.ready = true;
+    log(`ClaudeThread ready: chatId=${chatId} threadId=${threadId}`);
+    emitToChat(state, systemMessage("system_thread_ready", `\u2705 Your Codex thread is ready (threadId=${threadId}). You can now send messages via the reply tool.`));
+    broadcastStatus();
+  } catch (err) {
+    log(`ClaudeThread bootstrap failed for chatId=${chatId}: ${err?.message ?? err}`);
+    emitToChat(state, systemMessage("system_thread_failed", `\u274C Failed to provision Codex thread: ${err?.message ?? err}. Reconnect to retry.`));
   }
 }
-function detachClaude(ws, reason) {
-  if (attachedClaude !== ws)
+function createChatState(chatId) {
+  const state = {
+    chatId,
+    ws: null,
+    thread: new ClaudeThread({
+      appServerUrl: codex.appServerUrl,
+      chatId,
+      logFile: stateDir.logFile,
+      cwd: process.cwd()
+    }),
+    ready: false,
+    inAttentionWindow: false,
+    attentionWindowTimer: null,
+    replyRequired: false,
+    replyReceivedDuringTurn: false,
+    bufferedMessages: [],
+    statusBuffer: null,
+    disconnectTimer: null,
+    reaperTimer: null,
+    lastAttachStatusSentTs: 0,
+    onlineNoticeSent: false,
+    nextSystemMessageId: 0
+  };
+  state.statusBuffer = new StatusBuffer((summary) => emitToChat(state, summary));
+  state.thread.on("agentMessage", (msg) => {
+    if (msg.source !== "codex")
+      return;
+    const result = classifyMessage(msg.content, FILTER_MODE);
+    if (state.replyRequired) {
+      log(`[${chatId}] Codex \u2192 Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
+      state.replyReceivedDuringTurn = true;
+      if (state.statusBuffer.size > 0) {
+        state.statusBuffer.flush("reply-required message arrived");
+      }
+      emitToChat(state, msg);
+      return;
+    }
+    if (state.inAttentionWindow && result.marker === "status") {
+      log(`[${chatId}] Codex \u2192 Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
+      state.statusBuffer.add(msg);
+      return;
+    }
+    log(`[${chatId}] Codex \u2192 Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
+    switch (result.action) {
+      case "forward":
+        if (result.marker === "important" && state.statusBuffer.size > 0) {
+          state.statusBuffer.flush("important message arrived");
+        }
+        emitToChat(state, msg);
+        if (result.marker === "important")
+          startAttentionWindow(state);
+        break;
+      case "buffer":
+        state.statusBuffer.add(msg);
+        break;
+      case "drop":
+        break;
+    }
+  });
+  state.thread.on("turnStarted", () => {
+    log(`[${chatId}] Codex turn started`);
+    emitToChat(state, systemMessage("system_turn_started", "\u23F3 Codex is working on the current task. Wait for completion before sending a reply."));
+  });
+  state.thread.on("turnCompleted", () => {
+    log(`[${chatId}] Codex turn completed`);
+    state.statusBuffer.flush("turn completed");
+    if (state.replyRequired && !state.replyReceivedDuringTurn) {
+      log(`[${chatId}] \u26A0\uFE0F Reply was required but Codex did not send any agentMessage`);
+      emitToChat(state, systemMessage("system_reply_missing", "\u26A0\uFE0F Codex completed the turn without sending a reply (require_reply was set)."));
+    }
+    state.replyRequired = false;
+    state.replyReceivedDuringTurn = false;
+    emitToChat(state, systemMessage("system_turn_completed", "\u2705 Codex finished the current turn. You can reply now if needed."));
+    startAttentionWindow(state);
+  });
+  state.thread.on("close", () => {
+    log(`[${chatId}] ClaudeThread WS closed`);
+    state.ready = false;
+  });
+  state.thread.on("error", (err) => {
+    log(`[${chatId}] ClaudeThread error: ${err?.message ?? err}`);
+  });
+  return state;
+}
+function detachClaudeWs(state, reason) {
+  if (!state.ws)
     return;
-  attachedClaude = null;
-  ws.data.attached = false;
-  log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
-  scheduleClaudeDisconnectNotification(ws.data.clientId);
+  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason})`);
+  state.ws = null;
+  scheduleDisconnectTimer(state);
+  scheduleReaperTimer(state);
   scheduleIdleShutdown();
 }
-function startAttentionWindow() {
-  clearAttentionWindow();
-  inAttentionWindow = true;
-  statusBuffer.pause();
-  log(`Attention window started (${ATTENTION_WINDOW_MS}ms)`);
-  attentionWindowTimer = setTimeout(() => {
-    attentionWindowTimer = null;
-    inAttentionWindow = false;
-    statusBuffer.resume();
-    log("Attention window ended");
-  }, ATTENTION_WINDOW_MS);
-}
-function clearAttentionWindow() {
-  if (attentionWindowTimer) {
-    clearTimeout(attentionWindowTimer);
-    attentionWindowTimer = null;
-  }
-  if (inAttentionWindow) {
-    statusBuffer.resume();
-  }
-  inAttentionWindow = false;
-}
-function scheduleIdleShutdown() {
-  cancelIdleShutdown();
-  if (attachedClaude)
-    return;
-  const snapshot = tuiConnectionState.snapshot();
-  if (snapshot.tuiConnected)
-    return;
-  log(`No clients connected. Daemon will shut down in ${IDLE_SHUTDOWN_MS}ms if no one reconnects.`);
-  idleShutdownTimer = setTimeout(() => {
-    if (attachedClaude || tuiConnectionState.snapshot().tuiConnected) {
-      log("Idle shutdown cancelled: client reconnected during grace period");
+function scheduleReaperTimer(state) {
+  if (state.reaperTimer)
+    clearTimeout(state.reaperTimer);
+  state.reaperTimer = setTimeout(() => {
+    state.reaperTimer = null;
+    if (state.ws)
       return;
-    }
-    shutdown("idle \u2014 no clients connected");
-  }, IDLE_SHUTDOWN_MS);
+    log(`Reaping idle chat: chatId=${state.chatId} (no WS for ${CLAUDE_REAP_AFTER_MS}ms)`);
+    try {
+      state.thread.close();
+    } catch {}
+    state.statusBuffer.dispose();
+    if (state.attentionWindowTimer)
+      clearTimeout(state.attentionWindowTimer);
+    chats.delete(state.chatId);
+    broadcastStatus();
+  }, CLAUDE_REAP_AFTER_MS);
 }
-function cancelIdleShutdown() {
-  if (idleShutdownTimer) {
-    clearTimeout(idleShutdownTimer);
-    idleShutdownTimer = null;
+function clearReaperTimer(state, _reason) {
+  if (state.reaperTimer) {
+    clearTimeout(state.reaperTimer);
+    state.reaperTimer = null;
   }
 }
-function clearPendingClaudeDisconnect(reason) {
-  if (!claudeDisconnectTimer)
-    return;
-  clearTimeout(claudeDisconnectTimer);
-  claudeDisconnectTimer = null;
-  if (reason) {
-    log(`Cleared pending Claude disconnect notification (${reason})`);
-  }
-}
-function scheduleClaudeDisconnectNotification(clientId) {
-  clearPendingClaudeDisconnect("rescheduled");
-  claudeDisconnectTimer = setTimeout(() => {
-    claudeDisconnectTimer = null;
-    if (attachedClaude) {
-      log(`Skipping Claude disconnect notification for client #${clientId} because Claude already reconnected`);
-      return;
-    }
-    if (!tuiConnectionState.canReply()) {
-      log(`Suppressing Claude disconnect notification for client #${clientId} because Codex cannot reply`);
-      return;
-    }
-    if (!claudeOnlineNoticeSent) {
-      log(`Suppressing Claude disconnect notification for client #${clientId} because Claude was never announced online`);
-      return;
-    }
-    codex.injectMessage("\u26A0\uFE0F Claude Code went offline. AgentBridge is still running in the background; it will reconnect automatically when Claude reopens.");
-    claudeOnlineNoticeSent = false;
-    claudeOfflineNoticeShown = true;
-    log(`Claude disconnect persisted past grace window (client #${clientId})`);
+function scheduleDisconnectTimer(state) {
+  if (state.disconnectTimer)
+    clearTimeout(state.disconnectTimer);
+  state.disconnectTimer = setTimeout(() => {
+    state.disconnectTimer = null;
   }, CLAUDE_DISCONNECT_GRACE_MS);
 }
-function emitToClaude(message) {
-  if (attachedClaude && attachedClaude.readyState === WebSocket.OPEN) {
-    if (trySendBridgeMessage(attachedClaude, message))
-      return;
-    log("Send to Claude failed, buffering message for retry on reconnect");
-  }
-  bufferedMessages.push(message);
-  if (bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
-    const dropped = bufferedMessages.length - MAX_BUFFERED_MESSAGES;
-    bufferedMessages.splice(0, dropped);
-    log(`Message buffer overflow: dropped ${dropped} oldest message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
+function clearDisconnectTimer(state, _reason) {
+  if (state.disconnectTimer) {
+    clearTimeout(state.disconnectTimer);
+    state.disconnectTimer = null;
   }
 }
-function trySendBridgeMessage(ws, message) {
+function statusBufferFlushIfPaused(state, reason) {
+  if (state.statusBuffer.size > 0)
+    state.statusBuffer.flush(reason);
+}
+function handleClaudeToCodex(ws, message) {
+  const chatId = message.chatId ?? ws.data.chatId;
+  if (!chatId) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "No chatId \u2014 claude_connect was never sent."
+    });
+  }
+  const state = chats.get(chatId);
+  if (!state) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: `Unknown chatId ${chatId}. Reattach via claude_connect.`
+    });
+  }
+  if (message.message.source !== "claude") {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "Invalid message source"
+    });
+  }
+  if (!state.ready) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "Your Codex thread is still provisioning. Wait for system_thread_ready."
+    });
+  }
+  const requireReply = !!message.requireReply;
+  let contentWithReminder = message.message.content + `
+
+` + BRIDGE_CONTRACT_REMINDER;
+  if (requireReply) {
+    contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
+    state.replyRequired = true;
+    state.replyReceivedDuringTurn = false;
+    log(`[${chatId}] Reply required flag set`);
+  }
+  log(`[${chatId}] Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
+  const injected = state.thread.injectMessage(contentWithReminder);
+  if (!injected) {
+    const reason = state.thread.isTurnInProgress ? "Codex is busy executing a turn on your thread. Wait for it to finish." : "Injection failed: thread WS not connected.";
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: reason
+    });
+  }
+  clearAttentionWindow(state);
+  sendProtocolMessage(ws, {
+    type: "claude_to_codex_result",
+    requestId: message.requestId,
+    success: true
+  });
+}
+function startAttentionWindow(state) {
+  clearAttentionWindow(state);
+  state.inAttentionWindow = true;
+  state.statusBuffer.pause();
+  log(`[${state.chatId}] Attention window started (${ATTENTION_WINDOW_MS}ms)`);
+  state.attentionWindowTimer = setTimeout(() => {
+    state.attentionWindowTimer = null;
+    state.inAttentionWindow = false;
+    state.statusBuffer.resume();
+    log(`[${state.chatId}] Attention window ended`);
+  }, ATTENTION_WINDOW_MS);
+}
+function clearAttentionWindow(state) {
+  if (state.attentionWindowTimer) {
+    clearTimeout(state.attentionWindowTimer);
+    state.attentionWindowTimer = null;
+  }
+  if (state.inAttentionWindow)
+    state.statusBuffer.resume();
+  state.inAttentionWindow = false;
+}
+function emitToChat(state, message) {
+  if (state.ws && state.ws.readyState === WebSocket.OPEN) {
+    if (trySendBridgeMessage(state.ws, message, state.chatId))
+      return;
+    log(`[${state.chatId}] Send to Claude failed, buffering`);
+  }
+  state.bufferedMessages.push(message);
+  if (state.bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
+    const dropped = state.bufferedMessages.length - MAX_BUFFERED_MESSAGES;
+    state.bufferedMessages.splice(0, dropped);
+    log(`[${state.chatId}] Message buffer overflow: dropped ${dropped} oldest`);
+  }
+}
+function trySendBridgeMessage(ws, message, chatId) {
   try {
-    const result = ws.send(JSON.stringify({ type: "codex_to_claude", message }));
+    const payload = { type: "codex_to_claude", chatId, message };
+    const result = ws.send(JSON.stringify(payload));
     if (typeof result === "number" && result <= 0) {
       log(`Bridge message send returned ${result} (0=dropped, -1=backpressure)`);
       return false;
@@ -2225,28 +2544,31 @@ function trySendBridgeMessage(ws, message) {
     return false;
   }
 }
-function flushBufferedMessages(ws) {
-  const messages = bufferedMessages.splice(0, bufferedMessages.length);
+function flushBufferedMessages(state) {
+  if (!state.ws || state.bufferedMessages.length === 0)
+    return;
+  const messages = state.bufferedMessages.splice(0, state.bufferedMessages.length);
   for (const message of messages) {
-    if (!trySendBridgeMessage(ws, message)) {
-      const failedIndex = messages.indexOf(message);
-      const remaining = messages.slice(failedIndex);
-      bufferedMessages.unshift(...remaining);
-      log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
+    if (!trySendBridgeMessage(state.ws, message, state.chatId)) {
+      const idx = messages.indexOf(message);
+      state.bufferedMessages.unshift(...messages.slice(idx));
+      log(`[${state.chatId}] Flush interrupted: re-buffered ${messages.length - idx} message(s)`);
       return;
     }
   }
 }
-function sendBridgeMessage(ws, message) {
-  trySendBridgeMessage(ws, message);
+function broadcastToAllClaudes(message) {
+  for (const state of chats.values())
+    emitToChat(state, message);
 }
 function sendStatus(ws) {
   sendProtocolMessage(ws, { type: "status", status: currentStatus() });
 }
 function broadcastStatus() {
-  if (!attachedClaude)
-    return;
-  sendStatus(attachedClaude);
+  for (const state of chats.values()) {
+    if (state.ws && state.ws.readyState === WebSocket.OPEN)
+      sendStatus(state.ws);
+  }
 }
 function sendProtocolMessage(ws, message) {
   try {
@@ -2258,51 +2580,44 @@ function sendProtocolMessage(ws, message) {
 function currentStatus() {
   const snapshot = tuiConnectionState.snapshot();
   return {
-    bridgeReady: tuiConnectionState.canReply(),
+    bridgeReady: tuiConnectionState.canReply() || codexBootstrapped,
     tuiConnected: snapshot.tuiConnected,
     threadId: codex.activeThreadId,
-    queuedMessageCount: bufferedMessages.length + statusBuffer.size,
+    queuedMessageCount: [...chats.values()].reduce((n, s) => n + s.bufferedMessages.length + s.statusBuffer.size, 0),
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
-    pid: process.pid
+    pid: process.pid,
+    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length
   };
-}
-function currentWaitingMessage() {
-  return `\u23F3 Waiting for Codex TUI to connect. Run in another terminal:
-${attachCmd}`;
-}
-function currentReadyMessage() {
-  return `\u2705 Codex TUI connected (${codex.activeThreadId}). Bridge ready.`;
-}
-function notifyCodexClaudeOnline() {
-  const message = !codexCollaborationKickoffSent ? [
-    "\uD83E\uDD1D Claude Code has connected via AgentBridge.",
-    "You are now in a multi-agent collaboration session.",
-    "When you receive a complex task, propose a division of labor to Claude.",
-    "Claude can send you messages \u2014 they will appear as injected user messages.",
-    "Respond naturally and Claude will receive your output via AgentBridge."
-  ].join(`
-`) : "\u2705 AgentBridge connected to Claude Code.";
-  const delivered = codex.injectMessage(message);
-  if (!delivered) {
-    log("Deferred Claude-online notice to Codex \u2014 will retry after current turn completes");
-    return false;
-  }
-  claudeOnlineNoticeSent = true;
-  claudeOfflineNoticeShown = false;
-  codexCollaborationKickoffSent = true;
-  return true;
-}
-function shouldNotifyCodexClaudeOnline() {
-  return !claudeOnlineNoticeSent || claudeOfflineNoticeShown;
 }
 function systemMessage(idPrefix, content) {
   return {
-    id: `${idPrefix}_${++nextSystemMessageId}`,
+    id: `${idPrefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
     source: "codex",
     content,
     timestamp: Date.now()
   };
+}
+function scheduleIdleShutdown() {
+  cancelIdleShutdown();
+  if ([...chats.values()].some((s) => s.ws !== null))
+    return;
+  if (tuiConnectionState.snapshot().tuiConnected)
+    return;
+  log(`No clients connected. Daemon will shut down in ${IDLE_SHUTDOWN_MS}ms if no one reconnects.`);
+  idleShutdownTimer = setTimeout(() => {
+    if ([...chats.values()].some((s) => s.ws !== null) || tuiConnectionState.snapshot().tuiConnected) {
+      log("Idle shutdown cancelled: client reconnected during grace period");
+      return;
+    }
+    shutdown("idle \u2014 no clients connected");
+  }, IDLE_SHUTDOWN_MS);
+}
+function cancelIdleShutdown() {
+  if (idleShutdownTimer) {
+    clearTimeout(idleShutdownTimer);
+    idleShutdownTimer = null;
+  }
 }
 function writePidFile() {
   daemonLifecycle.writePid();
@@ -2322,7 +2637,7 @@ function removeStatusFile() {
   daemonLifecycle.removeStatusFile();
 }
 async function bootCodex() {
-  log("Starting AgentBridge daemon...");
+  log("Starting AgentBridge daemon (multi-Claude variant)...");
   log(`Codex app-server: ${codex.appServerUrl}`);
   log(`Codex proxy: ${codex.proxyUrl}`);
   log(`Control server: ws://127.0.0.1:${CONTROL_PORT}/ws`);
@@ -2330,11 +2645,10 @@ async function bootCodex() {
     await codex.start();
     codexBootstrapped = true;
     writeStatusFile();
-    emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));
     broadcastStatus();
   } catch (err) {
     log(`Failed to start Codex: ${err.message}`);
-    emitToClaude(systemMessage("system_codex_start_failed", `\u274C AgentBridge failed to start Codex app-server: ${err.message}`));
+    broadcastToAllClaudes(systemMessage("system_codex_start_failed", `\u274C AgentBridge failed to start Codex app-server: ${err.message}`));
     broadcastStatus();
   }
 }
@@ -2344,7 +2658,19 @@ function shutdown(reason) {
   shuttingDown = true;
   log(`Shutting down daemon (${reason})...`);
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);
-  clearPendingClaudeDisconnect(`daemon shutdown (${reason})`);
+  for (const state of chats.values()) {
+    if (state.attentionWindowTimer)
+      clearTimeout(state.attentionWindowTimer);
+    if (state.disconnectTimer)
+      clearTimeout(state.disconnectTimer);
+    if (state.reaperTimer)
+      clearTimeout(state.reaperTimer);
+    state.statusBuffer.dispose();
+    try {
+      state.thread.close();
+    } catch {}
+  }
+  chats.clear();
   controlServer?.stop();
   controlServer = null;
   codex.stop();
@@ -2369,7 +2695,7 @@ function log(msg) {
 `;
   process.stderr.write(line);
   try {
-    appendFileSync2(stateDir.logFile, line);
+    appendFileSync3(stateDir.logFile, line);
   } catch {}
 }
 if (daemonLifecycle.wasKilled()) {

--- a/probes/shared-thread/README.md
+++ b/probes/shared-thread/README.md
@@ -1,0 +1,39 @@
+# Shared-thread probes
+
+These probes target `docs/shared-thread-mode-spec.md` v2.2.
+
+Run from the package root:
+
+```bash
+bun probes/shared-thread/p05-secondary-picker-token.ts
+```
+
+`p08b-same-chat-after-pair-reap.ts` is the regression probe for reconnecting
+with the same `chatId` after `AGENTBRIDGE_PAIR_REAP_MS` expires. Expected
+behavior: the old paired chat state was reaped, so the reconnect is treated as a
+fresh attach and can claim the open proxy TUI slot again.
+
+Defaults:
+
+- daemon entry: `plugins/agentbridge/server/daemon.js`
+- ports: `4820`, `4821`, `4822`
+- state dir: `/tmp/agentbridge-shared-thread-<probe>-<pid>`
+
+Useful overrides:
+
+```bash
+AGENTBRIDGE_DAEMON_ENTRY=src/daemon.ts bun probes/shared-thread/p05-secondary-picker-token.ts
+ABG_PROBE_BASE_PORT=4920 bun probes/shared-thread/p01-tui-first-claude-pairs.ts
+```
+
+P5 is the gating discriminator probe. It verifies the daemon accepts a same-token
+secondary connection and rejects a foreign token using the same bearer-token path
+that `agentbridge codex --via-proxy` passes to codex-rs through
+`--remote-auth-token-env`. It does not itself drive the interactive codex-rs
+picker UI.
+
+P12 and P13 are best-effort live fault probes because codex-rs does not expose a
+test-only way to synthesize `turn/completed` without output or a top-level
+`error` notification. P14 is intentionally a source-level micro-probe for the
+pre-response echo race, which is not deterministic enough to force through a
+real app-server.

--- a/probes/shared-thread/lib.ts
+++ b/probes/shared-thread/lib.ts
@@ -1,0 +1,686 @@
+#!/usr/bin/env bun
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+
+export type Json = Record<string, any>;
+
+export interface BridgeMessage {
+  id: string;
+  source: "claude" | "codex";
+  content: string;
+  timestamp: number;
+}
+
+export interface ControlResult {
+  requestId: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface ProbeOptions {
+  name: string;
+  basePort?: number;
+  pairReapMs?: number;
+  daemonEntry?: string;
+  extraEnv?: Record<string, string>;
+}
+
+const DEFAULT_BASE_PORT = Number(process.env.ABG_PROBE_BASE_PORT ?? "4820");
+const DEFAULT_TIMEOUT_MS = Number(process.env.ABG_PROBE_TIMEOUT_MS ?? "120000");
+const DEFAULT_CWD = process.env.ABG_PROBE_CWD ?? "/tmp/agentbridge-shared-thread-cwd";
+
+export class ProbeFailure extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProbeFailure";
+  }
+}
+
+export function makeToken(prefix = "abg"): string {
+  return `${prefix}_${randomBytes(8).toString("hex")}`;
+}
+
+export function sha1_16(text: string): string {
+  return createHash("sha1").update(text).digest("hex").slice(0, 16);
+}
+
+export function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new ProbeFailure(message);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new ProbeFailure(`${label} timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export function rawDataToString(data: unknown): string {
+  if (typeof data === "string") return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf-8");
+  if (ArrayBuffer.isView(data)) return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf-8");
+  return String(data);
+}
+
+export function parseMaybeJson(data: unknown): Json | null {
+  try {
+    const value = JSON.parse(rawDataToString(data));
+    return value && typeof value === "object" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function extractItemText(item: any): string {
+  if (!item || typeof item !== "object") return "";
+  if (typeof item.text === "string") return item.text;
+  if (Array.isArray(item.content)) {
+    return item.content
+      .map((part: any) => {
+        if (typeof part?.text === "string") return part.text;
+        if (typeof part?.content === "string") return part.content;
+        return "";
+      })
+      .join("");
+  }
+  return "";
+}
+
+export function marker(name: string): string {
+  return `agentbridge-${name}-${randomBytes(4).toString("hex")}`;
+}
+
+function formatArgs(args: string[]): string {
+  return args.map((arg) => (/\s/.test(arg) ? JSON.stringify(arg) : arg)).join(" ");
+}
+
+export class SharedThreadProbe {
+  readonly name: string;
+  readonly stateDir: string;
+  readonly cwd: string;
+  readonly appPort: number;
+  readonly proxyPort: number;
+  readonly controlPort: number;
+  readonly controlUrl: string;
+  readonly proxyUrl: string;
+  readonly appServerUrl: string;
+  readonly startedAt = Date.now();
+
+  private daemon: ChildProcess | null = null;
+  private daemonLogChunks: string[] = [];
+  private readonly pairReapMs: number;
+  private readonly daemonEntry: string;
+  private readonly extraEnv: Record<string, string>;
+
+  constructor(options: ProbeOptions) {
+    this.name = options.name;
+    const base = options.basePort ?? DEFAULT_BASE_PORT;
+    this.appPort = base;
+    this.proxyPort = base + 1;
+    this.controlPort = base + 2;
+    this.controlUrl = `ws://127.0.0.1:${this.controlPort}/ws`;
+    this.proxyUrl = `ws://127.0.0.1:${this.proxyPort}`;
+    this.appServerUrl = `ws://127.0.0.1:${this.appPort}`;
+    this.stateDir = `/tmp/agentbridge-shared-thread-${this.name}-${process.pid}`;
+    this.cwd = `${DEFAULT_CWD}-${this.name}`;
+    this.pairReapMs = options.pairReapMs ?? Number(process.env.AGENTBRIDGE_PAIR_REAP_MS ?? "30000");
+    this.daemonEntry =
+      options.daemonEntry ??
+      process.env.AGENTBRIDGE_DAEMON_ENTRY ??
+      `${import.meta.dir}/../../plugins/agentbridge/server/daemon.js`;
+    this.extraEnv = options.extraEnv ?? {};
+  }
+
+  log(message: string): void {
+    const elapsed = Date.now() - this.startedAt;
+    process.stderr.write(`[${elapsed.toString().padStart(6)}ms] [${this.name}] ${message}\n`);
+  }
+
+  async startDaemon(): Promise<void> {
+    rmSync(this.stateDir, { recursive: true, force: true });
+    mkdirSync(this.stateDir, { recursive: true });
+    mkdirSync(this.cwd, { recursive: true });
+
+    const env = {
+      ...process.env,
+      AGENTBRIDGE_STATE_DIR: this.stateDir,
+      CODEX_WS_PORT: String(this.appPort),
+      CODEX_PROXY_PORT: String(this.proxyPort),
+      AGENTBRIDGE_CONTROL_PORT: String(this.controlPort),
+      AGENTBRIDGE_IDLE_SHUTDOWN_MS: "300000",
+      AGENTBRIDGE_FILTER_MODE: "full",
+      AGENTBRIDGE_PAIR_REAP_MS: String(this.pairReapMs),
+      AGENTBRIDGE_PAIR_RACE_MS: "0",
+      ...this.extraEnv,
+    };
+
+    this.log(`spawning daemon: bun ${this.daemonEntry}`);
+    this.daemon = spawn("bun", [this.daemonEntry], {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    this.daemon.stdout?.on("data", (chunk: Buffer) => this.captureDaemon("out", chunk));
+    this.daemon.stderr?.on("data", (chunk: Buffer) => this.captureDaemon("err", chunk));
+    this.daemon.on("exit", (code, signal) => {
+      this.log(`daemon exited code=${code ?? "null"} signal=${signal ?? "null"}`);
+    });
+
+    await this.waitReady();
+  }
+
+  private captureDaemon(stream: "out" | "err", chunk: Buffer): void {
+    const text = chunk.toString("utf-8");
+    this.daemonLogChunks.push(text);
+    for (const line of text.split("\n")) {
+      if (line.trim()) process.stderr.write(`[daemon:${stream}] ${line}\n`);
+    }
+  }
+
+  async waitReady(timeoutMs = 60_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(`http://127.0.0.1:${this.controlPort}/readyz`);
+        if (res.ok) {
+          this.log("daemon /readyz ok");
+          return;
+        }
+      } catch {}
+      await sleep(300);
+    }
+    throw new ProbeFailure(`daemon did not become ready on ${this.controlPort} within ${timeoutMs}ms`);
+  }
+
+  async status(): Promise<Json> {
+    const res = await fetch(`http://127.0.0.1:${this.controlPort}/healthz`);
+    assert(res.ok, `/healthz returned ${res.status}`);
+    return await res.json();
+  }
+
+  async connectTui(token: string, name = "tui", options?: TuiOptions): Promise<TuiClient> {
+    const client = new TuiClient(this, name, this.proxyUrl, options, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    await client.connect();
+    return client;
+  }
+
+  async connectProxyRaw(url: string, name = "raw", options?: RawWsOptions): Promise<RawWsClient> {
+    const client = new RawWsClient(this, name, url, options);
+    await client.connect();
+    return client;
+  }
+
+  async connectClaude(chatId: string): Promise<ClaudeClient> {
+    const client = new ClaudeClient(this, chatId);
+    await client.connect();
+    return client;
+  }
+
+  daemonLog(): string {
+    const fromMemory = this.daemonLogChunks.join("");
+    const logPath = `${this.stateDir}/agentbridge.log`;
+    if (!existsSync(logPath)) return fromMemory;
+    return `${fromMemory}\n${readFileSync(logPath, "utf-8")}`;
+  }
+
+  async stop(): Promise<void> {
+    const proc = this.daemon;
+    this.daemon = null;
+    if (!proc) return;
+    this.log("stopping daemon");
+    try { proc.kill("SIGTERM"); } catch {}
+    await sleep(1200);
+    try { proc.kill("SIGKILL"); } catch {}
+  }
+}
+
+export class RawWsClient {
+  readonly messages: Json[] = [];
+  readonly closes: Array<{ code: number; reason: string }> = [];
+  ws: WebSocket | null = null;
+
+  constructor(
+    protected readonly probe: SharedThreadProbe,
+    readonly name: string,
+    readonly url: string,
+    private readonly wsOptions: RawWsOptions = {},
+  ) {}
+
+  connect(timeoutMs = 20_000): Promise<void> {
+    return withTimeout(new Promise<void>((resolve, reject) => {
+      const ws = this.wsOptions.headers
+        ? new WebSocket(this.url, { headers: this.wsOptions.headers } as any)
+        : new WebSocket(this.url);
+      this.ws = ws;
+      let settled = false;
+      ws.onopen = () => {
+        settled = true;
+        this.probe.log(`[${this.name}] WS open ${this.url}`);
+        resolve();
+      };
+      ws.onerror = () => {
+        if (!settled) reject(new ProbeFailure(`[${this.name}] WS error during connect`));
+      };
+      ws.onclose = (event) => {
+        this.closes.push({ code: event.code, reason: event.reason });
+        this.probe.log(`[${this.name}] WS closed code=${event.code} reason=${event.reason || "-"}`);
+        if (!settled) {
+          settled = true;
+          reject(new ProbeFailure(`[${this.name}] WS closed during connect code=${event.code} reason=${event.reason}`));
+        }
+      };
+      ws.onmessage = (event) => {
+        const parsed = parseMaybeJson(event.data);
+        if (parsed) this.messages.push(parsed);
+        this.onMessage(parsed, rawDataToString(event.data));
+      };
+    }), timeoutMs, `${this.name} connect`);
+  }
+
+  protected onMessage(_message: Json | null, _raw: string): void {}
+
+  send(message: Json): void {
+    assert(this.ws?.readyState === WebSocket.OPEN, `[${this.name}] socket is not open`);
+    this.ws.send(JSON.stringify(message));
+  }
+
+  close(): void {
+    try { this.ws?.close(); } catch {}
+  }
+
+  async waitForClose(timeoutMs = 10_000): Promise<{ code: number; reason: string }> {
+    if (this.closes.length > 0) return this.closes[this.closes.length - 1];
+    return withTimeout(new Promise((resolve) => {
+      const old = this.ws?.onclose;
+      if (!this.ws) return;
+      this.ws.onclose = (event) => {
+        old?.call(this.ws, event);
+        const close = { code: event.code, reason: event.reason };
+        this.closes.push(close);
+        resolve(close);
+      };
+    }), timeoutMs, `${this.name} close`);
+  }
+}
+
+export interface TuiOptions {
+  approvalPolicy?: string;
+  autoApprove?: boolean;
+}
+
+export interface RawWsOptions {
+  headers?: Record<string, string>;
+}
+
+export class TuiClient extends RawWsClient {
+  readonly notifications: Json[] = [];
+  readonly responses = new Map<number | string, Json>();
+  readonly requests: Json[] = [];
+  readonly agentMessages: string[] = [];
+  readonly userMessages: string[] = [];
+  readonly itemTypes: string[] = [];
+  threadId: string | null = null;
+  private nextId = 1;
+  private readonly options: Required<TuiOptions>;
+
+  constructor(probe: SharedThreadProbe, name: string, url: string, options?: TuiOptions, rawOptions?: RawWsOptions) {
+    super(probe, name, url, rawOptions);
+    this.options = {
+      approvalPolicy: options?.approvalPolicy ?? "never",
+      autoApprove: options?.autoApprove ?? false,
+    };
+  }
+
+  protected override onMessage(message: Json | null, raw: string): void {
+    if (!message) return;
+    if (message.id !== undefined && message.method === undefined) {
+      this.responses.set(message.id, message);
+      return;
+    }
+    if (typeof message.method === "string" && message.id === undefined) {
+      this.notifications.push(message);
+      const item = message.params?.item;
+      if (item?.type) this.itemTypes.push(item.type);
+      if (message.method !== "item/agentMessage/delta") {
+        this.probe.log(`[${this.name}] ${message.method}${item?.type ? ` (${item.type})` : ""}`);
+      }
+      if (message.method === "item/completed" && item?.type === "agentMessage") {
+        this.agentMessages.push(extractItemText(item));
+      }
+      if (message.method === "item/completed" && item?.type === "userMessage") {
+        this.userMessages.push(extractItemText(item));
+      }
+      return;
+    }
+    if (typeof message.method === "string" && message.id !== undefined) {
+      this.requests.push(message);
+      this.probe.log(`[${this.name}] server request ${message.method} id=${String(message.id)}`);
+      if (this.options.autoApprove) this.respondToServerRequest(message, raw);
+    }
+  }
+
+  private respondToServerRequest(message: Json, _raw: string): void {
+    let result: Json | null = null;
+    switch (message.method) {
+      case "item/commandExecution/requestApproval":
+        result = { decision: "accept" };
+        break;
+      case "item/fileChange/requestApproval":
+        result = { decision: "accept" };
+        break;
+      case "item/permissions/requestApproval":
+        result = { permissions: {}, scope: "turn" };
+        break;
+      case "execCommandApproval":
+        result = { decision: "approved" };
+        break;
+      case "applyPatchApproval":
+        result = { decision: "denied" };
+        break;
+    }
+    if (!result) return;
+    this.send({ jsonrpc: "2.0", id: message.id, result });
+  }
+
+  async initializeAndStartThread(options?: {
+    approvalPolicy?: string;
+    cwd?: string;
+    sandbox?: string;
+  }): Promise<string> {
+    const initId = this.nextId++;
+    this.send({
+      jsonrpc: "2.0",
+      id: initId,
+      method: "initialize",
+      params: { clientInfo: { name: `agentbridge-probe-${this.name}`, version: "0.0.1" } },
+    });
+    await this.waitForResponse(initId, 30_000);
+    this.send({ jsonrpc: "2.0", method: "initialized", params: {} });
+
+    const threadIdReq = this.nextId++;
+    this.send({
+      jsonrpc: "2.0",
+      id: threadIdReq,
+      method: "thread/start",
+      params: {
+        cwd: options?.cwd ?? this.probe.cwd,
+        approvalPolicy: options?.approvalPolicy ?? this.options.approvalPolicy,
+        ...(options?.sandbox ? { sandbox: options.sandbox } : {}),
+      },
+    });
+    const response = await this.waitForResponse(threadIdReq, 45_000);
+    const threadId = response.result?.thread?.id;
+    assert(typeof threadId === "string" && threadId.length > 0, `[${this.name}] thread/start did not return thread.id`);
+    this.threadId = threadId;
+    this.probe.log(`[${this.name}] threadId=${threadId}`);
+    return threadId;
+  }
+
+  async sendRequest(method: string, params?: Json, timeoutMs = 30_000): Promise<Json> {
+    const id = this.nextId++;
+    this.send({ jsonrpc: "2.0", id, method, params });
+    return this.waitForResponse(id, timeoutMs);
+  }
+
+  async sendTurn(text: string, options?: {
+    approvalPolicy?: string;
+    sandboxPolicy?: Json;
+    effort?: string;
+  }): Promise<string | null> {
+    assert(this.threadId, `[${this.name}] no threadId`);
+    const response = await this.sendRequest("turn/start", {
+      threadId: this.threadId,
+      input: [{ type: "text", text }],
+      effort: options?.effort ?? "minimal",
+      ...(options?.approvalPolicy ? { approvalPolicy: options.approvalPolicy } : {}),
+      ...(options?.sandboxPolicy ? { sandboxPolicy: options.sandboxPolicy } : {}),
+    }, 30_000);
+    return response.result?.turn?.id ?? null;
+  }
+
+  async interrupt(turnId: string): Promise<Json> {
+    assert(this.threadId, `[${this.name}] no threadId`);
+    return this.sendRequest("turn/interrupt", { threadId: this.threadId, turnId }, 20_000);
+  }
+
+  async waitForResponse(id: number | string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<Json> {
+    return withTimeout(new Promise<Json>((resolve, reject) => {
+      const poll = () => {
+        const response = this.responses.get(id);
+        if (!response) {
+          setTimeout(poll, 50);
+          return;
+        }
+        if (response.error) reject(new ProbeFailure(`[${this.name}] response ${String(id)} error: ${response.error.message ?? JSON.stringify(response.error)}`));
+        else resolve(response);
+      };
+      poll();
+    }), timeoutMs, `${this.name} response ${String(id)}`);
+  }
+
+  async waitForNotification(
+    method: string,
+    predicate: (message: Json) => boolean = () => true,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<Json> {
+    return withTimeout(new Promise<Json>((resolve) => {
+      const poll = () => {
+        const found = this.notifications.find((message) => message.method === method && predicate(message));
+        if (found) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} notification ${method}`);
+  }
+
+  waitForAgentMessage(contains: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<string> {
+    return withTimeout(new Promise<string>((resolve) => {
+      const poll = () => {
+        const found = this.agentMessages.find((text) => text.includes(contains));
+        if (found !== undefined) resolve(found);
+        else setTimeout(poll, 100);
+      };
+      poll();
+    }), timeoutMs, `${this.name} agentMessage containing ${contains}`);
+  }
+
+  waitForUserMessage(contains: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<string> {
+    return withTimeout(new Promise<string>((resolve) => {
+      const poll = () => {
+        const found = this.userMessages.find((text) => text.includes(contains));
+        if (found !== undefined) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} userMessage containing ${contains}`);
+  }
+
+  async expectNoAgentMessage(contains: string, windowMs: number): Promise<void> {
+    await sleep(windowMs);
+    assert(!this.agentMessages.some((text) => text.includes(contains)), `[${this.name}] unexpected agentMessage containing ${contains}`);
+  }
+
+  async waitForServerRequest(
+    methodIncludes: string,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<Json> {
+    return withTimeout(new Promise<Json>((resolve) => {
+      const poll = () => {
+        const found = this.requests.find((req) => String(req.method).includes(methodIncludes));
+        if (found) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} server request ${methodIncludes}`);
+  }
+}
+
+export class ClaudeClient extends RawWsClient {
+  readonly bridgeMessages: BridgeMessage[] = [];
+  readonly results: ControlResult[] = [];
+  readonly statuses: Json[] = [];
+
+  constructor(probe: SharedThreadProbe, readonly chatId: string) {
+    super(probe, `claude:${chatId}`, probe.controlUrl);
+  }
+
+  override async connect(timeoutMs = 20_000): Promise<void> {
+    await super.connect(timeoutMs);
+    this.send({ type: "claude_connect", chatId: this.chatId });
+  }
+
+  protected override onMessage(message: Json | null, _raw: string): void {
+    if (!message) return;
+    if (message.type === "codex_to_claude") {
+      const msg = message.message as BridgeMessage;
+      this.bridgeMessages.push(msg);
+      this.probe.log(`[${this.name}] codex_to_claude ${msg.id} ${msg.content.slice(0, 96).replace(/\n/g, " ")}`);
+      return;
+    }
+    if (message.type === "claude_to_codex_result") {
+      this.results.push(message as ControlResult);
+      this.probe.log(`[${this.name}] result ${message.requestId} success=${message.success}${message.error ? ` error=${message.error}` : ""}`);
+      return;
+    }
+    if (message.type === "status") this.statuses.push(message.status);
+  }
+
+  async sendReply(text: string, options?: { requireReply?: boolean; timeoutMs?: number }): Promise<ControlResult> {
+    const requestId = `${this.chatId}_${Date.now()}_${randomBytes(2).toString("hex")}`;
+    this.send({
+      type: "claude_to_codex",
+      requestId,
+      chatId: this.chatId,
+      message: {
+        id: `${this.chatId}_msg_${Date.now()}`,
+        source: "claude",
+        content: text,
+        timestamp: Date.now(),
+      },
+      ...(options?.requireReply ? { requireReply: true } : {}),
+    });
+    return this.waitForResult(requestId, options?.timeoutMs ?? 20_000);
+  }
+
+  async waitForResult(requestId: string, timeoutMs = 20_000): Promise<ControlResult> {
+    return withTimeout(new Promise<ControlResult>((resolve) => {
+      const poll = () => {
+        const found = this.results.find((result) => result.requestId === requestId);
+        if (found) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} result ${requestId}`);
+  }
+
+  waitForBridgeMessage(
+    predicate: (message: BridgeMessage) => boolean,
+    label: string,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<BridgeMessage> {
+    return withTimeout(new Promise<BridgeMessage>((resolve) => {
+      const poll = () => {
+        const found = this.bridgeMessages.find(predicate);
+        if (found) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} bridge message ${label}`);
+  }
+
+  waitForContent(contains: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<BridgeMessage> {
+    return this.waitForBridgeMessage((msg) => msg.content.includes(contains), contains, timeoutMs);
+  }
+
+  waitForDedicatedThreadReady(timeoutMs = 90_000): Promise<string> {
+    return withTimeout(new Promise<string>((resolve) => {
+      const poll = () => {
+        for (const msg of this.bridgeMessages) {
+          const match = msg.content.match(/Your Codex thread is ready \(threadId=([0-9a-f-]+)\)/);
+          if (match) return resolve(match[1]);
+        }
+        setTimeout(poll, 100);
+      };
+      poll();
+    }), timeoutMs, `${this.name} dedicated thread ready`);
+  }
+
+  async expectNoContent(contains: string, windowMs: number): Promise<void> {
+    await sleep(windowMs);
+    assert(
+      !this.bridgeMessages.some((message) => message.content.includes(contains)),
+      `[${this.name}] unexpected bridge message containing ${contains}`,
+    );
+  }
+
+  async expectNoDedicatedThreadReady(windowMs: number): Promise<void> {
+    await sleep(windowMs);
+    assert(
+      !this.bridgeMessages.some((message) => message.content.includes("Your Codex thread is ready")),
+      `[${this.name}] unexpectedly received isolated ClaudeThread ready notice`,
+    );
+  }
+}
+
+export async function runProbe(
+  name: string,
+  fn: (probe: SharedThreadProbe) => Promise<void>,
+  options?: Omit<ProbeOptions, "name">,
+): Promise<void> {
+  const probe = new SharedThreadProbe({ name, ...options });
+  let failed = false;
+  try {
+    await probe.startDaemon();
+    await fn(probe);
+  } catch (err: any) {
+    failed = true;
+    probe.log(`ERROR: ${err?.stack ?? err}`);
+  } finally {
+    await probe.stop();
+  }
+  probe.log(failed ? "RESULT: FAILED" : "RESULT: PASSED");
+  process.exit(failed ? 1 : 0);
+}
+
+export async function expectForeignProxyRejected(
+  probe: SharedThreadProbe,
+  url: string,
+  label: string,
+  expectedCode = 4002,
+  options?: RawWsOptions,
+): Promise<void> {
+  const client = new RawWsClient(probe, label, url, options);
+  let opened = false;
+  try {
+    await client.connect(5_000);
+    opened = true;
+  } catch {
+    // Upgrade rejection before open is also acceptable.
+  }
+  if (opened) {
+    const close = await client.waitForClose(5_000);
+    assert(close.code === expectedCode, `${label} expected close ${expectedCode}, got ${close.code} (${close.reason})`);
+  }
+}

--- a/probes/shared-thread/p01-tui-first-claude-pairs.ts
+++ b/probes/shared-thread/p01-tui-first-claude-pairs.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe } from "./lib";
+
+void runProbe("p01", async (probe) => {
+  const token = makeToken("p01");
+  const tui = await probe.connectTui(token, "primary");
+  const tuiThreadId = await tui.initializeAndStartThread();
+
+  const claude = await probe.connectClaude("p01_pair");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const ok = marker("p01-ok");
+  const result = await claude.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `paired Claude reply was rejected: ${result.error ?? "unknown"}`);
+
+  await tui.waitForNotification("turn/started", undefined, 45_000);
+  await tui.waitForAgentMessage(ok, 180_000);
+  await claude.waitForContent(ok, 30_000);
+
+  const status = await probe.status();
+  assert(status.threadId === tuiThreadId, `daemon status threadId ${status.threadId} != TUI threadId ${tuiThreadId}`);
+});
+

--- a/probes/shared-thread/p02-claude-first-isolated.ts
+++ b/probes/shared-thread/p02-claude-first-isolated.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe } from "./lib";
+
+void runProbe("p02", async (probe) => {
+  const claude = await probe.connectClaude("p02_isolated");
+  const isolatedThreadId = await claude.waitForDedicatedThreadReady();
+
+  const tui = await probe.connectTui(makeToken("p02"), "late-tui");
+  const tuiThreadId = await tui.initializeAndStartThread();
+  assert(isolatedThreadId !== tuiThreadId, "Claude-first session reused the later TUI thread");
+
+  const isolatedMarker = marker("p02-claude");
+  const result = await claude.sendReply(
+    `Reply with exactly this marker and nothing else: ${isolatedMarker}`,
+    { requireReply: true },
+  );
+  assert(result.success, `isolated Claude reply failed: ${result.error ?? "unknown"}`);
+  await claude.waitForContent(isolatedMarker, 180_000);
+  await tui.expectNoAgentMessage(isolatedMarker, 5_000);
+
+  const tuiMarker = marker("p02-tui");
+  await tui.sendTurn(`Reply with exactly this marker and nothing else: ${tuiMarker}`);
+  await tui.waitForAgentMessage(tuiMarker, 180_000);
+  await claude.expectNoContent("Human typed in the paired Codex TUI", 5_000);
+});
+

--- a/probes/shared-thread/p03-one-tui-two-claudes.ts
+++ b/probes/shared-thread/p03-one-tui-two-claudes.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe } from "./lib";
+
+void runProbe("p03", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p03"), "primary");
+  await tui.initializeAndStartThread();
+
+  const paired = await probe.connectClaude("p03_paired");
+  await paired.expectNoDedicatedThreadReady(8_000);
+
+  const isolated = await probe.connectClaude("p03_isolated");
+  const isolatedThreadId = await isolated.waitForDedicatedThreadReady();
+  assert(isolatedThreadId.length > 0, "second Claude did not provision an isolated thread");
+
+  const pairMarker = marker("p03-pair");
+  let result = await paired.sendReply(
+    `Reply with exactly this marker and nothing else: ${pairMarker}`,
+    { requireReply: true },
+  );
+  assert(result.success, `paired reply failed: ${result.error ?? "unknown"}`);
+  await tui.waitForAgentMessage(pairMarker, 180_000);
+  await paired.waitForContent(pairMarker, 30_000);
+  await isolated.expectNoContent(pairMarker, 5_000);
+
+  const isolatedMarker = marker("p03-isolated");
+  result = await isolated.sendReply(
+    `Reply with exactly this marker and nothing else: ${isolatedMarker}`,
+    { requireReply: true },
+  );
+  assert(result.success, `isolated reply failed: ${result.error ?? "unknown"}`);
+  await isolated.waitForContent(isolatedMarker, 180_000);
+  await tui.expectNoAgentMessage(isolatedMarker, 5_000);
+  await paired.expectNoContent(isolatedMarker, 5_000);
+});
+

--- a/probes/shared-thread/p04-second-proxy-tui-rejected.ts
+++ b/probes/shared-thread/p04-second-proxy-tui-rejected.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env bun
+import { expectForeignProxyRejected, makeToken, runProbe } from "./lib";
+
+void runProbe("p04", async (probe) => {
+  const primary = await probe.connectTui(makeToken("p04_primary"), "primary");
+  await primary.initializeAndStartThread();
+
+  const foreignToken = makeToken("p04_foreign");
+  await expectForeignProxyRejected(
+    probe,
+    probe.proxyUrl,
+    "foreign-proxy-tui",
+    4002,
+    { headers: { authorization: `Bearer ${foreignToken}` } },
+  );
+
+  // The first TUI should still be usable after rejection.
+  await primary.sendRequest("thread/list", {}, 30_000);
+});

--- a/probes/shared-thread/p05-secondary-picker-token.ts
+++ b/probes/shared-thread/p05-secondary-picker-token.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+import { assert, expectForeignProxyRejected, makeToken, runProbe } from "./lib";
+
+void runProbe("p05", async (probe) => {
+  const token = makeToken("p05");
+  const primary = await probe.connectTui(token, "primary");
+  await primary.initializeAndStartThread();
+
+  const secondary = await probe.connectTui(token, "secondary-picker");
+  await secondary.sendRequest("initialize", {
+    clientInfo: { name: "agentbridge-probe-secondary-picker", version: "0.0.1" },
+  }, 30_000);
+  secondary.send({ jsonrpc: "2.0", method: "initialized", params: {} });
+  const listResponse = await secondary.sendRequest("thread/list", {}, 30_000);
+  assert(listResponse.result !== undefined, "same-token secondary picker did not receive thread/list response");
+
+  const foreignToken = makeToken("p05_foreign");
+  await expectForeignProxyRejected(
+    probe,
+    probe.proxyUrl,
+    "foreign-token-after-secondary",
+    4002,
+    { headers: { authorization: `Bearer ${foreignToken}` } },
+  );
+
+  const log = probe.daemonLog();
+  probe.log(
+    log.includes("Secondary") || log.includes("secondary")
+      ? "daemon log contains secondary-connection evidence"
+      : "daemon log did not include a secondary marker; WS behavior still proved same-token acceptance",
+  );
+});

--- a/probes/shared-thread/p06-user-message-routing-and-echo-dedup.ts
+++ b/probes/shared-thread/p06-user-message-routing-and-echo-dedup.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p06", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p06"), "primary");
+  await tui.initializeAndStartThread();
+  const claude = await probe.connectClaude("p06_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const humanMarker = marker("p06-human");
+  await tui.sendTurn(`Reply with exactly this marker and nothing else: ${humanMarker}`);
+  const routed = await claude.waitForBridgeMessage(
+    (msg) =>
+      msg.source === "codex" &&
+      msg.content.includes("[IMPORTANT] Human typed in the paired Codex TUI:") &&
+      msg.content.includes(humanMarker),
+    "prefixed TUI userMessage",
+    30_000,
+  );
+  assert(routed.source === "codex", `expected source=codex, got ${routed.source}`);
+  await tui.waitForAgentMessage(humanMarker, 180_000);
+
+  const echoMarker = marker("p06-echo");
+  const result = await claude.sendReply(
+    `Reply with exactly this marker and nothing else: ${echoMarker}`,
+    { requireReply: true },
+  );
+  assert(result.success, `paired reply failed: ${result.error ?? "unknown"}`);
+  await tui.waitForUserMessage(echoMarker, 30_000);
+  await tui.waitForAgentMessage(echoMarker, 180_000);
+  await claude.waitForContent(echoMarker, 30_000);
+  await sleep(2_000);
+  assert(
+    !claude.bridgeMessages.some((msg) =>
+      msg.content.includes("[IMPORTANT] Human typed in the paired Codex TUI:") &&
+      msg.content.includes(echoMarker),
+    ),
+    "Claude-originated injected text echoed back as a TUI userMessage",
+  );
+});
+

--- a/probes/shared-thread/p07-paired-claude-reconnect-within-grace.ts
+++ b/probes/shared-thread/p07-paired-claude-reconnect-within-grace.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p07", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p07"), "primary");
+  await tui.initializeAndStartThread();
+
+  const chatId = "p07_paired";
+  const first = await probe.connectClaude(chatId);
+  await first.expectNoDedicatedThreadReady(8_000);
+  first.close();
+  await sleep(1_000);
+
+  const resumed = await probe.connectClaude(chatId);
+  await resumed.expectNoDedicatedThreadReady(5_000);
+  const ok = marker("p07-ok");
+  const result = await resumed.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `reconnected paired reply failed: ${result.error ?? "unknown"}`);
+  await tui.waitForAgentMessage(ok, 180_000);
+  await resumed.waitForContent(ok, 30_000);
+});
+

--- a/probes/shared-thread/p08-paired-claude-reap-after-grace.ts
+++ b/probes/shared-thread/p08-paired-claude-reap-after-grace.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p08", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p08"), "primary");
+  await tui.initializeAndStartThread();
+
+  const first = await probe.connectClaude("p08_first");
+  await first.expectNoDedicatedThreadReady(8_000);
+  first.close();
+  await sleep(1_800);
+
+  const second = await probe.connectClaude("p08_second");
+  await second.expectNoDedicatedThreadReady(5_000);
+  const ok = marker("p08-ok");
+  const result = await second.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `new paired Claude reply failed after reap: ${result.error ?? "unknown"}`);
+  await tui.waitForAgentMessage(ok, 180_000);
+  await second.waitForContent(ok, 30_000);
+}, { pairReapMs: 1000 });
+

--- a/probes/shared-thread/p08b-same-chat-after-pair-reap.ts
+++ b/probes/shared-thread/p08b-same-chat-after-pair-reap.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p08b", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p08b"), "primary");
+  await tui.initializeAndStartThread();
+
+  const chatId = "p08b_same_chat";
+  const first = await probe.connectClaude(chatId);
+  await first.expectNoDedicatedThreadReady(8_000);
+  first.close();
+
+  // Probe runs with a shortened pair reap window. After expiry, daemon should
+  // fully delete the old ChatState; reconnecting with the same chatId should
+  // behave like a fresh attach and claim the still-open proxy TUI slot.
+  await sleep(1_800);
+
+  const second = await probe.connectClaude(chatId);
+  await second.expectNoDedicatedThreadReady(5_000);
+
+  const ok = marker("p08b-ok");
+  const result = await second.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `same-chat reattach after pair reap failed: ${result.error ?? "unknown"}`);
+  await tui.waitForAgentMessage(ok, 180_000);
+  await second.waitForContent(ok, 30_000);
+}, { pairReapMs: 1000 });
+

--- a/probes/shared-thread/p09-tui-disconnect-transitions-claude-isolated.ts
+++ b/probes/shared-thread/p09-tui-disconnect-transitions-claude-isolated.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p09", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p09"), "primary");
+  await tui.initializeAndStartThread();
+  const claude = await probe.connectClaude("p09_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  tui.close();
+  await claude.waitForContent("Shared Codex TUI thread is gone", 30_000);
+  const threadId = await claude.waitForDedicatedThreadReady(90_000);
+  assert(threadId.length > 0, "paired Claude did not transition to a fresh isolated thread");
+
+  const ok = marker("p09-ok");
+  const result = await claude.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `isolated reply after TUI disconnect failed: ${result.error ?? "unknown"}`);
+  await claude.waitForContent(ok, 180_000);
+  await sleep(500);
+});
+

--- a/probes/shared-thread/p10-approval-isolation.ts
+++ b/probes/shared-thread/p10-approval-isolation.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+import { assert, makeToken, runProbe, sleep } from "./lib";
+
+void runProbe("p10", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p10"), "primary", {
+    approvalPolicy: "on-request",
+    autoApprove: false,
+  });
+  await tui.initializeAndStartThread({ approvalPolicy: "on-request" });
+  const claude = await probe.connectClaude("p10_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  await tui.sendTurn(
+    "Run this shell command: echo agentbridge-p10-approval-isolation. Ask for approval if required, and do not skip the command.",
+    { approvalPolicy: "on-request" },
+  );
+  await tui.waitForServerRequest("requestApproval", 180_000);
+  await sleep(2_000);
+
+  assert(
+    !claude.bridgeMessages.some((msg) => /requestApproval|approval request|agentbridge-p10-approval-isolation/i.test(msg.content)),
+    "approval request leaked to paired Claude",
+  );
+});
+

--- a/probes/shared-thread/p11-tool-whitelist.ts
+++ b/probes/shared-thread/p11-tool-whitelist.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p11", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p11"), "primary", { autoApprove: true });
+  await tui.initializeAndStartThread({ approvalPolicy: "never" });
+  const claude = await probe.connectClaude("p11_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const commandMarker = marker("p11-shell");
+  await tui.sendTurn(
+    `Run the shell command: echo ${commandMarker}. Then reply with exactly "${commandMarker} done".`,
+    { approvalPolicy: "never" },
+  );
+  await tui.waitForNotification("item/completed", (msg) => msg.params?.item?.type === "commandExecution", 180_000);
+  await tui.waitForAgentMessage(`${commandMarker} done`, 180_000);
+  await sleep(2_000);
+
+  assert(
+    !claude.bridgeMessages.some((msg) => /commandExecution|shellCommand|requestApproval|aggregatedOutput/.test(msg.content)),
+    "internal tool/shell item leaked to paired Claude",
+  );
+});
+

--- a/probes/shared-thread/p12-require-reply-turn-completed-no-output.ts
+++ b/probes/shared-thread/p12-require-reply-turn-completed-no-output.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+import { assert, makeToken, runProbe } from "./lib";
+
+void runProbe("p12", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p12"), "primary");
+  await tui.initializeAndStartThread();
+  const claude = await probe.connectClaude("p12_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const result = await claude.sendReply(
+    "Begin a long-running task and do not produce a final answer until tools complete. This turn will be interrupted by the probe.",
+    { requireReply: true },
+  );
+  assert(result.success, `paired reply failed: ${result.error ?? "unknown"}`);
+
+  const started = await tui.waitForNotification("turn/started", undefined, 60_000);
+  const turnId = started.params?.turn?.id;
+  assert(typeof turnId === "string" && turnId.length > 0, "turn/started did not include turn.id");
+  await tui.interrupt(turnId);
+
+  await claude.waitForBridgeMessage(
+    (msg) => msg.content.includes("[system] Codex turn completed") || msg.content.includes("completed the turn without sending a reply"),
+    "turnCompleted no-output release",
+    60_000,
+  );
+
+  assert(
+    !claude.bridgeMessages.some((msg) => msg.content.includes("[system] Codex turn started") && msg.content.includes("satisfies")),
+    "turnStarted appeared to satisfy requireReply; check daemon release accounting",
+  );
+});
+

--- a/probes/shared-thread/p13-require-reply-error-release.ts
+++ b/probes/shared-thread/p13-require-reply-error-release.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env bun
+import { assert, makeToken, runProbe } from "./lib";
+
+void runProbe("p13", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p13"), "primary");
+  await tui.initializeAndStartThread({ approvalPolicy: "never", sandbox: "read-only" });
+  const claude = await probe.connectClaude("p13_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const result = await claude.sendReply(
+    "Try to create /tmp/agentbridge-p13-should-be-denied.txt using a shell command. If the environment denies it, report the exact error.",
+    { requireReply: true },
+  );
+  assert(result.success, `paired reply failed: ${result.error ?? "unknown"}`);
+
+  await claude.waitForBridgeMessage(
+    (msg) => msg.content.startsWith("[error]") || msg.content.includes("[error]") || msg.content.includes("permission") || msg.content.includes("denied"),
+    "error release",
+    180_000,
+  );
+});
+

--- a/probes/shared-thread/p14-echo-race-pre-response.ts
+++ b/probes/shared-thread/p14-echo-race-pre-response.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+import { assert, sha1_16 } from "./lib";
+import { CodexAdapter } from "../../src/codex-adapter";
+
+const text = `agentbridge-p14-echo-race-${Date.now()}`;
+const adapter = new CodexAdapter(1, 2, "/tmp/agentbridge-p14-no-daemon.log") as any;
+
+let emittedUserMessages = 0;
+adapter.on("userMessage", () => {
+  emittedUserMessages++;
+});
+
+if (!(adapter.pendingInjectionHashes instanceof Map)) {
+  throw new Error("CodexAdapter.pendingInjectionHashes Map is missing; implement §4.5 race dedup before running P14.");
+}
+if (typeof adapter.handleServerNotification !== "function") {
+  throw new Error("CodexAdapter.handleServerNotification is not reachable for the P14 micro-probe.");
+}
+
+adapter.pendingInjectionHashes.set(sha1_16(text), Date.now() + 5_000);
+adapter.handleServerNotification({
+  method: "item/completed",
+  params: {
+    threadId: "thread_p14",
+    turnId: "turn_p14_pre_response",
+    item: {
+      type: "userMessage",
+      id: "item_p14_user",
+      content: [{ type: "text", text }],
+    },
+  },
+});
+
+assert(emittedUserMessages === 0, "pre-response userMessage echo was emitted despite pendingInjectionHashes match");
+assert(!adapter.pendingInjectionHashes.has(sha1_16(text)), "pending hash was not consumed one-shot");
+
+adapter.handleServerNotification({
+  method: "item/completed",
+  params: {
+    threadId: "thread_p14",
+    turnId: "turn_p14_human",
+    item: {
+      type: "userMessage",
+      id: "item_p14_human",
+      content: [{ type: "text", text: `${text}-human` }],
+    },
+  },
+});
+
+assert(emittedUserMessages === 1, "non-echo userMessage was not emitted after the one-shot hash was consumed");
+process.stderr.write("RESULT: PASSED\n");
+

--- a/probes/shell-approval.ts
+++ b/probes/shell-approval.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env bun
+/**
+ * Approval-policy probe.
+ *
+ * Spawns the daemon on isolated ports, attaches one simulated Claude, and
+ * sends a turn that explicitly asks Codex to execute a shell command
+ * (`echo agentbridge-multi-fix-probe`). Pre-fix, the daemon's ClaudeThread
+ * auto-denied every server-initiated approval request with `-32601`,
+ * which made `exec_command` impossible. Post-fix, we set
+ * `approvalPolicy: "never"` at thread/start AND auto-accept any approval
+ * server-request that still arrives.
+ *
+ * The probe passes when:
+ *   1. The turn completes (turn/completed event observed).
+ *   2. Codex echoes the marker string back inside an agentMessage.
+ *   3. The bridge log shows no `auto-denied ... no UI to approve` lines for
+ *      this chat (pre-fix signature). Auto-accepts are OK to see.
+ *
+ * Cost: one short Codex turn that runs a single `echo`.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+
+const STATE_DIR = "/tmp/agentbridge-shell-approval-probe";
+const CTRL_PORT = 4702;
+const CODEX_WS_PORT = 4700;
+const CODEX_PROXY_PORT = 4701;
+const CONTROL_URL = `ws://127.0.0.1:${CTRL_PORT}/ws`;
+const MARKER = "agentbridge-multi-fix-probe-marker-9f1c4e";
+const CHAT_ID = "shell_probe_a";
+
+function elapsed(start: number) {
+  return Date.now() - start;
+}
+
+async function waitReady(timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${CTRL_PORT}/readyz`);
+      if (res.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`daemon /readyz not ready within ${timeoutMs}ms`);
+}
+
+async function main() {
+  rmSync(STATE_DIR, { recursive: true, force: true });
+  mkdirSync(STATE_DIR, { recursive: true });
+
+  const daemonJs = `${import.meta.dir}/../plugins/agentbridge/server/daemon.js`;
+  const env = {
+    ...process.env,
+    AGENTBRIDGE_STATE_DIR: STATE_DIR,
+    CODEX_WS_PORT: String(CODEX_WS_PORT),
+    CODEX_PROXY_PORT: String(CODEX_PROXY_PORT),
+    AGENTBRIDGE_CONTROL_PORT: String(CTRL_PORT),
+    AGENTBRIDGE_IDLE_SHUTDOWN_MS: "300000",
+  };
+
+  const start = Date.now();
+  const log = (s: string) => process.stderr.write(`[${elapsed(start).toString().padStart(6)}ms] ${s}\n`);
+
+  log(`spawning daemon: bun ${daemonJs}`);
+  const daemon = spawn("bun", [daemonJs], { env, stdio: ["ignore", "pipe", "pipe"] });
+  daemon.stderr.on("data", (b: Buffer) => process.stderr.write(`[daemon] ${b}`));
+  daemon.stdout.on("data", (b: Buffer) => process.stderr.write(`[daemon:out] ${b}`));
+  daemon.on("exit", (code) => log(`daemon exited code=${code}`));
+
+  let failed = false;
+  let threadReady = false;
+  let turnCompleted = false;
+  let echoSeen = false;
+  const agentMessages: string[] = [];
+
+  try {
+    await waitReady(45_000);
+    log("daemon /readyz ok");
+
+    const ws = new WebSocket(CONTROL_URL);
+    let resolveReady!: () => void;
+    let resolveDone!: () => void;
+    const readyP = new Promise<void>((r) => (resolveReady = r));
+    const doneP = new Promise<void>((r) => (resolveDone = r));
+
+    ws.onopen = () => {
+      log(`WS open → claude_connect chatId=${CHAT_ID}`);
+      ws.send(JSON.stringify({ type: "claude_connect", chatId: CHAT_ID }));
+    };
+
+    ws.onmessage = (ev) => {
+      let msg: any;
+      try { msg = JSON.parse(typeof ev.data === "string" ? ev.data : (ev.data as Buffer).toString()); }
+      catch { return; }
+
+      if (msg.type === "codex_to_claude") {
+        const content: string = msg.message?.content ?? "";
+        const idPrefix = (msg.message?.id ?? "").split("_").slice(0, 2).join("_");
+        log(`recv ${idPrefix} (${content.length} chars): ${content.slice(0, 80).replace(/\n/g, " ")}…`);
+
+        if (content.startsWith("✅ Your Codex thread is ready")) {
+          threadReady = true;
+          resolveReady();
+        }
+        if (content.startsWith("✅ Codex finished")) {
+          turnCompleted = true;
+          resolveDone();
+        }
+        if (!content.startsWith("⏳") && !content.startsWith("✅") && !content.startsWith("⚠️") && !content.startsWith("[STATUS")) {
+          agentMessages.push(content);
+          if (content.includes(MARKER)) echoSeen = true;
+        }
+      }
+    };
+
+    ws.onerror = (e: any) => log(`WS error: ${e?.message ?? e}`);
+    ws.onclose = (e) => log(`WS closed code=${e.code} reason=${e.reason || "-"}`);
+
+    log("waiting for thread ready...");
+    await Promise.race([
+      readyP,
+      new Promise<void>((_, rej) => setTimeout(() => rej(new Error("thread never ready in 45s")), 45_000)),
+    ]);
+
+    const prompt = `Run the shell command exactly: echo ${MARKER}\n\nAfter running, reply [IMPORTANT] with one short line confirming you saw the output containing the marker. No further commentary.`;
+    log(`firing turn with shell command...`);
+    ws.send(JSON.stringify({
+      type: "claude_to_codex",
+      requestId: `req_${Date.now()}`,
+      chatId: CHAT_ID,
+      message: { id: `${CHAT_ID}_msg`, source: "claude", content: prompt, timestamp: Date.now() },
+      requireReply: true,
+    }));
+
+    log("waiting up to 120s for turn completion...");
+    await Promise.race([
+      doneP,
+      new Promise<void>((_, rej) => setTimeout(() => rej(new Error("turn never completed in 120s")), 120_000)),
+    ]);
+
+    log(`turn done: turnCompleted=${turnCompleted} echoSeen=${echoSeen} msgCount=${agentMessages.length}`);
+    log(`agentMessages preview: ${agentMessages.map((m) => m.slice(0, 100)).join("  ||  ").slice(0, 400)}`);
+
+    ws.close();
+    await new Promise((r) => setTimeout(r, 400));
+  } catch (err: any) {
+    log(`ERROR: ${err?.stack ?? err}`);
+    failed = true;
+  } finally {
+    log("stopping daemon");
+    try { daemon.kill("SIGTERM"); } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+    try { daemon.kill("SIGKILL"); } catch {}
+  }
+
+  // Inspect the bridge log file for telltale pre-fix lines.
+  const logPath = `${STATE_DIR}/agentbridge.log`;
+  let autoDeniedNoUi = 0;
+  let autoAccepted = 0;
+  if (existsSync(logPath)) {
+    const text = readFileSync(logPath, "utf-8");
+    for (const line of text.split("\n")) {
+      if (line.includes("auto-denied by ClaudeThread (no UI to approve)")) autoDeniedNoUi++;
+      if (line.includes("auto-accepted item/")) autoAccepted++;
+    }
+  } else {
+    log(`(no daemon log at ${logPath})`);
+  }
+  log(`Log scan: pre-fix-auto-denies=${autoDeniedNoUi}  post-fix-auto-accepts=${autoAccepted}`);
+
+  const passed = threadReady && turnCompleted && echoSeen && autoDeniedNoUi === 0;
+  log(passed ? "RESULT: PASSED ✅" : "RESULT: FAILED ❌");
+  log(`  threadReady=${threadReady}  turnCompleted=${turnCompleted}  echoSeen=${echoSeen}  autoDeniedNoUi=${autoDeniedNoUi}`);
+  process.exit(passed && !failed ? 0 : 1);
+}
+
+void main();

--- a/probes/two-claudes.ts
+++ b/probes/two-claudes.ts
@@ -1,0 +1,229 @@
+#!/usr/bin/env bun
+/**
+ * End-to-end probe: two simulated Claude clients on one daemon.
+ *
+ * Spawns the multi-Claude daemon on isolated ports + state dir, then opens
+ * two control-port WebSockets pretending to be two Claude MCP instances.
+ * Each registers a different chatId, gets its own Codex thread, and sends a
+ * tiny turn concurrently. We check that:
+ *
+ *   1. Both `system_thread_ready` notifications arrive (provisioning OK).
+ *   2. After firing `claude_to_codex` on both, both `turn/started` (or our
+ *      proxy "system_turn_started") notifications arrive before either
+ *      `turn/completed` — i.e. the daemon executes them in parallel.
+ *   3. Each chat only receives its own thread's notifications.
+ *
+ * Cost: two minimal-effort turns against Codex's configured model.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+
+const STATE_DIR = "/tmp/agentbridge-multi-probe";
+const CTRL_PORT = 4702;
+const CODEX_WS_PORT = 4700;
+const CODEX_PROXY_PORT = 4701;
+const CONTROL_URL = `ws://127.0.0.1:${CTRL_PORT}/ws`;
+
+interface RecordedEvent {
+  ts: number;
+  chatId: string;
+  method: string;
+  content?: string;
+}
+
+const events: RecordedEvent[] = [];
+const startTs = Date.now();
+
+function elapsed() {
+  return Date.now() - startTs;
+}
+
+function log(s: string) {
+  process.stderr.write(`[${elapsed().toString().padStart(6)}ms] ${s}\n`);
+}
+
+async function waitHealthz(timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${CTRL_PORT}/readyz`);
+      if (res.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`daemon did not become ready at /readyz within ${timeoutMs}ms`);
+}
+
+interface Claude {
+  chatId: string;
+  ws: WebSocket;
+  ready: Promise<void>;
+  threadId: Promise<string | null>;
+  turnStarted: Promise<number>;
+  turnCompleted: Promise<number>;
+  agentMessages: string[];
+}
+
+function startClaude(chatId: string): Claude {
+  let resolveReady!: () => void;
+  let resolveThreadId!: (id: string | null) => void;
+  let resolveStarted!: (ts: number) => void;
+  let resolveCompleted!: (ts: number) => void;
+  const ready = new Promise<void>((r) => (resolveReady = r));
+  const threadIdP = new Promise<string | null>((r) => (resolveThreadId = r));
+  const turnStarted = new Promise<number>((r) => (resolveStarted = r));
+  const turnCompleted = new Promise<number>((r) => (resolveCompleted = r));
+
+  const ws = new WebSocket(CONTROL_URL);
+  const agentMessages: string[] = [];
+
+  ws.onopen = () => {
+    log(`[${chatId}] WS open → claude_connect`);
+    ws.send(JSON.stringify({ type: "claude_connect", chatId }));
+  };
+  ws.onmessage = (ev) => {
+    let msg: any;
+    try {
+      msg = JSON.parse(typeof ev.data === "string" ? ev.data : (ev.data as Buffer).toString());
+    } catch {
+      return;
+    }
+    if (msg.type === "codex_to_claude") {
+      const content: string = msg.message?.content ?? "";
+      const idPrefix = (msg.message?.id ?? "").split("_")[0] + "_" + ((msg.message?.id ?? "").split("_")[1] ?? "");
+      events.push({ ts: elapsed(), chatId, method: idPrefix, content: content.slice(0, 80) });
+      log(`[${chatId}] codex_to_claude id=${msg.message?.id} (${content.length} chars): ${content.slice(0, 60).replace(/\n/g, " ")}…`);
+      if (content.startsWith("✅ Your Codex thread is ready")) {
+        const match = content.match(/threadId=([0-9a-f-]+)\)/);
+        resolveThreadId(match ? match[1] : null);
+        resolveReady();
+      }
+      if (content.startsWith("⏳ Codex is working")) resolveStarted(elapsed());
+      if (content.startsWith("✅ Codex finished")) resolveCompleted(elapsed());
+      if (!content.startsWith("[STATUS") && !content.startsWith("⏳") && !content.startsWith("✅") && !content.startsWith("⚠️")) {
+        agentMessages.push(content);
+      }
+    } else if (msg.type === "claude_to_codex_result") {
+      log(`[${chatId}] claude_to_codex_result reqId=${msg.requestId} success=${msg.success}${msg.error ? " error=" + msg.error : ""}`);
+    } else if (msg.type === "status") {
+      // ignore for brevity
+    }
+  };
+  ws.onerror = (e: any) => log(`[${chatId}] WS error: ${e?.message ?? e}`);
+  ws.onclose = (e) => log(`[${chatId}] WS closed code=${e.code} reason=${e.reason || "-"}`);
+
+  return { chatId, ws, ready, threadId: threadIdP, turnStarted, turnCompleted, agentMessages };
+}
+
+function sendTurn(c: Claude, text: string): Promise<void> {
+  const reqId = `${c.chatId}_${Date.now()}`;
+  c.ws.send(JSON.stringify({
+    type: "claude_to_codex",
+    requestId: reqId,
+    chatId: c.chatId,
+    message: {
+      id: `${c.chatId}_msg`,
+      source: "claude",
+      content: text,
+      timestamp: Date.now(),
+    },
+  }));
+  return Promise.resolve();
+}
+
+async function main() {
+  rmSync(STATE_DIR, { recursive: true, force: true });
+  mkdirSync(STATE_DIR, { recursive: true });
+
+  // Spawn daemon directly via bun on the built bundle.
+  const daemonJs = `${import.meta.dir}/../plugins/agentbridge/server/daemon.js`;
+  const env = {
+    ...process.env,
+    AGENTBRIDGE_STATE_DIR: STATE_DIR,
+    CODEX_WS_PORT: String(CODEX_WS_PORT),
+    CODEX_PROXY_PORT: String(CODEX_PROXY_PORT),
+    AGENTBRIDGE_CONTROL_PORT: String(CTRL_PORT),
+    AGENTBRIDGE_IDLE_SHUTDOWN_MS: "300000",
+  };
+
+  log(`spawning daemon: bun ${daemonJs}`);
+  const daemon = spawn("bun", [daemonJs], { env, stdio: ["ignore", "pipe", "pipe"] });
+  daemon.stderr.on("data", (b: Buffer) => process.stderr.write(`[daemon] ${b}`));
+  daemon.stdout.on("data", (b: Buffer) => process.stderr.write(`[daemon:out] ${b}`));
+  daemon.on("exit", (code) => log(`daemon exited code=${code}`));
+
+  let failed = false;
+  try {
+    await waitHealthz(45_000);
+    log("daemon /readyz ok");
+
+    const a = startClaude("probe_a");
+    const b = startClaude("probe_b");
+
+    log("waiting for both threads ready...");
+    await Promise.all([a.ready, b.ready]);
+    const [tidA, tidB] = await Promise.all([a.threadId, b.threadId]);
+    log(`thread A=${tidA} / thread B=${tidB} (must differ)`);
+    if (!tidA || !tidB || tidA === tidB) {
+      log(`FAIL: thread IDs not distinct (${tidA} vs ${tidB})`);
+      failed = true;
+    }
+
+    const fireAt = elapsed();
+    log(`fire turn on both at ${fireAt}ms`);
+    const prompt = "Reply with exactly the two characters OK and absolutely nothing else. No reasoning, no tool calls.";
+    await Promise.all([sendTurn(a, prompt + " --A"), sendTurn(b, prompt + " --B")]);
+
+    log("waiting for both turn completions (timeout 90s)...");
+    const completedTimer = setTimeout(() => log("⏰ 90s timeout reached"), 90_000);
+    try {
+      const startedA = await Promise.race([a.turnStarted, new Promise<number>((_, rej) => setTimeout(() => rej(new Error("A turn never started")), 60_000))]);
+      const startedB = await Promise.race([b.turnStarted, new Promise<number>((_, rej) => setTimeout(() => rej(new Error("B turn never started")), 60_000))]);
+      const completedA = await Promise.race([a.turnCompleted, new Promise<number>((_, rej) => setTimeout(() => rej(new Error("A turn never completed")), 120_000))]);
+      const completedB = await Promise.race([b.turnCompleted, new Promise<number>((_, rej) => setTimeout(() => rej(new Error("B turn never completed")), 120_000))]);
+
+      log(`startedA=${startedA} startedB=${startedB} completedA=${completedA} completedB=${completedB}`);
+      const maxStart = Math.max(startedA, startedB);
+      const minComplete = Math.min(completedA, completedB);
+      const verdict = maxStart < minComplete ? "PARALLEL ✅" : "SERIALIZED ❌";
+      log(`Concurrency verdict: ${verdict}  (maxStart=${maxStart}ms < minComplete=${minComplete}ms ?)`);
+
+      log(`A agentMessages: ${JSON.stringify(a.agentMessages)}`);
+      log(`B agentMessages: ${JSON.stringify(b.agentMessages)}`);
+      // Cross-leak check
+      const aLeaked = a.agentMessages.some((m) => m.includes("--B"));
+      const bLeaked = b.agentMessages.some((m) => m.includes("--A"));
+      if (aLeaked || bLeaked) {
+        log(`FAIL: cross-chat leakage detected (a got --B? ${aLeaked}, b got --A? ${bLeaked})`);
+        failed = true;
+      } else {
+        log("Isolation: each chat only saw its own messages ✅");
+      }
+    } finally {
+      clearTimeout(completedTimer);
+    }
+
+    // Close cleanly
+    a.ws.close();
+    b.ws.close();
+    await new Promise((r) => setTimeout(r, 500));
+  } catch (err: any) {
+    log(`ERROR: ${err?.stack ?? err}`);
+    failed = true;
+  } finally {
+    log("stopping daemon");
+    try { daemon.kill("SIGTERM"); } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+    try { daemon.kill("SIGKILL"); } catch {}
+  }
+
+  log("=== EVENT TRACE ===");
+  for (const e of events) {
+    log(`  +${e.ts}ms  [${e.chatId}]  ${e.method}  ${e.content ?? ""}`);
+  }
+  log(failed ? "RESULT: FAILED" : "RESULT: PASSED");
+  process.exit(failed ? 1 : 0);
+}
+
+void main();

--- a/probes/two-tui-direct.ts
+++ b/probes/two-tui-direct.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+/**
+ * Multi-TUI viability probe.
+ *
+ * Question: can two independent WebSocket clients connect directly to a
+ * single `codex app-server` and each maintain their OWN stable thread —
+ * simulating two separate Codex TUI windows talking to the same backend?
+ *
+ * Setup:
+ *   1. Spawn a fresh `codex app-server` on an isolated port.
+ *   2. Open WS A, initialize, thread/start → thread_A.
+ *   3. Open WS B, initialize, thread/start → thread_B.
+ *   4. Both fire `turn/start` with a tiny prompt at the same time.
+ *   5. Watch for `thread/closed` notifications (the smoking gun for the
+ *      silent-TUI-exit bug we saw with the bridge proxy's secondaries) and
+ *      for turn completion on each side.
+ *
+ * Verdict:
+ *   - PASS if both threadIds remain valid, no thread/closed for either,
+ *     and both turns complete with assistant output containing the marker.
+ *   - FAIL if either thread is closed, or either turn fails to complete.
+ *
+ * This is the empirical evidence underpinning the "Path B" decision —
+ * pointing `agentbridge codex` straight at port 4500 is only safe if
+ * codex-rs handles two independent TUI-like clients without complaint.
+ *
+ * Cost: two minimal-effort Codex turns against the configured model.
+ */
+
+import { spawn } from "node:child_process";
+
+const APP_PORT = 4720;
+const APP_URL = `ws://127.0.0.1:${APP_PORT}`;
+const PROBE_CWD = "/tmp/agentbridge-two-tui-probe";
+const PROMPT_A = "Reply with exactly the marker probeA-OK-3jf and nothing else.";
+const PROMPT_B = "Reply with exactly the marker probeB-OK-9qx and nothing else.";
+
+interface Client {
+  name: string;
+  prompt: string;
+  marker: string;
+  ws: WebSocket;
+  ready: Promise<void>;
+  threadId: string | null;
+  turnDone: Promise<{ completed: boolean; closed: boolean; gotMarker: boolean }>;
+  events: string[];
+}
+
+const startTs = Date.now();
+function ms() { return Date.now() - startTs; }
+function log(s: string) { process.stderr.write(`[${ms().toString().padStart(6)}ms] ${s}\n`); }
+
+async function waitHealth(url: string, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`http://127.0.0.1:${APP_PORT}/healthz`);
+      if (r.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`app-server /healthz not ready within ${timeoutMs}ms`);
+}
+
+function startClient(name: string, prompt: string, marker: string): Client {
+  let resolveReady!: () => void;
+  let resolveDone!: (v: { completed: boolean; closed: boolean; gotMarker: boolean }) => void;
+  const ready = new Promise<void>((r) => (resolveReady = r));
+  const turnDone = new Promise<{ completed: boolean; closed: boolean; gotMarker: boolean }>((r) => (resolveDone = r));
+  const events: string[] = [];
+  let threadId: string | null = null;
+  let nextId = 1;
+  let completed = false;
+  let closed = false;
+  let gotMarker = false;
+
+  const ws = new WebSocket(APP_URL);
+
+  ws.onopen = async () => {
+    // initialize
+    ws.send(JSON.stringify({
+      jsonrpc: "2.0", id: nextId++, method: "initialize",
+      params: { clientInfo: { name: `probe-${name}`, version: "0.0.1" } },
+    }));
+  };
+
+  ws.onmessage = (ev) => {
+    let m: any;
+    try { m = JSON.parse(typeof ev.data === "string" ? ev.data : (ev.data as Buffer).toString()); }
+    catch { return; }
+    const tag = m.method ?? (m.result ? "result" : (m.error ? "error" : "?"));
+    events.push(`${ms()}ms ${tag}`);
+    if (m.method && m.method !== "item/agentMessage/delta") {
+      // log everything except the noisy delta stream
+      const itemType = m.params?.item?.type ?? "";
+      log(`[${name}] ${m.method}${itemType ? ` (${itemType})` : ""}`);
+    }
+
+    if (m.id && m.result && tag === "result") {
+      // initialize response → start thread
+      if (!threadId && m.id === 1) {
+        ws.send(JSON.stringify({
+          jsonrpc: "2.0", id: nextId++, method: "thread/start",
+          params: { cwd: PROBE_CWD, approvalPolicy: "never" },
+        }));
+        return;
+      }
+      // thread/start response → record threadId, mark ready
+      if (!threadId && m.id === 2) {
+        threadId = m.result?.thread?.id ?? null;
+        log(`[${name}] threadId=${threadId}`);
+        resolveReady();
+        return;
+      }
+    }
+
+    if (m.method === "thread/closed" && m.params?.threadId === threadId) {
+      log(`[${name}] ⚠️ thread/closed (threadId=${threadId})`);
+      closed = true;
+      resolveDone({ completed, closed, gotMarker });
+    }
+
+    if (m.method === "turn/started" && m.params?.threadId === threadId) {
+      log(`[${name}] turn/started`);
+    }
+    // item/* notifications are routed per-WS (each TUI has its own connection),
+    // so we don't filter by threadId — we trust the WS isolation.
+    if (m.method === "item/completed") {
+      const item = m.params?.item;
+      if (item?.type === "agentMessage") {
+        const text = (item.content ?? []).filter((c: any) => c.type === "text").map((c: any) => c.text).join("");
+        if (text.includes(marker)) gotMarker = true;
+        log(`[${name}] item/completed agentMessage (${text.length} chars): ${text.slice(0, 80)}`);
+      }
+    }
+    if (m.method === "turn/completed" && m.params?.threadId === threadId) {
+      completed = true;
+      log(`[${name}] turn/completed`);
+      resolveDone({ completed, closed, gotMarker });
+    }
+  };
+
+  ws.onerror = (e: any) => log(`[${name}] WS error: ${e?.message ?? e}`);
+  ws.onclose = (e) => log(`[${name}] WS closed code=${e.code}`);
+
+  return { name, prompt, marker, ws, ready, get threadId() { return threadId; }, turnDone, events } as any;
+}
+
+function fireTurn(c: Client) {
+  c.ws.send(JSON.stringify({
+    jsonrpc: "2.0", id: 100 + Math.floor(Math.random() * 1000), method: "turn/start",
+    params: {
+      threadId: c.threadId,
+      input: [{ type: "text", text: c.prompt }],
+      effort: "minimal",
+    },
+  }));
+}
+
+async function main() {
+  // ensure cwd exists
+  try { (await import("node:fs")).mkdirSync(PROBE_CWD, { recursive: true }); } catch {}
+
+  log(`spawning codex app-server on ${APP_URL}`);
+  const codex = spawn("codex", ["app-server", "--listen", APP_URL], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  codex.stderr.on("data", (b: Buffer) => process.stderr.write(`[codex] ${b}`));
+
+  let failed = false;
+  try {
+    await waitHealth(APP_URL);
+    log("/healthz ok, connecting two clients");
+
+    const a = startClient("A", PROMPT_A, "probeA-OK-3jf");
+    const b = startClient("B", PROMPT_B, "probeB-OK-9qx");
+
+    await Promise.all([a.ready, b.ready]);
+    log(`both threads ready: A=${a.threadId}  B=${b.threadId}  distinct=${a.threadId !== b.threadId}`);
+
+    // small stagger to avoid same-millisecond storm; not strictly needed
+    fireTurn(a);
+    fireTurn(b);
+    log("fired both turns");
+
+    const [resA, resB] = await Promise.all([
+      Promise.race([a.turnDone, new Promise<any>((_, rej) => setTimeout(() => rej(new Error("A timeout")), 120_000))]),
+      Promise.race([b.turnDone, new Promise<any>((_, rej) => setTimeout(() => rej(new Error("B timeout")), 120_000))]),
+    ]);
+
+    log(`A: completed=${resA.completed} closed=${resA.closed} gotMarker=${resA.gotMarker}`);
+    log(`B: completed=${resB.completed} closed=${resB.closed} gotMarker=${resB.gotMarker}`);
+
+    const ok = a.threadId !== b.threadId
+      && resA.completed && !resA.closed && resA.gotMarker
+      && resB.completed && !resB.closed && resB.gotMarker;
+    if (!ok) failed = true;
+    log(failed ? "RESULT: FAILED ❌" : "RESULT: PASSED ✅ — codex app-server supports 2 independent TUI-like clients");
+
+    a.ws.close(); b.ws.close();
+  } catch (e: any) {
+    log(`ERROR: ${e?.stack ?? e}`);
+    failed = true;
+  } finally {
+    log("stopping codex app-server");
+    try { codex.kill("SIGTERM"); } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+    try { codex.kill("SIGKILL"); } catch {}
+  }
+  process.exit(failed ? 1 : 0);
+}
+
+void main();

--- a/src/app-server-protocol.ts
+++ b/src/app-server-protocol.ts
@@ -33,6 +33,8 @@ export const APP_SERVER_NOTIFICATION_METHODS = [
   "item/started",
   "item/agentMessage/delta",
   "item/completed",
+  "error",
+  "thread/closed",
 ] as const;
 
 export type AppServerNotificationMethod = typeof APP_SERVER_NOTIFICATION_METHODS[number];
@@ -120,12 +122,20 @@ export type AppServerServerRequest =
   | AppServerRequest<"item/fileChange/requestApproval", Record<string, unknown>>
   | AppServerRequest<"item/commandExecution/requestApproval", Record<string, unknown>>;
 
+export interface AppServerErrorPayload {
+  code?: number;
+  message?: string;
+  data?: unknown;
+}
+
 export type AppServerNotification =
   | { jsonrpc?: "2.0"; id?: undefined; method: "turn/started"; params?: { turn?: AppServerTurn; [key: string]: unknown } }
   | { jsonrpc?: "2.0"; id?: undefined; method: "turn/completed"; params?: { turn?: AppServerTurn; [key: string]: unknown } }
   | { jsonrpc?: "2.0"; id?: undefined; method: "item/started"; params?: { item?: AppServerItem; [key: string]: unknown } }
   | { jsonrpc?: "2.0"; id?: undefined; method: "item/completed"; params?: { item?: AppServerItem; [key: string]: unknown } }
-  | { jsonrpc?: "2.0"; id?: undefined; method: "item/agentMessage/delta"; params?: { itemId?: string; delta?: string; [key: string]: unknown } };
+  | { jsonrpc?: "2.0"; id?: undefined; method: "item/agentMessage/delta"; params?: { itemId?: string; delta?: string; [key: string]: unknown } }
+  | { jsonrpc?: "2.0"; id?: undefined; method: "error"; params?: { error?: AppServerErrorPayload; [key: string]: unknown } }
+  | { jsonrpc?: "2.0"; id?: undefined; method: "thread/closed"; params?: { threadId?: string; [key: string]: unknown } };
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -19,7 +19,7 @@ const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_POR
 const CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 
 const claude = new ClaudeAdapter(stateDir.logFile);
-const daemonClient = new DaemonClient(CONTROL_WS_URL);
+const daemonClient = new DaemonClient(CONTROL_WS_URL, { chatId: claude.chatId });
 
 let shuttingDown = false;
 let daemonDisabled = false;

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -67,6 +67,13 @@ export class ClaudeAdapter extends EventEmitter {
   private sessionId: string;
   private readonly notificationIdPrefix: string;
   private readonly instanceId: string;
+  /**
+   * `chatId` uniquely identifies THIS MCP/Claude session to the daemon so
+   * the daemon can route messages to the right ClaudeThread. We reuse
+   * `sessionId` (already shown to Claude as `chat_id:` in channel headers)
+   * so the human-visible value and the routing key are the same string.
+   */
+  readonly chatId: string;
   private replySender: ReplySender | null = null;
   private readonly logFile: string;
 
@@ -81,7 +88,8 @@ export class ClaudeAdapter extends EventEmitter {
     super();
     this.logFile = logFile;
     this.instanceId = randomUUID().slice(0, 8);
-    this.sessionId = `codex_${Date.now()}`;
+    this.sessionId = `codex_${Date.now()}_${this.instanceId}`;
+    this.chatId = this.sessionId;
     this.notificationIdPrefix = randomUUID().replace(/-/g, "").slice(0, 12);
     this.log(`ClaudeAdapter created (instance=${this.instanceId})`);
 

--- a/src/claude-thread.ts
+++ b/src/claude-thread.ts
@@ -1,0 +1,322 @@
+/**
+ * ClaudeThread — one dedicated Codex thread per attached Claude session.
+ *
+ * Each Claude session gets its own WebSocket to the codex app-server and
+ * its own thread. Turns on different threads execute concurrently in the
+ * app-server (verified by `tools/agentbridge-multi/probes/concurrency.ts`).
+ *
+ * Lifecycle: bootstrap() opens the WS, runs initialize + thread/start, then
+ * emits "ready" with the threadId. injectMessage() sends turn/start on this
+ * thread. Notifications from codex are filtered to this threadId and
+ * surfaced via "agentMessage" / "turnStarted" / "turnCompleted" events so
+ * the daemon can route them back to the owning Claude WS by chatId.
+ *
+ * This is intentionally a LEAN adapter — no proxy, no TUI reconnect dance.
+ * For TUI flow see `codex-adapter.ts`.
+ */
+
+import { EventEmitter } from "node:events";
+import { appendFileSync } from "node:fs";
+import type { AppServerItem } from "./app-server-protocol";
+import type { BridgeMessage } from "./types";
+
+export interface ClaudeThreadOptions {
+  appServerUrl: string;
+  chatId: string;
+  logFile: string;
+  cwd?: string;
+}
+
+interface PendingRpc {
+  resolve: (value: any) => void;
+  reject: (err: Error) => void;
+  method: string;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const RPC_TIMEOUT_MS = 30_000;
+
+export class ClaudeThread extends EventEmitter {
+  readonly chatId: string;
+  private readonly appServerUrl: string;
+  private readonly logFile: string;
+  private readonly cwd: string | undefined;
+
+  private ws: WebSocket | null = null;
+  private threadId: string | null = null;
+  private nextId = 1;
+  private pending = new Map<number, PendingRpc>();
+  private turnInProgress = false;
+  private agentMessageBuffers = new Map<string, string[]>();
+  private bootstrapped = false;
+  private closed = false;
+
+  constructor(opts: ClaudeThreadOptions) {
+    super();
+    this.chatId = opts.chatId;
+    this.appServerUrl = opts.appServerUrl;
+    this.logFile = opts.logFile;
+    this.cwd = opts.cwd;
+  }
+
+  get activeThreadId(): string | null { return this.threadId; }
+  get isTurnInProgress(): boolean { return this.turnInProgress; }
+  get isReady(): boolean { return this.bootstrapped && this.threadId !== null; }
+
+  /** Open the WS, initialize, and start a thread. Resolves once ready. */
+  async bootstrap(): Promise<string> {
+    if (this.bootstrapped && this.threadId) return this.threadId;
+    await this.openSocket();
+    await this.callRpc("initialize", {
+      clientInfo: { name: "agentbridge-claude-thread", version: "0.1.0" },
+      capabilities: { experimentalApi: false },
+    });
+    const params: Record<string, unknown> = {};
+    if (this.cwd) params.cwd = this.cwd;
+    const startRes: any = await this.callRpc("thread/start", params);
+    const tid = startRes?.thread?.id ?? startRes?.threadId ?? null;
+    if (typeof tid !== "string" || tid.length === 0) {
+      throw new Error("thread/start did not return a threadId");
+    }
+    this.threadId = tid;
+    this.bootstrapped = true;
+    this.log(`bootstrap ok threadId=${tid}`);
+    this.emit("ready", tid);
+    return tid;
+  }
+
+  /** Send a turn/start on this thread. Returns true on send success. */
+  injectMessage(text: string): boolean {
+    if (!this.threadId) {
+      this.log("inject rejected: not bootstrapped");
+      return false;
+    }
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.log("inject rejected: ws not open");
+      return false;
+    }
+    if (this.turnInProgress) {
+      this.log(`inject rejected: turn already in progress`);
+      return false;
+    }
+    const id = this.nextId++;
+    const msg = {
+      jsonrpc: "2.0",
+      id,
+      method: "turn/start",
+      params: {
+        threadId: this.threadId,
+        input: [{ type: "text", text }],
+      },
+    };
+    try {
+      this.ws.send(JSON.stringify(msg));
+      return true;
+    } catch (err: any) {
+      this.log(`inject send failed: ${err.message}`);
+      return false;
+    }
+  }
+
+  /** Close the WS. Does NOT delete the thread on the server side (could be resumed). */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.ws) {
+      try { this.ws.close(); } catch {}
+      this.ws = null;
+    }
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(new Error("ClaudeThread closed"));
+    }
+    this.pending.clear();
+  }
+
+  // ── internals ──────────────────────────────────────────────
+
+  private openSocket(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.appServerUrl);
+      let settled = false;
+      ws.onopen = () => {
+        if (settled) return;
+        settled = true;
+        this.ws = ws;
+        this.attachHandlers(ws);
+        resolve();
+      };
+      ws.onerror = (e: any) => {
+        if (settled) return;
+        settled = true;
+        reject(new Error(`ws connect failed: ${e?.message ?? "unknown"}`));
+      };
+      ws.onclose = (e: any) => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(`ws closed during handshake (code=${e?.code})`));
+          return;
+        }
+      };
+    });
+  }
+
+  private attachHandlers(ws: WebSocket) {
+    ws.onmessage = (event) => {
+      const raw = typeof event.data === "string" ? event.data : event.data.toString();
+      this.handlePayload(raw);
+    };
+    ws.onclose = () => {
+      this.log(`ws closed (chatId=${this.chatId}, threadId=${this.threadId})`);
+      this.ws = null;
+      this.emit("close");
+    };
+    ws.onerror = (e: any) => {
+      this.log(`ws error: ${e?.message ?? "unknown"}`);
+      this.emit("error", e);
+    };
+  }
+
+  private handlePayload(raw: string) {
+    let parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    // response to one of our rpc requests
+    if (typeof parsed.id === "number" && this.pending.has(parsed.id) && (parsed.result !== undefined || parsed.error !== undefined)) {
+      const pending = this.pending.get(parsed.id)!;
+      this.pending.delete(parsed.id);
+      clearTimeout(pending.timer);
+      if (parsed.error) {
+        pending.reject(new Error(`${pending.method} failed: ${JSON.stringify(parsed.error).slice(0, 200)}`));
+      } else {
+        pending.resolve(parsed.result);
+      }
+      return;
+    }
+
+    // server-initiated request (approvals, fuzzy file, etc.) — auto-deny
+    if (parsed.id !== undefined && typeof parsed.method === "string") {
+      // Only respond if the request targets our thread; otherwise it's
+      // for a different client and we can ignore.
+      const tid = parsed.params?.threadId;
+      if (tid && this.threadId && tid !== this.threadId) return;
+      try {
+        this.ws?.send(JSON.stringify({
+          jsonrpc: "2.0",
+          id: parsed.id,
+          error: { code: -32601, message: "auto-denied by ClaudeThread (no UI to approve)" },
+        }));
+      } catch {}
+      return;
+    }
+
+    // notification (anything with method + no id)
+    if (typeof parsed.method === "string" && parsed.id === undefined) {
+      const tid = parsed.params?.threadId;
+      if (tid && this.threadId && tid !== this.threadId) {
+        // Notification for a different thread — ignore (defense in depth;
+        // each ClaudeThread has its own WS so this should not happen in practice).
+        return;
+      }
+      this.handleNotification(parsed.method as string, parsed.params ?? {});
+    }
+  }
+
+  private handleNotification(method: string, params: any) {
+    switch (method) {
+      case "turn/started": {
+        if (!this.turnInProgress) {
+          this.turnInProgress = true;
+          this.emit("turnStarted");
+        }
+        break;
+      }
+      case "item/started": {
+        const item: AppServerItem | undefined = (params as any)?.item;
+        if (item?.type === "agentMessage") this.agentMessageBuffers.set(item.id, []);
+        break;
+      }
+      case "item/agentMessage/delta": {
+        const itemId = (params as any)?.itemId;
+        const delta = (params as any)?.delta;
+        if (typeof itemId === "string") {
+          const buf = this.agentMessageBuffers.get(itemId);
+          if (buf && typeof delta === "string") buf.push(delta);
+        }
+        break;
+      }
+      case "item/completed": {
+        const item: AppServerItem | undefined = (params as any)?.item;
+        if (item?.type === "agentMessage") {
+          const content = this.extractContent(item);
+          this.agentMessageBuffers.delete(item.id);
+          if (content) {
+            const bridgeMsg: BridgeMessage = {
+              id: item.id,
+              source: "codex",
+              content,
+              timestamp: Date.now(),
+            };
+            this.emit("agentMessage", bridgeMsg);
+          }
+        }
+        break;
+      }
+      case "turn/completed": {
+        if (this.turnInProgress) {
+          this.turnInProgress = false;
+          this.emit("turnCompleted");
+        }
+        break;
+      }
+      case "turn/failed": {
+        if (this.turnInProgress) {
+          this.turnInProgress = false;
+          this.emit("turnCompleted");
+        }
+        this.emit("turnFailed", params);
+        break;
+      }
+    }
+  }
+
+  private extractContent(item: AppServerItem): string {
+    if (item.content?.length) {
+      return item.content.filter((c) => c.type === "text" && c.text).map((c) => c.text!).join("");
+    }
+    return this.agentMessageBuffers.get(item.id)?.join("") ?? "";
+  }
+
+  private callRpc(method: string, params: Record<string, unknown>): Promise<any> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("callRpc: ws not open"));
+    }
+    const id = this.nextId++;
+    const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    return new Promise<any>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(new Error(`${method} timed out after ${RPC_TIMEOUT_MS}ms`));
+        }
+      }, RPC_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, method, timer });
+      try {
+        this.ws!.send(msg);
+      } catch (err: any) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  private log(s: string) {
+    const line = `[${new Date().toISOString()}] [ClaudeThread:${this.chatId}] ${s}\n`;
+    process.stderr.write(line);
+    try { appendFileSync(this.logFile, line); } catch {}
+  }
+}

--- a/src/claude-thread.ts
+++ b/src/claude-thread.ts
@@ -71,7 +71,12 @@ export class ClaudeThread extends EventEmitter {
       clientInfo: { name: "agentbridge-claude-thread", version: "0.1.0" },
       capabilities: { experimentalApi: false },
     });
-    const params: Record<string, unknown> = {};
+    // Use approvalPolicy="never" so Codex never escalates approvals to us.
+    // Sandbox boundaries still apply; if a command can't run under the
+    // configured sandbox it fails as a turn error rather than triggering an
+    // interactive approval flow we have no UI to satisfy. Approval-method
+    // server requests are still handled below as a defense-in-depth fallback.
+    const params: Record<string, unknown> = { approvalPolicy: "never" };
     if (this.cwd) params.cwd = this.cwd;
     const startRes: any = await this.callRpc("thread/start", params);
     const tid = startRes?.thread?.id ?? startRes?.threadId ?? null;
@@ -198,19 +203,24 @@ export class ClaudeThread extends EventEmitter {
       return;
     }
 
-    // server-initiated request (approvals, fuzzy file, etc.) — auto-deny
+    // Server-initiated request (approvals, fuzzy file, etc.). We have no
+    // interactive UI bound to this thread — and we've already set
+    // approvalPolicy="never" at thread/start, so in steady state these
+    // should not arrive. This block is a defense-in-depth fallback:
+    //
+    //   - Approval-like methods (commandExecution / fileChange) → auto-accept,
+    //     since the human-equivalent for this thread is the Claude that
+    //     issued the task. Sandbox boundaries already constrain what can be
+    //     executed; a separate approval handshake adds no security here.
+    //   - Permission-grant requests → auto-deny (grant nothing extra) so the
+    //     sandbox can't be silently widened by Codex.
+    //   - Anything else (future server requests we don't know) → reply with
+    //     -32601 and log; surfacing a clear error is better than silently
+    //     ignoring the id and leaving Codex hung waiting for a response.
     if (parsed.id !== undefined && typeof parsed.method === "string") {
-      // Only respond if the request targets our thread; otherwise it's
-      // for a different client and we can ignore.
       const tid = parsed.params?.threadId;
       if (tid && this.threadId && tid !== this.threadId) return;
-      try {
-        this.ws?.send(JSON.stringify({
-          jsonrpc: "2.0",
-          id: parsed.id,
-          error: { code: -32601, message: "auto-denied by ClaudeThread (no UI to approve)" },
-        }));
-      } catch {}
+      this.respondToServerRequest(parsed.id, parsed.method, parsed.params);
       return;
     }
 
@@ -312,6 +322,68 @@ export class ClaudeThread extends EventEmitter {
         reject(err);
       }
     });
+  }
+
+  /**
+   * Respond to a server-initiated request (Codex asking the client to
+   * approve a command, file change, permission widening, etc.).
+   *
+   * See `ExecCommandApprovalResponse` / `CommandExecutionRequestApprovalResponse`
+   * / `FileChangeRequestApprovalResponse` / `PermissionsRequestApprovalResponse`
+   * in the codex app-server schema for the exact shapes.
+   */
+  private respondToServerRequest(
+    id: number | string,
+    method: string,
+    _params: unknown,
+  ): void {
+    let result: Record<string, unknown> | undefined;
+    let error: { code: number; message: string } | undefined;
+
+    switch (method) {
+      case "item/commandExecution/requestApproval":
+        // CommandExecutionApprovalDecision allowed values:
+        //   "accept" | "acceptForSession" | {acceptWithExecpolicyAmendment} |
+        //   {applyNetworkPolicyAmendment} | "decline" | "cancel"
+        result = { decision: "accept" };
+        this.log(`auto-accepted ${method} (id=${id})`);
+        break;
+      case "item/fileChange/requestApproval":
+        // FileChangeApprovalDecision: accept | acceptForSession | decline | cancel
+        result = { decision: "accept" };
+        this.log(`auto-accepted ${method} (id=${id})`);
+        break;
+      case "applyPatchApproval":
+      case "execCommandApproval":
+        // ReviewDecision: approved | approved_for_session | denied | timed_out | abort
+        result = { decision: "approved" };
+        this.log(`auto-approved ${method} (id=${id})`);
+        break;
+      case "item/permissions/requestApproval":
+        // PermissionsRequestApprovalResponse requires `permissions`. Returning
+        // an empty profile effectively grants nothing additional — the
+        // existing sandbox stays in force. This is the conservative path:
+        // we don't widen what Codex is allowed to do.
+        result = { permissions: {} };
+        this.log(`auto-denied permission widening for ${method} (id=${id})`);
+        break;
+      default:
+        error = {
+          code: -32601,
+          message: `ClaudeThread received unknown server request method '${method}' with no handler`,
+        };
+        this.log(`unknown server request method: ${method} (id=${id}) — replying -32601`);
+        break;
+    }
+
+    const payload: Record<string, unknown> = { jsonrpc: "2.0", id };
+    if (result !== undefined) payload.result = result;
+    if (error !== undefined) payload.error = error;
+    try {
+      this.ws?.send(JSON.stringify(payload));
+    } catch (err: any) {
+      this.log(`failed to send server-request response: ${err?.message ?? err}`);
+    }
   }
 
   private log(s: string) {

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -53,7 +53,40 @@ function buildChildEnv(): NodeJS.ProcessEnv {
 /** Flags that AgentBridge owns for codex command. */
 const OWNED_FLAGS = ["--remote"];
 
-export async function runCodex(args: string[]) {
+/**
+ * Connection mode for `agentbridge codex`:
+ *   - "direct" (default): connect each TUI straight to the codex app-server
+ *     so multiple TUI windows can run in parallel, each with its own thread.
+ *     Pre-multi-Claude AgentBridge proxied every TUI through one port, with
+ *     a "primary + secondary picker" assumption that breaks for two
+ *     long-lived TUI windows.
+ *   - "proxy": legacy behavior — route through the daemon's proxy port so
+ *     the proxy can intercept agentMessage events. Useful if you depend on
+ *     the daemon's TUI broadcast (which the multi-Claude daemon no longer
+ *     uses anyway). Opt in with `--via-proxy`.
+ */
+type CodexConnectionMode = "direct" | "proxy";
+
+function extractConnectionMode(args: string[]): { mode: CodexConnectionMode; rest: string[] } {
+  const rest: string[] = [];
+  let mode: CodexConnectionMode = "direct";
+  for (const a of args) {
+    if (a === "--via-proxy") {
+      mode = "proxy";
+      continue;
+    }
+    if (a === "--direct") {
+      mode = "direct";
+      continue;
+    }
+    rest.push(a);
+  }
+  return { mode, rest };
+}
+
+export async function runCodex(rawArgs: string[]) {
+  const { mode, rest: args } = extractConnectionMode(rawArgs);
+
   // Check for owned flag conflicts
   checkOwnedFlagConflicts(args, "agentbridge codex", OWNED_FLAGS);
 
@@ -98,25 +131,40 @@ export async function runCodex(args: string[]) {
     process.exit(1);
   }
 
-  // Read proxyUrl from daemon status or fall back to config
-  let proxyUrl: string;
+  // Resolve the WebSocket URL to hand to codex --remote.
+  //
+  // direct mode → app-server port (each TUI is an independent client of the
+  //               same codex backend; gets its own thread; no proxy).
+  // proxy mode  → daemon's proxy port (legacy; intercepts agentMessage events
+  //               for the multi-Claude broadcast that the multi-Claude daemon
+  //               no longer uses).
+  let remoteUrl: string;
   const status = lifecycle.readStatus();
-  if (status?.proxyUrl) {
-    proxyUrl = status.proxyUrl;
+  if (mode === "direct") {
+    if (status?.appServerUrl) {
+      remoteUrl = status.appServerUrl;
+    } else {
+      remoteUrl = `ws://127.0.0.1:${config.codex.appPort}`;
+      console.error(`[agentbridge] No daemon status found, using config default app-server URL: ${remoteUrl}`);
+    }
   } else {
-    proxyUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
-    console.error(`[agentbridge] No daemon status found, using config default: ${proxyUrl}`);
+    if (status?.proxyUrl) {
+      remoteUrl = status.proxyUrl;
+    } else {
+      remoteUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
+      console.error(`[agentbridge] No daemon status found, using config default proxy URL: ${remoteUrl}`);
+    }
   }
 
   try {
-    await waitForProxyReady(proxyUrl);
+    await waitForProxyReady(remoteUrl);
   } catch (err: any) {
     console.error(`[agentbridge] ${err.message}`);
     process.exit(1);
   }
 
   // Save terminal state and launch Codex with protection
-  console.log(`Connecting Codex TUI to AgentBridge at ${proxyUrl}...`);
+  console.log(`Connecting Codex TUI to AgentBridge at ${remoteUrl} (mode=${mode})...`);
 
   // Save terminal state
   let savedStty: string | null = null;
@@ -170,7 +218,7 @@ export async function runCodex(args: string[]) {
 
   const fullArgs = [
     "--enable", "tui_app_server",
-    "--remote", proxyUrl,
+    "--remote", remoteUrl,
     ...args,
   ];
 

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -17,6 +17,25 @@ import { StderrRingBuffer } from "../stderr-ring-buffer";
 import { checkOwnedFlagConflicts } from "./claude";
 
 /**
+ * Spec v2.2 §7: fetch live daemon /healthz JSON for pre-flight checks.
+ * Returns null if the daemon is unreachable (CLI falls through to its normal
+ * "ensure running" flow and surfaces a clearer error elsewhere).
+ */
+async function fetchLiveDaemonStatus(
+  controlPort: number,
+): Promise<{ proxyTuiConnected?: boolean } | null> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${controlPort}/healthz`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as { proxyTuiConnected?: boolean };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Write a timestamped entry to the codex wrapper log.
  *
  * Silent on IO failure — logging must never break the wrapper itself.
@@ -40,9 +59,10 @@ function appendWrapperLog(path: string, entry: string): void {
  * up in `~/.codex/log/codex-tui.log` and on stderr (which we also tee).
  * User-provided values take precedence — we only set defaults.
  */
-function buildChildEnv(): NodeJS.ProcessEnv {
+function buildChildEnv(extraEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
     ...process.env,
+    ...extraEnv,
     RUST_BACKTRACE: process.env.RUST_BACKTRACE ?? "full",
     RUST_LOG:
       process.env.RUST_LOG ??
@@ -51,7 +71,7 @@ function buildChildEnv(): NodeJS.ProcessEnv {
 }
 
 /** Flags that AgentBridge owns for codex command. */
-const OWNED_FLAGS = ["--remote"];
+const OWNED_FLAGS = ["--remote", "--remote-auth-token-env"];
 
 /**
  * Connection mode for `agentbridge codex`:
@@ -135,10 +155,16 @@ export async function runCodex(rawArgs: string[]) {
   //
   // direct mode → app-server port (each TUI is an independent client of the
   //               same codex backend; gets its own thread; no proxy).
-  // proxy mode  → daemon's proxy port (legacy; intercepts agentMessage events
-  //               for the multi-Claude broadcast that the multi-Claude daemon
-  //               no longer uses).
+  // proxy mode  → daemon's proxy port. Spec v2.2 §4.6: `--via-proxy` now
+  //               participates in the shared-thread pairing protocol. A
+  //               unique bearer token is passed via Codex's native
+  //               --remote-auth-token-env option so the daemon can
+  //               distinguish this TUI's secondary picker connection from a
+  //               foreign second instance. codex-cli rejects query strings in
+  //               --remote (accepted forms are ws://host:port / wss://host:port).
   let remoteUrl: string;
+  const childEnv: NodeJS.ProcessEnv = {};
+  const remoteAuthArgs: string[] = [];
   const status = lifecycle.readStatus();
   if (mode === "direct") {
     if (status?.appServerUrl) {
@@ -148,12 +174,31 @@ export async function runCodex(rawArgs: string[]) {
       console.error(`[agentbridge] No daemon status found, using config default app-server URL: ${remoteUrl}`);
     }
   } else {
+    // Spec v2.2 §7: pre-flight check — daemon should only have one proxy TUI
+    // at a time. Hit /healthz for the live state (status.json is stale).
+    const liveStatus = await fetchLiveDaemonStatus(controlPort);
+    if (liveStatus?.proxyTuiConnected) {
+      console.error("");
+      console.error("[agentbridge] Error: another `agentbridge codex --via-proxy` TUI is already connected to the daemon.");
+      console.error("");
+      console.error("Shared-thread mode supports at most one proxy TUI at a time.");
+      console.error("Either close the other TUI window first, or use `agentbridge codex` (direct mode) to run an independent parallel session.");
+      console.error("");
+      process.exit(1);
+    }
+
+    // Spec v2.2 §4.6: generate the token so codex-rs's primary AND secondary
+    // picker connections inherit it via the Authorization header.
+    const abgToken = (await import("node:crypto")).randomBytes(8).toString("hex");
     if (status?.proxyUrl) {
       remoteUrl = status.proxyUrl;
     } else {
       remoteUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
       console.error(`[agentbridge] No daemon status found, using config default proxy URL: ${remoteUrl}`);
     }
+    childEnv.AGENTBRIDGE_PROXY_TOKEN = abgToken;
+    remoteAuthArgs.push("--remote-auth-token-env", "AGENTBRIDGE_PROXY_TOKEN");
+    console.error(`[agentbridge] Shared-thread mode active. Token=${abgToken.slice(0, 8)}…`);
   }
 
   try {
@@ -219,6 +264,7 @@ export async function runCodex(rawArgs: string[]) {
   const fullArgs = [
     "--enable", "tui_app_server",
     "--remote", remoteUrl,
+    ...remoteAuthArgs,
     ...args,
   ];
 
@@ -238,7 +284,7 @@ export async function runCodex(rawArgs: string[]) {
   const child = spawn("codex", fullArgs, {
     // inherit stdin + stdout (TUI needs raw TTY), pipe stderr so we can tee.
     stdio: ["inherit", "inherit", "pipe"],
-    env: buildChildEnv(),
+    env: buildChildEnv(childEnv),
   });
 
   if (typeof child.pid === "number") {

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -13,6 +13,7 @@ import { spawn, execSync, type ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
 import { EventEmitter } from "node:events";
 import { appendFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { StateDirResolver } from "./state-dir";
 import type { BridgeMessage } from "./types";
 import type { ServerWebSocket } from "bun";
@@ -32,6 +33,18 @@ import {
 
 interface TuiSocketData {
   connId: number;
+  /**
+   * Spec v2.2 §4.6: bearer token (or legacy `abg_token` query fallback) at
+   * WS upgrade time. Used to distinguish codex-rs's own secondary picker
+   * (same token) from a second unrelated `abg codex --via-proxy` instance
+   * (different token).
+   *
+   * Empty string for legacy connections without a token — backward compat:
+   * legacy mode treats first connection as primary with empty token, and
+   * accepts subsequent legacy (empty-token) connections too. Mixing token
+   * and non-token connections triggers reject (spec §4.6).
+   */
+  token: string;
 }
 
 interface PendingServerRequest {
@@ -140,6 +153,21 @@ export class CodexAdapter extends EventEmitter {
   }>();
   private static readonly SESSION_REPLAY_TIMEOUT_MS = 5000;
 
+  // ── Shared Thread Mode (spec v2.2) ─────────────────────────
+  //
+  // When a Claude session is paired with this CodexAdapter's tuiWs (the
+  // proxy TUI), its replies are injected on the TUI's thread. To prevent
+  // those injections from echoing back to the same Claude as user input,
+  // we track the resulting turnId (primary, 60s TTL) and the injected
+  // content hash (race fallback for the pre-response window, 5s one-shot).
+  // See docs/shared-thread-mode-spec.md §4.5.
+  private pairedChatId: string | null = null;
+  private injectedTurnIds = new Map<string, number>(); // turnId → expiresAt
+  private pendingInjectionHashes = new Map<string, number>(); // contentHash → expiresAt
+  private pendingInjectionByReqId = new Map<number, string>(); // bridge requestId → contentHash
+  private static readonly ECHO_DEDUP_TTL_MS = 60_000;
+  private static readonly PENDING_HASH_TTL_MS = 5_000;
+
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
     this.appPort = appPort;
@@ -221,7 +249,12 @@ export class CodexAdapter extends EventEmitter {
     }
   }
 
-  /** Inject a message into the active Codex thread via turn/start. Returns true if sent. */
+  /**
+   * Inject a message into the active Codex thread via turn/start. Returns
+   * true if sent. Spec v2.2 §8 E8: rejects while `sessionRestoreInProgress`
+   * so paired Claude gets a clear "restoring shared Codex TUI session"
+   * error instead of an inject sent against a not-yet-restored app-server.
+   */
   injectMessage(text: string): boolean {
     if (!this.threadId) {
       this.log("Cannot inject: no active thread");
@@ -231,6 +264,10 @@ export class CodexAdapter extends EventEmitter {
       this.log("Cannot inject: app-server WebSocket not connected");
       return false;
     }
+    if (this.sessionRestoreInProgress) {
+      this.log(`Rejected injection: shared Codex TUI session restore in progress`);
+      return false;
+    }
     if (this.turnInProgress) {
       this.log(`Rejected injection: Codex turn is in progress (thread ${this.threadId})`);
       return false;
@@ -238,6 +275,12 @@ export class CodexAdapter extends EventEmitter {
     this.log(`Injecting message into Codex (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
     this.trackBridgeRequestId(requestId);
+    // Spec v2.2 §4.5 race protection: hash the content + remember expiry so we
+    // can suppress an echo userMessage notification that arrives before the
+    // turn/start response gives us a turnId to dedup on.
+    const contentHash = this.hashInjectionContent(text);
+    this.pendingInjectionHashes.set(contentHash, Date.now() + CodexAdapter.PENDING_HASH_TTL_MS);
+    this.pendingInjectionByReqId.set(requestId, contentHash);
     try {
       this.appServerWs.send(JSON.stringify({
         method: "turn/start",
@@ -247,9 +290,67 @@ export class CodexAdapter extends EventEmitter {
       return true;
     } catch (err: any) {
       this.untrackBridgeRequestId(requestId);
+      this.pendingInjectionByReqId.delete(requestId);
+      this.pendingInjectionHashes.delete(contentHash);
       this.log(`Injection send failed: ${err.message}`);
       return false;
     }
+  }
+
+  // ── Shared Thread Mode API (spec v2.2 §4.1) ────────────────
+
+  /** Set the chatId that this CodexAdapter is currently paired with (or null to clear). */
+  setPairedChat(chatId: string | null): void {
+    this.pairedChatId = chatId;
+    this.log(`Paired chat set to: ${chatId ?? "<none>"}`);
+  }
+
+  /** True if the given chatId is the current paired chat. */
+  isPaired(chatId: string): boolean {
+    return this.pairedChatId !== null && this.pairedChatId === chatId;
+  }
+
+  /** Read-only getter for daemon's pairing state machine. */
+  get currentPairedChatId(): string | null {
+    return this.pairedChatId;
+  }
+
+  private hashInjectionContent(text: string): string {
+    return createHash("sha1").update(text).digest("hex").slice(0, 16);
+  }
+
+  /**
+   * Spec v2.2 §4.5: check if a userMessage notification is an echo of a
+   * bridge-originated injection. Primary check is turnId match; fallback is
+   * content-hash match for the race window before turn/start response lands.
+   */
+  private isEchoOfInjection(content: string, turnId: string | undefined): boolean {
+    if (typeof turnId === "string" && turnId.length > 0) {
+      const expiresAt = this.injectedTurnIds.get(turnId);
+      if (expiresAt !== undefined) {
+        if (Date.now() <= expiresAt) return true;
+        this.injectedTurnIds.delete(turnId);
+      }
+    }
+    const hash = this.hashInjectionContent(content);
+    const hashExpiresAt = this.pendingInjectionHashes.get(hash);
+    if (hashExpiresAt !== undefined) {
+      if (Date.now() <= hashExpiresAt) {
+        this.pendingInjectionHashes.delete(hash); // one-shot consumption
+        return true;
+      }
+      this.pendingInjectionHashes.delete(hash);
+    }
+    return false;
+  }
+
+  private recordInjectedTurnId(turnId: string, contentHash: string | undefined) {
+    this.injectedTurnIds.set(turnId, Date.now() + CodexAdapter.ECHO_DEDUP_TTL_MS);
+    // Once we have a turnId, the content-hash entry is redundant (turnId is
+    // the canonical correlator). Clear it eagerly to free memory and avoid
+    // the rare case where a same-text user message gets falsely suppressed
+    // after the injection's response has landed.
+    if (contentHash) this.pendingInjectionHashes.delete(contentHash);
   }
 
   // ── Health Check ───────────────────────────────────────────
@@ -534,6 +635,8 @@ export class CodexAdapter extends EventEmitter {
     }
 
     this.sessionRestoreInProgress = true;
+    this.emit("sessionRestoreStart", { threadId: this.threadId });
+    let restoreSucceeded = false;
     try {
       this.log(
         `DIAGNOSTIC: replaying cached initialize to restore session (threadId=${this.threadId ?? "none"})`,
@@ -558,6 +661,7 @@ export class CodexAdapter extends EventEmitter {
       this.log(
         `DIAGNOSTIC: session restored after unintentional reconnect (threadId=${this.threadId ?? "none"})`,
       );
+      restoreSucceeded = true;
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log(
@@ -574,7 +678,18 @@ export class CodexAdapter extends EventEmitter {
       }
     } finally {
       this.sessionRestoreInProgress = false;
+      // Spec v2.2 §8 E8: emit ok=false on failure so daemon keeps paired
+      // readiness=not-ready. The TUI is being closed (1011) in the catch
+      // branch; the resulting tuiDisconnected event tears down the pair
+      // cleanly. Without ok=false, daemon would briefly flip to "ready" and
+      // tell paired Claude "session restored" — a lie.
+      this.emit("sessionRestoreEnd", { threadId: this.threadId, ok: restoreSucceeded });
     }
+  }
+
+  /** Spec v2.2 §8 E8: daemon checks this so paired `reply` returns restore error. */
+  get isSessionRestoreInProgress(): boolean {
+    return this.sessionRestoreInProgress;
   }
 
   /**
@@ -695,11 +810,19 @@ export class CodexAdapter extends EventEmitter {
       fetch(req, server) {
         const url = new URL(req.url);
         const isUpgrade = req.headers.get("upgrade")?.toLowerCase() === "websocket";
-        self.log(`HTTP ${req.method} ${url.pathname} (upgrade=${isUpgrade})`);
+        const queryToken = url.searchParams.get("abg_token") ?? "";
+        const authHeader = req.headers.get("authorization") ?? "";
+        const bearerToken = authHeader.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? "";
+        const token = bearerToken || queryToken;
+        const tokenSource = bearerToken ? "authorization" : queryToken ? "query" : "none";
+        self.log(`HTTP ${req.method} ${url.pathname} (upgrade=${isUpgrade}, token=${token ? token.slice(0, 8) + "…" : "<none>"}, tokenSource=${tokenSource})`);
         if (url.pathname === "/healthz" || url.pathname === "/readyz") {
           return fetch(`http://127.0.0.1:${self.appPort}${url.pathname}`);
         }
-        if (server.upgrade(req, { data: { connId: 0 } })) return undefined;
+        // Spec v2.2 §4.6: token discrimination is enforced in onTuiConnect after
+        // upgrade, so we can return a clean WS close with code 4002. Rejecting
+        // at fetch time would surface as a confusing HTTP 4xx to codex-rs.
+        if (server.upgrade(req, { data: { connId: 0, token } })) return undefined;
         self.log(`WARNING: non-upgrade HTTP request not handled: ${req.method} ${url.pathname}`);
         return new Response("AgentBridge Codex Proxy");
       },
@@ -723,7 +846,23 @@ export class CodexAdapter extends EventEmitter {
     // the main session connection stays open. Give the secondary its own
     // app-server WS so the primary is not disturbed.
     if (this.tuiWs) {
-      this.log(`Secondary TUI connected (conn #${connId}, primary is #${this.tuiConnId})`);
+      // Spec v2.2 §4.6: distinguish codex-rs's own secondary picker (carries
+      // the SAME bearer token as the primary) from a second unrelated
+      // `abg codex --via-proxy` instance (different token). Reject the latter
+      // with WS close 4002 so the CLI's pre-flight check surfaces a clear
+      // error rather than the primary getting silently disrupted.
+      const primaryToken = this.tuiWs.data.token;
+      const newToken = ws.data.token;
+      if (primaryToken !== newToken) {
+        this.log(`Rejecting second proxy TUI: token mismatch (primary conn #${this.tuiConnId} token=${primaryToken ? primaryToken.slice(0, 8) + "…" : "<none>"}, new conn #${connId} token=${newToken ? newToken.slice(0, 8) + "…" : "<none>"})`);
+        try {
+          ws.close(4002, "another --via-proxy TUI is already connected");
+        } catch (err: any) {
+          this.log(`Failed to close rejected second TUI cleanly: ${err.message}`);
+        }
+        return;
+      }
+      this.log(`Secondary TUI connected (conn #${connId}, primary is #${this.tuiConnId}, token matches)`);
       this.setupSecondaryConnection(ws, connId);
       return;
     }
@@ -735,8 +874,8 @@ export class CodexAdapter extends EventEmitter {
     // Reset threadId to prevent premature message injection before TUI completes
     // its handshake (initialize → thread/start or thread/resume).
     this.threadId = null;
-    this.log(`TUI connected (conn #${this.tuiConnId})`);
-    this.emit("tuiConnected", this.tuiConnId);
+    this.log(`TUI connected (conn #${this.tuiConnId}, token=${ws.data.token ? ws.data.token.slice(0, 8) + "…" : "<none>"})`);
+    this.emit("tuiConnected", this.tuiConnId, ws.data.token);
     if (previousConnId !== null) {
       this.retireConnectionState(previousConnId);
     }
@@ -1202,8 +1341,27 @@ export class CodexAdapter extends EventEmitter {
     if (!isNaN(numericId) && this.consumeBridgeRequestId(numericId)) {
       if (parsed.error) {
         this.log(`Bridge-originated request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
+        // Clear the pending injection-hash entry so a future legitimate
+        // identical user-typed message isn't suppressed.
+        const contentHash = this.pendingInjectionByReqId.get(numericId);
+        if (contentHash) {
+          this.pendingInjectionHashes.delete(contentHash);
+          this.pendingInjectionByReqId.delete(numericId);
+        }
       } else {
-        this.log(`Bridge-originated request completed (id ${responseId})`);
+        // Spec v2.2 §4.5 primary echo dedup: capture the turnId returned by
+        // codex-rs so subsequent userMessage notifications for this turn can
+        // be recognized as echoes of our own injection.
+        const result = (parsed.result ?? {}) as { turn?: { id?: string } };
+        const turnId = result.turn?.id;
+        const contentHash = this.pendingInjectionByReqId.get(numericId);
+        this.pendingInjectionByReqId.delete(numericId);
+        if (typeof turnId === "string" && turnId.length > 0) {
+          this.recordInjectedTurnId(turnId, contentHash);
+          this.log(`Bridge-originated request completed (id ${responseId}, turnId=${turnId} dedup)`);
+        } else {
+          this.log(`Bridge-originated request completed (id ${responseId}, no turnId — falling back to content-hash dedup)`);
+        }
       }
       return null;
     }
@@ -1255,9 +1413,15 @@ export class CodexAdapter extends EventEmitter {
   private handleServerNotification(msg: AppServerNotification) {
     const { method, params } = msg;
     switch (method) {
-      case "turn/started":
+      case "turn/started": {
+        // markTurnStarted emits "turnStarted" only on idle→busy transition
+        // (symmetric with turnCompleted on busy→idle). Spec v2.2 §4.3
+        // forwards turnStarted as a non-satisfying signal to paired Claude;
+        // daemon listens on that emit. The turnId arg is added so consumers
+        // can track per-turn state (e.g. sawAgentMessage).
         this.markTurnStarted(params?.turn?.id);
         break;
+      }
       case "item/started": {
         const item: AppServerItem | undefined = params?.item;
         if (item?.type === "agentMessage") this.agentMessageBuffers.set(item.id, []);
@@ -1281,16 +1445,57 @@ export class CodexAdapter extends EventEmitter {
               id: item.id, source: "codex" as const, content, timestamp: Date.now(),
             } satisfies BridgeMessage);
           }
+        } else if (item?.type === "userMessage") {
+          // Spec v2.2 §4.3: route human-typed TUI messages to paired Claude,
+          // but suppress echoes of paired Claude's own injection.
+          const content = this.extractContent(item);
+          if (content) {
+            const turnIdFromParams = typeof (params as Record<string, unknown> | undefined)?.turnId === "string"
+              ? ((params as Record<string, unknown>).turnId as string)
+              : undefined;
+            if (this.isEchoOfInjection(content, turnIdFromParams)) {
+              this.log(`Suppressed userMessage echo (item ${item.id}, ${content.length} chars)`);
+            } else {
+              this.log(`User message from TUI (${content.length} chars)`);
+              this.emit("userMessage", {
+                id: item.id,
+                source: "codex" as const,
+                content,
+                timestamp: Date.now(),
+                turnId: turnIdFromParams,
+              } satisfies BridgeMessage & { turnId?: string });
+            }
+          }
         }
         break;
       }
       case "turn/completed": {
         const wasInProgress = this.turnInProgress;
-        this.markTurnCompleted(params?.turn?.id);
-        // Only emit when all turns are done (symmetric with turnStarted)
+        const turnId = params?.turn?.id;
+        this.markTurnCompleted(turnId);
+        // Only emit when all turns are done (symmetric with turnStarted).
+        // Spec v2.2 §4.3: daemon tracks per-turnId sawAgentMessage to decide
+        // satisfiesRequireReply on the forwarded system message.
         if (wasInProgress && !this.turnInProgress) {
-          this.emit("turnCompleted");
+          this.emit("turnCompleted", { turnId });
         }
+        break;
+      }
+      case "error": {
+        // Spec v2.2 §4.3: top-level error notification (NOT a ThreadItem).
+        // Forward to daemon so paired Claude's requireReply releases.
+        const errorParams = (params ?? {}) as { error?: { code?: number; message?: string; data?: unknown } };
+        const detail = errorParams.error?.message ?? "(no error message)";
+        const code = errorParams.error?.code;
+        this.log(`App-server error notification: ${detail}${code !== undefined ? ` (code ${code})` : ""}`);
+        this.emit("errorItem", { code, message: detail, data: errorParams.error?.data });
+        break;
+      }
+      case "thread/closed": {
+        // Spec v2.2 §4.3: top-level thread lifecycle notification. Triggers
+        // daemon's TUI-disconnect-equivalent pair teardown (§5).
+        const closedThreadId = (params ?? {}) as { threadId?: string };
+        this.emit("threadClosed", { threadId: closedThreadId.threadId });
         break;
       }
     }
@@ -1416,7 +1621,7 @@ export class CodexAdapter extends EventEmitter {
 
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
-      this.emit("turnStarted");
+      this.emit("turnStarted", { turnId });
     }
   }
 

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -9,6 +9,12 @@ export interface DaemonStatus {
   appServerUrl: string;
   pid: number;
   attachedClaudeCount?: number;
+  /**
+   * Spec v2.2 §7: true when a `--via-proxy` TUI is currently connected.
+   * CLI uses this for pre-flight check before launching a second
+   * `agentbridge codex --via-proxy` instance.
+   */
+  proxyTuiConnected?: boolean;
 }
 
 /**

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -8,17 +8,38 @@ export interface DaemonStatus {
   proxyUrl: string;
   appServerUrl: string;
   pid: number;
+  attachedClaudeCount?: number;
 }
 
+/**
+ * `chatId` identifies a logical Claude session. Each Claude MCP instance
+ * generates and registers one on `claude_connect`. Subsequent control
+ * messages from that session carry the same id so the daemon can route
+ * inbound/outbound traffic to the correct ClaudeThread + Claude WebSocket.
+ *
+ * When omitted, the daemon falls back to legacy single-session behavior
+ * (assigns a synthetic chatId so the routing path still works).
+ */
 export type ControlClientMessage =
-  | { type: "claude_connect" }
-  | { type: "claude_disconnect" }
-  | { type: "claude_to_codex"; requestId: string; message: BridgeMessage; requireReply?: boolean }
+  | { type: "claude_connect"; chatId?: string }
+  | { type: "claude_disconnect"; chatId?: string }
+  | {
+      type: "claude_to_codex";
+      requestId: string;
+      chatId?: string;
+      message: BridgeMessage;
+      requireReply?: boolean;
+    }
   | { type: "status" };
 
 export type ControlServerMessage =
-  | { type: "codex_to_claude"; message: BridgeMessage }
-  | { type: "claude_to_codex_result"; requestId: string; success: boolean; error?: string }
+  | { type: "codex_to_claude"; chatId?: string; message: BridgeMessage }
+  | {
+      type: "claude_to_codex_result";
+      requestId: string;
+      success: boolean;
+      error?: string;
+    }
   | { type: "status"; status: DaemonStatus };
 
 /** WebSocket close code sent by the daemon when a newer Claude session replaces the current one. */

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -23,9 +23,15 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       timer: ReturnType<typeof setTimeout>;
     }
   >();
+  private chatId: string | undefined;
 
-  constructor(private readonly url: string) {
+  constructor(private readonly url: string, opts?: { chatId?: string }) {
     super();
+    this.chatId = opts?.chatId;
+  }
+
+  setChatId(chatId: string) {
+    this.chatId = chatId;
   }
 
   async connect() {
@@ -72,14 +78,14 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   }
 
   attachClaude() {
-    this.send({ type: "claude_connect" });
+    this.send({ type: "claude_connect", chatId: this.chatId });
   }
 
   async disconnect() {
     if (!this.ws) return;
 
     try {
-      this.send({ type: "claude_disconnect" });
+      this.send({ type: "claude_disconnect", chatId: this.chatId });
     } catch {}
 
     try {
@@ -106,6 +112,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       this.send({
         type: "claude_to_codex",
         requestId,
+        chatId: this.chatId,
         message,
         ...(requireReply ? { requireReply: true } : {}),
       });

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -124,7 +124,12 @@ export class DaemonLifecycle {
   }
 
   /** Read daemon status from status.json. */
-  readStatus(): { proxyUrl?: string; controlPort?: number; pid?: number } | null {
+  readStatus(): {
+    proxyUrl?: string;
+    appServerUrl?: string;
+    controlPort?: number;
+    pid?: number;
+  } | null {
     try {
       const raw = readFileSync(this.stateDir.statusFile, "utf-8");
       return JSON.parse(raw);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -47,6 +47,20 @@ interface ChatState {
   ws: ServerWebSocket<ControlSocketData> | null;
   thread: ClaudeThread;
   ready: boolean;
+  /**
+   * Spec v2.2 §5: when true, this chat shares the proxy TUI's thread via
+   * CodexAdapter (no own thread/start). Replies route through
+   * codex.injectMessage; outbound is fed by codex.on("agentMessage" etc).
+   * Paired chats skip ClaudeThread.bootstrap() — their `ready` flag flips
+   * when proxyTuiSlot.readiness becomes "ready".
+   */
+  paired: boolean;
+  /**
+   * Spec v2.2 §4.3: per-turn tracking so daemon can decide whether a
+   * `turn/completed` system message satisfies `requireReply`. Resets when
+   * a new turn starts on the shared thread.
+   */
+  pairedTurnSawAgentMessage: boolean;
 
   inAttentionWindow: boolean;
   attentionWindowTimer: ReturnType<typeof setTimeout> | null;
@@ -63,6 +77,23 @@ interface ChatState {
   nextSystemMessageId: number;
 }
 
+/**
+ * Spec v2.2 §5: daemon-wide state tracking the single proxy TUI (if any).
+ * `pairedChatId` is set when a Claude attaches while the slot is open.
+ * `readiness` flips to "ready" when CodexAdapter signals thread is ready.
+ * Only one slot exists at a time (CodexAdapter §4.6 enforces single TUI).
+ */
+type PairReadiness = "not-ready" | "ready";
+
+interface ProxyTuiSlot {
+  token: string;
+  pairedChatId: string | null;
+  readiness: PairReadiness;
+  attachedAt: number;
+  /** Set when paired Claude detaches; clears pairedChatId on expiry. */
+  pairReapTimer: ReturnType<typeof setTimeout> | null;
+}
+
 const stateDir = new StateDirResolver();
 stateDir.ensure();
 const configService = new ConfigService();
@@ -74,6 +105,7 @@ const CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10
 const TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 const CLAUDE_DISCONNECT_GRACE_MS = 5_000;
 const CLAUDE_REAP_AFTER_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_REAP_MS ?? "600000", 10); // 10 min
+const PAIR_REAP_MS = parseInt(process.env.AGENTBRIDGE_PAIR_REAP_MS ?? "30000", 10); // 30s grace for paired Claude reconnect (spec v2.2 §5)
 const MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 const FILTER_MODE: FilterMode =
   (process.env.AGENTBRIDGE_FILTER_MODE as FilterMode) === "full" ? "full" : "filtered";
@@ -100,6 +132,9 @@ let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** chatId → ChatState. Survives WS disconnects (lazy reap, see CLAUDE_REAP_AFTER_MS). */
 const chats = new Map<string, ChatState>();
+
+/** Spec v2.2 §5: single-slot proxy TUI tracking. null when no `--via-proxy` TUI connected. */
+let proxyTuiSlot: ProxyTuiSlot | null = null;
 
 const tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
@@ -130,21 +165,226 @@ const tuiConnectionState = new TuiConnectionState({
 codex.on("ready", (threadId: string) => {
   tuiConnectionState.markBridgeReady();
   log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
+  // Spec v2.2 §5: thread/started observed → flip readiness so paired Claude
+  // replies stop returning the "provisioning" error.
+  if (proxyTuiSlot) {
+    proxyTuiSlot.readiness = "ready";
+    if (proxyTuiSlot.pairedChatId) {
+      const state = chats.get(proxyTuiSlot.pairedChatId);
+      if (state && !state.ready) {
+        state.ready = true;
+        emitToChat(state, systemMessage("system_pair_ready",
+          `✅ Shared Codex TUI thread is now ready (threadId=${threadId}). Replies sent via the reply tool will appear in the right pane's TUI.`));
+      }
+    }
+  }
 });
 
-codex.on("tuiConnected", (connId: number) => {
+codex.on("tuiConnected", (connId: number, token: string = "") => {
   tuiConnectionState.handleTuiConnected(connId);
   cancelIdleShutdown();
-  log(`Codex TUI connected (conn #${connId})`);
+  log(`Codex TUI connected (conn #${connId}, token=${token ? token.slice(0, 8) + "…" : "<none>"})`);
+  // Spec v2.2 §5: a TUI carrying a non-empty shared-mode token is a proxy TUI.
+  // Initialize the slot. Empty token = direct/legacy TUI; no pairing intent.
+  if (token && !proxyTuiSlot) {
+    proxyTuiSlot = {
+      token,
+      pairedChatId: null,
+      readiness: "not-ready",
+      attachedAt: Date.now(),
+      pairReapTimer: null,
+    };
+    log(`Proxy TUI slot allocated (token=${token.slice(0, 8)}…)`);
+    // Spec v2.2 §5.1: PAIR_RACE_MS=0 — Claude-first stays isolated. Do NOT
+    // retroactively pair an already-attached isolated Claude. Only chats that
+    // attach AFTER this point (in attachClaude) can claim the slot.
+  }
   broadcastStatus();
 });
 
 codex.on("tuiDisconnected", (connId: number) => {
   tuiConnectionState.handleTuiDisconnected(connId);
   log(`Codex TUI disconnected (conn #${connId})`);
+  // Spec v2.2 §5: TUI disconnect tears down the proxy slot. Paired Claude (if
+  // any) transitions to isolated mode with a system notice. No prior context
+  // is replayed.
+  if (proxyTuiSlot) {
+    const wasPairedChat = proxyTuiSlot.pairedChatId;
+    if (proxyTuiSlot.pairReapTimer) clearTimeout(proxyTuiSlot.pairReapTimer);
+    proxyTuiSlot = null;
+    codex.setPairedChat(null);
+    if (wasPairedChat) {
+      const state = chats.get(wasPairedChat);
+      if (state) {
+        log(`Transitioning paired chat ${wasPairedChat} to isolated (TUI disconnect)`);
+        transitionToIsolated(state, "Shared Codex TUI thread is gone");
+      }
+    }
+  }
   broadcastStatus();
   scheduleIdleShutdown();
 });
+
+// ── Spec v2.2 §4.3 — shared transport outbound routing ────────
+//
+// When a chat is paired via proxyTuiSlot, CodexAdapter is the transport. All
+// shared-thread events route to the paired chat only.
+
+codex.on("agentMessage", (msg: BridgeMessage) => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  log(`[${paired.chatId}] CodexAdapter → paired Claude (agentMessage, ${msg.content.length} chars)`);
+  paired.pairedTurnSawAgentMessage = true;
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, msg);
+});
+
+codex.on("userMessage", (payload: { content: string; id?: string; turnId?: string }) => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  if (!payload.content) return;
+  log(`[${paired.chatId}] CodexAdapter → paired Claude (userMessage from TUI, ${payload.content.length} chars)`);
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, {
+    id: payload.id ?? `tui_user_${Date.now()}`,
+    source: "codex",
+    content: `[IMPORTANT] Human typed in the paired Codex TUI:\n${payload.content}`,
+    timestamp: Date.now(),
+  });
+});
+
+codex.on("turnStarted", () => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  // Spec v2.2 §4.3: emit as diagnostic, MUST NOT satisfy requireReply.
+  // Reset per-turn agentMessage tracker so turn/completed can detect the
+  // "no-output failure" mode.
+  paired.pairedTurnSawAgentMessage = false;
+  emitToChat(paired, systemMessage("system_codex_turn_started", "[system] Codex turn started"));
+});
+
+codex.on("turnCompleted", () => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  // Spec v2.2 §4.3: satisfies requireReply ONLY if the turn produced no
+  // agentMessage (the "no-output failure" signal). Otherwise the agentMessage
+  // already released requireReply earlier.
+  if (!paired.pairedTurnSawAgentMessage) {
+    log(`[${paired.chatId}] Codex turn completed with no agentMessage — surfacing as failure signal`);
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, systemMessage("system_codex_turn_completed_no_output",
+      "[system] Codex turn completed without any agentMessage — likely a failure or empty response."));
+  } else {
+    emitToChat(paired, systemMessage("system_codex_turn_completed", "[system] Codex turn completed"));
+  }
+  // Cleanup: reset per-turn flags so a future transition to isolated mode
+  // starts from a clean slate.
+  paired.replyRequired = false;
+  paired.replyReceivedDuringTurn = false;
+});
+
+codex.on("errorItem", (payload: { code?: number; message?: string }) => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  // Spec v2.2 §4.3: error notification satisfies requireReply.
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, systemMessage("system_codex_error",
+    `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
+  // Cleanup paired flags — error is a terminal signal for this turn.
+  paired.replyRequired = false;
+});
+
+// Spec v2.2 §8 E8: app-server reconnect restore flips paired readiness back
+// to not-ready, surfacing "restoring shared Codex TUI session, retry shortly"
+// to paired Claude until restore completes.
+codex.on("sessionRestoreStart", () => {
+  if (!proxyTuiSlot) return;
+  log(`Shared Codex session restore started — flipping paired readiness to not-ready`);
+  proxyTuiSlot.readiness = "not-ready";
+  const paired = getPairedChatState();
+  if (paired) paired.ready = false;
+});
+
+codex.on("sessionRestoreEnd", (payload: { ok?: boolean; threadId?: string } = {}) => {
+  if (!proxyTuiSlot) return;
+  if (payload.ok === false) {
+    // Spec v2.2 §8 E8: restore failure path. Keep paired readiness=not-ready.
+    // CodexAdapter's catch branch closes the TUI with 1011, which will fire
+    // tuiDisconnected and tear down the pair via the normal path. We just
+    // don't lie to paired Claude in the meantime.
+    log(`Shared Codex session restore FAILED — keeping paired readiness=not-ready, awaiting TUI tear-down`);
+    return;
+  }
+  log(`Shared Codex session restore succeeded — flipping paired readiness back to ready`);
+  proxyTuiSlot.readiness = "ready";
+  const paired = getPairedChatState();
+  if (paired) {
+    paired.ready = true;
+    emitToChat(paired, systemMessage("system_pair_restored",
+      "✅ Shared Codex TUI session restored. Replies can flow again."));
+  }
+});
+
+codex.on("threadClosed", () => {
+  const paired = getPairedChatState();
+  log(`Codex emitted thread/closed`);
+  if (proxyTuiSlot) {
+    const wasPairedChat = proxyTuiSlot.pairedChatId;
+    proxyTuiSlot = null;
+    codex.setPairedChat(null);
+    if (wasPairedChat && paired) {
+      log(`Transitioning paired chat ${wasPairedChat} to isolated (thread/closed)`);
+      transitionToIsolated(paired, "Shared Codex thread closed");
+    }
+  }
+});
+
+function getPairedChatState(): ChatState | null {
+  if (!proxyTuiSlot?.pairedChatId) return null;
+  return chats.get(proxyTuiSlot.pairedChatId) ?? null;
+}
+
+function pairChat(state: ChatState): void {
+  if (!proxyTuiSlot) return;
+  if (proxyTuiSlot.pairedChatId) return;
+  proxyTuiSlot.pairedChatId = state.chatId;
+  state.paired = true;
+  codex.setPairedChat(state.chatId);
+  state.ready = proxyTuiSlot.readiness === "ready";
+  log(`Paired chat ${state.chatId} with proxy TUI (readiness=${proxyTuiSlot.readiness})`);
+  if (state.ready) {
+    emitToChat(state, systemMessage("system_paired_ready",
+      "✅ This Claude session is paired with the right-pane Codex TUI. Replies will appear there; user typing in the TUI will be forwarded to you with an [IMPORTANT] prefix."));
+  } else {
+    emitToChat(state, systemMessage("system_paired_provisioning",
+      "✅ This Claude session is paired with the right-pane Codex TUI. Waiting for the shared thread to finish provisioning before replies can flow."));
+  }
+}
+
+function transitionToIsolated(state: ChatState, reason: string): void {
+  state.paired = false;
+  emitToChat(state, systemMessage("system_pair_torn_down",
+    `[system] ${reason}. Future replies will use a fresh isolated Codex thread (no prior shared-TUI context carried over).`));
+  // Re-bootstrap as isolated. Same chatId, new ClaudeThread.
+  state.thread = new ClaudeThread({
+    appServerUrl: codex.appServerUrl,
+    chatId: state.chatId,
+    logFile: stateDir.logFile,
+    cwd: process.cwd(),
+  });
+  state.ready = false;
+  wireClaudeThreadEvents(state);
+  state.thread.bootstrap()
+    .then((threadId) => {
+      state.ready = true;
+      emitToChat(state, systemMessage("system_isolated_ready",
+        `✅ Fresh isolated Codex thread ready (threadId=${threadId}).`));
+    })
+    .catch((err: any) => {
+      emitToChat(state, systemMessage("system_isolated_failed",
+        `❌ Failed to bootstrap isolated Codex thread: ${err?.message ?? err}.`));
+    });
+}
 
 codex.on("error", (err: Error) => {
   log(`Codex error: ${err.message}`);
@@ -267,7 +507,8 @@ async function attachClaude(
     return;
   }
 
-  // New chat: create state + ClaudeThread
+  // New chat: create state. Spec v2.2 §5: if a proxy TUI is connected and
+  // unpaired, this new Claude becomes the paired Claude. Otherwise, isolated.
   state = createChatState(chatId);
   chats.set(chatId, state);
   state.ws = ws;
@@ -276,6 +517,15 @@ async function attachClaude(
   log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
 
   sendStatus(ws);
+
+  if (proxyTuiSlot && proxyTuiSlot.pairedChatId === null) {
+    emitToChat(state, systemMessage("system_bridge_provisioning",
+      "✅ AgentBridge daemon attached. Pairing with the right-pane Codex TUI for shared-thread mode..."));
+    pairChat(state);
+    broadcastStatus();
+    return; // paired chats skip ClaudeThread.bootstrap (shared transport)
+  }
+
   emitToChat(state, systemMessage("system_bridge_provisioning",
     "✅ AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
 
@@ -304,6 +554,8 @@ function createChatState(chatId: string): ChatState {
       cwd: process.cwd(),
     }),
     ready: false,
+    paired: false,
+    pairedTurnSawAgentMessage: false,
     inAttentionWindow: false,
     attentionWindowTimer: null,
     replyRequired: false,
@@ -317,8 +569,16 @@ function createChatState(chatId: string): ChatState {
     nextSystemMessageId: 0,
   };
   state.statusBuffer = new StatusBuffer((summary) => emitToChat(state, summary));
+  wireClaudeThreadEvents(state);
+  return state;
+}
 
-  // Wire ClaudeThread events to per-chat routing.
+/**
+ * Spec v2.2: extracted so it can be called again when a paired chat
+ * transitions to isolated mode (new ClaudeThread instance, fresh event wiring).
+ */
+function wireClaudeThreadEvents(state: ChatState): void {
+  const chatId = state.chatId;
   state.thread.on("agentMessage", (msg: BridgeMessage) => {
     if (msg.source !== "codex") return;
     const result = classifyMessage(msg.content, FILTER_MODE);
@@ -393,16 +653,48 @@ function createChatState(chatId: string): ChatState {
   state.thread.on("error", (err: any) => {
     log(`[${chatId}] ClaudeThread error: ${err?.message ?? err}`);
   });
-
-  return state;
 }
 
 function detachClaudeWs(state: ChatState, reason: string) {
   if (!state.ws) return;
-  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason})`);
+  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason}, paired=${state.paired})`);
   state.ws = null;
   scheduleDisconnectTimer(state);
   scheduleReaperTimer(state);
+
+  // Spec v2.2 §5: paired Claude WS detach starts a grace timer. Same chatId
+  // reconnect within PAIR_REAP_MS keeps the pair alive; otherwise the slot
+  // becomes available for a new Claude to pair AND the orphan chat state is
+  // reaped (it never bootstrapped its own ClaudeThread; without the pair, it
+  // has no transport and cannot serve a future resume meaningfully).
+  if (state.paired && proxyTuiSlot && proxyTuiSlot.pairedChatId === state.chatId) {
+    if (proxyTuiSlot.pairReapTimer) clearTimeout(proxyTuiSlot.pairReapTimer);
+    proxyTuiSlot.pairReapTimer = setTimeout(() => {
+      if (!proxyTuiSlot) return;
+      const currentState = chats.get(state.chatId);
+      if (currentState?.ws) {
+        log(`Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
+        return;
+      }
+      log(`Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms — clearing pair slot and reaping chat state`);
+      proxyTuiSlot.pairedChatId = null;
+      proxyTuiSlot.pairReapTimer = null;
+      codex.setPairedChat(null);
+      // Full reap of the orphaned paired chat (matches the 10-min idle reaper's
+      // cleanup: close any thread WS, dispose buffers, delete from map). A
+      // future Claude with the same chatId gets a fresh chat state.
+      if (currentState) {
+        try { currentState.thread.close(); } catch {}
+        currentState.statusBuffer.dispose();
+        if (currentState.attentionWindowTimer) clearTimeout(currentState.attentionWindowTimer);
+        if (currentState.disconnectTimer) clearTimeout(currentState.disconnectTimer);
+        if (currentState.reaperTimer) clearTimeout(currentState.reaperTimer);
+        chats.delete(state.chatId);
+        broadcastStatus();
+      }
+    }, PAIR_REAP_MS);
+  }
+
   scheduleIdleShutdown();
 }
 
@@ -482,11 +774,26 @@ function handleClaudeToCodex(
   }
 
   if (!state.ready) {
+    // Spec v2.2 §5 + §8 E8: paired-but-not-ready returns a transient error so
+    // paired Claude can retry once the shared thread is provisioned or
+    // session-restored. Distinguish first-time provisioning from restore.
+    let errorMsg: string;
+    if (state.paired) {
+      if (codex.isSessionRestoreInProgress) {
+        errorMsg = "Restoring shared Codex TUI session, retry shortly.";
+      } else if (proxyTuiSlot) {
+        errorMsg = "Shared Codex TUI thread is still provisioning. Retry shortly.";
+      } else {
+        errorMsg = "Shared Codex TUI is no longer connected. Wait for transition to isolated mode.";
+      }
+    } else {
+      errorMsg = "Your Codex thread is still provisioning. Wait for system_thread_ready.";
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,
       success: false,
-      error: "Your Codex thread is still provisioning. Wait for system_thread_ready.",
+      error: errorMsg,
     });
   }
 
@@ -499,12 +806,24 @@ function handleClaudeToCodex(
     log(`[${chatId}] Reply required flag set`);
   }
 
-  log(`[${chatId}] Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-  const injected = state.thread.injectMessage(contentWithReminder);
+  log(`[${chatId}] Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply}, paired=${state.paired})`);
+
+  // Spec v2.2 §6: paired chats route through CodexAdapter (shared transport);
+  // isolated chats keep using their own ClaudeThread.
+  const injected = state.paired
+    ? codex.injectMessage(contentWithReminder)
+    : state.thread.injectMessage(contentWithReminder);
+
   if (!injected) {
-    const reason = state.thread.isTurnInProgress
-      ? "Codex is busy executing a turn on your thread. Wait for it to finish."
-      : "Injection failed: thread WS not connected.";
+    const reason = state.paired
+      ? "Shared Codex TUI is busy with another turn. Retry."
+      : (state.thread.isTurnInProgress
+          ? "Codex is busy executing a turn on your thread. Wait for it to finish."
+          : "Injection failed: thread WS not connected.");
+    if (requireReply) {
+      // Roll back the replyRequired flag since injection didn't happen.
+      state.replyRequired = false;
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,
@@ -625,6 +944,7 @@ function currentStatus(): DaemonStatus {
     appServerUrl: codex.appServerUrl,
     pid: process.pid,
     attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length,
+    proxyTuiConnected: proxyTuiSlot !== null,
   };
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -266,11 +266,14 @@ codex.on("turnStarted", () => {
 codex.on("turnCompleted", () => {
   const paired = getPairedChatState();
   if (!paired) return;
-  // Spec v2.2 §4.3: satisfies requireReply ONLY if the turn produced no
-  // agentMessage (the "no-output failure" signal). Otherwise the agentMessage
-  // already released requireReply earlier.
-  if (!paired.pairedTurnSawAgentMessage) {
-    log(`[${paired.chatId}] Codex turn completed with no agentMessage — surfacing as failure signal`);
+  // Bug fix (2026-05-16): only surface "no-output failure" when Claude was
+  // actually waiting for a reply (replyRequired=true). User-typed TUI turns
+  // can legitimately complete without an agentMessage (e.g. silent ack) —
+  // emitting failure wording there confused paired Claude. Spec v2.2 §4.3
+  // describes this as the "no-output failure signal" but does not require
+  // it for non-Claude-originated turns.
+  if (!paired.pairedTurnSawAgentMessage && paired.replyRequired) {
+    log(`[${paired.chatId}] Codex turn completed with no agentMessage while replyRequired — surfacing as failure signal`);
     paired.replyReceivedDuringTurn = true;
     emitToChat(paired, systemMessage("system_codex_turn_completed_no_output",
       "[system] Codex turn completed without any agentMessage — likely a failure or empty response."));
@@ -290,8 +293,17 @@ codex.on("errorItem", (payload: { code?: number; message?: string }) => {
   paired.replyReceivedDuringTurn = true;
   emitToChat(paired, systemMessage("system_codex_error",
     `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
-  // Cleanup paired flags — error is a terminal signal for this turn.
+  // Bug fix (2026-05-16): mark the turn as "Claude has been informed" so a
+  // subsequent turn/completed does not fire a spurious no-output failure on
+  // top of the error we already surfaced. Naming is slightly stretched here
+  // ("sawAgentMessage" is now "saw something Claude needs to know about")
+  // but renaming would touch too many call sites for a minor fix.
+  paired.pairedTurnSawAgentMessage = true;
   paired.replyRequired = false;
+  // Symmetric reset (Codex review 2026-05-16): match the cleanup in the
+  // turn/completed handler so an error doesn't leave a stale "received during
+  // turn" flag that could confuse later logic.
+  paired.replyReceivedDuringTurn = false;
 });
 
 // Spec v2.2 §8 E8: app-server reconnect restore flips paired readiness back
@@ -361,8 +373,98 @@ function pairChat(state: ChatState): void {
   }
 }
 
+/**
+ * Bug fix (2026-05-16): isolated-bootstrap retry helper.
+ *
+ * Previously `transitionToIsolated` did a one-shot `bootstrap()` whose catch
+ * branch only emitted a system_isolated_failed message and left state.ready
+ * stuck at false — paired Claude was effectively stranded with no recovery
+ * path. This helper retries up to ISOLATED_BOOTSTRAP_MAX_ATTEMPTS times with
+ * a delay between attempts, and surfaces a definitive "give up" message
+ * only after exhausting them, including explicit instructions for the user.
+ */
+const ISOLATED_BOOTSTRAP_MAX_ATTEMPTS = parseInt(
+  process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_MAX_ATTEMPTS ?? "2",
+  10,
+);
+const ISOLATED_BOOTSTRAP_RETRY_DELAY_MS = parseInt(
+  process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_RETRY_DELAY_MS ?? "2000",
+  10,
+);
+
+function bootstrapIsolatedThread(state: ChatState, attempt = 1): void {
+  state.thread.bootstrap()
+    .then((threadId) => {
+      state.ready = true;
+      emitToChat(state, systemMessage("system_isolated_ready",
+        `✅ Fresh isolated Codex thread ready (threadId=${threadId}).`));
+    })
+    .catch((err: any) => {
+      const errMsg = err?.message ?? String(err);
+      log(`[${state.chatId}] Isolated bootstrap attempt ${attempt}/${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS} failed: ${errMsg}`);
+      if (attempt < ISOLATED_BOOTSTRAP_MAX_ATTEMPTS) {
+        emitToChat(state, systemMessage("system_isolated_retry",
+          `⚠️ Bootstrap of isolated Codex thread failed (attempt ${attempt}/${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS}): ${errMsg}. Retrying in ${ISOLATED_BOOTSTRAP_RETRY_DELAY_MS}ms.`));
+        setTimeout(() => {
+          // Codex review (2026-05-16): close the prior ClaudeThread before
+          // constructing a replacement so a half-open WS / RPC handle from
+          // the failed attempt does not leak.
+          try { state.thread.close(); } catch {}
+          state.thread = new ClaudeThread({
+            appServerUrl: codex.appServerUrl,
+            chatId: state.chatId,
+            logFile: stateDir.logFile,
+            cwd: process.cwd(),
+          });
+          wireClaudeThreadEvents(state);
+          bootstrapIsolatedThread(state, attempt + 1);
+        }, ISOLATED_BOOTSTRAP_RETRY_DELAY_MS);
+      } else {
+        emitToChat(state, systemMessage("system_isolated_failed",
+          `❌ Failed to bootstrap isolated Codex thread after ${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS} attempts: ${errMsg}. Closing this chat — please reconnect Claude (close the window and re-attach) to start a fresh attempt.`));
+        // Bug fix (Codex review 2026-05-16): reap the chat so the advertised
+        // recovery path ("reconnect Claude") actually works. Without this,
+        // attachClaude takes the resume branch for the same chatId, never
+        // re-enters bootstrapIsolatedThread, and the user follows our own
+        // instructions but stays stuck. Reaping forces the next attach to
+        // construct a fresh ChatState with a fresh bootstrap.
+        reapChatState(state, "isolated bootstrap exhausted");
+      }
+    });
+}
+
+/**
+ * Forcefully tear down a chat: close the active WS (clients can reconnect
+ * fresh), clear timers, dispose StatusBuffer, close the ClaudeThread, and
+ * remove the entry from `chats`. Used both for natural reaper expiry paths
+ * and for the isolated-bootstrap final-failure path.
+ */
+function reapChatState(state: ChatState, reason: string): void {
+  log(`Reaping chat state: chatId=${state.chatId} (${reason})`);
+  if (state.ws) {
+    try { state.ws.close(1011, `chat reaped: ${reason}`); } catch {}
+    state.ws = null;
+  }
+  if (state.attentionWindowTimer) clearTimeout(state.attentionWindowTimer);
+  if (state.disconnectTimer) clearTimeout(state.disconnectTimer);
+  if (state.reaperTimer) clearTimeout(state.reaperTimer);
+  try { state.statusBuffer.dispose(); } catch {}
+  try { state.thread.close(); } catch {}
+  chats.delete(state.chatId);
+  broadcastStatus();
+}
+
 function transitionToIsolated(state: ChatState, reason: string): void {
   state.paired = false;
+  // Bug fix (Codex review 2026-05-16): pair teardown is a terminal boundary
+  // for the old shared turn. Reset paired-turn flags so they don't bleed
+  // into the fresh isolated thread — a stale `replyRequired=true` would
+  // otherwise force-forward the first isolated message via the
+  // require-reply path in wireClaudeThreadEvents and could fire a bogus
+  // "missing reply" warning at turn/completed.
+  state.replyRequired = false;
+  state.replyReceivedDuringTurn = false;
+  state.pairedTurnSawAgentMessage = false;
   emitToChat(state, systemMessage("system_pair_torn_down",
     `[system] ${reason}. Future replies will use a fresh isolated Codex thread (no prior shared-TUI context carried over).`));
   // Re-bootstrap as isolated. Same chatId, new ClaudeThread.
@@ -374,16 +476,7 @@ function transitionToIsolated(state: ChatState, reason: string): void {
   });
   state.ready = false;
   wireClaudeThreadEvents(state);
-  state.thread.bootstrap()
-    .then((threadId) => {
-      state.ready = true;
-      emitToChat(state, systemMessage("system_isolated_ready",
-        `✅ Fresh isolated Codex thread ready (threadId=${threadId}).`));
-    })
-    .catch((err: any) => {
-      emitToChat(state, systemMessage("system_isolated_failed",
-        `❌ Failed to bootstrap isolated Codex thread: ${err?.message ?? err}.`));
-    });
+  bootstrapIsolatedThread(state);
 }
 
 codex.on("error", (err: Error) => {
@@ -1059,16 +1152,85 @@ function log(msg: string) {
   } catch {}
 }
 
-// Refuse to start if user intentionally killed the daemon.
-if (daemonLifecycle.wasKilled()) {
-  log("Killed sentinel found — daemon was intentionally stopped. Exiting immediately.");
-  process.exit(0);
+function startDaemon() {
+  // Refuse to start if user intentionally killed the daemon.
+  if (daemonLifecycle.wasKilled()) {
+    log("Killed sentinel found — daemon was intentionally stopped. Exiting immediately.");
+    process.exit(0);
+  }
+
+  writePidFile();
+  startControlServer();
+  void bootCodex();
 }
 
-writePidFile();
-startControlServer();
-void bootCodex();
+// `import.meta.main` is true only when this module is the entrypoint (run via
+// `bun daemon.js` or the bundled CLI). When imported as a library (e.g. by
+// `src/unit-test/daemon.test.ts`), the side-effectful boot is skipped so
+// tests can exercise the state machine without spinning up sockets or
+// spawning the Codex app-server.
+if (import.meta.main) {
+  startDaemon();
+}
 
 // Silence unused-warning for the legacy import; we keep the symbol around in
 // case future tooling wants to surface the attach command in status.
 void attachCmd;
+
+// ── Testing harness ─────────────────────────────────────────────
+//
+// Exported strictly for `src/unit-test/daemon.test.ts`. Not part of any
+// public API; do not import from production code. The shape and guarantees
+// here are subject to change to suit testing needs.
+
+export const __testing = {
+  /** Read current single-slot proxy TUI state. */
+  get proxyTuiSlot(): ProxyTuiSlot | null {
+    return proxyTuiSlot;
+  },
+  /** Overwrite the slot (set to null to clear). Tests use this to seed scenarios. */
+  setProxyTuiSlot(next: ProxyTuiSlot | null): void {
+    proxyTuiSlot = next;
+  },
+  /** Direct handle to the chat registry — tests can read/write/clear. */
+  chats,
+  /** Direct handle to the singleton CodexAdapter — tests can emit events on it. */
+  codex,
+  /** Daemon-level functions exposed for direct invocation in tests. */
+  fns: {
+    pairChat,
+    transitionToIsolated,
+    bootstrapIsolatedThread,
+    getPairedChatState,
+    createChatState,
+    detachClaudeWs,
+    emitToChat,
+  } as const,
+  /** Constants captured at module load — useful for asserting timer behavior. */
+  config: {
+    PAIR_REAP_MS,
+    CLAUDE_REAP_AFTER_MS,
+    ISOLATED_BOOTSTRAP_MAX_ATTEMPTS,
+    ISOLATED_BOOTSTRAP_RETRY_DELAY_MS,
+  } as const,
+  /** Reset every mutable module-level field to its clean state. Call in beforeEach. */
+  reset(): void {
+    if (proxyTuiSlot?.pairReapTimer) {
+      clearTimeout(proxyTuiSlot.pairReapTimer);
+    }
+    for (const state of chats.values()) {
+      if (state.attentionWindowTimer) clearTimeout(state.attentionWindowTimer);
+      if (state.disconnectTimer) clearTimeout(state.disconnectTimer);
+      if (state.reaperTimer) clearTimeout(state.reaperTimer);
+      try { state.statusBuffer.dispose(); } catch {}
+      try { state.thread.close(); } catch {}
+    }
+    chats.clear();
+    proxyTuiSlot = null;
+    // Codex review (2026-05-16): also clear CodexAdapter's internal
+    // pairedChatId so it does not leak across tests.
+    try { codex.setPairedChat(null); } catch {}
+  },
+  /** Direct reap helper exposed for tests that need to assert the reap behavior. */
+  reapChatState,
+};

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,8 +1,26 @@
 #!/usr/bin/env bun
 
+/**
+ * AgentBridge daemon — multi-Claude variant.
+ *
+ * Each attached Claude session gets:
+ *   - A `chatId` (sent by the MCP at `claude_connect` time).
+ *   - A dedicated `ClaudeThread` (own WebSocket to codex app-server, own
+ *     codex thread). Turns on different threads run in parallel — verified
+ *     by the concurrency probe under `probes/`.
+ *   - Per-chat attention window, statusBuffer, replyRequired, and offline
+ *     message buffer.
+ *
+ * Codex TUI continues to use the existing CodexAdapter proxy with its own
+ * thread. TUI activity is NOT cross-broadcast to attached Claudes — every
+ * Claude sees only events from its own ClaudeThread. This keeps the two
+ * surfaces (TUI = human ↔ Codex, Claude = MCP ↔ Codex) isolated.
+ */
+
 import { appendFileSync } from "node:fs";
 import type { ServerWebSocket } from "bun";
 import { CodexAdapter } from "./codex-adapter";
+import { ClaudeThread } from "./claude-thread";
 import {
   BRIDGE_CONTRACT_REMINDER,
   REPLY_REQUIRED_INSTRUCTION,
@@ -21,6 +39,28 @@ import type { BridgeMessage } from "./types";
 interface ControlSocketData {
   clientId: number;
   attached: boolean;
+  chatId: string | null;
+}
+
+interface ChatState {
+  chatId: string;
+  ws: ServerWebSocket<ControlSocketData> | null;
+  thread: ClaudeThread;
+  ready: boolean;
+
+  inAttentionWindow: boolean;
+  attentionWindowTimer: ReturnType<typeof setTimeout> | null;
+  replyRequired: boolean;
+  replyReceivedDuringTurn: boolean;
+
+  bufferedMessages: BridgeMessage[];
+  statusBuffer: StatusBuffer;
+
+  disconnectTimer: ReturnType<typeof setTimeout> | null;
+  reaperTimer: ReturnType<typeof setTimeout> | null;
+  lastAttachStatusSentTs: number;
+  onlineNoticeSent: boolean;
+  nextSystemMessageId: number;
 }
 
 const stateDir = new StateDirResolver();
@@ -33,11 +73,19 @@ const CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.
 const CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 const TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 const CLAUDE_DISCONNECT_GRACE_MS = 5_000;
+const CLAUDE_REAP_AFTER_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_REAP_MS ?? "600000", 10); // 10 min
 const MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 const FILTER_MODE: FilterMode =
   (process.env.AGENTBRIDGE_FILTER_MODE as FilterMode) === "full" ? "full" : "filtered";
-const IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
-const ATTENTION_WINDOW_MS = parseInt(process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS ?? String(config.turnCoordination.attentionWindowSeconds * 1000), 10);
+const IDLE_SHUTDOWN_MS = parseInt(
+  process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000),
+  10,
+);
+const ATTENTION_WINDOW_MS = parseInt(
+  process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS ??
+    String(config.turnCoordination.attentionWindowSeconds * 1000),
+  10,
+);
 
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 
@@ -45,30 +93,19 @@ const codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFil
 const attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 
 let controlServer: ReturnType<typeof Bun.serve> | null = null;
-let attachedClaude: ServerWebSocket<ControlSocketData> | null = null;
 let nextControlClientId = 0;
-let nextSystemMessageId = 0;
 let codexBootstrapped = false;
-let attentionWindowTimer: ReturnType<typeof setTimeout> | null = null;
-let inAttentionWindow = false;
-let replyRequired = false;
-let replyReceivedDuringTurn = false;
 let shuttingDown = false;
 let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
-let claudeDisconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let claudeOnlineNoticeSent = false;
-let claudeOfflineNoticeShown = false;
-let codexCollaborationKickoffSent = false;
-let lastAttachStatusSentTs = 0;
-const ATTACH_STATUS_COOLDOWN_MS = 30_000; // Don't re-send status on rapid reattach
 
-const bufferedMessages: BridgeMessage[] = [];
+/** chatId → ChatState. Survives WS disconnects (lazy reap, see CLAUDE_REAP_AFTER_MS). */
+const chats = new Map<string, ChatState>();
 
 const tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
   log,
   onDisconnectPersisted: (connId) => {
-    emitToClaude(
+    broadcastToAllClaudes(
       systemMessage(
         "system_tui_disconnected",
         `⚠️ Codex TUI disconnected (conn #${connId}). Codex is still running in the background — reconnect the TUI to resume.`,
@@ -76,115 +113,23 @@ const tuiConnectionState = new TuiConnectionState({
     );
   },
   onReconnectAfterNotice: (connId) => {
-    emitToClaude(
+    broadcastToAllClaudes(
       systemMessage(
         "system_tui_reconnected",
-        `✅ Codex TUI reconnected (conn #${connId}). Bridge restored, communication can continue.`,
+        `✅ Codex TUI reconnected (conn #${connId}). Bridge restored.`,
       ),
     );
-    codex.injectMessage("✅ Claude Code is still online, bridge restored. Bidirectional communication can continue.");
   },
 });
 
-const statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
-
-codex.on("turnStarted", () => {
-  log("Codex turn started");
-  emitToClaude(
-    systemMessage(
-      "system_turn_started",
-      "⏳ Codex is working on the current task. Wait for completion before sending a reply.",
-    ),
-  );
-});
-
-codex.on("agentMessage", (msg: BridgeMessage) => {
-  if (msg.source !== "codex") return;
-  const result = classifyMessage(msg.content, FILTER_MODE);
-
-  // When replyRequired is active, force-forward ALL messages regardless of marker
-  if (replyRequired) {
-    log(`Codex → Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
-    replyReceivedDuringTurn = true;
-    if (statusBuffer.size > 0) {
-      statusBuffer.flush("reply-required message arrived");
-    }
-    emitToClaude(msg);
-    return;
-  }
-
-  // During attention window, suppress STATUS to give Claude space to respond
-  if (inAttentionWindow && result.marker === "status") {
-    log(`Codex → Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
-    statusBuffer.add(msg);
-    return;
-  }
-
-  log(`Codex → Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
-  switch (result.action) {
-    case "forward":
-      if (result.marker === "important" && statusBuffer.size > 0) {
-        statusBuffer.flush("important message arrived");
-      }
-      emitToClaude(msg);
-      // IMPORTANT message — give Claude an attention window to respond
-      if (result.marker === "important") {
-        startAttentionWindow();
-      }
-      break;
-    case "buffer":
-      statusBuffer.add(msg);
-      break;
-    case "drop":
-      break;
-  }
-});
-
-codex.on("turnCompleted", () => {
-  log("Codex turn completed");
-  statusBuffer.flush("turn completed");
-
-  // Check if reply was required but Codex didn't send any agentMessage
-  if (replyRequired && !replyReceivedDuringTurn) {
-    log("⚠️ Reply was required but Codex did not send any agentMessage");
-    emitToClaude(
-      systemMessage(
-        "system_reply_missing",
-        "⚠️ Codex completed the turn without sending a reply (require_reply was set). Codex may not have generated an agentMessage. You may want to retry or rephrase.",
-      ),
-    );
-  }
-
-  // Reset reply-required state
-  replyRequired = false;
-  replyReceivedDuringTurn = false;
-
-  emitToClaude(
-    systemMessage(
-      "system_turn_completed",
-      "✅ Codex finished the current turn. You can reply now if needed.",
-    ),
-  );
-  startAttentionWindow();
-
-  // Retry Claude-online notice if it was deferred while the turn was in progress.
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
-});
+// ── TUI / app-server event wiring ────────────────────────────────
+// Codex TUI activity is INTENTIONALLY not cross-broadcast to Claude sessions.
+// We only listen for lifecycle events that affect all chats (TUI connected,
+// codex ready, codex exit, etc.).
 
 codex.on("ready", (threadId: string) => {
   tuiConnectionState.markBridgeReady();
-  log(`Codex ready — thread ${threadId}`);
-  log("Bridge fully operational");
-
-  emitToClaude(
-    systemMessage("system_ready", currentReadyMessage()),
-  );
-
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
+  log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
 });
 
 codex.on("tuiConnected", (connId: number) => {
@@ -206,21 +151,23 @@ codex.on("error", (err: Error) => {
 });
 
 codex.on("exit", (code: number | null) => {
-  log(`Codex process exited (code ${code})`);
+  log(`Codex app-server process exited (code ${code})`);
   codexBootstrapped = false;
-  statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
-  clearPendingClaudeDisconnect("Codex process exited");
-  claudeOnlineNoticeSent = false;
-  claudeOfflineNoticeShown = false;
-  emitToClaude(
+  broadcastToAllClaudes(
     systemMessage(
       "system_codex_exit",
-      `⚠️ Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running, but the Codex side needs to be restarted.`,
+      `⚠️ Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`,
     ),
   );
+  for (const state of chats.values()) {
+    try { state.thread.close(); } catch {}
+    state.ready = false;
+  }
   broadcastStatus();
 });
+
+// ── Control server / Claude WS handling ─────────────────────────
 
 function startControlServer() {
   controlServer = Bun.serve({
@@ -229,31 +176,32 @@ function startControlServer() {
     fetch(req, server) {
       const url = new URL(req.url);
 
-      if (url.pathname === "/healthz") {
-        return Response.json(currentStatus());
-      }
-
+      if (url.pathname === "/healthz") return Response.json(currentStatus());
       if (url.pathname === "/readyz") {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
-
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false } })) {
+      if (url.pathname === "/ws" &&
+          server.upgrade(req, { data: { clientId: 0, attached: false, chatId: null } })) {
         return undefined;
       }
 
       return new Response("AgentBridge daemon");
     },
     websocket: {
-      idleTimeout: 960, // 16 minutes — prevent premature idle disconnects
+      idleTimeout: 960,
       sendPings: true,
       open: (ws: ServerWebSocket<ControlSocketData>) => {
         ws.data.clientId = ++nextControlClientId;
         log(`Frontend socket opened (#${ws.data.clientId})`);
       },
       close: (ws: ServerWebSocket<ControlSocketData>, code: number, reason: string) => {
-        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
-        if (attachedClaude === ws) {
-          detachClaude(ws, "frontend socket closed");
+        const chatId = ws.data.chatId;
+        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, chatId=${chatId ?? "-"})`);
+        if (chatId) {
+          const state = chats.get(chatId);
+          if (state && state.ws === ws) {
+            detachClaudeWs(state, "frontend socket closed");
+          }
         }
       },
       message: (ws: ServerWebSocket<ControlSocketData>, raw) => {
@@ -275,157 +223,430 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
 
   switch (message.type) {
     case "claude_connect":
-      attachClaude(ws);
+      void attachClaude(ws, message.chatId);
       return;
-    case "claude_disconnect":
-      detachClaude(ws, "frontend requested disconnect");
+    case "claude_disconnect": {
+      const chatId = message.chatId ?? ws.data.chatId;
+      if (!chatId) return;
+      const state = chats.get(chatId);
+      if (state) detachClaudeWs(state, "frontend requested disconnect");
       return;
+    }
     case "status":
       sendStatus(ws);
       return;
-    case "claude_to_codex": {
-      if (message.message.source !== "claude") {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Invalid message source",
-        });
-        return;
-      }
+    case "claude_to_codex":
+      handleClaudeToCodex(ws, message);
+      return;
+  }
+}
 
-      if (!tuiConnectionState.canReply()) {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Codex is not ready. Wait for TUI to connect and create a thread.",
-        });
-        return;
-      }
+async function attachClaude(
+  ws: ServerWebSocket<ControlSocketData>,
+  requestedChatId?: string,
+) {
+  const chatId = requestedChatId ?? `auto_${ws.data.clientId}_${Date.now()}`;
+  ws.data.chatId = chatId;
 
-      const requireReply = !!message.requireReply;
-      let contentWithReminder = message.message.content + "\n\n" + BRIDGE_CONTRACT_REMINDER;
-      if (requireReply) {
-        contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
-        replyRequired = true;
-        replyReceivedDuringTurn = false;
-        log(`Reply required flag set for this message`);
+  let state = chats.get(chatId);
+  if (state) {
+    // Resume: same chatId reconnecting. If another WS is still bound, replace it.
+    if (state.ws && state.ws !== ws && state.ws.readyState !== WebSocket.CLOSED) {
+      log(`Replacing prior WS for chatId=${chatId} (#${state.ws.data.clientId} → #${ws.data.clientId})`);
+      try { state.ws.close(CLOSE_CODE_REPLACED, "replaced by newer connection for same chatId"); } catch {}
+    }
+    state.ws = ws;
+    ws.data.attached = true;
+    clearDisconnectTimer(state, "claude resumed");
+    clearReaperTimer(state, "claude resumed");
+    cancelIdleShutdown();
+    log(`Claude resumed chatId=${chatId} (#${ws.data.clientId})`);
+    statusBufferFlushIfPaused(state, "claude resumed");
+    flushBufferedMessages(state);
+    sendStatus(ws);
+    return;
+  }
+
+  // New chat: create state + ClaudeThread
+  state = createChatState(chatId);
+  chats.set(chatId, state);
+  state.ws = ws;
+  ws.data.attached = true;
+  cancelIdleShutdown();
+  log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
+
+  sendStatus(ws);
+  emitToChat(state, systemMessage("system_bridge_provisioning",
+    "✅ AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
+
+  try {
+    const threadId = await state.thread.bootstrap();
+    state.ready = true;
+    log(`ClaudeThread ready: chatId=${chatId} threadId=${threadId}`);
+    emitToChat(state, systemMessage("system_thread_ready",
+      `✅ Your Codex thread is ready (threadId=${threadId}). You can now send messages via the reply tool.`));
+    broadcastStatus();
+  } catch (err: any) {
+    log(`ClaudeThread bootstrap failed for chatId=${chatId}: ${err?.message ?? err}`);
+    emitToChat(state, systemMessage("system_thread_failed",
+      `❌ Failed to provision Codex thread: ${err?.message ?? err}. Reconnect to retry.`));
+  }
+}
+
+function createChatState(chatId: string): ChatState {
+  const state: ChatState = {
+    chatId,
+    ws: null,
+    thread: new ClaudeThread({
+      appServerUrl: codex.appServerUrl,
+      chatId,
+      logFile: stateDir.logFile,
+      cwd: process.cwd(),
+    }),
+    ready: false,
+    inAttentionWindow: false,
+    attentionWindowTimer: null,
+    replyRequired: false,
+    replyReceivedDuringTurn: false,
+    bufferedMessages: [],
+    statusBuffer: null as any, // assigned below
+    disconnectTimer: null,
+    reaperTimer: null,
+    lastAttachStatusSentTs: 0,
+    onlineNoticeSent: false,
+    nextSystemMessageId: 0,
+  };
+  state.statusBuffer = new StatusBuffer((summary) => emitToChat(state, summary));
+
+  // Wire ClaudeThread events to per-chat routing.
+  state.thread.on("agentMessage", (msg: BridgeMessage) => {
+    if (msg.source !== "codex") return;
+    const result = classifyMessage(msg.content, FILTER_MODE);
+
+    if (state.replyRequired) {
+      log(`[${chatId}] Codex → Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
+      state.replyReceivedDuringTurn = true;
+      if (state.statusBuffer.size > 0) {
+        state.statusBuffer.flush("reply-required message arrived");
       }
-      log(`Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-      const injected = codex.injectMessage(contentWithReminder);
-      if (!injected) {
-        const reason = codex.turnInProgress
-          ? "Codex is busy executing a turn. Wait for it to finish before sending another message."
-          : "Injection failed: no active thread or WebSocket not connected.";
-        log(`Injection rejected: ${reason}`);
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: reason,
-        });
-        return;
-      }
-      clearAttentionWindow(); // Claude successfully replied, end attention window
-      sendProtocolMessage(ws, {
-        type: "claude_to_codex_result",
-        requestId: message.requestId,
-        success: true,
-      });
+      emitToChat(state, msg);
+      return;
+    }
+
+    if (state.inAttentionWindow && result.marker === "status") {
+      log(`[${chatId}] Codex → Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
+      state.statusBuffer.add(msg);
+      return;
+    }
+
+    log(`[${chatId}] Codex → Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
+    switch (result.action) {
+      case "forward":
+        if (result.marker === "important" && state.statusBuffer.size > 0) {
+          state.statusBuffer.flush("important message arrived");
+        }
+        emitToChat(state, msg);
+        if (result.marker === "important") startAttentionWindow(state);
+        break;
+      case "buffer":
+        state.statusBuffer.add(msg);
+        break;
+      case "drop":
+        break;
+    }
+  });
+
+  state.thread.on("turnStarted", () => {
+    log(`[${chatId}] Codex turn started`);
+    emitToChat(state, systemMessage(
+      "system_turn_started",
+      "⏳ Codex is working on the current task. Wait for completion before sending a reply.",
+    ));
+  });
+
+  state.thread.on("turnCompleted", () => {
+    log(`[${chatId}] Codex turn completed`);
+    state.statusBuffer.flush("turn completed");
+
+    if (state.replyRequired && !state.replyReceivedDuringTurn) {
+      log(`[${chatId}] ⚠️ Reply was required but Codex did not send any agentMessage`);
+      emitToChat(state, systemMessage(
+        "system_reply_missing",
+        "⚠️ Codex completed the turn without sending a reply (require_reply was set).",
+      ));
+    }
+    state.replyRequired = false;
+    state.replyReceivedDuringTurn = false;
+
+    emitToChat(state, systemMessage(
+      "system_turn_completed",
+      "✅ Codex finished the current turn. You can reply now if needed.",
+    ));
+    startAttentionWindow(state);
+  });
+
+  state.thread.on("close", () => {
+    log(`[${chatId}] ClaudeThread WS closed`);
+    state.ready = false;
+  });
+
+  state.thread.on("error", (err: any) => {
+    log(`[${chatId}] ClaudeThread error: ${err?.message ?? err}`);
+  });
+
+  return state;
+}
+
+function detachClaudeWs(state: ChatState, reason: string) {
+  if (!state.ws) return;
+  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason})`);
+  state.ws = null;
+  scheduleDisconnectTimer(state);
+  scheduleReaperTimer(state);
+  scheduleIdleShutdown();
+}
+
+function scheduleReaperTimer(state: ChatState) {
+  if (state.reaperTimer) clearTimeout(state.reaperTimer);
+  state.reaperTimer = setTimeout(() => {
+    state.reaperTimer = null;
+    if (state.ws) return; // reattached
+    log(`Reaping idle chat: chatId=${state.chatId} (no WS for ${CLAUDE_REAP_AFTER_MS}ms)`);
+    try { state.thread.close(); } catch {}
+    state.statusBuffer.dispose();
+    if (state.attentionWindowTimer) clearTimeout(state.attentionWindowTimer);
+    chats.delete(state.chatId);
+    broadcastStatus();
+  }, CLAUDE_REAP_AFTER_MS);
+}
+
+function clearReaperTimer(state: ChatState, _reason: string) {
+  if (state.reaperTimer) {
+    clearTimeout(state.reaperTimer);
+    state.reaperTimer = null;
+  }
+}
+
+function scheduleDisconnectTimer(state: ChatState) {
+  if (state.disconnectTimer) clearTimeout(state.disconnectTimer);
+  state.disconnectTimer = setTimeout(() => {
+    state.disconnectTimer = null;
+    // No-op placeholder for future "tell codex this claude went offline" logic.
+  }, CLAUDE_DISCONNECT_GRACE_MS);
+}
+
+function clearDisconnectTimer(state: ChatState, _reason: string) {
+  if (state.disconnectTimer) {
+    clearTimeout(state.disconnectTimer);
+    state.disconnectTimer = null;
+  }
+}
+
+function statusBufferFlushIfPaused(state: ChatState, reason: string) {
+  if (state.statusBuffer.size > 0) state.statusBuffer.flush(reason);
+}
+
+// ── Claude → Codex injection ────────────────────────────────────
+
+function handleClaudeToCodex(
+  ws: ServerWebSocket<ControlSocketData>,
+  message: Extract<ControlClientMessage, { type: "claude_to_codex" }>,
+) {
+  const chatId = message.chatId ?? ws.data.chatId;
+  if (!chatId) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "No chatId — claude_connect was never sent.",
+    });
+  }
+
+  const state = chats.get(chatId);
+  if (!state) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: `Unknown chatId ${chatId}. Reattach via claude_connect.`,
+    });
+  }
+
+  if (message.message.source !== "claude") {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "Invalid message source",
+    });
+  }
+
+  if (!state.ready) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "Your Codex thread is still provisioning. Wait for system_thread_ready.",
+    });
+  }
+
+  const requireReply = !!message.requireReply;
+  let contentWithReminder = message.message.content + "\n\n" + BRIDGE_CONTRACT_REMINDER;
+  if (requireReply) {
+    contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
+    state.replyRequired = true;
+    state.replyReceivedDuringTurn = false;
+    log(`[${chatId}] Reply required flag set`);
+  }
+
+  log(`[${chatId}] Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
+  const injected = state.thread.injectMessage(contentWithReminder);
+  if (!injected) {
+    const reason = state.thread.isTurnInProgress
+      ? "Codex is busy executing a turn on your thread. Wait for it to finish."
+      : "Injection failed: thread WS not connected.";
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: reason,
+    });
+  }
+  clearAttentionWindow(state);
+  sendProtocolMessage(ws, {
+    type: "claude_to_codex_result",
+    requestId: message.requestId,
+    success: true,
+  });
+}
+
+// ── Per-chat helpers ────────────────────────────────────────────
+
+function startAttentionWindow(state: ChatState) {
+  clearAttentionWindow(state);
+  state.inAttentionWindow = true;
+  state.statusBuffer.pause();
+  log(`[${state.chatId}] Attention window started (${ATTENTION_WINDOW_MS}ms)`);
+  state.attentionWindowTimer = setTimeout(() => {
+    state.attentionWindowTimer = null;
+    state.inAttentionWindow = false;
+    state.statusBuffer.resume();
+    log(`[${state.chatId}] Attention window ended`);
+  }, ATTENTION_WINDOW_MS);
+}
+
+function clearAttentionWindow(state: ChatState) {
+  if (state.attentionWindowTimer) {
+    clearTimeout(state.attentionWindowTimer);
+    state.attentionWindowTimer = null;
+  }
+  if (state.inAttentionWindow) state.statusBuffer.resume();
+  state.inAttentionWindow = false;
+}
+
+function emitToChat(state: ChatState, message: BridgeMessage) {
+  if (state.ws && state.ws.readyState === WebSocket.OPEN) {
+    if (trySendBridgeMessage(state.ws, message, state.chatId)) return;
+    log(`[${state.chatId}] Send to Claude failed, buffering`);
+  }
+  state.bufferedMessages.push(message);
+  if (state.bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
+    const dropped = state.bufferedMessages.length - MAX_BUFFERED_MESSAGES;
+    state.bufferedMessages.splice(0, dropped);
+    log(`[${state.chatId}] Message buffer overflow: dropped ${dropped} oldest`);
+  }
+}
+
+function trySendBridgeMessage(
+  ws: ServerWebSocket<ControlSocketData>,
+  message: BridgeMessage,
+  chatId: string,
+): boolean {
+  try {
+    const payload: ControlServerMessage = { type: "codex_to_claude", chatId, message };
+    const result = ws.send(JSON.stringify(payload));
+    if (typeof result === "number" && result <= 0) {
+      log(`Bridge message send returned ${result} (0=dropped, -1=backpressure)`);
+      return false;
+    }
+    return true;
+  } catch (err: any) {
+    log(`Failed to send bridge message: ${err.message}`);
+    return false;
+  }
+}
+
+function flushBufferedMessages(state: ChatState) {
+  if (!state.ws || state.bufferedMessages.length === 0) return;
+  const messages = state.bufferedMessages.splice(0, state.bufferedMessages.length);
+  for (const message of messages) {
+    if (!trySendBridgeMessage(state.ws, message, state.chatId)) {
+      const idx = messages.indexOf(message);
+      state.bufferedMessages.unshift(...messages.slice(idx));
+      log(`[${state.chatId}] Flush interrupted: re-buffered ${messages.length - idx} message(s)`);
       return;
     }
   }
 }
 
-function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
-  if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
-    // Reject the new connection — don't disrupt the existing active session.
-    // Check !== CLOSED (not === OPEN) so that CLOSING state is also treated as
-    // "slot occupied", preventing a race where a new session slips in before
-    // the old one finishes its close handshake.
-    log(`Rejecting Claude frontend #${ws.data.clientId} — another session (#${attachedClaude.data.clientId}) is already attached (readyState=${attachedClaude.readyState})`);
-    ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
-    return;
-  }
+function broadcastToAllClaudes(message: BridgeMessage) {
+  for (const state of chats.values()) emitToChat(state, message);
+}
 
-  clearPendingClaudeDisconnect("Claude frontend attached");
-  attachedClaude = ws;
-  ws.data.attached = true;
-  cancelIdleShutdown();
-  log(`Claude frontend attached (#${ws.data.clientId})`);
+function sendStatus(ws: ServerWebSocket<ControlSocketData>) {
+  sendProtocolMessage(ws, { type: "status", status: currentStatus() });
+}
 
-  statusBuffer.flush("claude reconnected");
-  sendStatus(ws);
-
-  const now = Date.now();
-  const isRapidReattach = now - lastAttachStatusSentTs < ATTACH_STATUS_COOLDOWN_MS;
-
-  if (bufferedMessages.length > 0) {
-    flushBufferedMessages(ws);
-  } else if (!isRapidReattach) {
-    // Only send status messages if this is not a rapid reattach (avoid flooding Claude)
-    if (tuiConnectionState.canReply()) {
-      sendBridgeMessage(ws, systemMessage("system_ready", currentReadyMessage()));
-    } else if (codexBootstrapped) {
-      sendBridgeMessage(ws, systemMessage("system_waiting", currentWaitingMessage()));
-    }
-  }
-
-  lastAttachStatusSentTs = now;
-
-  if (tuiConnectionState.canReply() && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
+function broadcastStatus() {
+  for (const state of chats.values()) {
+    if (state.ws && state.ws.readyState === WebSocket.OPEN) sendStatus(state.ws);
   }
 }
 
-function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
-  if (attachedClaude !== ws) return;
-
-  attachedClaude = null;
-  ws.data.attached = false;
-  log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
-
-  scheduleClaudeDisconnectNotification(ws.data.clientId);
-
-  scheduleIdleShutdown();
-}
-
-function startAttentionWindow() {
-  clearAttentionWindow();
-  inAttentionWindow = true;
-  statusBuffer.pause();
-  log(`Attention window started (${ATTENTION_WINDOW_MS}ms)`);
-  attentionWindowTimer = setTimeout(() => {
-    attentionWindowTimer = null;
-    inAttentionWindow = false;
-    statusBuffer.resume();
-    log("Attention window ended");
-  }, ATTENTION_WINDOW_MS);
-}
-
-function clearAttentionWindow() {
-  if (attentionWindowTimer) {
-    clearTimeout(attentionWindowTimer);
-    attentionWindowTimer = null;
+function sendProtocolMessage(ws: ServerWebSocket<ControlSocketData>, message: ControlServerMessage) {
+  try {
+    ws.send(JSON.stringify(message));
+  } catch (err: any) {
+    log(`Failed to send control message: ${err.message}`);
   }
-  if (inAttentionWindow) {
-    statusBuffer.resume();
-  }
-  inAttentionWindow = false;
 }
+
+function currentStatus(): DaemonStatus {
+  const snapshot = tuiConnectionState.snapshot();
+  return {
+    bridgeReady: tuiConnectionState.canReply() || codexBootstrapped,
+    tuiConnected: snapshot.tuiConnected,
+    threadId: codex.activeThreadId,
+    queuedMessageCount: [...chats.values()].reduce(
+      (n, s) => n + s.bufferedMessages.length + s.statusBuffer.size,
+      0,
+    ),
+    proxyUrl: codex.proxyUrl,
+    appServerUrl: codex.appServerUrl,
+    pid: process.pid,
+    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length,
+  };
+}
+
+function systemMessage(idPrefix: string, content: string): BridgeMessage {
+  return {
+    id: `${idPrefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    source: "codex",
+    content,
+    timestamp: Date.now(),
+  };
+}
+
+// ── Idle shutdown ───────────────────────────────────────────────
 
 function scheduleIdleShutdown() {
   cancelIdleShutdown();
-  if (attachedClaude) return; // still has a client
-
-  const snapshot = tuiConnectionState.snapshot();
-  if (snapshot.tuiConnected) return; // TUI still connected
+  if ([...chats.values()].some((s) => s.ws !== null)) return; // still have a live claude
+  if (tuiConnectionState.snapshot().tuiConnected) return;
 
   log(`No clients connected. Daemon will shut down in ${IDLE_SHUTDOWN_MS}ms if no one reconnects.`);
   idleShutdownTimer = setTimeout(() => {
-    // Re-check before shutting down
-    if (attachedClaude || tuiConnectionState.snapshot().tuiConnected) {
+    if ([...chats.values()].some((s) => s.ws !== null) || tuiConnectionState.snapshot().tuiConnected) {
       log("Idle shutdown cancelled: client reconnected during grace period");
       return;
     }
@@ -440,178 +661,10 @@ function cancelIdleShutdown() {
   }
 }
 
-function clearPendingClaudeDisconnect(reason?: string) {
-  if (!claudeDisconnectTimer) return;
-  clearTimeout(claudeDisconnectTimer);
-  claudeDisconnectTimer = null;
-  if (reason) {
-    log(`Cleared pending Claude disconnect notification (${reason})`);
-  }
-}
+// ── Lifecycle ───────────────────────────────────────────────────
 
-function scheduleClaudeDisconnectNotification(clientId: number) {
-  clearPendingClaudeDisconnect("rescheduled");
-  claudeDisconnectTimer = setTimeout(() => {
-    claudeDisconnectTimer = null;
-
-    if (attachedClaude) {
-      log(
-        `Skipping Claude disconnect notification for client #${clientId} because Claude already reconnected`,
-      );
-      return;
-    }
-
-    if (!tuiConnectionState.canReply()) {
-      log(
-        `Suppressing Claude disconnect notification for client #${clientId} because Codex cannot reply`,
-      );
-      return;
-    }
-
-    if (!claudeOnlineNoticeSent) {
-      log(
-        `Suppressing Claude disconnect notification for client #${clientId} because Claude was never announced online`,
-      );
-      return;
-    }
-
-    codex.injectMessage(
-      "⚠️ Claude Code went offline. AgentBridge is still running in the background; it will reconnect automatically when Claude reopens.",
-    );
-    claudeOnlineNoticeSent = false;
-    claudeOfflineNoticeShown = true;
-    log(`Claude disconnect persisted past grace window (client #${clientId})`);
-  }, CLAUDE_DISCONNECT_GRACE_MS);
-}
-
-function emitToClaude(message: BridgeMessage) {
-  if (attachedClaude && attachedClaude.readyState === WebSocket.OPEN) {
-    if (trySendBridgeMessage(attachedClaude, message)) return;
-    // Send failed — fall through to buffer
-    log("Send to Claude failed, buffering message for retry on reconnect");
-  }
-
-  bufferedMessages.push(message);
-  if (bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
-    const dropped = bufferedMessages.length - MAX_BUFFERED_MESSAGES;
-    bufferedMessages.splice(0, dropped);
-    log(`Message buffer overflow: dropped ${dropped} oldest message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
-  }
-}
-
-function trySendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: BridgeMessage): boolean {
-  try {
-    const result = ws.send(JSON.stringify({ type: "codex_to_claude", message } satisfies ControlServerMessage));
-    if (typeof result === "number" && result <= 0) {
-      log(`Bridge message send returned ${result} (0=dropped, -1=backpressure)`);
-      return false;
-    }
-    return true;
-  } catch (err: any) {
-    log(`Failed to send bridge message: ${err.message}`);
-    return false;
-  }
-}
-
-function flushBufferedMessages(ws: ServerWebSocket<ControlSocketData>) {
-  const messages = bufferedMessages.splice(0, bufferedMessages.length);
-  for (const message of messages) {
-    if (!trySendBridgeMessage(ws, message)) {
-      // Re-buffer this and all remaining messages on failure
-      const failedIndex = messages.indexOf(message);
-      const remaining = messages.slice(failedIndex);
-      bufferedMessages.unshift(...remaining);
-      log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
-      return;
-    }
-  }
-}
-
-function sendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: BridgeMessage) {
-  trySendBridgeMessage(ws, message);
-}
-
-function sendStatus(ws: ServerWebSocket<ControlSocketData>) {
-  sendProtocolMessage(ws, { type: "status", status: currentStatus() });
-}
-
-function broadcastStatus() {
-  if (!attachedClaude) return;
-  sendStatus(attachedClaude);
-}
-
-function sendProtocolMessage(ws: ServerWebSocket<ControlSocketData>, message: ControlServerMessage) {
-  try {
-    ws.send(JSON.stringify(message));
-  } catch (err: any) {
-    log(`Failed to send control message: ${err.message}`);
-  }
-}
-
-function currentStatus(): DaemonStatus {
-  const snapshot = tuiConnectionState.snapshot();
-  return {
-    bridgeReady: tuiConnectionState.canReply(),
-    tuiConnected: snapshot.tuiConnected,
-    threadId: codex.activeThreadId,
-    queuedMessageCount: bufferedMessages.length + statusBuffer.size,
-    proxyUrl: codex.proxyUrl,
-    appServerUrl: codex.appServerUrl,
-    pid: process.pid,
-  };
-}
-
-function currentWaitingMessage() {
-  return `⏳ Waiting for Codex TUI to connect. Run in another terminal:\n${attachCmd}`;
-}
-
-function currentReadyMessage() {
-  return `✅ Codex TUI connected (${codex.activeThreadId}). Bridge ready.`;
-}
-
-function notifyCodexClaudeOnline(): boolean {
-  const message = !codexCollaborationKickoffSent
-    ? [
-        "🤝 Claude Code has connected via AgentBridge.",
-        "You are now in a multi-agent collaboration session.",
-        "When you receive a complex task, propose a division of labor to Claude.",
-        "Claude can send you messages — they will appear as injected user messages.",
-        "Respond naturally and Claude will receive your output via AgentBridge.",
-      ].join("\n")
-    : "✅ AgentBridge connected to Claude Code.";
-
-  const delivered = codex.injectMessage(message);
-  if (!delivered) {
-    log("Deferred Claude-online notice to Codex — will retry after current turn completes");
-    return false;
-  }
-
-  claudeOnlineNoticeSent = true;
-  claudeOfflineNoticeShown = false;
-  codexCollaborationKickoffSent = true;
-  return true;
-}
-
-function shouldNotifyCodexClaudeOnline() {
-  return !claudeOnlineNoticeSent || claudeOfflineNoticeShown;
-}
-
-function systemMessage(idPrefix: string, content: string): BridgeMessage {
-  return {
-    id: `${idPrefix}_${++nextSystemMessageId}`,
-    source: "codex",
-    content,
-    timestamp: Date.now(),
-  };
-}
-
-function writePidFile() {
-  daemonLifecycle.writePid();
-}
-
-function removePidFile() {
-  daemonLifecycle.removePidFile();
-}
+function writePidFile() { daemonLifecycle.writePid(); }
+function removePidFile() { daemonLifecycle.removePidFile(); }
 
 function writeStatusFile() {
   daemonLifecycle.writeStatus({
@@ -622,12 +675,10 @@ function writeStatusFile() {
   });
 }
 
-function removeStatusFile() {
-  daemonLifecycle.removeStatusFile();
-}
+function removeStatusFile() { daemonLifecycle.removeStatusFile(); }
 
 async function bootCodex() {
-  log("Starting AgentBridge daemon...");
+  log("Starting AgentBridge daemon (multi-Claude variant)...");
   log(`Codex app-server: ${codex.appServerUrl}`);
   log(`Codex proxy: ${codex.proxyUrl}`);
   log(`Control server: ws://127.0.0.1:${CONTROL_PORT}/ws`);
@@ -636,12 +687,10 @@ async function bootCodex() {
     await codex.start();
     codexBootstrapped = true;
     writeStatusFile();
-
-    emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));
     broadcastStatus();
   } catch (err: any) {
     log(`Failed to start Codex: ${err.message}`);
-    emitToClaude(
+    broadcastToAllClaudes(
       systemMessage(
         "system_codex_start_failed",
         `❌ AgentBridge failed to start Codex app-server: ${err.message}`,
@@ -656,7 +705,14 @@ function shutdown(reason: string) {
   shuttingDown = true;
   log(`Shutting down daemon (${reason})...`);
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);
-  clearPendingClaudeDisconnect(`daemon shutdown (${reason})`);
+  for (const state of chats.values()) {
+    if (state.attentionWindowTimer) clearTimeout(state.attentionWindowTimer);
+    if (state.disconnectTimer) clearTimeout(state.disconnectTimer);
+    if (state.reaperTimer) clearTimeout(state.reaperTimer);
+    state.statusBuffer.dispose();
+    try { state.thread.close(); } catch {}
+  }
+  chats.clear();
   controlServer?.stop();
   controlServer = null;
   codex.stop();
@@ -684,8 +740,6 @@ function log(msg: string) {
 }
 
 // Refuse to start if user intentionally killed the daemon.
-// This prevents stale auto-reconnect loops from relaunching us.
-// Only `agentbridge codex` / `ensureRunning` clears the sentinel before launching.
 if (daemonLifecycle.wasKilled()) {
   log("Killed sentinel found — daemon was intentionally stopped. Exiting immediately.");
   process.exit(0);
@@ -694,3 +748,7 @@ if (daemonLifecycle.wasKilled()) {
 writePidFile();
 startControlServer();
 void bootCodex();
+
+// Silence unused-warning for the legacy import; we keep the symbol around in
+// case future tooling wants to surface the attach command in status.
+void attachCmd;

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -236,7 +236,11 @@ class CliE2EHarness {
     );
   }
 
-  readShimCalls(command: "claude" | "codex"): Array<{ args: string[]; cwd: string }> {
+  readShimCalls(command: "claude" | "codex"): Array<{
+    args: string[];
+    cwd: string;
+    env?: Record<string, string | null>;
+  }> {
     const logPath = join(this.shimLogDir, `${command}.jsonl`);
     return readJsonLines(logPath);
   }
@@ -415,7 +419,7 @@ describe("E2E: CLI surface", () => {
     });
   });
 
-  test("agentbridge codex ensures daemon is running and injects remote args", async () => {
+  test("agentbridge codex ensures daemon is running and injects direct remote args", async () => {
     await withHarness(async (harness) => {
       const result = await harness.runCli(["codex", "--model", "o3"]);
 
@@ -425,6 +429,7 @@ describe("E2E: CLI surface", () => {
       expect(harness.readLaunches()).toHaveLength(1);
       expect(harness.readPid()).not.toBeNull();
       expect(harness.readStatus()?.proxyUrl).toBe(`ws://127.0.0.1:${harness.proxyPort}`);
+      expect(harness.readStatus()?.appServerUrl).toBe(`ws://127.0.0.1:${harness.appPort}`);
       expect(harness.readTuiPid()).toBeNull();
 
       const invocations = harness
@@ -435,10 +440,36 @@ describe("E2E: CLI surface", () => {
         "--enable",
         "tui_app_server",
         "--remote",
-        `ws://127.0.0.1:${harness.proxyPort}`,
+        `ws://127.0.0.1:${harness.appPort}`,
         "--model",
         "o3",
       ]);
+    });
+  }, 20000);
+
+  test("agentbridge codex --via-proxy uses bearer auth token instead of query URL", async () => {
+    await withHarness(async (harness) => {
+      const result = await harness.runCli(["codex", "--via-proxy", "--model", "o3"]);
+
+      expect(result.code).toBe(0);
+      await harness.waitForHealth();
+
+      const invocations = harness
+        .readShimCalls("codex")
+        .filter((entry) => entry.args[0] !== "--version");
+      expect(invocations).toHaveLength(1);
+      expect(invocations[0]?.args).toEqual([
+        "--enable",
+        "tui_app_server",
+        "--remote",
+        `ws://127.0.0.1:${harness.proxyPort}`,
+        "--remote-auth-token-env",
+        "AGENTBRIDGE_PROXY_TOKEN",
+        "--model",
+        "o3",
+      ]);
+      expect(invocations[0]?.args.join(" ")).not.toContain("abg_token=");
+      expect(invocations[0]?.env?.AGENTBRIDGE_PROXY_TOKEN).toMatch(/^[0-9a-f]{16}$/);
     });
   }, 20000);
 
@@ -447,6 +478,10 @@ describe("E2E: CLI surface", () => {
       const remoteConflict = await harness.runCli(["codex", "--remote", "ws://127.0.0.1:7777"]);
       expect(remoteConflict.code).toBe(1);
       expect(remoteConflict.stderr).toContain("\"--remote\" is automatically set by agentbridge codex");
+
+      const remoteAuthConflict = await harness.runCli(["codex", "--remote-auth-token-env", "TOKEN"]);
+      expect(remoteAuthConflict.code).toBe(1);
+      expect(remoteAuthConflict.stderr).toContain("\"--remote-auth-token-env\" is automatically set by agentbridge codex");
 
       const enableConflict = await harness.runCli(["codex", "--enable", "tui_app_server"]);
       expect(enableConflict.code).toBe(1);
@@ -457,7 +492,7 @@ describe("E2E: CLI surface", () => {
     });
   });
 
-  test("agentbridge codex reuses healthy daemon and prefers status.json proxyUrl", async () => {
+  test("agentbridge codex reuses healthy daemon and prefers status.json appServerUrl", async () => {
     await withHarness({ configProxyPort: 49991 }, async (harness) => {
       const daemonProc = await harness.startManagedFakeDaemon();
       const pidBefore = harness.readPid();
@@ -478,7 +513,7 @@ describe("E2E: CLI surface", () => {
         "--enable",
         "tui_app_server",
         "--remote",
-        `ws://127.0.0.1:${harness.proxyPort}`,
+        `ws://127.0.0.1:${harness.appPort}`,
         "--profile",
         "default",
       ]);
@@ -505,7 +540,7 @@ describe("E2E: CLI surface", () => {
       for (const invocation of invocations) {
         expect(invocation.args[0]).toBe("--enable");
         expect(invocation.args[2]).toBe("--remote");
-        expect(invocation.args[3]).toBe(`ws://127.0.0.1:${harness.proxyPort}`);
+        expect(invocation.args[3]).toBe(`ws://127.0.0.1:${harness.appPort}`);
       }
     });
   }, 30000);
@@ -595,7 +630,7 @@ describe("E2E: CLI surface", () => {
       const codexRun = harness
         .readShimCalls("codex")
         .find((entry) => entry.args[0] === "--enable");
-      expect(codexRun?.args[3]).toBe(`ws://127.0.0.1:${harness.proxyPort}`);
+      expect(codexRun?.args[3]).toBe(`ws://127.0.0.1:${harness.appPort}`);
     });
   }, 30000);
 });
@@ -789,7 +824,13 @@ mkdirSync(dirname(logPath), { recursive: true });
 const args = process.argv.slice(2);
 appendFileSync(
   logPath,
-  JSON.stringify({ args, cwd: process.cwd() }) + "\\n",
+  JSON.stringify({
+    args,
+    cwd: process.cwd(),
+    env: {
+      AGENTBRIDGE_PROXY_TOKEN: process.env.AGENTBRIDGE_PROXY_TOKEN ?? null,
+    },
+  }) + "\\n",
   "utf-8",
 );
 
@@ -910,6 +951,18 @@ const server = Bun.serve({
   },
 });
 
+const appServer = Bun.serve({
+  port: appPort,
+  hostname: "127.0.0.1",
+  fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname === "/healthz" || url.pathname === "/readyz") {
+      return Response.json({ ok: true, appServerUrl });
+    }
+    return new Response("fake codex app-server");
+  },
+});
+
 const proxyServer = Bun.serve({
   port: proxyPort,
   hostname: "127.0.0.1",
@@ -925,6 +978,7 @@ const proxyServer = Bun.serve({
 function shutdown() {
   cleanupFiles();
   server.stop();
+  appServer.stop();
   proxyServer.stop();
   process.exit(0);
 }

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -1608,3 +1608,173 @@ describe("CodexAdapter thread/closed diagnostic sniffer", () => {
     expect(diag.length).toBe(0);
   });
 });
+
+// ── Spec v2.2 §4.1 — paired-chat state ──────────────────────────
+
+describe("CodexAdapter paired-chat state (spec v2.2 §4.1)", () => {
+  test("setPairedChat / isPaired / currentPairedChatId roundtrip", () => {
+    const adapter = createAdapter();
+    expect(adapter.isPaired("chat_abc")).toBe(false);
+    expect(adapter.currentPairedChatId).toBe(null);
+
+    adapter.setPairedChat("chat_abc");
+    expect(adapter.isPaired("chat_abc")).toBe(true);
+    expect(adapter.isPaired("chat_xyz")).toBe(false);
+    expect(adapter.currentPairedChatId).toBe("chat_abc");
+
+    adapter.setPairedChat(null);
+    expect(adapter.isPaired("chat_abc")).toBe(false);
+    expect(adapter.currentPairedChatId).toBe(null);
+  });
+});
+
+// ── Spec v2.2 §4.3 — outbound event emissions ───────────────────
+
+describe("CodexAdapter outbound events for shared transport (spec v2.2 §4.3)", () => {
+  test("emits userMessage when item/completed has type userMessage and content", () => {
+    const adapter = createAdapter();
+    const events: Array<{ event: string; payload: any }> = [];
+    adapter.on("userMessage", (p: any) => events.push({ event: "userMessage", payload: p }));
+    adapter.on("agentMessage", (p: any) => events.push({ event: "agentMessage", payload: p }));
+
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u1", type: "userMessage", content: [{ type: "text", text: "hello from tui" }] },
+        turnId: "t1",
+      },
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].event).toBe("userMessage");
+    expect(events[0].payload.content).toBe("hello from tui");
+    expect(events[0].payload.source).toBe("codex");
+    expect(events[0].payload.turnId).toBe("t1");
+  });
+
+  test("emits errorItem on top-level error notification", () => {
+    const adapter = createAdapter();
+    const events: Array<{ code?: number; message?: string; data?: unknown }> = [];
+    adapter.on("errorItem", (p: any) => events.push(p));
+
+    adapter.handleServerNotification({
+      method: "error",
+      params: { error: { code: -32601, message: "Method not found" } },
+    });
+
+    expect(events).toEqual([{ code: -32601, message: "Method not found", data: undefined }]);
+  });
+
+  test("emits threadClosed on top-level thread/closed notification", () => {
+    const adapter = createAdapter();
+    const events: Array<{ threadId?: string }> = [];
+    adapter.on("threadClosed", (p: any) => events.push(p));
+
+    adapter.handleServerNotification({
+      method: "thread/closed",
+      params: { threadId: "th-99" },
+    });
+
+    expect(events).toEqual([{ threadId: "th-99" }]);
+  });
+
+  test("does NOT forward toolCall / shellCommand / approval items (whitelist exclusion §4.4)", () => {
+    const adapter = createAdapter();
+    const events: string[] = [];
+    adapter.on("agentMessage", () => events.push("agentMessage"));
+    adapter.on("userMessage", () => events.push("userMessage"));
+
+    for (const itemType of ["toolCall", "shellCommand", "fileChange", "reasoning"]) {
+      adapter.handleServerNotification({
+        method: "item/completed",
+        params: { item: { id: `i_${itemType}`, type: itemType, content: [{ type: "text", text: "x" }] } },
+      });
+    }
+
+    expect(events).toEqual([]);
+  });
+});
+
+// ── Spec v2.2 §4.5 — echo dedup ─────────────────────────────────
+
+describe("CodexAdapter echo dedup (spec v2.2 §4.5)", () => {
+  test("turnId match suppresses userMessage echo of injected text", () => {
+    const adapter = createAdapter();
+    const events: any[] = [];
+    adapter.on("userMessage", (p: any) => events.push(p));
+
+    // Simulate that an injection's turn/start response gave us this turnId.
+    adapter.recordInjectedTurnId("turn_inj_1", undefined);
+
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u1", type: "userMessage", content: [{ type: "text", text: "echo me" }] },
+        turnId: "turn_inj_1",
+      },
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  test("content-hash match suppresses echo when turnId not yet known (race window)", () => {
+    const adapter = createAdapter();
+    const events: any[] = [];
+    adapter.on("userMessage", (p: any) => events.push(p));
+
+    // Simulate that injectMessage was called (which would populate this map)
+    // but the turn/start response has not yet landed.
+    const hash = adapter.hashInjectionContent("race-window text");
+    adapter.pendingInjectionHashes.set(hash, Date.now() + 5_000);
+
+    // Notification arrives WITHOUT turnId (rare but possible in races).
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u2", type: "userMessage", content: [{ type: "text", text: "race-window text" }] },
+      },
+    });
+
+    expect(events).toEqual([]);
+    // Hash is one-shot consumed.
+    expect(adapter.pendingInjectionHashes.has(hash)).toBe(false);
+  });
+
+  test("legitimate user-typed message with no prior injection IS forwarded", () => {
+    const adapter = createAdapter();
+    const events: any[] = [];
+    adapter.on("userMessage", (p: any) => events.push(p));
+
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u3", type: "userMessage", content: [{ type: "text", text: "fresh user input" }] },
+        turnId: "turn_99",
+      },
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].content).toBe("fresh user input");
+  });
+
+  test("expired turnId entry does not suppress (TTL respected)", () => {
+    const adapter = createAdapter();
+    const events: any[] = [];
+    adapter.on("userMessage", (p: any) => events.push(p));
+
+    // Manually set expired entry
+    adapter.injectedTurnIds.set("turn_old", Date.now() - 1000);
+
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u4", type: "userMessage", content: [{ type: "text", text: "after ttl" }] },
+        turnId: "turn_old",
+      },
+    });
+
+    expect(events.length).toBe(1);
+    // Expired entry should have been cleaned up by isEchoOfInjection
+    expect(adapter.injectedTurnIds.has("turn_old")).toBe(false);
+  });
+});

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Unit tests for the daemon pairing state machine (spec v2.2 §9 / §5).
+ *
+ * The daemon module's top-level boot is gated by `import.meta.main`, so
+ * importing it from here does NOT spin up sockets, the Codex app-server,
+ * or any background processes. We drive the state machine through the
+ * `__testing` harness, emit events directly on the singleton CodexAdapter,
+ * and inspect each chat's `bufferedMessages` to verify what was emitted.
+ *
+ * Coverage:
+ *   §9 Pairing FIFO
+ *   §9 Grace window (AGENTBRIDGE_PAIR_REAP_MS)
+ *   §9 Race-protection (PAIR_RACE_MS=0 — no retroactive pairing)
+ *   §9 Isolation transition on TUI disconnect / thread/closed
+ *   Bug regression A (2026-05-16): no-output failure gated on replyRequired
+ *   Bug regression B (2026-05-16): bootstrap failure surfaces final error
+ *   Bug regression C (2026-05-16): errorItem sets pairedTurnSawAgentMessage
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test, beforeEach, afterAll } from "bun:test";
+import type { BridgeMessage } from "../types";
+
+// Test-only env overrides MUST be set before the daemon module loads,
+// because daemon.ts captures several constants (PAIR_REAP_MS, the isolated-
+// bootstrap retry knobs, IDLE_SHUTDOWN_MS, ...) at the top of the file.
+// Static ESM `import` statements are hoisted above module body code, so we
+// use a dynamic `await import()` here to guarantee env precedence.
+const testStateDir = mkdtempSync(join(tmpdir(), "agentbridge-daemon-test-"));
+process.env.AGENTBRIDGE_STATE_DIR = testStateDir;
+process.env.AGENTBRIDGE_PAIR_REAP_MS = "100";
+// MAX_ATTEMPTS=2 + RETRY_DELAY=5ms gives the retry test a real loop to
+// exercise (attempt 1 fails → emit retry → attempt 2 fails → emit final
+// failure + reap), and stays under 100ms total.
+process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_MAX_ATTEMPTS = "2";
+process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_RETRY_DELAY_MS = "5";
+process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS = "60000";
+// Point the daemon at a deliberately unbound port so any ClaudeThread
+// bootstrap attempt in tests (e.g. via transitionToIsolated) fails fast
+// instead of accidentally connecting to a real Codex app-server that
+// happens to be running on the developer's machine.
+process.env.CODEX_WS_PORT = "24500";
+process.env.CODEX_PROXY_PORT = "24501";
+
+const daemonModule = await import("../daemon");
+const { __testing } = daemonModule;
+const { fns, codex, chats, config } = __testing;
+
+function makeSlot(opts: { pairedChatId?: string | null; readiness?: "not-ready" | "ready" } = {}) {
+  return {
+    token: "test-token-" + Math.random().toString(36).slice(2, 8),
+    pairedChatId: opts.pairedChatId ?? null,
+    readiness: opts.readiness ?? "ready" as const,
+    attachedAt: Date.now(),
+    pairReapTimer: null as ReturnType<typeof setTimeout> | null,
+  };
+}
+
+function attachFakeWs(chat: ReturnType<typeof fns.createChatState>) {
+  // Minimal WS shape sufficient for detachClaudeWs's guard / clientId log.
+  chat.ws = {
+    data: { clientId: 999, attached: true, chatId: chat.chatId },
+    readyState: 1, // OPEN
+    send: () => 0,
+    close: () => {},
+  } as any;
+}
+
+function findMessage(messages: BridgeMessage[], idPrefix: string): BridgeMessage | undefined {
+  return messages.find((m) => m.id.startsWith(idPrefix));
+}
+
+function findMessageContaining(messages: BridgeMessage[], needle: string): BridgeMessage | undefined {
+  return messages.find((m) => m.content.includes(needle));
+}
+
+beforeEach(() => {
+  __testing.reset();
+});
+
+afterAll(() => {
+  __testing.reset();
+  rmSync(testStateDir, { recursive: true, force: true });
+});
+
+// ── §9 Pairing FIFO ─────────────────────────────────────────────
+
+describe("daemon pairing FIFO (spec v2.2 §5)", () => {
+  test("first attached Claude claims the slot, second stays isolated", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat1 = fns.createChatState("chat_one");
+    chats.set("chat_one", chat1);
+    fns.pairChat(chat1);
+
+    expect(chat1.paired).toBe(true);
+    expect(chat1.ready).toBe(true);
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBe("chat_one");
+
+    const chat2 = fns.createChatState("chat_two");
+    chats.set("chat_two", chat2);
+    fns.pairChat(chat2);
+
+    // Second pair attempt is rejected by the guard inside pairChat — slot
+    // stays with chat_one and chat_two never flips `paired`.
+    expect(chat2.paired).toBe(false);
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBe("chat_one");
+  });
+
+  test("pairChat is a no-op when proxyTuiSlot is null", () => {
+    const chat = fns.createChatState("chat_solo");
+    chats.set("chat_solo", chat);
+    fns.pairChat(chat);
+
+    expect(chat.paired).toBe(false);
+    expect(__testing.proxyTuiSlot).toBeNull();
+  });
+
+  test("pairing flips ready according to slot readiness (provisioning case)", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "not-ready" }));
+
+    const chat = fns.createChatState("chat_prov");
+    chats.set("chat_prov", chat);
+    fns.pairChat(chat);
+
+    expect(chat.paired).toBe(true);
+    expect(chat.ready).toBe(false); // waits for codex.on("ready") to flip it
+
+    const provisioningMsg = findMessage(chat.bufferedMessages, "system_paired_provisioning");
+    expect(provisioningMsg).toBeDefined();
+  });
+});
+
+// ── §9 Grace window ─────────────────────────────────────────────
+
+describe("daemon paired-Claude grace window (spec v2.2 §5)", () => {
+  test("pairReapTimer expires after PAIR_REAP_MS and clears the slot", async () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_g");
+    chats.set("chat_g", chat);
+    attachFakeWs(chat);
+    fns.pairChat(chat);
+
+    fns.detachClaudeWs(chat, "test detach");
+
+    expect(__testing.proxyTuiSlot?.pairReapTimer).not.toBeNull();
+
+    // Wait past the grace window — PAIR_REAP_MS is 100ms in test env.
+    await new Promise((r) => setTimeout(r, config.PAIR_REAP_MS + 80));
+
+    // Slot's pairedChatId cleared; orphaned chat state fully reaped.
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBeNull();
+    expect(chats.has("chat_g")).toBe(false);
+  });
+
+  test("reconnecting within grace cancels the reaper and preserves pair", async () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_grace_keep");
+    chats.set("chat_grace_keep", chat);
+    attachFakeWs(chat);
+    fns.pairChat(chat);
+
+    fns.detachClaudeWs(chat, "test detach");
+
+    // Reattach a WS before the grace expires (simulates same chatId
+    // reconnecting). The reaper's body checks `currentState.ws` and bails.
+    await new Promise((r) => setTimeout(r, 30));
+    attachFakeWs(chat);
+
+    // Wait past where the original reaper would have fired.
+    await new Promise((r) => setTimeout(r, config.PAIR_REAP_MS + 80));
+
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBe("chat_grace_keep");
+    expect(chats.has("chat_grace_keep")).toBe(true);
+  });
+});
+
+// ── §9 Race protection (PAIR_RACE_MS=0) ─────────────────────────
+
+describe("daemon race protection (spec v2.2 §5.1, PAIR_RACE_MS=0)", () => {
+  test("Claude-first stays isolated when TUI connects later (no retroactive pairing)", () => {
+    // Existing isolated chat — already provisioned before any TUI shows up.
+    const chat = fns.createChatState("chat_preexisting");
+    chat.ready = true; // pretend its own ClaudeThread bootstrap already finished
+    chats.set("chat_preexisting", chat);
+
+    expect(chat.paired).toBe(false);
+    expect(__testing.proxyTuiSlot).toBeNull();
+
+    // TUI connects, carrying a token (this is what makes it a proxy TUI).
+    codex.emit("tuiConnected", 1, "race-token-abc");
+
+    // Slot is allocated — but the existing chat is NOT retroactively paired.
+    expect(__testing.proxyTuiSlot).not.toBeNull();
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBeNull();
+    expect(chat.paired).toBe(false);
+  });
+
+  test("tuiConnected with empty token does NOT allocate a proxy slot (legacy TUI)", () => {
+    expect(__testing.proxyTuiSlot).toBeNull();
+    codex.emit("tuiConnected", 1, "");
+    expect(__testing.proxyTuiSlot).toBeNull();
+  });
+});
+
+// ── §9 Isolation transition ─────────────────────────────────────
+
+describe("daemon isolation transition (spec v2.2 §5)", () => {
+  test("TUI disconnect tears down the slot and transitions paired chat to isolated", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_iso_tui");
+    chats.set("chat_iso_tui", chat);
+    fns.pairChat(chat);
+    expect(chat.paired).toBe(true);
+
+    // Capture bufferedMessages length BEFORE the transition so we can find
+    // the new system_pair_torn_down message specifically.
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("tuiDisconnected", 1);
+
+    expect(chat.paired).toBe(false);
+    expect(__testing.proxyTuiSlot).toBeNull();
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    const tornDown = findMessage(newMessages, "system_pair_torn_down");
+    expect(tornDown).toBeDefined();
+    expect(tornDown!.content).toContain("Shared Codex TUI thread is gone");
+  });
+
+  test("thread/closed notification triggers same isolation transition", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_iso_tc");
+    chats.set("chat_iso_tc", chat);
+    fns.pairChat(chat);
+    expect(chat.paired).toBe(true);
+
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("threadClosed", { threadId: "tid-xyz" });
+
+    expect(chat.paired).toBe(false);
+    expect(__testing.proxyTuiSlot).toBeNull();
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    const tornDown = findMessage(newMessages, "system_pair_torn_down");
+    expect(tornDown).toBeDefined();
+    expect(tornDown!.content).toContain("Shared Codex thread closed");
+  });
+});
+
+// ── Bug regressions ─────────────────────────────────────────────
+
+describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
+  test("Bug A: turn/completed with no agentMessage does NOT emit no-output failure when replyRequired=false", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_a");
+    chats.set("chat_bug_a", chat);
+    fns.pairChat(chat);
+
+    // User typed in TUI scenario — replyRequired stayed false, no agentMessage.
+    chat.replyRequired = false;
+    chat.pairedTurnSawAgentMessage = false;
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("turnCompleted");
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    expect(findMessage(newMessages, "system_codex_turn_completed_no_output")).toBeUndefined();
+    expect(findMessage(newMessages, "system_codex_turn_completed")).toBeDefined();
+  });
+
+  test("Bug A: no-output failure IS emitted when replyRequired=true (Claude waiting for reply)", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_a_pos");
+    chats.set("chat_bug_a_pos", chat);
+    fns.pairChat(chat);
+
+    chat.replyRequired = true;
+    chat.pairedTurnSawAgentMessage = false;
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("turnCompleted");
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    const failure = findMessage(newMessages, "system_codex_turn_completed_no_output");
+    expect(failure).toBeDefined();
+    // Cleanup flags are reset at end of handler.
+    expect(chat.replyRequired).toBe(false);
+    expect(chat.replyReceivedDuringTurn).toBe(false);
+  });
+
+  test("Bug C: errorItem sets pairedTurnSawAgentMessage so subsequent turn/completed does NOT fire spurious failure", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_c");
+    chats.set("chat_bug_c", chat);
+    fns.pairChat(chat);
+
+    // Simulate: Claude was waiting for reply, error arrives, then turn ends.
+    chat.replyRequired = true;
+    chat.pairedTurnSawAgentMessage = false;
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("errorItem", { code: -32601, message: "Method not found" });
+
+    expect(chat.pairedTurnSawAgentMessage).toBe(true);
+    expect(chat.replyRequired).toBe(false);
+
+    const afterErrorCount = chat.bufferedMessages.length;
+    const errMsg = findMessageContaining(
+      chat.bufferedMessages.slice(beforeCount),
+      "Method not found",
+    );
+    expect(errMsg).toBeDefined();
+
+    // Now turn/completed fires after the error. Should NOT emit a second
+    // failure system message — Claude already heard the error.
+    codex.emit("turnCompleted");
+    const newMessages = chat.bufferedMessages.slice(afterErrorCount);
+    expect(findMessage(newMessages, "system_codex_turn_completed_no_output")).toBeUndefined();
+    expect(findMessage(newMessages, "system_codex_turn_completed")).toBeDefined();
+  });
+
+  test("Bug B: bootstrap retry config is wired in via env", () => {
+    // Smoke test for the retry plumbing — verify env-driven knobs landed.
+    expect(config.ISOLATED_BOOTSTRAP_MAX_ATTEMPTS).toBe(2);
+    expect(config.ISOLATED_BOOTSTRAP_RETRY_DELAY_MS).toBe(5);
+  });
+
+  test("Bug B: transitionToIsolated exercises the retry loop and emits a definitive 'failed' message when all attempts fail", async () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_b");
+    chats.set("chat_bug_b", chat);
+    fns.pairChat(chat);
+
+    const beforeCount = chat.bufferedMessages.length;
+
+    // Trigger transition. The ClaudeThread it constructs will try to
+    // bootstrap against ws://127.0.0.1:24500 (unbound), so each bootstrap
+    // attempt rejects. With MAX_ATTEMPTS=2 + RETRY_DELAY=5ms we should see
+    // attempt 1 → emit retry → attempt 2 → emit final failure + reap.
+    fns.transitionToIsolated(chat, "test reason");
+
+    await new Promise((r) => setTimeout(r, 400));
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    const retryMsg = findMessage(newMessages, "system_isolated_retry");
+    expect(retryMsg).toBeDefined();
+    expect(retryMsg!.content).toContain("(attempt 1/2)");
+
+    const failed = findMessage(newMessages, "system_isolated_failed");
+    expect(failed).toBeDefined();
+    expect(failed!.content).toContain("after 2 attempts");
+    expect(failed!.content).toContain("reconnect Claude");
+  });
+
+  test("Bug B (Codex review): final failure REAPS the chat so subsequent attach gets a fresh bootstrap", async () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_b_reap");
+    chats.set("chat_bug_b_reap", chat);
+    fns.pairChat(chat);
+
+    expect(chats.has("chat_bug_b_reap")).toBe(true);
+
+    fns.transitionToIsolated(chat, "test reason");
+
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Without this Codex-review fix, the chat stays in the map and the
+    // "reconnect Claude" guidance is a lie because attachClaude takes the
+    // resume branch and never re-bootstraps.
+    expect(chats.has("chat_bug_b_reap")).toBe(false);
+  });
+
+  test("Codex review #2: transitionToIsolated clears stale paired-turn flags so they don't bleed into isolated thread", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bleed");
+    chats.set("chat_bleed", chat);
+    fns.pairChat(chat);
+
+    // Mid-turn state when TUI disconnects.
+    chat.replyRequired = true;
+    chat.replyReceivedDuringTurn = true;
+    chat.pairedTurnSawAgentMessage = true;
+
+    fns.transitionToIsolated(chat, "test reason");
+
+    // After transition the flags are reset so the fresh isolated thread
+    // does not inherit a stale "Claude is waiting for a reply" state.
+    expect(chat.replyRequired).toBe(false);
+    expect(chat.replyReceivedDuringTurn).toBe(false);
+    expect(chat.pairedTurnSawAgentMessage).toBe(false);
+  });
+
+  test("Codex review #3: errorItem clears replyReceivedDuringTurn (symmetric with turnCompleted)", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_err_sym");
+    chats.set("chat_err_sym", chat);
+    fns.pairChat(chat);
+
+    chat.replyRequired = true;
+    chat.replyReceivedDuringTurn = false;
+
+    codex.emit("errorItem", { code: -32000, message: "test error" });
+
+    // turnCompleted-style cleanup: both flags reset, plus
+    // pairedTurnSawAgentMessage tracked so a follow-on turnCompleted
+    // does not fire spurious no-output failure.
+    expect(chat.replyRequired).toBe(false);
+    expect(chat.replyReceivedDuringTurn).toBe(false);
+    expect(chat.pairedTurnSawAgentMessage).toBe(true);
+  });
+});


### PR DESCRIPTION
# Multi-Claude + Multi-TUI Support / 多 Claude × 多 TUI 并行支持

Self-contained notes for the PR description. The work landed as three
commits — each addresses a distinct constraint in the current
single-session bridge.

---

## TL;DR (English)

Three things are blocking parallel agent use today:

1. The daemon rejects the second Claude Code session with
   `CLOSE_CODE_REPLACED` — only one Claude can attach to one bridge.
2. Even after lifting that, the new per-Claude codex thread silently
   denied every `requestApproval` server-request, so any shell command
   (`exec_command`) inside that thread failed with
   `CreateProcess { message: "Rejected" }`.
3. Running `agentbridge codex` twice gives the second TUI the
   "secondary/resume-picker" path, which codex-rs reacts to by sending
   `thread/closed` and exiting the TUI silently.

This PR fixes all three:

- **Multi-Claude routing** (`src/daemon.ts`, `src/claude-thread.ts`,
  `src/control-protocol.ts`, `src/daemon-client.ts`,
  `src/claude-adapter.ts`, `src/bridge.ts`): replaces the single
  `attachedClaude` slot with `Map<chatId, ChatState>`. Each Claude
  session gets a dedicated codex thread via the lean new
  `ClaudeThread` helper, which opens its own WebSocket to
  `codex app-server`.
- **Approval policy + auto-accept fallback** (`src/claude-thread.ts`):
  thread/start now passes `approvalPolicy: "never"`, telling Codex not
  to escalate. As defense-in-depth, the three server-request approval
  methods are auto-handled with correctly-shaped responses (per the
  `codex app-server` schema) instead of `-32601`.
- **Direct-mode CLI for multi-TUI** (`src/cli/codex.ts`): default
  `agentbridge codex` now points `codex --remote` at the daemon's
  `appServerUrl` (port 4500) rather than the proxy port (4501). This
  lets the user open multiple TUI windows in parallel; each becomes
  an independent client of the shared app-server. `--via-proxy` is
  kept as an opt-in for the legacy primary/secondary path.

## TL;DR (中文)

并行用 agent 当前有三道坎：

1. daemon 单 `attachedClaude` slot —— 第二个 Claude 进来被
   `CLOSE_CODE_REPLACED` 拒掉。
2. 把第一道坎解了之后，新建的 per-Claude codex thread 把所有 `requestApproval`
   server-request 全 -32601 拒掉，导致里面跑 `exec_command` 立刻报
   `CreateProcess { message: "Rejected" }`。
3. 并行跑两次 `agentbridge codex` 时，第二个 TUI 走"secondary/resume-picker"
   路径，codex-rs 给它发 `thread/closed`、TUI 静默 exit。

本 PR 三个 commit 各扫一道：

- **Multi-Claude 路由**：`Map<chatId, ChatState>` 替换单 slot，每个
  Claude 通过新增的 `ClaudeThread` 拿自己专属的 codex thread。
- **approvalPolicy + auto-accept 兜底**：thread/start 带
  `approvalPolicy: "never"` 不再触发批准请求；万一服务端还是发了，三
  种 server-request 用 schema 定义的正确响应形状 auto-handle。
- **Direct-mode CLI 让多 TUI 并行**：`agentbridge codex` 默认连 4500
  （app-server 直连），不再走 4501（proxy）。`--via-proxy` 是旧行为
  opt-in。

---

## What changed

| File | Why |
|---|---|
| **`src/claude-thread.ts`** (new) | Lean WS wrapper that owns one thread per chatId. Initialize → `thread/start` with `approvalPolicy: "never"` → `turn/start`. Listens for `item/started` / `item/agentMessage/delta` / `item/completed` / `turn/started` / `turn/completed`. Server-initiated approval requests are typed-responded (auto-accept for `commandExecution` / `fileChange` / `applyPatch` / `execCommand`; empty grant for `permissions`); unknown server-request methods return `-32601`. |
| **`src/daemon.ts`** | Single-slot `attachedClaude` → `Map<chatId, ChatState>`. Each ChatState owns its `ClaudeThread`, attention window, `statusBuffer`, `replyRequired` tracking, offline buffer, disconnect/reap timers. Disconnected chats reaped after `AGENTBRIDGE_CLAUDE_REAP_MS` (default 600s) so a reconnect within that window resumes the same Codex thread. |
| **`src/control-protocol.ts`** | Optional `chatId` field on `claude_connect` / `claude_disconnect` / `claude_to_codex` / `codex_to_claude`. `attachedClaudeCount` added to `DaemonStatus`. Backward-compatible (older clients omitting `chatId` get a synthesized one). |
| **`src/daemon-client.ts`** | `DaemonClient` accepts `{ chatId }` in its constructor and stamps every outbound message. |
| **`src/claude-adapter.ts`** | Public `chatId` (= existing `sessionId` plus the random `instanceId`) for `bridge.ts` to wire through. |
| **`src/bridge.ts`** | One-line: pass `claude.chatId` into the `DaemonClient` constructor. |
| **`src/cli/codex.ts`** | New `--direct` (default) / `--via-proxy` toggle. Direct mode points `codex --remote` at the daemon's `appServerUrl` so multiple TUI windows can coexist. `--via-proxy` opts back into the legacy primary/secondary path. |
| **`src/daemon-lifecycle.ts`** | `readStatus()` return type widened to expose `appServerUrl` (already written by the daemon; just the static type was missing). |
| **`plugins/agentbridge/server/*.js`** | Rebuilt with `bun run build:plugin`. |
| **`probes/two-claudes.ts`** (new) | E2E probe: spawns the daemon on isolated ports, attaches two simulated MCP clients with distinct chatIds, fires turns concurrently, asserts parallel execution + cross-chat isolation. |
| **`probes/shell-approval.ts`** (new) | E2E probe for the approval-policy fix: drives a real `exec_command` turn through a ClaudeThread and checks the marker is echoed back, with zero `auto-denied (no UI to approve)` log lines. |
| **`probes/two-tui-direct.ts`** (new) | Lower-level probe: opens two independent WS clients directly against `codex app-server`, verifies two distinct threads with concurrent `turn/started` and zero `thread/closed` — the empirical basis for the direct-mode CLI change. |

`UPSTREAM_PR_NOTES.md`, `install.sh`, `restore.sh`, `upstream.patch` —
**not part of this PR**. They are local-only tooling for activating
the fork before merge.

## Behavior changes to flag for review

### TUI ↔ Claude broadcast removed
In the current single-Claude design, `daemon.ts` listens to
`codex.on("agentMessage")` from the TUI proxy and forwards those events
to the attached Claude — making the TUI's thread visible to that Claude.
In this PR each Claude has its own dedicated thread, and the daemon no
longer broadcasts TUI events into Claude chats. A 1→N broadcast in
multi-Claude mode would cross-contaminate every Claude's context, so the
clean isolation seems more valuable. **If strict single-Claude backward
compatibility matters**, the legacy behavior can be restored by gating
the broadcast on `chats.size === 1 && state.bindToTui === true`.

### Approval auto-accept (vs. previous auto-deny)
Pre-fix, the new per-Claude path denied every server-request approval
with `-32601`. Post-fix: `approvalPolicy: "never"` is the primary
defense; the auto-accept handler is a defense-in-depth fallback.
Permission-widening requests are still auto-denied (returning an empty
`GrantedPermissionProfile`) so Codex can't quietly widen the sandbox.
A future enhancement could route the approval request back to the owning
Claude session for an explicit decision — the helper is structured to
make that drop-in.

### Multi-TUI direct mode default
Direct-mode TUIs lose the proxy's app-server-restart healing (session
restore via cached `thread/resume`). For a local long-lived app-server
this rarely matters; if you rely on it, pass `--via-proxy`. The
proxy is still spawned and listens on 4501; nothing was removed.

codex-rs's TUI filters incoming notifications by its own threadId, so
the cross-talk that *exists* at the app-server WS layer (Codex
broadcasts notifications to all connected WSes) is invisible to the
end user. Verified manually with two `abg codex` windows on the same
project: each window only shows its own thread's output.

### Other notes
- `codexCollaborationKickoffSent` ("🤝 Claude Code has connected"
  notice injected into the TUI's thread on first Claude attach) is
  intentionally dropped in this version. Could be revived on first
  attach if useful.
- `claudeDisconnectTimer` in the legacy daemon also injected
  "⚠️ Claude Code went offline" into the TUI. Dropped for the same
  isolation reason.
- The reaper lets a Claude session resume the same Codex thread within
  10 min of disconnect (chatId match). Set
  `AGENTBRIDGE_CLAUDE_REAP_MS=0` to disable.

## Empirical evidence

### `codex app-server` supports concurrent turns on different threads

(Earlier probe, kept as Python in our local tree; not committed.)

```
0.0ms     send initialize
148.4ms   fire turn/start on thread #1
148.5ms   fire turn/start on thread #2
205.4ms   turn/started on #1
205.4ms   turn/started on #2     ← both accepted in the same ms
4414ms    turn/completed #1
10733ms   turn/completed #2
VERDICT: PARALLEL
```

### End-to-end through the modified daemon (`probes/two-claudes.ts`)

```
thread A=019e2ab1-eb5b-7f23-ad56-0910a2c514c3
thread B=019e2ab1-eb5b-7f23-ad56-0901b488fca5     ← distinct threads
Concurrency verdict: PARALLEL ✅  (maxStart=888ms < minComplete=8378ms)
Isolation: each chat only saw its own messages ✅
RESULT: PASSED
```

### Approval-policy fix (`probes/shell-approval.ts`)

```
threadReady=true  turnCompleted=true  echoSeen=true  autoDeniedNoUi=0
agentMessages preview: [IMPORTANT] Saw output containing marker
                        agentbridge-multi-fix-probe-marker-9f1c4e.
RESULT: PASSED ✅
```

### Two TUI-equivalent WS clients directly on app-server (`probes/two-tui-direct.ts`)

```
[182ms]  [A] threadId received
[182ms]  [B] threadId received                 ← two distinct threads
[202ms]  [A] turn/started
[203ms]  [B] turn/started                      ← parallel
[5970ms] [A] turn/completed
[7624ms] [B] turn/completed
zero thread/closed across the run              ← codex-rs does NOT enforce single-client
```

(Probes cost a few minimal-effort Codex turns total. Happy to move them
to `src/unit-test/` behind an env-gate if you'd prefer.)

## Test status

- `bun run typecheck`: clean.
- `bun test src`: **219 pass / 0 fail / 620 expect() calls** —
  unchanged from upstream.
- New probes pass.
- Manual: two `abg codex` windows running side-by-side, isolated.

## Open questions for the maintainer

1. **TUI broadcast**: drop entirely (current PR), keep for
   `chats.size === 1`, or make it explicit subscriptions per chat?
2. **`--via-proxy` naming**: keep, rename to `--proxy` /
   `--legacy-proxy`, or move to env (`AGENTBRIDGE_TUI_VIA_PROXY=1`)?
3. **Long-term proxy**: do we still need the proxy at all once
   multi-Claude routing settles? `secondaryConnections` becomes
   largely vestigial.
4. **Probe location**: keep `probes/` separate from `src/unit-test/`
   (LLM-cost gated), or wrap them in an env-gated test in
   `src/unit-test/`?
5. **`chatId` shape**: currently `codex_<ts>_<8-char-instanceId>`. We
   could move to plain UUIDs if you prefer a more opaque format.
6. **Reaper window**: 10 minutes is a guess. Should it move to
   `~/.agentbridge/config.json` instead of env-only?
7. **Auto-accept of permissions widening**: currently denied (returns
   empty `GrantedPermissionProfile`). The conservative choice; happy
   to route to owning Claude instead if you'd prefer.

Happy to split this into smaller PRs if the size is uncomfortable —
each commit is independently coherent.

---

## How to verify locally

```bash
git clone https://github.com/<your-fork>/agent-bridge
cd agent-bridge
git checkout feat/multi-claude-routing
bun install
bun run typecheck
bun test src
bun run build:plugin

# With a working codex CLI on PATH and authenticated:
bun probes/two-claudes.ts
bun probes/shell-approval.ts
bun probes/two-tui-direct.ts
```

To live-test multi-TUI: rebuild the CLI (`bun run build:cli`), then run
`abg codex --cd <project>` in two terminals — both should attach and
each show its own thread.
