### PR TITLE
feat: STM v2.3 multi-pair vertical upgrade + perf + bootstrap-reap fix

### DIFF
--- a/docs/shared-thread-mode-spec.md
+++ b/docs/shared-thread-mode-spec.md
@@ -1,0 +1,464 @@
+# Shared Thread Mode — Design Spec (v2.2)
+
+**Status:** Final — Codex go-with-edits (codex_msg_34d65b44c51d_25) applied. Ready for implementation.
+**Branch:** `feat/shared-thread-mode`
+**Author:** Claude (Opus 4.7), with design input from Codex
+**Date:** 2026-05-15
+
+## 0. v1 → v2 → v2.1 → v2.2 changelog
+
+v1 proposed `ClaudeThread + thread/resume(tuiThreadId)` as the sharing mechanism. Codex's independent review found this **blocked by codex-rs**: `thread/resume` rejects unmaterialized threads (`no rollout found for thread id`), confirmed by source test `thread_resume_rejects_unmaterialized_thread` and reproduced locally on codex-cli 0.130.0.
+
+v2 adopted Codex's counter-proposal: **paired Claude uses CodexAdapter as shared transport** (the v1 mechanism from this project's earliest version), no thread/resume needed. ClaudeThread + thread/start path is kept for **unpaired (isolated) Claudes only**, preserving multi-Claude isolation.
+
+v2.2 applies Codex's go-with-edits final review:
+- **§4.3 protocol fix**: `error` is a top-level notification (`params.error`), NOT a `ThreadItem` variant. `thread/closed` likewise. Update protocol allowlist.
+- **§4.3 + ClaudeAdapter rule**: `turnStarted` system message MUST NOT satisfy `requireReply`. Only `agentMessage`, `error`, `threadClosed`, or `turnCompleted-without-agentMessage` releases it. Otherwise no-output failures get masked by the start message.
+- **§4.5 race fix**: implement content-hash echo dedup alongside turnId, narrowly scoped to the pre-response window (~5s). turnId stays the 60s primary mechanism.
+- **R3 confirmed**: `AGENTBRIDGE_PAIR_REAP_MS = 30000` (separate from CLAUDE_REAP_MS).
+- **Wording**: "restoring shared Codex TUI session, retry shortly" for app-server reconnect window (vs "provisioning" for first-time bootstrap).
+- **Consistency fixes**: §5.1 default reconciled to `PAIR_RACE_MS=0`; P6 uses `source:"codex"` with prefix; E1 references §4.6.
+
+v2.1 refined v2 with Codex's second review:
+- **Echo prevention**: turnId dedup (not content-hash) as primary mechanism
+- **Whitelist expansion**: control-plane events (`turn/started`, `turn/completed`, `error`, `thread/closed`) MUST forward, otherwise paired Claude's `requireReply` hangs silently on failures
+- **Source-type encoding**: keep `BridgeMessage.source` as `"claude"|"codex"`. User-typed text forwarded as `source:"codex"` with explicit prefix
+- **§8 E7 correction**: `injectMessage` returns `false` when turn-in-progress, no queue. Paired Claude gets a `busy, retry` error
+- **New paired state**: `paired-but-not-ready` — pairing happens on TUI WS connect, but injection requires `thread/started` first. `reply` returns provisioning error during this window
+- **Token discrimination transport**: implementation uses Codex's native `--remote-auth-token-env` Authorization header path. Current `codex-cli 0.130.0` rejects query strings in `--remote` (`ws://host:port` only). The proxy still accepts legacy `abg_token` query values for probes/backcompat.
+
+## 1. Motivation
+
+(unchanged from v1) User wants the right-pane Codex TUI to show Claude↔Codex activity in real time AND accept user typing as a third voice, while keeping multi-Claude parallelism. Restore v1 UX of this project, conditional on a single paired (Claude, TUI) pair.
+
+## 2. Goals & non-goals
+
+### Goals
+- Designated "paired" (Claude, TUI) duo shares a single Codex thread (the TUI's thread).
+- Paired Claude's turn/start is **injected through the TUI's WS** (via `CodexAdapter.injectMessage`), so:
+  - The TUI sees the turn natively (it's a normal turn on its own thread).
+  - The TUI sees responses normally.
+- User-typed messages in the TUI route back to the paired Claude (so Claude has full conversation context).
+- Multi-Claude isolation preserved: a second Claude attaches as an isolated ClaudeThread, untouched.
+- Pairing opt-in via `--via-proxy` on the TUI; default `agentbridge codex` stays direct.
+
+### Non-goals
+- Multiple `--via-proxy` TUIs simultaneously. The first wins; subsequent are rejected at WS handshake.
+- Multiple paired Claudes sharing one TUI. The first Claude wins; subsequent Claudes go isolated.
+- Mirroring multiple Claude threads into one TUI.
+- Standalone observability dashboard for N-Claude scenarios (separate effort).
+- Daemon-crash recovery for paired sessions. If daemon dies, both sides must restart (document the limit).
+- `thread/resume` semantics. Not used by this design.
+
+## 3. Architecture overview
+
+```
+                    ┌────────────────────────────┐
+                    │   Codex app-server :4500   │
+                    │   (thread T_proxy lives)   │
+                    └────────────┬───────────────┘
+                                 │  WS (proxy intercepts)
+              ┌──────────────────┴────────────────┐
+              │   CodexAdapter (in daemon)        │
+              │   - tuiWs ──── shared transport   │
+              │   - pairedChatId: "claude_abc"    │
+              │   - injectMessage(text) for paired│
+              │   - emits item/userMessage  ─┐    │
+              │   - emits item/agentMessage ─┤    │
+              └────────┬──────────────────┬──┴────┘
+                       │ WS :4501         │ control plane
+                       │                  │
+                ┌──────▼──────┐    ┌──────▼──────────────────────┐
+                │  Proxy TUI  │    │  Daemon (chats map)         │
+                │  (right     │    │  - paired Claude: chat_abc  │
+                │   pane)     │    │  - isolated Claude(s):      │
+                │             │    │    chat_xyz → ClaudeThread  │
+                └─────────────┘    └─────────────────────────────┘
+                                          │
+                  ┌───────────────────────┼──────────────────┐
+                  │                       │                  │
+            ┌─────▼────┐            ┌─────▼─────┐      ┌─────▼─────┐
+            │ Paired   │            │ Isolated  │      │ Isolated  │
+            │ Claude   │            │ Claude #2 │      │ Claude #N │
+            │ (reply → │            │ (own      │      │ (own      │
+            │ inject) │             │  thread)  │      │  thread)  │
+            └──────────┘            └───────────┘      └───────────┘
+```
+
+**Key invariants:**
+1. At most one `tuiWs` (paired TUI) per daemon. Second WS connection that's not the paired TUI's own secondary picker is rejected.
+2. At most one `pairedChatId`. Set when first eligible Claude attaches while `tuiWs != null`.
+3. Paired Claude has **no ClaudeThread**. Its reply/turn flows entirely through CodexAdapter.
+4. Isolated Claudes (chatId ≠ pairedChatId) use ClaudeThread normally — unchanged.
+
+## 4. CodexAdapter changes
+
+### 4.1 Paired-chat ownership
+
+Add to `CodexAdapter`:
+
+```ts
+private pairedChatId: string | null = null;
+
+setPairedChat(chatId: string | null): void {
+  this.pairedChatId = chatId;
+  this.logger(`[CodexAdapter] paired chat set to: ${chatId ?? "<none>"}`);
+}
+
+isPaired(chatId: string): boolean {
+  return this.pairedChatId === chatId;
+}
+```
+
+Daemon calls `setPairedChat()` exactly once per pairing event. Cleared on Claude detach (after grace) OR on proxy TUI disconnect (full clear).
+
+### 4.2 Inbound: Claude → injectMessage → tuiWs
+
+`injectMessage(text: string): boolean` already exists at line 225. No signature change. Daemon's per-chat routing decides which transport to use:
+
+- If `chatId === codexAdapter.pairedChatId`: call `codexAdapter.injectMessage(text)`. The text becomes a `turn/start` injected on the TUI's WS, so codex-rs treats it as if the TUI's user typed it.
+- Otherwise: existing ClaudeThread path (`thread/start` + own thread).
+
+### 4.3 Outbound: items routed to paired Claude
+
+Without a ClaudeThread, paired Claude has no native turn-tracking. The CodexAdapter must emit enough signals so paired Claude's `requireReply` doesn't hang on errors. Items routed:
+
+**Transcript items** (rendered as conversation):
+- `item/completed` with `item.type === "agentMessage"` — Codex's response → forwarded as `BridgeMessage{ source: "codex", content }` (unchanged from existing)
+- `item/completed` with `item.type === "userMessage"` AND `params.turnId NOT in injectedTurnIds` — user typed in TUI → forwarded as `BridgeMessage{ source: "codex", content: "[IMPORTANT] Human typed in the paired Codex TUI:\n${text}" }`
+
+**Control-plane events** (forwarded as system messages so paired Claude knows turn state):
+- `turn/started` (notification) — emit system message `{ source: "codex", content: "[system] Codex turn started", satisfiesRequireReply: false }`. **Diagnostic only, MUST NOT satisfy `requireReply`** — otherwise no-output failures get masked by the start message.
+- `turn/completed` (notification) — emit system message `{ source: "codex", content: "[system] Codex turn completed", satisfiesRequireReply: true (only if no agentMessage came in this turn) }`. Used as the "no-output failure" signal: if a turn started and completed without an agentMessage, this is the only signal paired Claude has that something went wrong.
+- `error` (top-level notification, NOT a ThreadItem) — codex-rs emits this as `{ method: "error", params: { error: { code, message } } }`. Emit system message `{ source: "codex", content: "[error] ${params.error.message}", satisfiesRequireReply: true }`.
+- `thread/closed` (top-level notification, NOT a ThreadItem) — emit system message `{ source: "codex", content: "[system] Shared Codex thread closed — pair is being torn down", satisfiesRequireReply: true }`. Triggers daemon's TUI-disconnect-equivalent transition (§5).
+
+**Protocol allowlist update** (`src/app-server-protocol.ts`): the `AppServerNotification` union must include `"error"` and `"thread/closed"` so `isAppServerNotification()` recognizes them. Currently the union only lists `turn/started`, `turn/completed`, `item/started`, `item/completed`, `item/agentMessage/delta`. Add:
+```ts
+| { jsonrpc?: "2.0"; id?: undefined; method: "error"; params?: { error?: { code?: number; message?: string; data?: unknown } } }
+| { jsonrpc?: "2.0"; id?: undefined; method: "thread/closed"; params?: { threadId?: string } }
+```
+
+**`requireReply` release rule** (enforced in ClaudeAdapter or daemon's per-chat outbound path):
+- Messages flagged `satisfiesRequireReply: true` release any outstanding `require_reply` wait.
+- `turnStarted` (false) does not release.
+- `agentMessage`, `error`, `threadClosed`: release.
+- `turnCompleted`: release ONLY if no `agentMessage` was emitted earlier in this same turnId — tracks "turn finished with no output" failure mode. (Daemon keeps a per-turnId `sawAgentMessage` bool.)
+- `userMessage` (after echo dedup): release. The human just spoke in the TUI, that counts as a response Claude should react to.
+
+**Source-type encoding rationale**: `BridgeMessage.source` is `"claude" | "codex"` today (`src/types.ts`). v2.2 keeps the type unchanged. User-typed text and system messages are encoded as `source: "codex"` with explicit text prefixes. This avoids invasive type widening across `claude-adapter`, `daemon-client`, control-protocol, and formatting paths.
+
+### 4.4 What does NOT go to paired Claude (whitelist exclusion)
+
+To avoid Claude's context being polluted with internal Codex execution noise:
+
+- `toolCall`, `shellCommand`, `fileChange` items: NOT forwarded. These are Codex's own internal actions; Claude doesn't need them as conversation context. (TUI shows them natively.)
+- Approval requests (`item/permissions/requestApproval`, `item/fileChange/requestApproval`, `item/commandExecution/requestApproval`): NOT forwarded to Claude. The user (via TUI) approves, not Claude.
+- `reasoning`, `plan`, raw `response` items: NOT forwarded.
+- `item/agentMessage/delta` (streaming chunks): NOT forwarded individually — only the final `item/completed` is emitted, as today.
+
+### 4.5 Echo prevention: turnId dedup
+
+When daemon routes a paired Claude's reply through `CodexAdapter.injectMessage(text)`, codex-rs will subsequently emit `item/completed{ item.type: "userMessage", params.turnId: T }` for the very same text. Without dedup, this would echo back to the paired Claude as a user message.
+
+**Mechanism (primary):**
+
+```ts
+// In CodexAdapter
+private injectedTurnIds = new Map<string, number>();  // turnId → expiresAt
+private readonly ECHO_DEDUP_TTL_MS = 60_000;
+
+injectMessage(text: string): boolean {
+  // existing turn-in-progress check ...
+  const reqId = nextProxyId();
+  const turnStart = { jsonrpc: "2.0", id: reqId, method: "turn/start", params: { /* ... */ } };
+  this.appServerWs.send(JSON.stringify(turnStart));
+  this.pendingInjects.set(reqId, { text, sentAt: Date.now() });
+  return true;
+}
+
+// On turn/start response:
+private handleInjectionTurnStartResponse(response: AppServerResponse<TurnStartResponse>) {
+  const turnId = response.result?.turn?.id;
+  if (turnId) {
+    this.injectedTurnIds.set(turnId, Date.now() + this.ECHO_DEDUP_TTL_MS);
+  }
+  // existing logic ...
+}
+
+// In item/completed handler for userMessage:
+const turnId = params?.turnId;
+if (typeof turnId === "string" && this.isInjectedTurn(turnId)) {
+  return;  // suppress echo
+}
+
+private isInjectedTurn(turnId: string): boolean {
+  const expiresAt = this.injectedTurnIds.get(turnId);
+  if (!expiresAt) return false;
+  if (Date.now() > expiresAt) {
+    this.injectedTurnIds.delete(turnId);
+    return false;
+  }
+  return true;
+}
+```
+
+**Race protection (content-hash, also implemented)**: Even when turnId is present, a `userMessage` notification could arrive **before** the `turn/start` response populates `injectedTurnIds`. The window is tiny but non-zero. Mitigation: a parallel `pendingInjectionHashes: Map<contentHash, expiresAt>` with 5s TTL.
+
+```ts
+private pendingInjectionHashes = new Map<string, number>();
+private readonly PENDING_HASH_TTL_MS = 5_000;
+
+injectMessage(text: string): boolean {
+  // existing turn-in-progress check ...
+  const hash = sha1(text).slice(0, 16);
+  this.pendingInjectionHashes.set(hash, Date.now() + this.PENDING_HASH_TTL_MS);
+  // ... send turn/start, etc.
+}
+
+// In item/completed handler for userMessage:
+private isEchoOfInjection(text: string, turnId: string | undefined): boolean {
+  if (turnId && this.isInjectedTurn(turnId)) return true;        // primary: turnId match
+  const hash = sha1(text).slice(0, 16);
+  const expires = this.pendingInjectionHashes.get(hash);
+  if (expires && Date.now() <= expires) {
+    this.pendingInjectionHashes.delete(hash);                    // consume; one-shot
+    return true;
+  }
+  return false;
+}
+```
+
+The hash map is one-shot (delete on match) to avoid suppressing a legitimate user-typed message that happens to match an earlier injection's text. TTL 5s is well under realistic typing latency for a duplicate.
+
+Metadata-marker approach is rejected — codex-rs's `ThreadItem` does not preserve arbitrary fields on round-trip.
+
+### 4.6 Secondary-picker discrimination
+
+Rejecting any second proxy WS would break codex-rs's own secondary "resume picker" connection (current adapter intentionally supports these via `secondaryConnections` Map at line 83).
+
+**Mechanism: Authorization bearer token.**
+
+- `agentbridge codex --via-proxy` generates a random 16-char token at startup, sets `AGENTBRIDGE_PROXY_TOKEN=<token>`, and starts codex with `--remote ws://127.0.0.1:4501 --remote-auth-token-env AGENTBRIDGE_PROXY_TOKEN`.
+- Codex-rs applies this as `Authorization: Bearer <token>` on each remote app-server WebSocket connection. This path is required because current `codex-cli 0.130.0` rejects query strings in `--remote` and only accepts `ws://host:port` / `wss://host:port`.
+- Daemon proxy at WS upgrade reads `Authorization: Bearer <token>` as canonical input. It also accepts legacy `?abg_token=<token>` for probe/backcompat coverage.
+- Accept/reject logic:
+  - If token absent: reject (foreign WS or stale picker from a dead session).
+  - If token matches the existing `proxyTuiSlot.token`: allow as secondary picker (route via existing `secondaryConnections` path).
+  - If token differs from existing `proxyTuiSlot.token`: reject with WS close 4002 + reason `"another --via-proxy TUI is already connected"`.
+
+If no `proxyTuiSlot` yet (first connect): accept and store `proxyTuiSlot.token = token`.
+
+## 5. Daemon pairing state machine
+
+```ts
+type PairReadiness = "not-ready" | "ready";
+
+type ProxyTuiSlot = {
+  ws: ServerWebSocket;
+  token: string;
+  pairedChatId: string | null;
+  readiness: PairReadiness;        // becomes "ready" when CodexAdapter has activeThreadId
+  attachedAt: number;
+};
+
+class Daemon {
+  private proxyTuiSlot: ProxyTuiSlot | null = null;
+}
+```
+
+**`readiness` state lifecycle:**
+- TUI WS opens → `readiness = "not-ready"`. Pairing CAN happen (a Claude attaches) but `reply` returns "thread provisioning, retry in a moment" until ready.
+- CodexAdapter observes `thread/started` (existing event path) → daemon flips `readiness = "ready"`. Now `injectMessage` will succeed.
+- App-server reconnect / session restore → readiness may flip back to "not-ready" momentarily during `handleSessionRestoreAfterReconnect`. Same provisioning error returned.
+
+**Transitions:**
+
+| Event | Effect |
+|---|---|
+| Proxy TUI connects with new token | `proxyTuiSlot = {ws, token, pairedChatId: null, readiness: "not-ready", attachedAt: now}`. Notify CodexAdapter via `setProxyTui()`. |
+| CodexAdapter emits `thread-ready` (after observing `thread/started` on TUI WS) | `proxyTuiSlot.readiness = "ready"`. If a paired Claude was already attached waiting, no action needed — its next `reply` will succeed. |
+| Claude attaches (chat created) | If `proxyTuiSlot && !proxyTuiSlot.pairedChatId` → pair (regardless of readiness): `proxyTuiSlot.pairedChatId = chatId`; call `codexAdapter.setPairedChat(chatId)`; **skip ClaudeThread construction** for this chat. Else: construct ClaudeThread normally (isolated). |
+| Paired Claude calls `reply` while `readiness === "not-ready"` | Return error to Claude: `"Shared Codex TUI thread is still provisioning. Retry shortly."` Do NOT inject. Do not hang. |
+| Paired Claude calls `reply` while `readiness === "ready"` | Daemon calls `codexAdapter.injectMessage(text)`. If `injectMessage` returns `false` (turn-in-progress, see §8 E7), return error `"Shared Codex TUI is busy with another turn. Retry."` Same surface, different reason. |
+| Paired Claude WS detaches | Start grace timer (default `AGENTBRIDGE_PAIR_REAP_MS = 30000`). On expiry, clear `proxyTuiSlot.pairedChatId` and call `codexAdapter.setPairedChat(null)`. Within grace, same chatId reconnect re-pairs immediately. |
+| Same Claude reconnects within grace | Cancel grace timer. Pair preserved. No state change in CodexAdapter. |
+| Proxy TUI WS disconnects | Clear `proxyTuiSlot = null`. Call `codexAdapter.setPairedChat(null)`. **If a paired Claude was still attached: send Claude a system notice (§4.3 control-plane event), then transition that Claude to isolated mode** — daemon now constructs a fresh ClaudeThread for this chatId (new `thread/start`, new threadId, no replay of TUI conversation context). The system notice content: `"[system] Shared Codex TUI thread is gone. Future replies will use a fresh isolated Codex thread (no prior context carried over)."` |
+| Paired Claude receives `thread/closed` notification (forwarded as system message per §4.3) | Same as "Proxy TUI WS disconnects" — pair torn down, transition to isolated, system notice sent. |
+| Second proxy TUI connect (foreign token) | Reject at WS upgrade. Daemon does not touch `proxyTuiSlot`. |
+| Second proxy TUI connect (same token) | Treat as secondary picker. Route via CodexAdapter's existing `secondaryConnections` path. |
+
+### 5.1 Race window (Claude vs TUI startup order)
+
+- **No grace window.** If Claude attaches and `proxyTuiSlot == null`, it goes straight to isolated. No waiting.
+- `AGENTBRIDGE_PAIR_RACE_MS` env var exists for future opt-in but **default is `0`** (no race window). Resolved per Codex review Q4 — predictability over race tolerance.
+
+If user starts TUI after Claude, they must restart Claude to enable pairing. This is documented in the kickoff message:
+> "Shared Codex TUI mode is opt-in via `agentbridge codex --via-proxy`. To use it, start the TUI before attaching Claude. If Claude is already attached when you open the TUI, only future Claude sessions can pair."
+
+## 6. ClaudeAdapter / ClaudeThread changes
+
+- `ClaudeAdapter`: unchanged. Its public API (`reply`, `get_messages`) is the same for both paired and isolated chats. The routing decision happens in daemon.
+- `ClaudeThread`: unchanged. Just not constructed for the paired chat.
+- `Daemon.handleClaudeAttach`: branch on "paired or isolated", construct ClaudeThread only for isolated.
+
+Inbound (Claude → Codex) routing in daemon:
+```ts
+async onClaudeMessage(chatId: string, text: string): Promise<ReplyResult> {
+  if (codexAdapter.isPaired(chatId)) {
+    if (proxyTuiSlot.readiness !== "ready") {
+      return { ok: false, error: "Shared Codex TUI thread is still provisioning. Retry shortly." };
+    }
+    const accepted = codexAdapter.injectMessage(text);
+    if (!accepted) {
+      return { ok: false, error: "Shared Codex TUI is busy with another turn. Retry." };
+    }
+    return { ok: true };
+  }
+  // isolated path:
+  chats.get(chatId).claudeThread.injectTurn(text);
+  return { ok: true };
+}
+```
+
+Outbound (Codex → Claude) routing — all encoded as `source: "codex"` with explicit prefixes:
+```ts
+codexAdapter.on("agentMessage", ({ content }) => {
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, { source: "codex", content });
+  }
+});
+
+codexAdapter.on("userMessage", ({ content, turnId }) => {
+  // §4.5 echo dedup already applied inside CodexAdapter; this event only fires for genuine user typing
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, {
+      source: "codex",
+      content: `[IMPORTANT] Human typed in the paired Codex TUI:\n${content}`,
+    });
+  }
+});
+
+codexAdapter.on("turnStarted", () => {
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, { source: "codex", content: "[system] Codex turn started" });
+  }
+});
+
+codexAdapter.on("turnCompleted", () => {
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, { source: "codex", content: "[system] Codex turn completed" });
+  }
+});
+
+codexAdapter.on("errorItem", ({ detail }) => {
+  if (codexAdapter.pairedChatId) {
+    forwardToClaude(codexAdapter.pairedChatId, { source: "codex", content: `[error] ${detail}` });
+  }
+});
+
+codexAdapter.on("threadClosed", () => {
+  // also drives §5 transition
+  daemon.handleSharedThreadClosed();
+});
+```
+
+Isolated Claudes get their messages from their own ClaudeThread's existing event flow — unchanged.
+
+## 7. CLI changes (`src/cli/codex.ts`)
+
+- When `--via-proxy`: generate `abgToken = crypto.randomBytes(8).toString("hex")`; spawn codex with the bare proxy URL plus `--remote-auth-token-env AGENTBRIDGE_PROXY_TOKEN`, setting that env var to the token.
+- **Pre-flight check**: before spawning codex-rs, hit daemon's `/status` endpoint to check `proxyTuiConnected`. If true: exit(1) with `error: another --via-proxy TUI is already running. Close it first, or use 'agentbridge codex' (direct mode) for parallel.`
+- Daemon's `DaemonStatus` adds `proxyTuiConnected: boolean`.
+
+## 8. Edge cases (Codex's review items addressed)
+
+| # | Edge case | Resolution |
+|---|---|---|
+| E1 | Second `--via-proxy` TUI conflated with codex-rs picker | Token discrimination (§4.6). Same token = picker. New token = reject. |
+| E2 | Claude-first, TUI-later | Goes isolated. User must restart Claude to pair. Document in kickoff. |
+| E3 | User-typed TUI text not visible to Claude | New `userMessage` event emission (§4.3). |
+| E4 | Daemon crash recovery | Out of scope. Both clients restart. Documented. |
+| E5 | Transient paired-Claude disconnect race | 30s grace window (§5). Same chatId reconnect resumes pair. |
+| E6 | Tool/approval/system noise leaking into Claude context | Strict whitelist in §4.3 (forward agentMessage + userMessage + control-plane events) and §4.4 (block tool/approval/reasoning items). |
+| E7 | Turn-arbitration: Claude tries to inject while TUI mid-turn | **Corrected:** `CodexAdapter.injectMessage()` returns `false` when `turnInProgress` — it does not queue. Daemon surfaces `"Shared Codex TUI is busy with another turn. Retry."` to paired Claude. No internal queue in v1. |
+| E8 | App-server restart mid-pair | Existing `handleSessionRestoreAfterReconnect` (codex-adapter.ts:566) handles TUI; paired Claude has no separate session to restore. Pair survives, but during restore window `readiness` flips back to `"not-ready"` and `reply` returns provisioning error. |
+| E9 | Paired Claude sends `reply` before `thread/started` lands | `readiness === "not-ready"` → daemon returns provisioning error. Paired Claude retries; once `thread/started` arrives, readiness flips to `"ready"` and injection proceeds. |
+| E10 | Echo loop: paired Claude's injected text comes back as userMessage | `injectedTurnIds` Set (§4.5). When `item/completed{type: userMessage, params.turnId in set}` arrives, suppress forwarding. Content-hash fallback if turnId absent. |
+| E11 | Paired Claude `requireReply` hanging silently on Codex error | Control-plane events (`turn/completed`, `error`, `thread/closed`) forwarded as system messages (§4.3). `requireReply` releases on first forwarded message; error path is observable. |
+
+## 9. Test matrix
+
+Probe scripts (real WS clients) in `probes/shared-thread/`:
+
+| # | Scenario | Asserts |
+|---|---|---|
+| P1 | TUI (with token) first, Claude second | Claude reply via CodexAdapter; TUI receives turn/started + agentMessage events; both clients see same threadId |
+| P2 | Claude first, TUI second | Claude is isolated (own threadId); TUI is unpaired (own threadId); they don't interact |
+| P3 | TUI + 2 Claudes | First Claude pairs; second goes isolated. Both Claudes can converse independently. Pair-Claude's turn shows in TUI; isolated-Claude's turn does not. |
+| P4 | 2 `--via-proxy` TUIs (different tokens) | Second rejected with 4002 at WS upgrade. CLI exits 1 with clear message. First TUI keeps running. |
+| P5 | 1 `--via-proxy` TUI + its secondary picker (same token) | Both accepted. Routing through existing `secondaryConnections`. Pair still works. |
+| P6 | TUI sends `userMessage`, paired Claude attached | Claude receives a BridgeMessage with `source: "codex"` and content prefixed `[IMPORTANT] Human typed in the paired Codex TUI:\n...`. Verifies §4.3 encoding + §4.5 echo dedup (the TUI-originated message must reach Claude, while Claude-originated injection echoes must not). |
+| P7 | Paired Claude WS disconnects, reconnects within 30s | Pair preserved; CodexAdapter.pairedChatId unchanged. |
+| P8 | Paired Claude WS disconnects, doesn't reconnect within 30s | After grace: `pairedChatId = null`. Next attaching Claude can re-pair. |
+| P9 | Proxy TUI disconnects (paired Claude still attached) | Pair cleared. Claude transitions to isolated mode (new ClaudeThread). Verify continuity from Claude's side (no message loss). |
+| P10 | Approval request from TUI thread mid-pair | Approval goes only to TUI. Paired Claude does NOT see approval-request items. |
+| P11 | Tool/shellCommand items mid-pair | Not forwarded to paired Claude (whitelist enforcement). |
+| P12 | Paired Claude `reply` with `requireReply=true`, Codex turn completes without an `agentMessage` | Paired Claude's wait releases on `turn/completed` (the "no-output failure" signal). Without this, `requireReply` would hang. |
+| P13 | Paired Claude `reply` with `requireReply=true`, codex-rs emits `error` notification (e.g. permission denied) | Paired Claude's wait releases on error system message. Content prefix `[error] ...` visible. |
+| P14 | Echo race: paired Claude calls `injectMessage`; `userMessage` notification arrives BEFORE `turn/start` response | Content-hash fallback suppresses echo. Verifies §4.5 race protection. |
+
+Unit tests:
+- `codex-adapter.test.ts`: setPairedChat/isPaired; userMessage emission; whitelist (no toolCall/approval leakage); token-based secondary discrimination.
+- `daemon.test.ts`: pairing FIFO; grace window; race-protection window; isolation-on-TUI-disconnect transition.
+- `cli/codex.test.ts`: token generation; pre-flight status check; `--via-proxy` error path.
+
+## 10. Open questions — status
+
+Questions from v2's first review pass (Codex msg #21), resolved in v2.1:
+
+| Q | Topic | Resolution |
+|---|---|---|
+| Q1 | Whitelist completeness | **Resolved**: control-plane events (turn/started, turn/completed, error, thread/closed) added (§4.3). Internal noise (tool/approval/reasoning) explicitly blocked (§4.4). |
+| Q2 | Token propagation | **Resolved**: implementation uses Codex's `--remote-auth-token-env` bearer header path because `codex-cli 0.130.0` rejects query strings in `--remote`. P5 validates same-token/foreign-token behavior through the proxy. |
+| Q3 | TUI-disconnect → isolated transition | **Resolved per Codex**: transition to fresh isolated (new conversation, no replay), with explicit system notice to Claude (§5). |
+| Q4 | Race window default | **Resolved**: `PAIR_RACE_MS = 0` (no race window). Document "start TUI first" in kickoff. |
+| Q5 | Echo loop | **Resolved**: `injectedTurnIds` Set with TTL keyed on `params.turnId` from `turn/start` response (§4.5). Content-hash fallback documented but not implemented unless P6 reveals turnId missing. |
+
+Open items remaining (resolved by Codex final review):
+
+- **R1**: Token discrimination transport (§4.6). **Status**: resolved to Authorization header via `--remote-auth-token-env`; proxy keeps legacy query parsing only for probes/backcompat.
+- **R2**: Content-hash race protection. **Status**: Codex recommended implementing now alongside turnId (§4.5 updated). Both mechanisms ship together; turnId primary (60s TTL), content-hash race-protection (5s TTL, one-shot).
+- **R3**: `AGENTBRIDGE_PAIR_REAP_MS` default. **Status**: confirmed `30000` (separate constant from CLAUDE_REAP_MS=600000).
+
+## 11. Implementation order
+
+1. **Spec v2.1 final sign-off from Codex** — confirm R1/R2/R3 in §10 don't block; agree on P5 as the gating empirical test before merging.
+2. **CodexAdapter §4 changes**: pairedChatId state, item event emission (agentMessage/userMessage/turnStarted/turnCompleted/errorItem/threadClosed), §4.4 exclusion whitelist enforcement, §4.5 injectedTurnIds dedup, §4.6 token-based secondary discrimination, §5 readiness signaling.
+3. **Daemon §5 state machine**: pairing transitions, readiness state, grace window, isolation transition on TUI disconnect with system notice.
+4. **ClaudeAdapter routing in daemon §6**: branch on isPaired with paired-not-ready and busy error returns.
+5. **CLI §7 changes**: token generation, pre-flight status check, kickoff message documenting "start TUI first".
+6. **Unit tests** (§9): codex-adapter, daemon, cli/codex.
+7. **Probes P1–P11** (Codex's deliverable, my/user-side execution). **P5 must run** to lock §4.6 path.
+8. **Manual cross-test**: left Claude + right `abg codex --via-proxy`, observe 3-way chat; second `abg codex` (direct) in third terminal stays parallel.
+9. **Bilingual release notes** + sync `plugins/agentbridge/server/{bridge-server,daemon}.js` bundle via `bun run build:plugin`.
+
+## 12. Division of labor
+
+- **Claude (me)**: §4 CodexAdapter changes, §5 daemon state machine, §6 routing, §7 CLI. Unit tests for each. Spec maintenance.
+- **Codex**: Probes P1–P11 in `probes/shared-thread/`. Empirical verification of P5 (token discriminator path). Cross-review of state machine for races I missed. Cross-review of implementation PRs.
+- **Both**: `bun run check` before every commit. Bilingual release notes are bilateral.
+
+Sandbox note: Codex's environment cannot bind local listeners (`Bun.serve({port:0})` and `codex app-server --listen ws://...` both fail with `Operation not permitted`). Probes can be written there but final live execution must run on my side or user-side terminals.
+
+---
+
+**Status**: v2.2 has Codex's go-with-edits sign-off. All 4 final-review edits applied. Implementation begins next.
+
+**Implementation kickoff order**:
+1. Sync state: `bun run typecheck && bun test src` (baseline green check).
+2. Branch off `feat/shared-thread-mode` is current. Start with `app-server-protocol.ts` (§4.3 protocol allowlist) — small, foundational, unblocks CodexAdapter changes.
+3. CodexAdapter changes incrementally (each behind a unit test).
+4. Daemon state machine.
+5. CLI.
+6. Probes (Codex's deliverable; P5 first to lock §4.6 path; P14 last as the trickiest race test).

--- a/docs/shared-thread-mode-v2.3-spec.md
+++ b/docs/shared-thread-mode-v2.3-spec.md
@@ -1,0 +1,783 @@
+# Shared Thread Mode — Multi-Pair Vertical Upgrade (v2.3)
+
+**Status:** Draft v0.3 — Codex second-pass review (codex_msg_5753c73beafc_70) integrated. §0-§4 awaiting third-pass (lock) review before §5-§12 are drafted.
+**Builds on:** `docs/shared-thread-mode-spec.md` (v2.2, implemented in commits `f84346e` + `54e806e`).
+**Author:** Claude (Opus 4.7), cross-reviewed by Codex.
+**Date:** 2026-05-16
+
+## 0. v2.2 → v2.3 changelog
+
+v2.2 ships a single `proxyTuiSlot` per daemon and a single shared Codex thread. By design, only one `--via-proxy` TUI can connect at a time; a second is rejected at the WS handshake (spec v2.2 §2 non-goal, §4.6 rejection logic, §8 E1). That decision was correct for v2.2's scope but it explicitly excludes the use case the user actually wants: running several independent (Claude, TUI, Codex thread) pairs in parallel on the same machine, each isolated from the others.
+
+v2.3 lifts this restriction by generalizing the daemon's cardinality from "one slot" to "N slots", where each slot owns its own CodexAdapter, its own Codex app-server port, and its own paired Claude. The single-pair v2.2 case continues to work without any user-visible change.
+
+### v0.1 → v0.2
+
+- §2 Goals: split "stable pair identifiers" into namespace-vs-binding clarification; added "pair crash isolation" as an explicit goal.
+- §3 Architecture: added explicit singleton-vs-per-pair table; removed misleading "TUI passes pair id at WS handshake" wording — pair identity is implicit in the per-pair proxy port, which CLI obtains by `ensurePair`-ing the daemon first.
+- §4: revised D2/D3/D4 per Codex finding; added pair-name validation rules to D1; added migration-impact details to D5; introduced D6-D9 (duplicate TUI, status schema, resource limits, event routing).
+
+### v0.2 → v0.3 (this revision)
+
+Codex second-pass review (codex_msg_5753c73beafc_70) flagged spec-level protocol/lifecycle gaps. Architecture direction was approved; this revision tightens contracts before §5-§12 depend on them.
+
+- **D1**: clarified `--pair default` semantics — it is accepted as an explicit alias for omission (not rejected). "Reserved" only means the user-allocation path cannot remove or remap it, not that the name is unspeakable.
+- **D2**: rewrote port-allocation persistence and recovery — registry source-of-truth is the state-dir's `pairs/registry.json` (NOT the project-local `.agentbridge/config.json` which `ConfigService` reads). Added in-daemon `ensurePairInFlight` mutex to serialize concurrent allocations. Specified atomic registry write (temp file + rename). Defined `PAIR_PORTS_BUSY` recovery semantics.
+- **D3**: added an explicit daemon-restart row to the lifecycle table — restart cancels all in-flight grace windows, brings no pairs live, reconciles stale pair dirs/pids on first `ensurePair`, and surfaces `PAIR_NOT_FOUND` for a Claude that explicit-attaches before any TUI ensures the pair.
+- **D5**: corrected migration-impact list per Codex investigation — `e2e-cli.test.ts` does not actually read root `codex-wrapper.log`; the real touch points are `codex-tui.pid`, top-level `status.json` field readers, fake daemon status fixtures, `state-dir.test`, and `kill.ts`'s single-pid walk. Added an explicit implementation-order constraint: **P1 must not move filesystem layout — D5 changes land in P3 alongside the `ensurePair` API**.
+- **D6**: added `requestId` correlation to all pair-management control messages; added `claude_connect_result` to the protocol shape so the bridge can surface explicit-pair failures as a user-visible disabled state; clarified `/readyz` semantics — in v2.3 daemon readiness means "control-plane ready", pair readiness is conveyed by `ensurePair`'s response.
+- **D9**: replaced `removeAllListeners()` with targeted `off(name, ref)` tracking — pair tear-down only removes the handlers it registered, leaving diagnostics or future internal listeners intact.
+
+## 1. Motivation
+
+Today, the user works on multiple projects in parallel — for example, two Claude Code windows side-by-side, each with its own Codex TUI on the right. v2.2's hard limit means the second window's `abg codex --via-proxy` exits with:
+
+```
+[agentbridge] Error: another `agentbridge codex --via-proxy` TUI is already
+connected to the daemon. Shared-thread mode supports at most one proxy TUI
+at a time.
+```
+
+The workaround in v2.2 (`abg codex` direct mode, no proxy, no pairing) is not equivalent: it loses the right-pane TUI ↔ paired Claude shared-thread experience that v2.2 was built for. The user wants that experience for every window.
+
+This is explicitly the "C-1 vertical upgrade" path agreed upon during v2.2 kickoff (`project_agentbridge_v2_kickoff.md`).
+
+## 2. Goals & non-goals
+
+### Goals
+
+- **Multiple parallel pairs**: N independent (Claude, TUI, Codex thread) pairs on the same machine, each isolated from the others. No cross-talk in messages, threads, or state.
+- **v2.2 single-pair compatibility**: `abg codex --via-proxy` with no extra flags should behave exactly as it does in v2.2. No user retraining for the simple case.
+- **Per-pair Codex app-server**: each pair has its own `codex app-server` process listening on its own port. The daemon manages all of them.
+- **Per-pair CodexAdapter**: the daemon owns a `Map<pairId, CodexAdapter>` instead of a single `codex` singleton.
+- **Per-pair proxy slot**: the daemon owns a `Map<pairId, ProxyTuiSlot>` instead of a single `proxyTuiSlot`.
+- **Pair-aware ClaudeAdapter routing**: each Claude is associated with at most one pair (its "home pair"). Reply / inject / event routing happens within that pair's scope only.
+- **Stable pair identifier namespace + config across daemon restarts**: pair *names* and their port assignments (the registry) survive daemon restarts; live pair *bindings* (which Claude is paired with which slot) do not. This makes "reconnect Claude to its previous pair" mean "reconnect to a pair with the same id and ports", not "restore the in-memory paired-chat state". (Per Codex review: §1-§2 finding on conflicting wording.)
+- **Pair crash isolation**: one pair's Codex app-server crashing or its TUI dying must not affect any other pair. Each pair is its own failure domain. (Per Codex review: explicitly elevated from edge case to goal.)
+- **Backwards-compatible MCP surface**: the existing `reply` / `get_messages` tools keep working without per-pair API; pair context is derived from the Claude's connection (via the `pairId` field carried in the `claude_connect` control message — see D4).
+
+### Non-goals
+
+- **Cross-pair routing**: messages stay inside their pair. No `@pair-other:` addressing in v2.3. That belongs to a future "rooms" model (`docs/v2-architecture.zh-CN.md`).
+- **Pair migration**: once a Claude is paired with pair X, it cannot be moved to pair Y without disconnect+reconnect.
+- **Mid-session pair rename**: pair IDs are immutable for the lifetime of the pair.
+- **SQLite persistence of pair live state**: live pair binding (paired-chat slot, readiness, in-flight turn flags) is in-memory; daemon restart loses it. Pair *registry* (id → port assignment) MAY be persisted via a small JSON file under the state dir — see D2.
+- **Approval/permission cross-pair UI**: each TUI shows only its own pair's approvals.
+- **Auto-pairing policies beyond FIFO**: v2.3 keeps the v2.2 rule (first attaching Claude claims the slot it can claim) — no semantic matching, no name-based affinity. That's `v2-architecture.zh-CN.md` Policy layer territory.
+
+## 3. Architecture overview
+
+```
+                  ┌──────────────────────────────────────────┐
+                  │             AgentBridge Daemon           │
+                  │     (control WS :4502, shared by all)    │
+                  │                                          │
+                  │  pairs: Map<pairId, PairState> {         │
+                  │    "default" → PairState (4500/4501)     │
+                  │    "work"    → PairState (4510/4511)     │
+                  │    "side"    → PairState (4520/4521)     │
+                  │  }                                       │
+                  │                                          │
+                  │  chats: Map<chatId, ChatState> {         │
+                  │    chat_a → home=default, paired         │
+                  │    chat_b → home=work,    paired         │
+                  │    chat_c → home=default, isolated       │
+                  │    chat_d → home=null,    isolated       │
+                  │  }                                       │
+                  └─────────┬──────────────┬─────────────────┘
+                            │              │
+            ┌───────────────┴──────────────┴──────────────┐
+            │              │              │               │
+   ┌────────▼────┐ ┌───────▼─────┐ ┌──────▼────────┐ ┌────▼─────────┐
+   │ CodexAdapter│ │ CodexAdapter│ │ proxy TUI     │ │ proxy TUI    │
+   │ pair=default│ │ pair=work   │ │ pair=default  │ │ pair=work    │
+   │ app:4500    │ │ app:4510    │ │ via :4501     │ │ via :4511    │
+   │ proxy:4501  │ │ proxy:4511  │ │               │ │              │
+   └─────────────┘ └─────────────┘ └───────────────┘ └──────────────┘
+            │              │
+   ┌────────▼─────────┐ ┌──▼─────────────┐
+   │ codex app-server │ │ codex app-server│
+   │  port 4500       │ │  port 4510      │
+   └──────────────────┘ └─────────────────┘
+```
+
+### What stays singleton vs what becomes per-pair
+
+Per Codex review: explicit list of cardinality.
+
+| Concept | v2.2 location | v2.3 cardinality |
+|---|---|---|
+| Daemon control WebSocket (`:4502`) | global | **singleton** (shared by all bridges/CLI clients) |
+| `daemon.pid` / `daemon.lock` / `killed` sentinel | global state dir | **singleton** |
+| `agentbridge.log` (daemon-level events) | global state dir | **singleton** |
+| Root `status.json` | global state dir | **singleton**, but content becomes aggregate (see D7) |
+| `ConfigService` | global | **singleton** |
+| `chats: Map<chatId, ChatState>` | global | **singleton** (chats know their home pair via `homePairId` field) |
+| `idleShutdownTimer` coordinator | global | **singleton** (considers all pairs + chats) |
+| `TuiConnectionState` | global | **per-pair** (each pair has its own connect/disconnect notice flow) |
+| `CodexAdapter` instance | global `codex` | **per-pair** (one per pair, with its own ports/process/event emitter) |
+| `proxyTuiSlot` | global `let` | **per-pair** (each `PairState` owns its slot) |
+| Codex app-server process | global | **per-pair** (spawned by the pair's CodexAdapter) |
+| Per-pair log (`codex-<pair>.log` or `pairs/<pair>/codex.log`) | n/a (single `codex-wrapper.log`) | **per-pair** (see D5) |
+
+### How pair identity reaches the TUI
+
+There is no pair id field in the TUI ↔ daemon WebSocket handshake. Instead:
+
+1. User runs `abg codex --pair work --via-proxy`.
+2. CLI sends `ensure_pair("work")` over the existing daemon control WS (see D6 for the protocol shape).
+3. Daemon allocates ports for `work`, spawns the per-pair CodexAdapter + Codex app-server, and returns `{ proxyUrl: "ws://127.0.0.1:4511", appServerUrl: "ws://127.0.0.1:4510" }`.
+4. CLI spawns `codex --remote ws://127.0.0.1:4511 --remote-auth-token-env AGENTBRIDGE_PROXY_TOKEN ...` as it does in v2.2.
+5. Pair identity is **implicit in the proxy port** the TUI is connected to. Daemon looks up the pair by the proxy port it observed the connection on.
+
+The Authorization Bearer token from v2.2 §4.6 still applies — but only to distinguish the primary `--via-proxy` TUI from its own secondary picker connection *within the same pair*. It does not encode pair identity.
+
+## 4. Key architectural decisions
+
+Nine decisions that shape §5-§12. After Codex first-pass review (codex_msg_5753c73beafc_65) D2/D3/D4 were revised, D1/D5 had validation/migration details added, and D6-D9 were introduced.
+
+### D1. Pair identification: how are pairs named?
+
+**Decision: named pairs with strict validation; `default` is explicit-addressable.**
+
+- User chooses the name: `abg codex --pair work`.
+- Omitting `--pair` defaults to `"default"`. `abg codex --pair default` is **accepted** as an explicit alias for omission — same code path, same pair, no error. (Codex v0.3 clarification: `default` is "reserved" in the sense that no one can remove or remap it, not that the name is unspeakable.)
+- Valid pair name regex: `^[a-z0-9][a-z0-9_-]{0,31}$`. Lowercase letters, digits, underscores, hyphens; first character must be alphanumeric; length 1-32 chars.
+- Disallowed names: `.`, `..`, anything containing `/`, `\`, control chars, whitespace, or other filesystem-sensitive characters. (`default` itself is permitted, see above.)
+- Pair names are case-sensitive but lowercase-only (so collision on case folding is impossible).
+- Validation lives in a single helper (`isValidPairName`) reused by CLI parsing, control protocol message validation, and state-dir path construction.
+
+**Why these limits**: D5 uses pair id directly as a filesystem path component (`pairs/<pair>/...`). Anything that's safe as a path component and a JSON key is safe everywhere else we use pair ids. (Codex review: validation is not optional with D5 in place.)
+
+### D2. Port allocation: how does each pair get its ports?
+
+**Decision: state-dir registry as source of truth, fixed `default`, mutex-guarded allocation, atomic writes, with CLI always asking the daemon for the actual URL.**
+
+**Source of truth (Codex v0.3 clarification):**
+
+The pair → port assignment lives in `<stateDir>/pairs/registry.json` — NOT in the project-local `.agentbridge/config.json` that `ConfigService` reads. Reasoning: ports are a machine-global concern (you can't have two daemons own the same port), so the assignment must live next to the daemon's other machine-global state. `ConfigService` stays project-scoped for project-tunable settings (filter mode, attention window, etc.) and is not extended for pair ports.
+
+**Allocation algorithm:**
+
+- `default` pair gets fixed ports `4500/4501` (the v2.2 values). Always. The default entry is materialized in the registry on first daemon boot if missing.
+- Named pairs are assigned the next free stride: `4510/4511`, `4520/4521`, `4530/4531`, ... up to `AGENTBRIDGE_PAIR_PORT_MAX` (default 20 strides, max ports `4710/4711`).
+- Stride step (`AGENTBRIDGE_PAIR_PORT_STRIDE`, default 10) leaves headroom for future per-pair ports (e.g. a per-pair health endpoint) without colliding with the next pair.
+- Optional **machine-global override** via an env var read by the daemon at boot: `AGENTBRIDGE_PAIR_PORTS_FILE` pointing to a JSON like `{ "work": { "appPort": 5510, "proxyPort": 5511 } }`. If set and the file exists, those entries take precedence over stride allocation but are still merged into the registry on first ensure. This is the escape hatch for power users; the registry remains the live source-of-truth that the daemon reads/writes during normal operation.
+- **CLI never assumes ports from a stride formula.** `abg codex --pair NAME` always calls `ensurePair(NAME)` first and uses the daemon's reply for `--remote ws://...`.
+
+**Concurrency safety (Codex v0.3 finding):**
+
+- Daemon maintains an in-memory `ensurePairInFlight: Map<pairId, Promise<EnsurePairResult>>`. A second `ensurePair(pairId)` arriving while the first is mid-flight subscribes to the same promise rather than racing into a duplicate allocation/spawn path.
+- Registry writes are **atomic**: write to `<stateDir>/pairs/registry.json.tmp.<random>`, then `rename()` over the target. A partial write or crash mid-write cannot corrupt the registry.
+- On startup, daemon reads the registry, validates each entry (port range, name regex), and discards any entry that fails validation with a logged warning.
+
+**Port-busy recovery (`PAIR_PORTS_BUSY`):**
+
+- If a registry-assigned port is held by a foreign process at `ensurePair` time, daemon returns `pair_error { code: "PAIR_PORTS_BUSY", message, details: { conflictPort, conflictPid } }` and does NOT reallocate.
+- Registry entry is preserved (so the user can fix the upstream conflict and retry).
+- User recovery actions:
+  - Stop the conflicting process and retry `ensurePair`.
+  - Use `abg pairs rm NAME --forget` to drop the registry entry; the next `ensurePair(NAME)` allocates from the stride table again.
+  - Manually edit registry.json (with daemon stopped) or use `AGENTBRIDGE_PAIR_PORTS_FILE` override.
+- Daemon does NOT auto-kill AgentBridge-owned stale processes (to avoid cascading kills across pairs). If `conflictPid` matches an entry in `<stateDir>/pairs/<other>/codex.pid`, the daemon logs that the conflict is internal so the user knows to use `abg kill` rather than fight with random PIDs.
+
+**Why this rather than pure deterministic stride**: with lazy creation, `work` could be 4510 today and 4520 tomorrow depending on which pair was created first. Registry persistence breaks that ambiguity. The stride is only a default; once a port is assigned it sticks.
+
+### D3. Pair lifecycle: when are pairs created and destroyed?
+
+**Decision: lazy creation by CLI via `ensurePair`, lazy destruction with separate TUI grace and Claude grace.**
+
+**Creation:**
+- Daemon starts with empty `pairs` map (the registry is loaded but not live).
+- `abg codex --pair NAME` calls `ensurePair(NAME)` on the daemon:
+  - If pair already live → return its current URLs.
+  - If pair has a registry entry → bring it up using the registered ports.
+  - If pair is new → validate name (D1), allocate ports (D2), persist to registry, start the CodexAdapter + Codex app-server, return URLs.
+- Pair creation is bounded by `AGENTBRIDGE_MAX_PAIRS` (default 8) — see D8.
+
+**Destruction (the key clarification per Codex review):**
+
+The two grace windows from v2.2 §5 split into independent dimensions in v2.3:
+
+| Trigger | What gets reaped | What stays |
+|---|---|---|
+| Proxy TUI WS disconnect on pair P | After `AGENTBRIDGE_TUI_REAP_MS` grace (default 30s): tear down pair P entirely — stop CodexAdapter, kill codex app-server, release ports, transition P's paired chat to isolated (using v2.2's `transitionToIsolated` machinery). | Other pairs unaffected. P's registry entry survives so a future `ensurePair(P)` re-allocates the same ports. |
+| Paired Claude WS detaches on pair P | After `AGENTBRIDGE_PAIR_REAP_MS` grace (default 30s, same as v2.2): clear `pairs.get(P).pairedChatId`; reap the paired chat state (same as v2.2 `detachClaudeWs` reaper). | Pair P itself stays live — its Codex app-server, TUI, and ports remain. Another Claude can attach and claim the now-empty slot. |
+| Both TUI and Claude gone with no other Claude in P | TUI grace fires first (or simultaneously) → pair tear-down → no Claude transition needed. | Other pairs unaffected. |
+| Daemon receives an explicit `destroyPair(P)` control message | Immediate teardown of P, equivalent to TUI grace expiry. | Other pairs unaffected. Registry entry survives unless `--forget` flag is set. |
+| Daemon restart (`abg kill` + `abg codex` cycle, or process crash + supervisor restart) | All in-flight grace timers cancelled; `pairs` map is empty on boot (no pairs live); chats map is empty (lost with daemon); any stale `pairs/<pair>/codex.pid` files are reconciled on first `ensurePair(P)` for that pair (existing pid checked; if dead, file removed and fresh app-server spawned; if alive but unowned, returns `PAIR_PORTS_BUSY` per D2). | Registry survives on disk. Pair names + port assignments preserved for the next `ensurePair`. |
+
+`ensurePair` and `destroyPair` are new control messages in the existing daemon control WS — see D6 for the API choice and protocol shape.
+
+**Edge-case interaction with D4 after daemon restart**: a Claude that attaches with an explicit `pairId` (e.g. `AGENTBRIDGE_PAIR=work`) before any TUI has called `ensurePair("work")` since the daemon came back up will get `PAIR_NOT_FOUND` from `attachClaude`, NOT auto-creation. The user must start the TUI first (`abg codex --pair work --via-proxy`) so the pair goes live again. This is the strict semantics already specified in D4; the daemon-restart row is what makes it visible.
+
+### D4. Claude → pair binding: how is a Claude assigned to a pair?
+
+**Decision: pair id travels in `claude_connect` as a typed field; FIFO claim when omitted; strict error when an explicit pair is unavailable.**
+
+**Path** (Codex review: env cannot reach daemon directly):
+
+```
+User opens Claude window
+  → MCP client launches Claude Code (`agentbridge claude` or normal `claude`)
+  → ENV is propagated: AGENTBRIDGE_PAIR=work (optional)
+  → bridge.ts reads process.env.AGENTBRIDGE_PAIR
+  → DaemonClient.attachClaude(chatId, { pairId: "work" })
+  → control message: { type: "claude_connect", chatId, pairId?: "work" }
+  → daemon's attachClaude resolves pairId
+```
+
+**Resolution rules in `attachClaude`:**
+
+1. If `pairId` is provided in `claude_connect`:
+   - Validate name (D1). If invalid → reply with `claude_connect_result { ok: false, error: "INVALID_PAIR_NAME" }`.
+   - If pair is not live → reply with `claude_connect_result { ok: false, error: "PAIR_NOT_FOUND" }`. Do NOT auto-create; pairs are created by `abg codex`, not by Claude.
+   - If pair is live and has no paired chat → claim it.
+   - If pair is live but already paired → reply with `claude_connect_result { ok: false, error: "PAIR_BUSY" }`. Claude stays unattached; no fallback to isolated.
+2. If `pairId` is omitted:
+   - Iterate `pairs` in registry insertion order. Claim the first pair that is live AND has `pairedChatId === null`.
+   - If no such pair exists, attach as isolated (`homePairId = null`).
+   - This is the v2.2 default behavior preserved as FIFO-across-pairs.
+
+**Once bound, `homePairId` is sticky for the chat's lifetime.** Reconnect with the same chatId re-binds to the same home pair (assuming that pair is still live).
+
+### D5. State directory layout
+
+**Decision: per-pair subdir + migration map.**
+
+**Layout:**
+
+```
+~/Library/Application Support/AgentBridge/      (on macOS)
+├── daemon.pid                  ← daemon-wide, singleton
+├── daemon.lock                 ← daemon-wide, singleton
+├── killed                      ← daemon-wide kill sentinel
+├── agentbridge.log             ← daemon-wide events
+├── status.json                 ← daemon-wide status (aggregate — see D7)
+├── pairs/
+│   ├── registry.json           ← pair name → port assignments (D2)
+│   ├── default/
+│   │   ├── codex.pid           ← per-pair codex app-server pid
+│   │   ├── codex-wrapper.log   ← per-pair codex-tui spawn log (was root-level in v2.2)
+│   │   └── status.json         ← per-pair detailed status (optional)
+│   ├── work/
+│   │   ├── codex.pid
+│   │   ├── codex-wrapper.log
+│   │   └── status.json
+│   └── ...
+```
+
+**Migration impact (Codex v0.3 investigated against actual repo state):**
+
+- v2.2's `codex-tui.pid` at the state-dir root → moves to `pairs/default/codex.pid`. Touch points: `DaemonLifecycle` (writes/reads pid), `cli/codex.ts` (reads via `lifecycle.readTuiPid()`), `kill.ts` (currently kills a single root-level pid).
+- v2.2's `codex-wrapper.log` at the root → moves to `pairs/<pair>/codex-wrapper.log`. Touch points: `CodexAdapter` writes it via `StateDirResolver.codexWrapperLogFile`. (Codex investigated: `e2e-cli.test.ts` does NOT read this file directly — earlier v0.2 wording was wrong.)
+- Root `status.json` becomes aggregate with `pairs: [...]` (see D7). Top-level `appServerUrl` / `proxyUrl` / `tuiConnected` / `proxyTuiConnected` / `threadId` keep working as `default`-pair flat-compat shims. Touch points: `DaemonLifecycle.writeStatus()`, the e2e fake-daemon fixture in `e2e-cli.test.ts:appServer / proxyServer` blocks (which fabricate a `DaemonStatus`), and `state-dir.test`.
+- `abg kill` (`src/cli/kill.ts` per current layout) must walk `pairs/*/codex.pid` and SIGTERM each before SIGTERM-ing the daemon. Cleanup must be best-effort: a malformed pair dir should not block kill of others.
+- D1 name validation is a precondition for D5 — daemon must never accept a pair name that escapes `pairs/`.
+
+**Implementation-order constraint (Codex v0.3 finding):**
+
+D5 changes (filesystem layout, fake-daemon fixtures, kill walker) land in **P3** alongside the `ensurePair` API and registry — NOT in P1's internal refactor. P1 keeps the v2.2 root-level paths intact and merely introduces the `Map<pairId, PairState>` data structure keyed by `"default"`. This preserves the "P1 behavior unchanged" promise (see §11 phasing) and keeps the existing test suite green without touching test fixtures until P3 is ready to redo them coherently.
+
+### D6. Pair management API: control WS or HTTP?
+
+**Decision: extend the existing control WS protocol with request-correlated `ensurePair` / `destroyPair` / `listPairs` messages plus a typed `claude_connect_result`.**
+
+**Protocol shape (Codex v0.3 finding: all messages need `requestId` for correlation):**
+
+```typescript
+// Existing claude_connect now carries optional pairId (D4) and the daemon
+// MUST reply with a typed result so the bridge can surface explicit-pair
+// failures as a user-visible disabled state.
+{ type: "claude_connect", requestId, chatId, pairId?: string }
+  → { type: "claude_connect_result", requestId, ok: true, homePairId: string | null, paired: boolean }
+  → { type: "claude_connect_result", requestId, ok: false, error: "INVALID_PAIR_NAME" | "PAIR_NOT_FOUND" | "PAIR_BUSY" }
+
+// New: lazy pair creation
+{ type: "ensure_pair", requestId, pairId: string }
+  → { type: "pair_ensured", requestId, pairId, appServerUrl, proxyUrl, isLive: true }
+  → { type: "pair_error", requestId, pairId, code: "INVALID_PAIR_NAME" | "PAIR_PORTS_BUSY" | "MAX_PAIRS" | "ALLOCATION_FAILED", message, details? }
+
+// New: destroy
+{ type: "destroy_pair", requestId, pairId: string, forget?: boolean }
+  → { type: "pair_destroyed", requestId, pairId, registryEntryRemoved: boolean }
+  → { type: "pair_error", requestId, pairId, code: "PAIR_NOT_FOUND" | "PAIR_BUSY_NOT_FORCED", message }
+
+// New: introspection
+{ type: "list_pairs", requestId }
+  → { type: "pair_list", requestId, pairs: PairStatus[] }   // PairStatus shape defined in D7
+```
+
+- All messages reuse the existing `ControlClientMessage` / `ControlServerMessage` union from `src/control-protocol.ts`. `requestId` is added uniformly (existing `claude_to_codex` already uses it; the rest follow the same pattern).
+- Why not HTTP: the existing daemon already uses control WS for `claude_connect`/`claude_to_codex`. Adding HTTP for one operation creates two parallel surfaces. Keeping it in control WS preserves a single auth/dispatch path.
+
+**Liveness vs readiness (Codex v0.3 clarification):**
+
+- `/healthz` GET endpoint stays for liveness — daemon process is up and the control WS is accepting connections. Returns aggregate `DaemonStatus` (see D7).
+- `/readyz` GET endpoint changes semantics: in v2.2 it meant "the single Codex app-server is booted". In v2.3 lazy pairs mean there is no single app-server to wait for. **`/readyz` in v2.3 means "control plane ready"** — i.e. the daemon can accept WS connections and answer `ensurePair`. Pair-level readiness is conveyed by `pair_ensured`'s `isLive: true` field, not by `/readyz`.
+- CLI clients should treat `/readyz` as "daemon is up, you can call `ensurePair`". They should NOT poll `/readyz` and assume that means their pair's app-server is reachable.
+
+**CLI usage:**
+
+- `abg codex --pair NAME --via-proxy` connects to daemon control WS as a transient client, sends `ensure_pair(NAME)` with a fresh `requestId`, waits for the correlated `pair_ensured` or `pair_error`, then spawns codex with the returned `proxyUrl`.
+- Optional new commands: `abg pairs ls`, `abg pairs rm NAME`. Both are thin wrappers around `list_pairs` / `destroy_pair`.
+
+### D7. Status schema: aggregate vs flat
+
+**Decision: aggregate `DaemonStatus` with a flat-compatibility shim for `default`.**
+
+`DaemonStatus` in `src/control-protocol.ts` becomes:
+
+```typescript
+interface DaemonStatus {
+  bridgeReady: boolean;
+  pid: number;
+  // Backwards-compat fields populated from `pairs.default` (or null if no default pair live):
+  appServerUrl: string | null;
+  proxyUrl: string | null;
+  tuiConnected: boolean;
+  proxyTuiConnected: boolean;
+  threadId: string | null;
+  // New aggregate fields:
+  attachedClaudeCount: number;            // total across all pairs + isolated
+  queuedMessageCount: number;             // total across all chats
+  pairs: PairStatus[];                    // detailed per-pair view
+}
+
+interface PairStatus {
+  pairId: string;
+  isLive: boolean;
+  appServerUrl: string;
+  proxyUrl: string;
+  tuiConnected: boolean;
+  proxyTuiConnected: boolean;
+  pairedChatId: string | null;
+  threadId: string | null;
+  attachedClaudes: { chatId: string; paired: boolean }[];  // chats whose homePairId === pairId
+}
+```
+
+Existing code that reads `appServerUrl`/`proxyUrl`/`tuiConnected` at the top level keeps working as long as the user has a default pair. Tests that drove specific pairs in v2.2 (only one ever existed) trivially target `default`.
+
+### D8. Resource limits and crash isolation
+
+**Decision: caps + per-pair process supervision + crash containment.**
+
+| Limit / behavior | Default | Override |
+|---|---|---|
+| Maximum live pairs | 8 | `AGENTBRIDGE_MAX_PAIRS` |
+| Maximum strides scanned for allocation | 20 (`4500..4710`) | `AGENTBRIDGE_PAIR_PORT_MAX` |
+| TUI reap grace | 30s | `AGENTBRIDGE_TUI_REAP_MS` |
+| Pair reap grace (paired-Claude detach) | 30s | `AGENTBRIDGE_PAIR_REAP_MS` |
+| Stride step | 10 | `AGENTBRIDGE_PAIR_PORT_STRIDE` |
+
+**Crash isolation rules:**
+
+- Each pair's codex app-server is spawned by its CodexAdapter and supervised by it. If app-server exits, only that pair's CodexAdapter emits an `exit` event and only that pair's chats are notified.
+- An exception thrown in one pair's event handler must not unwind the whole daemon. Per-pair handlers are wrapped in `try/catch` at the registration site (best-effort; the v2.2 daemon already has a top-level `uncaughtException` handler that we keep as final safety net).
+- `bun run check` adds a smoke test that brings up 3 pairs, kills one's codex app-server, and asserts the others still respond.
+
+### D9. Event routing pattern across multiple CodexAdapters
+
+**Decision: each CodexAdapter is an independent EventEmitter; daemon handlers close over the pair's id at registration time.**
+
+In v2.2, daemon code looks like:
+
+```typescript
+codex.on("agentMessage", (msg) => {
+  const paired = getPairedChatState();   // walks the single proxyTuiSlot
+  ...
+});
+```
+
+In v2.3, the equivalent registration is per-pair, closing over `pairId`:
+
+```typescript
+function attachPairHandlers(pair: PairState) {
+  const { pairId, codex } = pair;
+  codex.on("agentMessage", (msg) => {
+    const paired = getPairedChatStateForPair(pairId);  // walks pair.proxyTuiSlot
+    if (!paired) return;
+    ...
+  });
+  // turnCompleted, errorItem, threadClosed, etc. — all the v2.2 handlers, rebound here.
+}
+```
+
+`attachPairHandlers` runs when a pair becomes live (`ensurePair`). A symmetric `detachPairHandlers` runs on tear-down.
+
+**Handler tracking (Codex v0.3 finding):**
+
+`detachPairHandlers` MUST NOT call `removeAllListeners()` on the per-pair CodexAdapter — that would wipe diagnostics listeners, internal CodexAdapter machinery, and any future subscribers that the daemon does not own. Instead, `attachPairHandlers` records each `(eventName, handlerRef)` pair it registers, and `detachPairHandlers` walks that list calling `codex.off(eventName, handlerRef)` for exactly the handlers it added:
+
+```typescript
+type PairHandlerRegistration = { eventName: string; handler: (...args: unknown[]) => void };
+
+function attachPairHandlers(pair: PairState): PairHandlerRegistration[] {
+  const refs: PairHandlerRegistration[] = [];
+  const register = <E extends string>(eventName: E, handler: (...args: any[]) => void) => {
+    pair.codex.on(eventName, handler);
+    refs.push({ eventName, handler });
+  };
+
+  register("agentMessage", (msg) => { /* ... */ });
+  register("turnCompleted", () => { /* ... */ });
+  // ... all v2.2 handlers, rebound here.
+
+  return refs;
+}
+
+function detachPairHandlers(pair: PairState) {
+  for (const { eventName, handler } of pair.handlerRefs) {
+    pair.codex.off(eventName, handler);
+  }
+  pair.handlerRefs = [];
+}
+```
+
+**No shared event emitter.** Daemon never registers a global `codex.on(...)` callback — every handler is scoped to one pair. This is the cleanest way to prevent event leaks across pairs and keep crash isolation (a thrown handler can't take down sibling pairs' subscriptions).
+
+## 5. CodexAdapter changes
+
+The CodexAdapter class is unchanged in spirit — it still owns one Codex app-server connection, one proxy TUI slot, and one `pairedChatId`. The change is that the daemon now instantiates **N adapters** (one per pair) instead of a singleton.
+
+### 5.1 Constructor signature
+
+v2.2:
+
+```typescript
+new CodexAdapter(appPort = 4500, proxyPort = 4501, logFile = stateDir.logFile)
+```
+
+v2.3:
+
+```typescript
+interface CodexAdapterOptions {
+  pairId: string;
+  appPort: number;
+  proxyPort: number;
+  logFile: string;       // per-pair wrapper log path under pairs/<pairId>/ (P3+)
+  // optional knobs already present in v2.2 are unchanged
+}
+new CodexAdapter(opts: CodexAdapterOptions)
+```
+
+Why an options object: positional args are already ambiguous (`appPort` / `proxyPort` are easy to swap). Adding `pairId` as a positional fourth arg compounds that. The options object is also easier to extend in P5+ for additional per-pair tunables.
+
+### 5.2 New accessor
+
+```typescript
+get pairId(): string { return this.opts.pairId; }
+```
+
+Used by the daemon's per-pair event handlers (D9) for logging and message correlation. Not used by CodexAdapter's own logic — the adapter doesn't need to know its pair id to do its job.
+
+### 5.3 What is NOT changing
+
+- `pairedChatId` semantics, `setPairedChat()`, `isPaired()`, `injectMessage()` — all per-adapter, unchanged.
+- Secondary-picker token discrimination (spec v2.2 §4.6) — still per-adapter. Each adapter has its own `proxyTuiSlot.token`; the WS-upgrade check compares the incoming `Authorization: Bearer` against THAT adapter's token. Different pairs have different tokens by construction (each `abg codex --pair NAME` generates its own `AGENTBRIDGE_PROXY_TOKEN`), so there is no cross-pair token reuse concern.
+- Echo dedup (spec v2.2 §4.5) — per-adapter `injectedTurnIds` / `pendingInjectionHashes` maps stay scoped to the adapter instance.
+- Event names and payload shapes (`agentMessage`, `turnStarted`, `turnCompleted`, `userMessage`, `errorItem`, `threadClosed`, etc.) — unchanged.
+
+### 5.4 Process supervision
+
+CodexAdapter already owns its `codex app-server` child process via `spawn()`. v2.3 does not change that — each adapter spawns its own. Per-pair crash isolation (D8) comes for free: adapter A's app-server dying triggers only adapter A's `exit` event; the daemon's per-pair handler decides whether to surface that as a system message to A's chats and tear A down. Adapter B keeps running.
+
+## 6. Daemon state machine
+
+### 6.1 New types
+
+```typescript
+interface PairState {
+  pairId: string;
+  appPort: number;
+  proxyPort: number;
+  codex: CodexAdapter;                                        // owns the app-server + proxy WS
+  tuiConnectionState: TuiConnectionState;                     // per-pair (was singleton in v2.2)
+  proxyTuiSlot: ProxyTuiSlot | null;                          // same shape as v2.2, scoped per pair
+  pairedChatId: string | null;                                // mirror of proxyTuiSlot.pairedChatId for fast lookups
+  readiness: "not-ready" | "ready";
+  tuiReapTimer: ReturnType<typeof setTimeout> | null;         // expires the pair after TUI gone
+  pairReapTimer: ReturnType<typeof setTimeout> | null;        // expires the paired-chat slot
+  handlerRefs: PairHandlerRegistration[];                     // for D9 targeted off()
+  isLive: boolean;                                            // false during ensurePair race window or after destroyPair
+  createdAt: number;
+}
+
+interface ChatState {
+  // ... all v2.2 fields ...
+  homePairId: string | null;                                  // NEW: which pair this chat belongs to (null = isolated, no home)
+}
+
+// Daemon globals replace v2.2's `codex` + `proxyTuiSlot` + assorted timers:
+const pairs: Map<string, PairState> = new Map();
+const pairRegistry: PairRegistry = loadRegistry(stateDir);    // pairs/registry.json
+const ensurePairInFlight: Map<string, Promise<EnsurePairResult>> = new Map();
+const chats: Map<string, ChatState> = new Map();              // unchanged from v2.2 except for homePairId field
+```
+
+### 6.2 `ensurePair(pairId)` flow
+
+```
+1. validate pairId per D1 — reject INVALID_PAIR_NAME
+2. if pairs.has(pairId) && pairs.get(pairId).isLive → return existing URLs
+3. if ensurePairInFlight.has(pairId) → return the existing promise
+4. promise = (async () => {
+     a. resolve ports:
+        - if pairId === "default" → (4500, 4501)
+        - else if registry has entry → use it
+        - else allocate next stride; reject MAX_PAIRS if exhausted
+     b. probe ports for foreign-process conflict → reject PAIR_PORTS_BUSY with conflictPid/Port
+     c. write registry atomically (temp+rename) if entry is new
+     d. construct CodexAdapter({pairId, appPort, proxyPort, logFile: pairLogPath(pairId)})
+     e. construct PairState; set isLive=false until step (g)
+     f. attachPairHandlers(pair) per D9 — record handler refs
+     g. await codex.start() — spawns app-server, awaits health
+     h. pair.isLive = true; pairs.set(pairId, pair); broadcastStatus()
+     i. return { pairId, appServerUrl, proxyUrl, isLive: true }
+   })().finally(() => ensurePairInFlight.delete(pairId))
+5. ensurePairInFlight.set(pairId, promise)
+6. return promise
+```
+
+If step (a) — (h) throws, the promise rejects with a `pair_error`. The partial state (CodexAdapter spawned but not started, registry written but not used) is cleaned up in a `catch` before rejecting: kill child process if any, leave registry entry intact (so the next attempt sees the same ports).
+
+### 6.3 `destroyPair(pairId, { forget })`
+
+```
+1. validate pairId
+2. pair = pairs.get(pairId); if !pair return pair_error PAIR_NOT_FOUND
+3. cancel pair.tuiReapTimer / pair.pairReapTimer
+4. detachPairHandlers(pair) per D9
+5. for each chat where chat.homePairId === pairId:
+     - if chat.paired → transitionChatToIsolatedAcrossPairs(chat) — see 6.5
+     - else chat.homePairId = null (chat keeps its own ClaudeThread; no message)
+6. pair.codex.stop()         // closes WS, kills app-server child
+7. pairs.delete(pairId)
+8. if forget → remove registry entry (atomic write); else keep entry so ensurePair re-allocates same ports
+9. broadcastStatus()
+10. respond pair_destroyed
+```
+
+`destroyPair` is the explicit teardown. The implicit teardown via TUI reap grace (D3) goes through the same step list except step (1)-(2) come from a timer callback instead of an inbound control message.
+
+### 6.4 `attachClaude` v2.3
+
+```
+1. parse claude_connect → { chatId, pairId? } (D4 protocol shape)
+2. if chats.has(chatId): resume branch (unchanged from v2.2 except for pairId reconciliation below)
+3. else: new chat branch
+4. resolve homePairId:
+     a. if pairId provided:
+        - validate per D1; reject INVALID_PAIR_NAME if bad
+        - if !pairs.has(pairId) || !pair.isLive → reply claude_connect_result { ok:false, error: PAIR_NOT_FOUND }
+        - if pair.pairedChatId !== null → reply { ok:false, error: PAIR_BUSY }
+        - claim: pair.pairedChatId = chatId; chat.homePairId = pairId; chat.paired = true
+     b. else: iterate pairs in registry insertion order; claim the first live pair with pairedChatId === null:
+        - claim same as above
+        - if none found → chat.homePairId = null; chat.paired = false (isolated)
+5. if chat.paired: skip ClaudeThread.bootstrap() — uses pair.codex.injectMessage; chat.ready = pair.readiness === "ready"
+6. else: construct ClaudeThread targeting (we still need a Codex app-server for isolated chats — see 6.6 below)
+7. reply claude_connect_result { ok:true, homePairId, paired }
+```
+
+### 6.5 Cross-pair isolation transition
+
+When a pair tears down (TUI gone or `destroyPair`), its paired chat needs to keep working. v2.2's `transitionToIsolated(state, reason)` is generalized:
+
+```typescript
+function transitionChatToIsolatedAcrossPairs(state: ChatState) {
+  const formerPair = pairs.get(state.homePairId!);  // may already be undefined post-tear-down
+  state.paired = false;
+  state.homePairId = null;                          // chat is now homeless / isolated
+  // remaining steps identical to v2.2 transitionToIsolated:
+  //  - reset replyRequired / replyReceivedDuringTurn / pairedTurnSawAgentMessage
+  //  - emit system_pair_torn_down
+  //  - construct fresh ClaudeThread targeting the chat's old app-server URL
+  //  - bootstrap with the v2.2 retry helper bootstrapIsolatedThread()
+}
+```
+
+The ClaudeThread for the new isolated chat targets which app-server? Two options:
+
+- **(a)** Target the former pair's `appServerUrl` if that app-server is still up (e.g. only the TUI WS died, the codex process is still healthy). Reuse the existing thread connection. **Risk**: pair tear-down kills the app-server too (6.3 step 6), so by the time `transitionChatToIsolatedAcrossPairs` runs, the URL points to nothing.
+- **(b)** Target the `default` pair's app-server, ensuring `default` is live first. This guarantees the isolated chat has a working backend, but it means a `work`-paired Claude transitions onto the `default` Codex thread, which may be running unrelated turns for other chats.
+
+**Spec choice (a) with a caveat**: tear-down ordering is changed so `transitionChatToIsolatedAcrossPairs` runs BEFORE `pair.codex.stop()`. The chat's new ClaudeThread connects to the soon-to-die app-server during a small window where the app-server is still alive. The thread bootstrap establishes a new Codex thread (per v2.2 §5 "no replay"), and then `pair.codex.stop()` kills the app-server. Result: the chat's new isolated ClaudeThread loses its connection almost immediately and triggers the v2.2 retry helper (`bootstrapIsolatedThread`, max 2 attempts). The retries will fail (no app-server), and the chat ends in the v2.2 "reap chat after retries exhausted" path with the "reconnect Claude" instruction — which IS now actionable thanks to commit 54e806e.
+
+This is acceptable because the alternative (option b, attaching to `default`) violates pair isolation (D8). If a user wants the chat to continue, they should re-attach Claude — the daemon will then iterate pairs, find `default` (or whichever is now live) and either claim its slot or attach isolated against its app-server.
+
+### 6.6 Isolated chats and their app-server
+
+A chat that is `homePairId = null` (was never paired, or was reaped) needs a Codex app-server to talk to. v2.2 had only one; v2.3 has N. Spec choice: **isolated chats target the `default` pair's app-server**. The `default` pair is always present in the registry (D1) and is always live during normal use (its app-server starts on first `abg codex --via-proxy` with no `--pair` flag).
+
+If `default` is not live (e.g. user destroyed it explicitly), isolated chats are stranded — `bootstrapIsolatedThread` fails and the chat is reaped with the "reconnect Claude" instruction. This is consistent with v2.2 behavior where the singleton codex going down strands all chats.
+
+## 7. ClaudeAdapter / routing changes
+
+The MCP-facing surface (`reply`, `get_messages`) is unchanged. Pair routing is entirely server-side; Claude never sees a `pairId` in the tool surface.
+
+### 7.1 Per-chat pair context
+
+`ChatState.homePairId` (added in §6.1) is the only routing knob. Every server-side branching point that v2.2 keyed off `state.paired` now keys off `state.homePairId` + `state.paired`:
+
+```typescript
+function handleClaudeToCodex(ws, message) {
+  // ... existing chatId resolution and state lookup ...
+  if (state.paired) {
+    const pair = pairs.get(state.homePairId!);  // homePairId is set when paired===true
+    if (!pair?.isLive || pair.readiness !== "ready") {
+      return sendError("Shared Codex TUI thread is still provisioning. Retry shortly.");
+    }
+    const injected = pair.codex.injectMessage(contentWithReminder);
+    // ... rest identical to v2.2 ...
+  } else {
+    // isolated path: state.thread (a ClaudeThread targeting default pair's app-server) — unchanged
+    const injected = state.thread.injectMessage(contentWithReminder);
+    // ... rest identical to v2.2 ...
+  }
+}
+```
+
+### 7.2 Outbound event routing
+
+D9 already locked the pattern: per-pair handlers close over `pairId`, look up `pair.pairedChatId`, emit to that chat only. The v2.2 daemon-level `codex.on(...)` handlers all move into `attachPairHandlers(pair)`, with the existing logic preserved verbatim — the only change is replacing `proxyTuiSlot` / `codex` references with `pair.proxyTuiSlot` / `pair.codex`.
+
+### 7.3 UX clarity: surfacing pair id in system messages
+
+System messages emitted to a paired chat are augmented with `[pair: NAME]` prefix when there is more than one live pair:
+
+```
+"✅ This Claude session is paired with the right-pane Codex TUI."
+   → "✅ [pair: work] This Claude session is paired with the right-pane Codex TUI."  (when N > 1)
+```
+
+When only one pair exists (the v2.2 single-pair case), the prefix is omitted to preserve the v2.2 user experience. The "more than one" check happens at message-emission time so the prefix appears/disappears dynamically.
+
+### 7.4 `get_messages` and the offline buffer
+
+Unchanged. The offline buffer is per-chat (already), so cross-pair leakage is impossible by construction — messages buffered for chat A are only flushed to chat A's WS.
+
+## 8. CLI changes
+
+### 8.1 `abg codex` flag changes
+
+- New flag: `--pair NAME`. Default value is `"default"`. Passes `NAME` to the daemon via `ensure_pair` (§6.2).
+- `--pair default` is accepted (D1) and equivalent to omitting the flag.
+- Validation: CLI rejects invalid pair names locally (`isValidPairName` regex from D1) before contacting the daemon, returning a clear `error: invalid --pair value` message with the allowed character set spelled out.
+- Pre-flight flow (replaces the v2.2 `/healthz` `proxyTuiConnected` check):
+  1. CLI calls `ensure_pair(NAME)` over control WS.
+  2. On `pair_error PAIR_PORTS_BUSY` → CLI exits with `error: ports for pair "NAME" (appPort=X, proxyPort=Y) are held by PID Z. Stop that process or use 'abg pairs rm NAME --forget' to reassign.`
+  3. On `pair_error MAX_PAIRS` → CLI exits with `error: max pairs reached (N). Destroy an unused pair with 'abg pairs rm NAME'.`
+  4. On `pair_ensured` with `proxyTuiConnected: true` (returned via a follow-up `list_pairs` call if the spec wants strict separation, or piggybacked on `pair_ensured`) → CLI exits with the v2.2-style "another --via-proxy TUI is already connected" message, scoped to this pair.
+  5. On `pair_ensured` clean → CLI proceeds to spawn `codex` with `--remote <proxyUrl>` and `--remote-auth-token-env AGENTBRIDGE_PROXY_TOKEN`. Pair id is NOT passed to codex — it does not need to know.
+
+### 8.2 New commands
+
+- `abg pairs ls` → calls `list_pairs`, prints a table:
+  ```
+  PAIR     APP-SERVER          PROXY                TUI  PAIRED-CHAT       CHATS
+  default  ws://...:4500       ws://...:4501        ●    chat_abc          2
+  work     ws://...:4510       ws://...:4511        ●    chat_def          1
+  side     (not live)          (not live)           ○    -                 0
+  ```
+- `abg pairs rm NAME [--forget]` → calls `destroy_pair(NAME, { forget })`. Without `--forget`, the registry entry stays so the same name + ports can be re-ensured later. With `--forget`, the registry entry is deleted and a fresh `ensure_pair(NAME)` will allocate a new stride.
+- `abg pairs rm NAME` is rejected if `NAME` is currently paired with a live Claude unless `--force` is also passed (avoids accidentally killing a working session).
+- `abg pairs` with no subcommand prints help.
+
+### 8.3 `agentbridge claude` flag changes
+
+- New flag: `--pair NAME`. Sets `AGENTBRIDGE_PAIR=NAME` in the spawned Claude's environment. Default: not set, which yields the FIFO claim behavior from D4.
+- This is the only env-wiring needed. `bridge.ts` reads `process.env.AGENTBRIDGE_PAIR` at MCP connection time and includes the value in `DaemonClient.attachClaude()`'s `claude_connect` message.
+
+### 8.4 `abg kill` walker change
+
+Per D5, `abg kill` must walk `<stateDir>/pairs/*/codex.pid` and SIGTERM each before SIGTERM-ing the daemon. Cleanup is best-effort — a malformed pair dir (missing or unreadable `codex.pid`) is logged and skipped, not fatal.
+
+## 9. Edge cases
+
+| # | Scenario | Resolution |
+|---|---|---|
+| ME1 | `ensure_pair("work")` racing with `ensure_pair("work")` from two CLI clients | `ensurePairInFlight` mutex (§6.2 / D2). Both subscribers see the same resolved URLs. |
+| ME2 | `ensure_pair("work")` racing with `ensure_pair("side")` from two CLI clients | No conflict — different pairId. Two independent promises, two atomic registry writes. Registry writes use temp+rename so concurrent renames serialize via filesystem. |
+| ME3 | Registry corruption (manual edit, partial write before crash) | Daemon validates each entry on startup (port range, name regex); invalid entries are dropped with a logged warning and the user gets a clean slate for those names. Valid entries continue to work. |
+| ME4 | Daemon restart with stale `pairs/<pair>/codex.pid` files | Next `ensure_pair(pair)` checks `pid` against `isProcessAlive`. If dead → file removed, fresh app-server spawned. If alive but unowned (foreign user) → `PAIR_PORTS_BUSY` per D2. |
+| ME5 | `destroy_pair("work")` while a paired Claude is mid-turn | Tear-down proceeds: the chat is transitioned to isolated (§6.5), but the in-flight turn is abandoned — the paired Claude sees `system_pair_torn_down` and a subsequent retry error. v2.2 had no equivalent because singleton tear-down meant the whole daemon went down. Documented in D3. |
+| ME6 | Codex app-server crash on pair `work` (other pairs healthy) | Per-pair `exit` event handler emits `system_codex_exit` to chats whose `homePairId === "work"` only. Other pairs' handlers do not fire. CodexAdapter records the exit; the next `ensure_pair("work")` re-spawns. (D8 crash isolation.) |
+| ME7 | `MAX_PAIRS` reached (default 8 live pairs) | `ensure_pair` returns `pair_error MAX_PAIRS`. CLI exits with a clear message. Already-live pairs unaffected. |
+| ME8 | Port range exhaustion (`AGENTBRIDGE_PAIR_PORT_MAX` strides all assigned in registry to different names) | `ensure_pair` for a new name returns `pair_error MAX_PAIRS` (same code, message clarifies it's a port range issue). User must `destroy_pair NAME --forget` an unused entry or extend the stride range. |
+| ME9 | Claude with `AGENTBRIDGE_PAIR=ghost` attaches before any TUI ensures `"ghost"` | Per D4 strict semantics → `claude_connect_result { ok:false, error: "PAIR_NOT_FOUND" }`. Bridge surfaces a `system_bridge_disabled` message to the user explaining how to start the TUI for that pair. |
+| ME10 | Two TUIs `abg codex --pair work` in quick succession | Second TUI's `ensure_pair("work")` returns `pair_ensured` (idempotent), then the CLI's `list_pairs` follow-up shows `proxyTuiConnected: true` and exits with the v2.2-style message scoped to pair "work". First TUI keeps running. |
+| ME11 | `default` pair port (4500/4501) conflicts at daemon startup (e.g. unrelated process bound 4500) | On daemon startup, only the registry is loaded — no pairs go live. The first `ensure_pair("default")` (triggered by the first `abg codex --via-proxy`) then runs the port probe and surfaces `PAIR_PORTS_BUSY` to that CLI. Daemon itself stays up. |
+| ME12 | Renaming a pair (user wants `work` to become `office`) | Not supported in v2.3 (non-goal §2). Workaround: `abg pairs rm work --forget`, then `abg codex --pair office --via-proxy`. |
+| ME13 | `kill` command racing with `ensure_pair` | `kill` writes the killed sentinel and SIGTERMs daemon; SIGTERM handler in daemon rejects any in-flight `ensurePairInFlight` promises with a `pair_error DAEMON_SHUTTING_DOWN`. Pair processes get killed by `kill` walking `pairs/*/codex.pid` (§8.4). |
+
+## 10. Test matrix
+
+Mirrors v2.2 spec §9 — probe scripts under `probes/multi-pair/` plus daemon-level unit tests extending the v2.2 suite.
+
+### 10.1 Probes (live WS clients, run manually or via `bun probes/multi-pair/m*.ts`)
+
+| # | Scenario | Asserts |
+|---|---|---|
+| M01 | Bring up two pairs (`default` + `work`), one Claude each, send a message in each. | Two distinct threadIds. Messages routed to the correct paired Claude. No cross-talk. |
+| M02 | Bring up two pairs; kill `work`'s codex app-server with SIGKILL. | `work` chats see `system_codex_exit`; `default` chats unaffected; `default` keeps responding to messages. |
+| M03 | Two `abg codex --pair work` invocations in series; second exits 1 with "already connected" message scoped to pair "work". | Pre-flight rejection works per-pair. |
+| M04 | Claude with `AGENTBRIDGE_PAIR=work` attaches before TUI ensures "work". | `claude_connect_result.error === "PAIR_NOT_FOUND"`. Bridge enters disabled state with a clear system message. |
+| M05 | Three Claudes attach with no `AGENTBRIDGE_PAIR`; two pairs live (`default`, `work`); user typed in TUI of each. | FIFO claim: Claude 1 → default (paired), Claude 2 → work (paired), Claude 3 → isolated against default's app-server. |
+| M06 | `destroy_pair("work")` while paired Claude is mid-turn. | Paired Claude receives `system_pair_torn_down`; new ClaudeThread created targeting default; bootstrap retries exhausted (work's app-server is dying); chat reaped with "reconnect Claude" instruction. |
+| M07 | `ensure_pair("work")` registered with port 4510; user starts an unrelated process on 4510; `abg codex --pair work --via-proxy` retried. | `pair_error PAIR_PORTS_BUSY` with `conflictPid` populated; CLI message includes the PID. |
+| M08 | Daemon restart with `default` and `work` previously live. | Registry survives; both pairs absent from `pairs` map until each is `ensure_pair`'d again. CLI's first `abg codex --pair work` rehydrates work with the same ports. |
+| M09 | Concurrent `ensure_pair("work")` from two CLI clients (race ME1). | Both see the same `pair_ensured` payload; only one CodexAdapter constructed; registry written once. |
+| M10 | `abg pairs ls` with three live pairs and varied state. | Output table matches §8.2 example: live indicator, TUI dot, paired-chat column. |
+| M11 | `abg pairs rm work --forget` while work is paired. | Rejected unless `--force`. With `--force`: transition chat to isolated, kill app-server, remove registry entry, port stride released. |
+| M12 | Crash isolation: throw in one pair's `agentMessage` handler. | Other pairs' handlers still fire. Daemon-level `uncaughtException` logs the throw. |
+
+Sandbox note (same as v2.2 §12): Codex cannot bind local listeners. Probes are written there but executed on user-side terminals or in Claude's local environment.
+
+### 10.2 Unit tests (extends `src/unit-test/daemon.test.ts`)
+
+| # | Scenario | What gets asserted |
+|---|---|---|
+| U01 | `isValidPairName` boundary cases | Regex matches D1 exactly; reserved-but-allowed `default` returns true; `..`, `/x`, `Work`, empty string return false. |
+| U02 | Registry round-trip | `loadRegistry` after `saveRegistry({work: {4510,4511}})` returns same object; atomic write uses temp+rename (verify via file watcher). |
+| U03 | `ensurePairInFlight` mutex | Two concurrent `ensurePair("work")` calls produce one promise; both callers see same `pair_ensured`. |
+| U04 | `attachPairHandlers` / `detachPairHandlers` symmetry | After detach, `pair.codex.listenerCount(event)` is unchanged from baseline (no leaks, no over-removal). |
+| U05 | `attachClaude` FIFO across pairs | Two live unpaired pairs; two Claudes attach without `pairId`; first claims pair 1, second claims pair 2. |
+| U06 | `attachClaude` PAIR_BUSY | Pair with `pairedChatId` set; Claude attaches with explicit `pairId` for same pair; receives `claude_connect_result.error === "PAIR_BUSY"`. |
+| U07 | `attachClaude` PAIR_NOT_FOUND | Pair not in pairs map; explicit `pairId` attach receives error. |
+| U08 | `transitionChatToIsolatedAcrossPairs` flag reset | Pair-paired chat with `replyRequired=true`; trigger tear-down; chat's flag is `false` after transition (carries over the v2.2 bug fix from 54e806e). |
+| U09 | `destroyPair` with `forget=false` keeps registry; `forget=true` removes | Verify registry.json contents after each. |
+| U10 | Daemon restart reconciliation | Pre-seeded registry + stale `codex.pid` pointing to a dead PID; `ensurePair` on that pair cleans the pid file and spawns fresh. |
+
+### 10.3 What stays from v2.2
+
+All 17 tests in `daemon.test.ts` from commit `54e806e` continue to apply, but reframed: every "the proxy slot" becomes "the default pair's proxy slot". P1's internal refactor keeps the v2.2 tests passing unchanged by hardcoding `pairId = "default"` everywhere v2.2 referenced the singleton.
+
+## 11. Implementation phases
+
+Five small PRs, each independently mergeable to `master` (or the v2.3 long-running branch), each gated on `bun run check` and Codex review.
+
+| Phase | Scope | Behavior change | Test impact |
+|---|---|---|---|
+| **P1** | Internal refactor: replace daemon-level singletons (`codex`, `proxyTuiSlot`, `TuiConnectionState`) with `pairs: Map<pairId, PairState>` keyed only by `"default"`. `ChatState` gains `homePairId` field, always set to `"default"`. CodexAdapter constructor moves to options object. No new control messages, no CLI flags, no filesystem layout change. | Externally none — `abg codex --via-proxy` works exactly as in v2.2. | All 17 daemon tests + 14 codex-adapter tests + e2e tests pass unchanged. |
+| **P2** | CodexAdapter lifecycle as a peer-managed component: daemon spawns / stops adapters via `ensurePair` / `destroyPair` internal calls (no control-protocol API yet). Pair-aware event handler attach/detach (D9 pattern). Still only `default` ever ensured. | Externally none. | Add 5-8 daemon tests covering `attachPairHandlers` symmetry + lifecycle. |
+| **P3** | `ensure_pair` / `destroy_pair` / `list_pairs` control protocol (D6). Registry + atomic writes (D2). State dir layout (D5) — files MOVE here, root-level pids/logs deprecated. `kill` walker (§8.4). `claude_connect_result` typed reply (D6). Fake-daemon fixtures and `state-dir.test` updated. | Behavioral: tooling that read root `codex-tui.pid` / `codex-wrapper.log` will break — only `kill.ts` and tests touch those, both updated in this PR. | Add 6-10 daemon tests for registry + protocol + cross-restart. |
+| **P4** | CLI `--pair` flag in `abg codex` and `agentbridge claude` (D4, §8.1, §8.3). `abg pairs ls/rm` commands (§8.2). Pre-flight ports-busy / max-pairs error surfacing. | Behavioral: users can now create / list / destroy pairs. `default` remains the only pair anyone has unless they pass `--pair`. | Add CLI tests for new flag parsing + subcommands. Probes M03, M07, M10, M11 land here. |
+| **P5** | FIFO pair claim + explicit `AGENTBRIDGE_PAIR` env path (D4 §6.4). Cross-pair isolation transition (§6.5). UX prefix for pair id (§7.3). Multi-pair probes M01, M02, M04, M05, M06, M08, M09, M12. Crash isolation smoke (M02 + M12). | Behavioral: multi-pair is now end-to-end functional. v2.3 use case ships. | Probes + daemon tests cover the new state machine paths. |
+
+PRs land in order. Each merges to a v2.3 long-running branch; the branch merges to master after P5 lands and end-to-end probes pass.
+
+## 12. Division of labor
+
+Same model as v2.2 (`docs/shared-thread-mode-spec.md` §12), with one caveat learned during STM v2.2 implementation:
+
+- **Claude (designer / reviewer / Git operator)**: Spec authorship + iteration. Architecture sign-off. PR review. All Git operations (commit, push, branch ops). Final commit messages (bilingual).
+- **Codex (implementer / verifier)**: Per-PR implementation. Unit tests + probes. Empirical verification (`bun run check`, probe execution where Codex's sandbox allows it). Independent analysis of the spec at design time and of the diff at code-review time.
+- **Both**: Cross-review at each phase boundary. Spec amendments when implementation surfaces unknowns.
+
+**Caveat (from v2.2 retrospective in `project_agentbridge_v2_kickoff.md`)**: Codex's sandbox during STM v2.2 implementation was forced to `read-only` and could not write files via `apply_patch`. If that constraint persists into v2.3, the fallback is Claude-implements + Codex-read-only-review, as used in commit `54e806e`. The spec assumes the standard Codex-implements path; deviations are recorded in the PR description.
+
+---
+
+**Status**: Draft v0.3, locked. §0-§12 ready for implementation phases (§11) to begin with P1.

--- a/docs/shared-thread-mode-v2.3-spec.md
+++ b/docs/shared-thread-mode-v2.3-spec.md
@@ -756,8 +756,8 @@ Unchanged. The offline buffer is per-chat (already), so cross-pair leakage is im
   work     ws://...:4510       ws://...:4511        ●    chat_def          1
   side     (not live)          (not live)           ○    -                 0
   ```
-- `abg pairs rm NAME [--forget]` → calls `destroy_pair(NAME, { forget })`. Without `--forget`, the registry entry stays so the same name + ports can be re-ensured later. With `--forget`, the registry entry is deleted and a fresh `ensure_pair(NAME)` will allocate a new stride.
-- `abg pairs rm NAME` is rejected if `NAME` is currently paired with a live Claude unless `--force` is also passed (avoids accidentally killing a working session).
+- `abg pairs rm NAME [--forget] [--force]` → calls `destroy_pair(NAME, { forget, force })`. Without `--forget`, the registry entry stays so the same name + ports can be re-ensured later. With `--forget`, the registry entry is deleted and a fresh `ensure_pair(NAME)` will allocate a new stride.
+- `--force` is required when `NAME` is currently paired with a live Claude (avoids accidentally killing a working session). Without `--force`, the protocol responds `pair_error PAIR_BUSY_NOT_FORCED` and the CLI prints a message pointing at the paired Claude.
 - `abg pairs` with no subcommand prints help.
 
 ### 8.3 `agentbridge claude` flag changes
@@ -774,7 +774,7 @@ Per D5, `abg kill` must walk `<stateDir>/pairs/*/codex.pid` and SIGTERM each bef
 | # | Scenario | Resolution |
 |---|---|---|
 | ME1 | `ensure_pair("work")` racing with `ensure_pair("work")` from two CLI clients | `ensurePairInFlight` mutex (§6.2 / D2). Both subscribers see the same resolved URLs. |
-| ME2 | `ensure_pair("work")` racing with `ensure_pair("side")` from two CLI clients | No conflict — different pairId. Two independent promises, two atomic registry writes. Registry writes use temp+rename so concurrent renames serialize via filesystem. |
+| ME2 | `ensure_pair("work")` racing with `ensure_pair("side")` from two CLI clients | Different pairId means `ensurePairInFlight` cannot dedup them — they get independent promises. The daemon-wide `registryWriteMutex` (§6.2 v0.4) serializes their registry read-modify-write sequences so neither allocation sees stale state; atomic temp+rename provides the on-disk crash safety. |
 | ME3 | Registry corruption (manual edit, partial write before crash) | Daemon validates each entry on startup (port range, name regex); invalid entries are dropped with a logged warning and the user gets a clean slate for those names. Valid entries continue to work. |
 | ME4 | Daemon restart with stale `pairs/<pair>/codex.pid` files | Next `ensure_pair(pair)` checks `pid` against `isProcessAlive`. If dead → file removed, fresh app-server spawned. If alive but unowned (foreign user) → `PAIR_PORTS_BUSY` per D2. |
 | ME5 | `destroy_pair("work")` while a paired Claude is mid-turn | Tear-down proceeds: the chat is transitioned to isolated (§6.5), but the in-flight turn is abandoned — the paired Claude sees `system_pair_torn_down` and a subsequent retry error. v2.2 had no equivalent because singleton tear-down meant the whole daemon went down. Documented in D3. |
@@ -800,7 +800,7 @@ Mirrors v2.2 spec §9 — probe scripts under `probes/multi-pair/` plus daemon-l
 | M03 | Two `abg codex --pair work` invocations in series; second exits 1 with "already connected" message scoped to pair "work". | Pre-flight rejection works per-pair. |
 | M04 | Claude with `AGENTBRIDGE_PAIR=work` attaches before TUI ensures "work". | `claude_connect_result.error === "PAIR_NOT_FOUND"`. Bridge enters disabled state with a clear system message. |
 | M05 | Three Claudes attach with no `AGENTBRIDGE_PAIR`; two pairs live (`default`, `work`); user typed in TUI of each. | FIFO claim: Claude 1 → default (paired), Claude 2 → work (paired), Claude 3 → isolated against default's app-server. |
-| M06 | `destroy_pair("work")` while paired Claude is mid-turn. | Paired Claude receives `system_pair_torn_down`; new ClaudeThread created targeting default; bootstrap retries exhausted (work's app-server is dying); chat reaped with "reconnect Claude" instruction. |
+| M06 | `destroy_pair("work")` while paired Claude is mid-turn, default pair live. | Paired Claude receives `system_pair_torn_down`; `transitionPairedChatOnTeardown` Path A bootstraps a fresh ClaudeThread on default's app-server; chat continues isolated. (If default were NOT live, Path B would reap the chat with the "reconnect Claude" instruction instead.) |
 | M07 | `ensure_pair("work")` registered with port 4510; user starts an unrelated process on 4510; `abg codex --pair work --via-proxy` retried. | `pair_error PAIR_PORTS_BUSY` with `conflictPid` populated; CLI message includes the PID. |
 | M08 | Daemon restart with `default` and `work` previously live. | Registry survives; both pairs absent from `pairs` map until each is `ensure_pair`'d again. CLI's first `abg codex --pair work` rehydrates work with the same ports. |
 | M09 | Concurrent `ensure_pair("work")` from two CLI clients (race ME1). | Both see the same `pair_ensured` payload; only one CodexAdapter constructed; registry written once. |
@@ -821,7 +821,7 @@ Sandbox note (same as v2.2 §12): Codex cannot bind local listeners. Probes are 
 | U05 | `attachClaude` FIFO across pairs | Two live unpaired pairs; two Claudes attach without `pairId`; first claims pair 1, second claims pair 2. |
 | U06 | `attachClaude` PAIR_BUSY | Pair with `pairedChatId` set; Claude attaches with explicit `pairId` for same pair; receives `claude_connect_result.error === "PAIR_BUSY"`. |
 | U07 | `attachClaude` PAIR_NOT_FOUND | Pair not in pairs map; explicit `pairId` attach receives error. |
-| U08 | `transitionChatToIsolatedAcrossPairs` flag reset | Pair-paired chat with `replyRequired=true`; trigger tear-down; chat's flag is `false` after transition (carries over the v2.2 bug fix from 54e806e). |
+| U08 | `transitionPairedChatOnTeardown` flag reset | Pair-paired chat with `replyRequired=true`; trigger tear-down with default live; chat's `replyRequired` / `replyReceivedDuringTurn` / `pairedTurnSawAgentMessage` all `false` after transition; chat re-bootstraps against default's app-server (Path A). Carries over the v2.2 bug fix from commit 54e806e. |
 | U09 | `destroyPair` with `forget=false` keeps registry; `forget=true` removes | Verify registry.json contents after each. |
 | U10 | Daemon restart reconciliation | Pre-seeded registry + stale `codex.pid` pointing to a dead PID; `ensurePair` on that pair cleans the pid file and spawns fresh. |
 
@@ -855,4 +855,4 @@ Same model as v2.2 (`docs/shared-thread-mode-spec.md` §12), with one caveat lea
 
 ---
 
-**Status**: Draft v0.4. §0-§4 locked at v0.3; §5-§12 revised per Codex final-pass review (codex_msg_5753c73beafc_78). Ready for P1 implementation pending one short Codex re-pass on the v0.4 deltas.
+**Status**: Draft v0.4 (final spec). §0-§4 locked at v0.3, §5-§12 revised per Codex final-pass review (codex_msg_5753c73beafc_78) and re-confirmed GO for P1 by Codex (codex_msg_5753c73beafc_83) plus 4 editorial nits applied. Implementation phase begins with P1.

--- a/docs/shared-thread-mode-v2.3-spec.md
+++ b/docs/shared-thread-mode-v2.3-spec.md
@@ -1,6 +1,6 @@
 # Shared Thread Mode — Multi-Pair Vertical Upgrade (v2.3)
 
-**Status:** Draft v0.3 — Codex second-pass review (codex_msg_5753c73beafc_70) integrated. §0-§4 awaiting third-pass (lock) review before §5-§12 are drafted.
+**Status:** Draft v0.4 — Codex final-pass review of §5-§12 (codex_msg_5753c73beafc_78) integrated. §0-§12 ready for P1 implementation.
 **Builds on:** `docs/shared-thread-mode-spec.md` (v2.2, implemented in commits `f84346e` + `54e806e`).
 **Author:** Claude (Opus 4.7), cross-reviewed by Codex.
 **Date:** 2026-05-16
@@ -17,7 +17,7 @@ v2.3 lifts this restriction by generalizing the daemon's cardinality from "one s
 - §3 Architecture: added explicit singleton-vs-per-pair table; removed misleading "TUI passes pair id at WS handshake" wording — pair identity is implicit in the per-pair proxy port, which CLI obtains by `ensurePair`-ing the daemon first.
 - §4: revised D2/D3/D4 per Codex finding; added pair-name validation rules to D1; added migration-impact details to D5; introduced D6-D9 (duplicate TUI, status schema, resource limits, event routing).
 
-### v0.2 → v0.3 (this revision)
+### v0.2 → v0.3
 
 Codex second-pass review (codex_msg_5753c73beafc_70) flagged spec-level protocol/lifecycle gaps. Architecture direction was approved; this revision tightens contracts before §5-§12 depend on them.
 
@@ -27,6 +27,17 @@ Codex second-pass review (codex_msg_5753c73beafc_70) flagged spec-level protocol
 - **D5**: corrected migration-impact list per Codex investigation — `e2e-cli.test.ts` does not actually read root `codex-wrapper.log`; the real touch points are `codex-tui.pid`, top-level `status.json` field readers, fake daemon status fixtures, `state-dir.test`, and `kill.ts`'s single-pid walk. Added an explicit implementation-order constraint: **P1 must not move filesystem layout — D5 changes land in P3 alongside the `ensurePair` API**.
 - **D6**: added `requestId` correlation to all pair-management control messages; added `claude_connect_result` to the protocol shape so the bridge can surface explicit-pair failures as a user-visible disabled state; clarified `/readyz` semantics — in v2.3 daemon readiness means "control-plane ready", pair readiness is conveyed by `ensurePair`'s response.
 - **D9**: replaced `removeAllListeners()` with targeted `off(name, ref)` tracking — pair tear-down only removes the handlers it registered, leaving diagnostics or future internal listeners intact.
+
+### v0.3 → v0.4 (this revision)
+
+§0-§4 were LOCKED by Codex third-pass review (codex_msg_5753c73beafc_74). §5-§12 were then drafted against the locked contracts and went out for Codex's final-pass review (codex_msg_5753c73beafc_78). The final-pass surfaced 5 blocking and 2 editorial findings, all in §5-§12 content (not in §0-§4 decisions). This revision integrates them.
+
+- **D2 / §6.2 — registry race across pairs**: previously the spec only had `ensurePairInFlight` keyed by pairId, so two simultaneous `ensure_pair("work")` calls were safe but two simultaneous `ensure_pair("work")` + `ensure_pair("side")` could race on registry write (atomic rename prevents torn files but not lost updates). Added a daemon-wide `registryWriteMutex` that serializes ALL registry read-modify-write sequences regardless of pairId. The per-pair `ensurePairInFlight` map remains (it deduplicates same-pairId concurrent requests so subscribers share one promise); the new mutex sits on the registry path inside each ensurePair flow.
+- **D6 / §6.3 — destroy_pair semantics**: previously `destroy_pair` returned `PAIR_NOT_FOUND` for entries that exist in the registry but are not live, which made D2's "use `rm --forget` after PAIR_PORTS_BUSY" instruction impossible to execute. Now `destroy_pair { forget: true }` succeeds on registry-only entries (it removes the registry entry and reports `registryEntryRemoved: true`). Also added `force?: boolean` field to the protocol and the matching `PAIR_BUSY_NOT_FORCED` error code (previously §8.2 / M11 referenced `--force` but the protocol shape had no slot for it).
+- **§6.5 — cross-pair isolation transition rewritten**: previously chose option (a) "target former pair's dying app-server then fail through retries", which Codex correctly called out as "controlled disconnect, not transition". Rewrote to use the **isolated chats target default pair's app-server** mechanism (§6.6): when a non-default pair tears down, its paired chat is reassigned `homePairId = null` and a fresh ClaudeThread is bootstrapped against `default`'s app-server. If `default` is not live, fall back to the v2.2 reap-with-instruction pattern (`reapChatState` + "reconnect Claude" message from commit 54e806e).
+- **§6.6 — direct mode and Claude-only isolated paths**: added explicit handling for `abg codex` (direct mode, no `--via-proxy`) and Claude-only isolated sessions (claude_connect with no pairId and no live pair to claim). Both rely on `default` being live; daemon auto-ensures `default` on first need to preserve v2.2 ergonomics.
+- **§11 — P3 phasing**: previously P3 added `ensure_pair` protocol but CLI usage was deferred to P4, which would leave `default` un-ensured in P3 and break v2.2-style `abg codex --via-proxy`. Now P3 explicitly auto-ensures `default` on daemon boot (or on first claude_connect / first ensurePair, whichever comes first). P4 still owns the user-facing `--pair` flag but `default` is no longer a "lazy" pair in any sense — it acts like v2.2's singleton until users opt into multi-pair.
+- **§8.1 nit — pre-flight semantics**: removed the "piggyback on `pair_ensured`" alternative; pre-flight always uses a follow-up `list_pairs` to check `proxyTuiConnected` for the target pair. Keeps D6 response shape stable.
 
 ## 1. Motivation
 
@@ -165,10 +176,13 @@ The pair → port assignment lives in `<stateDir>/pairs/registry.json` — NOT i
 - Optional **machine-global override** via an env var read by the daemon at boot: `AGENTBRIDGE_PAIR_PORTS_FILE` pointing to a JSON like `{ "work": { "appPort": 5510, "proxyPort": 5511 } }`. If set and the file exists, those entries take precedence over stride allocation but are still merged into the registry on first ensure. This is the escape hatch for power users; the registry remains the live source-of-truth that the daemon reads/writes during normal operation.
 - **CLI never assumes ports from a stride formula.** `abg codex --pair NAME` always calls `ensurePair(NAME)` first and uses the daemon's reply for `--remote ws://...`.
 
-**Concurrency safety (Codex v0.3 finding):**
+**Concurrency safety (Codex v0.3 + v0.4 findings):**
 
-- Daemon maintains an in-memory `ensurePairInFlight: Map<pairId, Promise<EnsurePairResult>>`. A second `ensurePair(pairId)` arriving while the first is mid-flight subscribes to the same promise rather than racing into a duplicate allocation/spawn path.
-- Registry writes are **atomic**: write to `<stateDir>/pairs/registry.json.tmp.<random>`, then `rename()` over the target. A partial write or crash mid-write cannot corrupt the registry.
+Two layers of mutual exclusion protect different concerns:
+
+- **Per-pair dedup mutex** (`ensurePairInFlight: Map<pairId, Promise<EnsurePairResult>>`): a second `ensurePair("work")` arriving while the first is mid-flight subscribes to the same promise rather than racing into a duplicate allocation/spawn path. Both callers see the same resolved URLs.
+- **Daemon-wide registry mutex** (`registryWriteMutex: Promise<void>`): the per-pair mutex above does NOT protect against `ensurePair("work")` and `ensurePair("side")` running concurrently and both touching the registry — atomic rename prevents file corruption but not lost updates if both reads observe an old state before either writes. The registry-write critical section (read current registry → decide allocation → write new registry) executes inside a daemon-wide serialized chain. Implementation: each registry write is `registryWriteMutex = registryWriteMutex.then(doWrite)`, which chains writes single-file. The mutex is acquired by anything that mutates the registry (ensurePair allocation path, destroyPair --forget, future repair tools).
+- Registry writes are **atomic on disk**: write to `<stateDir>/pairs/registry.json.tmp.<random>`, then `rename()` over the target. A partial write or crash mid-write cannot corrupt the registry.
 - On startup, daemon reads the registry, validates each entry (port range, name regex), and discards any entry that fails validation with a logged warning.
 
 **Port-busy recovery (`PAIR_PORTS_BUSY`):**
@@ -299,9 +313,9 @@ D5 changes (filesystem layout, fake-daemon fixtures, kill walker) land in **P3**
   → { type: "pair_error", requestId, pairId, code: "INVALID_PAIR_NAME" | "PAIR_PORTS_BUSY" | "MAX_PAIRS" | "ALLOCATION_FAILED", message, details? }
 
 // New: destroy
-{ type: "destroy_pair", requestId, pairId: string, forget?: boolean }
-  → { type: "pair_destroyed", requestId, pairId, registryEntryRemoved: boolean }
-  → { type: "pair_error", requestId, pairId, code: "PAIR_NOT_FOUND" | "PAIR_BUSY_NOT_FORCED", message }
+{ type: "destroy_pair", requestId, pairId: string, forget?: boolean, force?: boolean }
+  → { type: "pair_destroyed", requestId, pairId, registryEntryRemoved: boolean, wasLive: boolean }
+  → { type: "pair_error", requestId, pairId, code: "PAIR_NOT_FOUND" | "PAIR_BUSY_NOT_FORCED" | "INVALID_PAIR_NAME", message }
 
 // New: introspection
 { type: "list_pairs", requestId }
@@ -542,24 +556,38 @@ const chats: Map<string, ChatState> = new Map();              // unchanged from 
 
 If step (a) — (h) throws, the promise rejects with a `pair_error`. The partial state (CodexAdapter spawned but not started, registry written but not used) is cleaned up in a `catch` before rejecting: kill child process if any, leave registry entry intact (so the next attempt sees the same ports).
 
-### 6.3 `destroyPair(pairId, { forget })`
+### 6.3 `destroyPair(pairId, { forget, force })`
+
+Per Codex v0.4 finding: must handle both live pairs and registry-only entries (the latter enables D2's `--forget` recovery after `PAIR_PORTS_BUSY`). The `force` flag bypasses the safety check that protects an actively-paired chat.
 
 ```
-1. validate pairId
-2. pair = pairs.get(pairId); if !pair return pair_error PAIR_NOT_FOUND
-3. cancel pair.tuiReapTimer / pair.pairReapTimer
-4. detachPairHandlers(pair) per D9
-5. for each chat where chat.homePairId === pairId:
-     - if chat.paired → transitionChatToIsolatedAcrossPairs(chat) — see 6.5
-     - else chat.homePairId = null (chat keeps its own ClaudeThread; no message)
-6. pair.codex.stop()         // closes WS, kills app-server child
-7. pairs.delete(pairId)
-8. if forget → remove registry entry (atomic write); else keep entry so ensurePair re-allocates same ports
-9. broadcastStatus()
-10. respond pair_destroyed
+1. validate pairId per D1; return pair_error INVALID_PAIR_NAME if bad
+2. pair = pairs.get(pairId); inRegistry = pairRegistry.has(pairId)
+3. if !pair && !inRegistry → return pair_error PAIR_NOT_FOUND
+4. if pair && pair.pairedChatId !== null && !force → return pair_error PAIR_BUSY_NOT_FORCED
+5. if pair (live teardown):
+     a. cancel pair.tuiReapTimer / pair.pairReapTimer
+     b. detachPairHandlers(pair) per D9
+     c. for each chat where chat.homePairId === pairId:
+          - if chat.paired → transitionPairedChatOnTeardown(chat) — see 6.5
+          - else chat.homePairId = null (re-target ClaudeThread to default if alive — see 6.6)
+     d. pair.codex.stop()       // closes WS, kills app-server child
+     e. pairs.delete(pairId)
+6. if forget (whether or not the pair was live):
+     - acquire registryWriteMutex
+     - remove pairId from registry; atomic temp+rename
+     - release mutex
+7. broadcastStatus()
+8. respond pair_destroyed { pairId, wasLive: !!pair, registryEntryRemoved: !!forget }
 ```
 
-`destroyPair` is the explicit teardown. The implicit teardown via TUI reap grace (D3) goes through the same step list except step (1)-(2) come from a timer callback instead of an inbound control message.
+`destroyPair` is the explicit teardown. The implicit teardown via TUI reap grace (D3) goes through the live-teardown path (step 5) without the `force` check (timer-driven, not user-driven) and without `forget` (registry entry survives so the same name+ports can be re-ensured).
+
+**Edge cases (Codex v0.4 specifically):**
+
+- `destroy_pair("work", { forget: true })` on a registry-only `work` (never live, or live + then reaped) succeeds with `wasLive: false, registryEntryRemoved: true`. This is the recovery path after `PAIR_PORTS_BUSY` told the user the registered ports are conflicting.
+- `destroy_pair("work")` on a paired-live `work` without `force` fails with `PAIR_BUSY_NOT_FORCED`. User gets a clear error pointing at the paired Claude.
+- `destroy_pair("work", { force: true })` on a paired-live `work` proceeds: the paired chat is reassigned through §6.5 (transition to default-backed isolated or reap), then the live teardown completes.
 
 ### 6.4 `attachClaude` v2.3
 
@@ -581,37 +609,84 @@ If step (a) — (h) throws, the promise rejects with a `pair_error`. The partial
 7. reply claude_connect_result { ok:true, homePairId, paired }
 ```
 
-### 6.5 Cross-pair isolation transition
+### 6.5 Transition paired chat on pair tear-down
 
-When a pair tears down (TUI gone or `destroyPair`), its paired chat needs to keep working. v2.2's `transitionToIsolated(state, reason)` is generalized:
+When a pair tears down (TUI gone, `destroyPair`, or app-server crash), its paired chat (if any) needs a new home. v2.2's `transitionToIsolated(state, reason)` generalizes to:
 
 ```typescript
-function transitionChatToIsolatedAcrossPairs(state: ChatState) {
-  const formerPair = pairs.get(state.homePairId!);  // may already be undefined post-tear-down
+function transitionPairedChatOnTeardown(state: ChatState, reason: string) {
+  // Reset paired-turn flags (v2.2 commit 54e806e Codex review #2):
   state.paired = false;
-  state.homePairId = null;                          // chat is now homeless / isolated
-  // remaining steps identical to v2.2 transitionToIsolated:
-  //  - reset replyRequired / replyReceivedDuringTurn / pairedTurnSawAgentMessage
-  //  - emit system_pair_torn_down
-  //  - construct fresh ClaudeThread targeting the chat's old app-server URL
-  //  - bootstrap with the v2.2 retry helper bootstrapIsolatedThread()
+  state.homePairId = null;
+  state.replyRequired = false;
+  state.replyReceivedDuringTurn = false;
+  state.pairedTurnSawAgentMessage = false;
+  emitToChat(state, systemMessage("system_pair_torn_down", reason));
+
+  // Choose a continuation backend: default pair if it's live, otherwise reap.
+  const def = pairs.get("default");
+  if (def?.isLive && def.readiness === "ready") {
+    // Path A: chat continues as an isolated chat against default's app-server.
+    // This is the same "isolated chat = uses default pair's app-server"
+    // mechanism §6.6 specifies for every other isolated chat.
+    state.thread = new ClaudeThread({
+      appServerUrl: def.codex.appServerUrl,
+      chatId: state.chatId,
+      logFile: stateDir.logFile,
+      cwd: process.cwd(),
+    });
+    state.ready = false;
+    wireClaudeThreadEvents(state);
+    bootstrapIsolatedThread(state);   // v2.2 commit 54e806e retry helper
+  } else {
+    // Path B: no fallback. Reap chat with explicit "reconnect" instruction
+    // (matches v2.2 commit 54e806e final-failure path, which is actionable).
+    emitToChat(state, systemMessage("system_isolated_no_fallback",
+      "❌ The pair has torn down and no default pair is available to continue. " +
+      "Closing this chat — please reconnect Claude (close the window and re-attach) " +
+      "to start a fresh attempt; if you destroyed the default pair, re-run " +
+      "`abg codex --via-proxy` first."));
+    reapChatState(state, "pair torn down with no default fallback");
+  }
 }
 ```
 
-The ClaudeThread for the new isolated chat targets which app-server? Two options:
+**Why this is not "isolation transition" in the v2.2 sense, and why that's fine** (Codex v0.4 finding addressed):
 
-- **(a)** Target the former pair's `appServerUrl` if that app-server is still up (e.g. only the TUI WS died, the codex process is still healthy). Reuse the existing thread connection. **Risk**: pair tear-down kills the app-server too (6.3 step 6), so by the time `transitionChatToIsolatedAcrossPairs` runs, the URL points to nothing.
-- **(b)** Target the `default` pair's app-server, ensuring `default` is live first. This guarantees the isolated chat has a working backend, but it means a `work`-paired Claude transitions onto the `default` Codex thread, which may be running unrelated turns for other chats.
+In v2.2, "transition to isolated" meant the paired Claude becomes an isolated Claude with its own ClaudeThread on the SAME codex app-server (there was only one). v2.3 has N app-servers, so when a non-default pair tears down, the chat literally has nowhere to go on that pair's app-server. Path A above reroutes the chat to `default`'s app-server, which is the canonical "isolated chats live here" backend per §6.6. The chat keeps its `chatId`, its message buffer, and its WS — it just gets a fresh Codex thread on a different app-server. This is consistent with v2.2 semantics: "isolated chat = own thread on the daemon's available app-server". v2.3 makes "the daemon's available app-server" specifically `default`.
 
-**Spec choice (a) with a caveat**: tear-down ordering is changed so `transitionChatToIsolatedAcrossPairs` runs BEFORE `pair.codex.stop()`. The chat's new ClaudeThread connects to the soon-to-die app-server during a small window where the app-server is still alive. The thread bootstrap establishes a new Codex thread (per v2.2 §5 "no replay"), and then `pair.codex.stop()` kills the app-server. Result: the chat's new isolated ClaudeThread loses its connection almost immediately and triggers the v2.2 retry helper (`bootstrapIsolatedThread`, max 2 attempts). The retries will fail (no app-server), and the chat ends in the v2.2 "reap chat after retries exhausted" path with the "reconnect Claude" instruction — which IS now actionable thanks to commit 54e806e.
+**Ordering note**: step 5 of §6.3 runs `transitionPairedChatOnTeardown` BEFORE `pair.codex.stop()`. The transition itself does not depend on the former pair's app-server (it targets default), so there is no race window where the chat connects to a dying server.
 
-This is acceptable because the alternative (option b, attaching to `default`) violates pair isolation (D8). If a user wants the chat to continue, they should re-attach Claude — the daemon will then iterate pairs, find `default` (or whichever is now live) and either claim its slot or attach isolated against its app-server.
+### 6.6 Isolated chats, direct mode, and the default-pair fallback
 
-### 6.6 Isolated chats and their app-server
+A chat with `homePairId = null` (was never paired, was reaped from a torn-down pair via §6.5, or whose `agentbridge claude` invocation didn't claim any pair) needs a Codex app-server to talk to. v2.2 had only one app-server; v2.3 has N. Spec choice: **isolated chats target the `default` pair's app-server**.
 
-A chat that is `homePairId = null` (was never paired, or was reaped) needs a Codex app-server to talk to. v2.2 had only one; v2.3 has N. Spec choice: **isolated chats target the `default` pair's app-server**. The `default` pair is always present in the registry (D1) and is always live during normal use (its app-server starts on first `abg codex --via-proxy` with no `--pair` flag).
+**Default auto-ensure** (per Codex v0.4 finding on §11 P3 phasing):
 
-If `default` is not live (e.g. user destroyed it explicitly), isolated chats are stranded — `bootstrapIsolatedThread` fails and the chat is reaped with the "reconnect Claude" instruction. This is consistent with v2.2 behavior where the singleton codex going down strands all chats.
+The `default` pair is treated specially throughout the daemon:
+
+- On daemon boot, if `default` exists in the registry but is not live, daemon does NOT auto-start it (lazy). It is brought live by the first event that needs it:
+  - First `claude_connect` with no `pairId` and no other live pair to FIFO-claim → triggers `ensure_pair("default")` internally.
+  - First `abg codex --via-proxy` with no `--pair` flag → CLI calls `ensure_pair("default")`.
+  - First `abg codex` direct mode (no `--via-proxy`) → daemon calls `ensure_pair("default")` to bring up the app-server the direct-mode TUI will target.
+- Once `default` is live, isolated chats and direct-mode TUIs use its `appServerUrl`.
+- If `default` is not live AND cannot be auto-ensured (e.g. its ports are held by another process and `PAIR_PORTS_BUSY` fires), isolated chats are reaped per §6.5 Path B and direct-mode `abg codex` exits with the same `PAIR_PORTS_BUSY` message scoped to `default`.
+
+**Direct mode** (`abg codex` without `--via-proxy`, the v1 backwards-compat path from commit `b687cc5`):
+
+- CLI calls `ensure_pair("default")` to make sure the app-server is up, then spawns codex with `--remote <default.appServerUrl>` directly (no proxy). No `--pair` flag is supported in direct mode because direct-mode TUIs do NOT participate in the pairing protocol — they are independent clients of the app-server, get their own threads, and never appear in any `proxyTuiSlot`.
+- Future: a direct-mode TUI on a non-default pair (`abg codex --pair work` without `--via-proxy`) is technically achievable (ensure pair, take its appServerUrl, spawn direct codex). v2.3 keeps this out of scope — direct mode stays default-only — to limit the test surface. Adding it later is a small follow-up PR.
+
+**Claude-only isolated session** (Claude attaches, no live pair to claim, no explicit pairId):
+
+- D4's FIFO step iterates pairs and finds no unpaired live pair (every pair is either un-ensured or already-paired).
+- attachClaude calls `ensure_pair("default")` internally (idempotent: no-op if already live).
+- ChatState gets `homePairId = null` (isolated) and its ClaudeThread targets `default.appServerUrl`. Same as v2.2's "isolated Claude without TUI" behavior.
+
+**Explicit non-default attach when default is not live**:
+
+- Claude with `AGENTBRIDGE_PAIR=work` attaches; `work` is unpaired and live → claim. `default` is not auto-ensured in this case (the chat doesn't need `default`).
+- If `work` later tears down → §6.5 Path B reap (no fallback) UNLESS another pair (or `default`) has come live by then.
 
 ## 7. ClaudeAdapter / routing changes
 
@@ -669,8 +744,8 @@ Unchanged. The offline buffer is per-chat (already), so cross-pair leakage is im
   1. CLI calls `ensure_pair(NAME)` over control WS.
   2. On `pair_error PAIR_PORTS_BUSY` → CLI exits with `error: ports for pair "NAME" (appPort=X, proxyPort=Y) are held by PID Z. Stop that process or use 'abg pairs rm NAME --forget' to reassign.`
   3. On `pair_error MAX_PAIRS` → CLI exits with `error: max pairs reached (N). Destroy an unused pair with 'abg pairs rm NAME'.`
-  4. On `pair_ensured` with `proxyTuiConnected: true` (returned via a follow-up `list_pairs` call if the spec wants strict separation, or piggybacked on `pair_ensured`) → CLI exits with the v2.2-style "another --via-proxy TUI is already connected" message, scoped to this pair.
-  5. On `pair_ensured` clean → CLI proceeds to spawn `codex` with `--remote <proxyUrl>` and `--remote-auth-token-env AGENTBRIDGE_PROXY_TOKEN`. Pair id is NOT passed to codex — it does not need to know.
+  4. On `pair_ensured` clean → CLI calls `list_pairs` to check `proxyTuiConnected` for the just-ensured pair. (Codex v0.4 nit: keeps the `pair_ensured` response shape stable and uses `list_pairs` as the canonical introspection path. The follow-up is one extra round-trip but eliminates a payload-shape variant.) If `proxyTuiConnected === true` → CLI exits with the v2.2-style "another --via-proxy TUI is already connected" message, scoped to this pair.
+  5. Otherwise → CLI proceeds to spawn `codex` with `--remote <proxyUrl>` and `--remote-auth-token-env AGENTBRIDGE_PROXY_TOKEN`. Pair id is NOT passed to codex — it does not need to know.
 
 ### 8.2 New commands
 
@@ -762,7 +837,7 @@ Five small PRs, each independently mergeable to `master` (or the v2.3 long-runni
 |---|---|---|---|
 | **P1** | Internal refactor: replace daemon-level singletons (`codex`, `proxyTuiSlot`, `TuiConnectionState`) with `pairs: Map<pairId, PairState>` keyed only by `"default"`. `ChatState` gains `homePairId` field, always set to `"default"`. CodexAdapter constructor moves to options object. No new control messages, no CLI flags, no filesystem layout change. | Externally none — `abg codex --via-proxy` works exactly as in v2.2. | All 17 daemon tests + 14 codex-adapter tests + e2e tests pass unchanged. |
 | **P2** | CodexAdapter lifecycle as a peer-managed component: daemon spawns / stops adapters via `ensurePair` / `destroyPair` internal calls (no control-protocol API yet). Pair-aware event handler attach/detach (D9 pattern). Still only `default` ever ensured. | Externally none. | Add 5-8 daemon tests covering `attachPairHandlers` symmetry + lifecycle. |
-| **P3** | `ensure_pair` / `destroy_pair` / `list_pairs` control protocol (D6). Registry + atomic writes (D2). State dir layout (D5) — files MOVE here, root-level pids/logs deprecated. `kill` walker (§8.4). `claude_connect_result` typed reply (D6). Fake-daemon fixtures and `state-dir.test` updated. | Behavioral: tooling that read root `codex-tui.pid` / `codex-wrapper.log` will break — only `kill.ts` and tests touch those, both updated in this PR. | Add 6-10 daemon tests for registry + protocol + cross-restart. |
+| **P3** | `ensure_pair` / `destroy_pair` / `list_pairs` control protocol (D6) with `requestId` + `force`/`forget`. Registry + atomic writes + global registry mutex (D2 / §6.2). State dir layout (D5) — files MOVE here, root-level pids/logs deprecated. `kill` walker (§8.4). `claude_connect_result` typed reply (D6). Fake-daemon fixtures and `state-dir.test` updated. **`default` auto-ensure**: daemon implicitly calls `ensure_pair("default")` on first claude_connect / first `abg codex --via-proxy` / first direct-mode `abg codex` (§6.6) so v2.2-style invocations keep working without a `--pair` flag. | Behavioral: tooling that read root `codex-tui.pid` / `codex-wrapper.log` will break — only `kill.ts` and tests touch those, both updated in this PR. v2.2-style `abg codex --via-proxy` still works (default auto-ensured). | Add 6-10 daemon tests for registry + protocol + cross-restart + default auto-ensure. |
 | **P4** | CLI `--pair` flag in `abg codex` and `agentbridge claude` (D4, §8.1, §8.3). `abg pairs ls/rm` commands (§8.2). Pre-flight ports-busy / max-pairs error surfacing. | Behavioral: users can now create / list / destroy pairs. `default` remains the only pair anyone has unless they pass `--pair`. | Add CLI tests for new flag parsing + subcommands. Probes M03, M07, M10, M11 land here. |
 | **P5** | FIFO pair claim + explicit `AGENTBRIDGE_PAIR` env path (D4 §6.4). Cross-pair isolation transition (§6.5). UX prefix for pair id (§7.3). Multi-pair probes M01, M02, M04, M05, M06, M08, M09, M12. Crash isolation smoke (M02 + M12). | Behavioral: multi-pair is now end-to-end functional. v2.3 use case ships. | Probes + daemon tests cover the new state machine paths. |
 
@@ -780,4 +855,4 @@ Same model as v2.2 (`docs/shared-thread-mode-spec.md` §12), with one caveat lea
 
 ---
 
-**Status**: Draft v0.3, locked. §0-§12 ready for implementation phases (§11) to begin with P1.
+**Status**: Draft v0.4. §0-§4 locked at v0.3; §5-§12 revised per Codex final-pass review (codex_msg_5753c73beafc_78). Ready for P1 implementation pending one short Codex re-pass on the v0.4 deltas.

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13758,6 +13758,7 @@ class ClaudeAdapter extends EventEmitter {
   sessionId;
   notificationIdPrefix;
   instanceId;
+  chatId;
   replySender = null;
   logFile;
   configuredMode;
@@ -13769,7 +13770,8 @@ class ClaudeAdapter extends EventEmitter {
     super();
     this.logFile = logFile;
     this.instanceId = randomUUID().slice(0, 8);
-    this.sessionId = `codex_${Date.now()}`;
+    this.sessionId = `codex_${Date.now()}_${this.instanceId}`;
+    this.chatId = this.sessionId;
     this.notificationIdPrefix = randomUUID().replace(/-/g, "").slice(0, 12);
     this.log(`ClaudeAdapter created (instance=${this.instanceId})`);
     const envMode = process.env.AGENTBRIDGE_MODE;
@@ -14004,9 +14006,14 @@ class DaemonClient extends EventEmitter2 {
   wsId = 0;
   nextRequestId = 1;
   pendingReplies = new Map;
-  constructor(url) {
+  chatId;
+  constructor(url, opts) {
     super();
     this.url = url;
+    this.chatId = opts?.chatId;
+  }
+  setChatId(chatId) {
+    this.chatId = chatId;
   }
   async connect() {
     if (this.ws?.readyState === WebSocket.OPEN) {
@@ -14048,13 +14055,13 @@ class DaemonClient extends EventEmitter2 {
     });
   }
   attachClaude() {
-    this.send({ type: "claude_connect" });
+    this.send({ type: "claude_connect", chatId: this.chatId });
   }
   async disconnect() {
     if (!this.ws)
       return;
     try {
-      this.send({ type: "claude_disconnect" });
+      this.send({ type: "claude_disconnect", chatId: this.chatId });
     } catch {}
     try {
       this.ws.close();
@@ -14076,6 +14083,7 @@ class DaemonClient extends EventEmitter2 {
       this.send({
         type: "claude_to_codex",
         requestId,
+        chatId: this.chatId,
         message,
         ...requireReply ? { requireReply: true } : {}
       });
@@ -14517,7 +14525,7 @@ var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 var claude = new ClaudeAdapter(stateDir.logFile);
-var daemonClient = new DaemonClient(CONTROL_WS_URL);
+var daemonClient = new DaemonClient(CONTROL_WS_URL, { chatId: claude.chatId });
 var shuttingDown = false;
 var daemonDisabled = false;
 var daemonDisabledReason = null;

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14194,6 +14194,15 @@ class DaemonClient extends EventEmitter2 {
       pending.resolve({ success: false, error: error2 });
       this.pendingReplies.delete(requestId);
     }
+    for (const [requestId, pending] of this.pendingAttachReplies.entries()) {
+      clearTimeout(pending.timer);
+      pending.resolve({
+        ok: false,
+        error: "DAEMON_SHUTTING_DOWN",
+        message: `claude_connect interrupted: ${error2}`
+      });
+      this.pendingAttachReplies.delete(requestId);
+    }
   }
   send(message) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
@@ -14777,7 +14786,16 @@ async function pollDisabledRecovery() {
     log("Disabled-state recovery conditions met \u2014 attempting direct daemon reconnect");
     try {
       await daemonClient.connect();
-      daemonClient.attachClaude();
+      const attachResult = await daemonClient.attachClaude();
+      if (!attachResult.ok) {
+        const pairCtx = PAIR_ID ? ` (requested pair: "${PAIR_ID}")` : "";
+        log(`Recovery attach rejected: ${attachResult.error} \u2014 ${attachResult.message}${pairCtx}`);
+        daemonDisabled = true;
+        daemonDisabledReason = "daemon_rejected_attach";
+        stopDisabledRecoveryPoller();
+        await claude.pushNotification(systemMessage("system_bridge_disabled", `\u274C AgentBridge recovery failed: ${attachResult.error}. ${attachResult.message}${pairCtx}`));
+        return;
+      }
       daemonDisabled = false;
       daemonDisabledReason = null;
       stopDisabledRecoveryPoller();

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13714,6 +13714,21 @@ class StateDirResolver {
   get killedFile() {
     return join(this.stateDir, "killed");
   }
+  pairDir(pairId) {
+    return join(this.stateDir, "pairs", pairId);
+  }
+  pairCodexPidFile(pairId) {
+    return join(this.pairDir(pairId), "codex.pid");
+  }
+  pairCodexWrapperLogFile(pairId) {
+    return join(this.pairDir(pairId), "codex-wrapper.log");
+  }
+  ensurePairDir(pairId) {
+    const dir = this.pairDir(pairId);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
 }
 
 // src/claude-adapter.ts
@@ -14007,13 +14022,18 @@ class DaemonClient extends EventEmitter2 {
   nextRequestId = 1;
   pendingReplies = new Map;
   chatId;
+  pairId;
   constructor(url, opts) {
     super();
     this.url = url;
     this.chatId = opts?.chatId;
+    this.pairId = opts?.pairId;
   }
   setChatId(chatId) {
     this.chatId = chatId;
+  }
+  setPairId(pairId) {
+    this.pairId = pairId;
   }
   async connect() {
     if (this.ws?.readyState === WebSocket.OPEN) {
@@ -14055,7 +14075,7 @@ class DaemonClient extends EventEmitter2 {
     });
   }
   attachClaude() {
-    this.send({ type: "claude_connect", chatId: this.chatId });
+    this.send({ type: "claude_connect", chatId: this.chatId, pairId: this.pairId });
   }
   async disconnect() {
     if (!this.ws)
@@ -14525,7 +14545,8 @@ var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 var claude = new ClaudeAdapter(stateDir.logFile);
-var daemonClient = new DaemonClient(CONTROL_WS_URL, { chatId: claude.chatId });
+var PAIR_ID = process.env.AGENTBRIDGE_PAIR;
+var daemonClient = new DaemonClient(CONTROL_WS_URL, { chatId: claude.chatId, pairId: PAIR_ID });
 var shuttingDown = false;
 var daemonDisabled = false;
 var daemonDisabledReason = null;

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14021,6 +14021,7 @@ class DaemonClient extends EventEmitter2 {
   wsId = 0;
   nextRequestId = 1;
   pendingReplies = new Map;
+  pendingAttachReplies = new Map;
   chatId;
   pairId;
   constructor(url, opts) {
@@ -14074,8 +14075,21 @@ class DaemonClient extends EventEmitter2 {
       };
     });
   }
-  attachClaude() {
-    this.send({ type: "claude_connect", chatId: this.chatId, pairId: this.pairId });
+  async attachClaude(timeoutMs = 5000) {
+    const requestId = `attach_${Date.now()}_${this.nextRequestId++}`;
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingAttachReplies.delete(requestId);
+        resolve({ ok: true, homePairId: null, paired: false });
+      }, timeoutMs);
+      this.pendingAttachReplies.set(requestId, { resolve, timer });
+      this.send({
+        type: "claude_connect",
+        requestId,
+        chatId: this.chatId,
+        pairId: this.pairId
+      });
+    });
   }
   async disconnect() {
     if (!this.ws)
@@ -14129,6 +14143,29 @@ class DaemonClient extends EventEmitter2 {
           clearTimeout(pending.timer);
           this.pendingReplies.delete(message.requestId);
           pending.resolve({ success: message.success, error: message.error });
+          return;
+        }
+        case "claude_connect_result": {
+          if (!message.requestId)
+            return;
+          const pending = this.pendingAttachReplies.get(message.requestId);
+          if (!pending)
+            return;
+          clearTimeout(pending.timer);
+          this.pendingAttachReplies.delete(message.requestId);
+          if (message.ok) {
+            pending.resolve({
+              ok: true,
+              homePairId: message.homePairId,
+              paired: message.paired
+            });
+          } else {
+            pending.resolve({
+              ok: false,
+              error: message.error,
+              message: message.message
+            });
+          }
           return;
         }
         case "status":
@@ -14533,6 +14570,8 @@ function disabledReplyError(reason) {
       return "AgentBridge rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset.";
     case "killed":
       return "AgentBridge is disabled by `agentbridge kill`. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.";
+    case "daemon_rejected_attach":
+      return "AgentBridge could not attach this Claude session \u2014 the daemon rejected the pair binding. See the most recent system message for the specific error (PAIR_NOT_FOUND / PAIR_BUSY / INVALID_PAIR_NAME). Restart Claude Code after fixing the underlying issue.";
   }
 }
 
@@ -14627,10 +14666,19 @@ async function connectToDaemon(isReconnect = false) {
   try {
     await daemonLifecycle.ensureRunning();
     await daemonClient.connect();
-    daemonClient.attachClaude();
+    const attachResult = await daemonClient.attachClaude();
+    if (!attachResult.ok) {
+      const pairCtx = PAIR_ID ? ` (requested pair: "${PAIR_ID}")` : "";
+      log(`Daemon rejected claude_connect: ${attachResult.error} \u2014 ${attachResult.message}${pairCtx}`);
+      daemonDisabled = true;
+      daemonDisabledReason = "daemon_rejected_attach";
+      await claude.pushNotification(systemMessage("system_bridge_disabled", `\u274C AgentBridge could not attach this Claude session: ${attachResult.error}. ${attachResult.message}${pairCtx}`));
+      return;
+    }
     daemonDisabledReason = null;
     if (!isReconnect) {
-      claude.pushNotification(systemMessage("system_bridge_ready", "\u2705 AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: agentbridge codex"));
+      const pairCtx = attachResult.paired && attachResult.homePairId ? ` (paired with pair "${attachResult.homePairId}")` : attachResult.homePairId && attachResult.homePairId !== "default" ? ` (home pair: "${attachResult.homePairId}")` : "";
+      claude.pushNotification(systemMessage("system_bridge_ready", `\u2705 AgentBridge bridge is ready. Daemon connected${pairCtx}. Start Codex in another terminal with: agentbridge codex`));
     }
   } catch (err) {
     log(`Failed to connect to daemon: ${err.message}`);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -61,6 +61,21 @@ class StateDirResolver {
   get killedFile() {
     return join(this.stateDir, "killed");
   }
+  pairDir(pairId) {
+    return join(this.stateDir, "pairs", pairId);
+  }
+  pairCodexPidFile(pairId) {
+    return join(this.pairDir(pairId), "codex.pid");
+  }
+  pairCodexWrapperLogFile(pairId) {
+    return join(this.pairDir(pairId), "codex-wrapper.log");
+  }
+  ensurePairDir(pairId) {
+    const dir = this.pairDir(pairId);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
 }
 
 // src/app-server-protocol.ts
@@ -2847,7 +2862,7 @@ function startControlServer() {
       if (url.pathname === "/healthz")
         return Response.json(currentStatus());
       if (url.pathname === "/readyz") {
-        return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
+        return Response.json(currentStatus(), { status: 200 });
       }
       if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, chatId: null } })) {
         return;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2562,6 +2562,12 @@ var CLOSE_CODE_REPLACED = 4001;
 var stateDir = new StateDirResolver;
 stateDir.ensure();
 var daemonLogger = getAsyncFileLogger(stateDir.logFile);
+var stderrBroken = false;
+process.stderr.on("error", (err) => {
+  if (err?.code === "EPIPE" || err?.code === "ERR_STREAM_DESTROYED") {
+    stderrBroken = true;
+  }
+});
 var configService = new ConfigService;
 var config = configService.loadOrDefault();
 var CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.codex.appPort), 10);
@@ -3892,7 +3898,15 @@ process.on("unhandledRejection", (reason) => {
 function log(msg) {
   const line = `[${new Date().toISOString()}] [AgentBridgeDaemon] ${msg}
 `;
-  process.stderr.write(line);
+  if (!stderrBroken) {
+    try {
+      process.stderr.write(line);
+    } catch (err) {
+      if (err?.code === "EPIPE" || err?.code === "ERR_STREAM_DESTROYED") {
+        stderrBroken = true;
+      }
+    }
+  }
   daemonLogger.write(line);
 }
 function startDaemon() {
@@ -3932,7 +3946,8 @@ var __testing = {
     handleEnsurePair,
     handleDestroyPair,
     handleListPairs,
-    attachClaude
+    attachClaude,
+    log
   },
   pairRegistry,
   runUnderRegistryMutex,

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3411,21 +3411,25 @@ function detachClaudeWs(state, reason) {
   state.ws = null;
   scheduleDisconnectTimer(state);
   scheduleReaperTimer(state);
-  if (state.paired && proxyTuiSlot && proxyTuiSlot.pairedChatId === state.chatId) {
-    if (proxyTuiSlot.pairReapTimer)
-      clearTimeout(proxyTuiSlot.pairReapTimer);
-    proxyTuiSlot.pairReapTimer = setTimeout(() => {
-      if (!proxyTuiSlot)
+  const homePair = state.paired && state.homePairId ? pairs.get(state.homePairId) : undefined;
+  if (state.paired && homePair && homePair.proxyTuiSlot && homePair.proxyTuiSlot.pairedChatId === state.chatId) {
+    const slot = homePair.proxyTuiSlot;
+    if (slot.pairReapTimer)
+      clearTimeout(slot.pairReapTimer);
+    slot.pairReapTimer = setTimeout(() => {
+      const currentPair = pairs.get(state.homePairId);
+      const currentSlot = currentPair?.proxyTuiSlot;
+      if (!currentSlot)
         return;
       const currentState = chats.get(state.chatId);
       if (currentState?.ws) {
-        log(`Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
+        log(`[pair=${state.homePairId}] Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
         return;
       }
-      log(`Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms \u2014 clearing pair slot and reaping chat state`);
-      proxyTuiSlot.pairedChatId = null;
-      proxyTuiSlot.pairReapTimer = null;
-      codex.setPairedChat(null);
+      log(`[pair=${state.homePairId}] Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms \u2014 clearing pair slot and reaping chat state`);
+      currentSlot.pairedChatId = null;
+      currentSlot.pairReapTimer = null;
+      currentPair.codex.setPairedChat(null);
       if (currentState) {
         try {
           currentState.thread.close();

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3535,8 +3535,17 @@ function handleClaudeToCodex(ws, message) {
     state.replyReceivedDuringTurn = false;
     log(`[${chatId}] Reply required flag set`);
   }
-  log(`[${chatId}] Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply}, paired=${state.paired})`);
-  const injected = state.paired ? codex.injectMessage(contentWithReminder) : state.thread.injectMessage(contentWithReminder);
+  log(`[${chatId}] Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply}, paired=${state.paired}, homePair=${state.homePairId})`);
+  const homePair = state.paired && state.homePairId ? pairs.get(state.homePairId) : undefined;
+  if (state.paired && (!homePair || !homePair.isLive)) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: `Home pair "${state.homePairId}" is no longer live; reconnect Claude to re-home.`
+    });
+  }
+  const injected = state.paired ? homePair.codex.injectMessage(contentWithReminder) : state.thread.injectMessage(contentWithReminder);
   if (!injected) {
     const reason = state.paired ? "Shared Codex TUI is busy with another turn. Retry." : state.thread.isTurnInProgress ? "Codex is busy executing a turn on your thread. Wait for it to finish." : "Injection failed: thread WS not connected.";
     if (requireReply) {
@@ -3969,7 +3978,8 @@ var __testing = {
     wireClaudeThreadEvents,
     setShuttingDownForTest(value) {
       shuttingDown = value;
-    }
+    },
+    handleClaudeToCodex
   },
   pairRegistry,
   runUnderRegistryMutex,

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3060,14 +3060,25 @@ function currentStatus() {
   const snapshot = tuiConnectionState.snapshot();
   return {
     bridgeReady: tuiConnectionState.canReply() || codexBootstrapped,
-    tuiConnected: snapshot.tuiConnected,
-    threadId: codex.activeThreadId,
-    queuedMessageCount: [...chats.values()].reduce((n, s) => n + s.bufferedMessages.length + s.statusBuffer.size, 0),
+    pid: process.pid,
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
-    pid: process.pid,
+    tuiConnected: snapshot.tuiConnected,
+    proxyTuiConnected: proxyTuiSlot !== null,
+    threadId: codex.activeThreadId,
     attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length,
-    proxyTuiConnected: proxyTuiSlot !== null
+    queuedMessageCount: [...chats.values()].reduce((n, s) => n + s.bufferedMessages.length + s.statusBuffer.size, 0),
+    pairs: [...pairs.values()].map((pair) => ({
+      pairId: pair.pairId,
+      isLive: pair.isLive,
+      appServerUrl: pair.codex.appServerUrl,
+      proxyUrl: pair.codex.proxyUrl,
+      tuiConnected: pair.tuiConnectionState.snapshot().tuiConnected,
+      proxyTuiConnected: pair.proxyTuiSlot !== null,
+      pairedChatId: pair.proxyTuiSlot?.pairedChatId ?? null,
+      threadId: pair.codex.activeThreadId,
+      attachedClaudes: [...chats.values()].filter((s) => s.homePairId === pair.pairId).map((s) => ({ chatId: s.chatId, paired: s.paired }))
+    }))
   };
 }
 function systemMessage(idPrefix, content) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -178,6 +178,13 @@ function isAppServerResponseMessage(value) {
 }
 
 // src/codex-adapter.ts
+function buildCodexAppServerArgs(appServerUrl, sandbox) {
+  const args = ["app-server", "--listen", appServerUrl];
+  if (sandbox)
+    args.push("--sandbox", sandbox);
+  return args;
+}
+
 class CodexAdapter extends EventEmitter {
   static RESPONSE_TRACKING_TTL_MS = 30000;
   proc = null;
@@ -246,8 +253,10 @@ class CodexAdapter extends EventEmitter {
   async start() {
     this.intentionalDisconnect = false;
     await this.checkPorts();
-    this.log(`Spawning codex app-server on ${this.appServerUrl}`);
-    this.proc = spawn("codex", ["app-server", "--listen", this.appServerUrl], {
+    const sandbox = process.env.AGENTBRIDGE_CODEX_SANDBOX;
+    const args = buildCodexAppServerArgs(this.appServerUrl, sandbox);
+    this.log(`Spawning codex app-server on ${this.appServerUrl}${sandbox ? ` (sandbox=${sandbox})` : ""}`);
+    this.proc = spawn("codex", args, {
       stdio: ["pipe", "pipe", "pipe"]
     });
     this.proc.on("error", (err) => this.emit("error", err));

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2404,8 +2404,8 @@ codex.on("turnCompleted", () => {
   const paired = getPairedChatState();
   if (!paired)
     return;
-  if (!paired.pairedTurnSawAgentMessage) {
-    log(`[${paired.chatId}] Codex turn completed with no agentMessage \u2014 surfacing as failure signal`);
+  if (!paired.pairedTurnSawAgentMessage && paired.replyRequired) {
+    log(`[${paired.chatId}] Codex turn completed with no agentMessage while replyRequired \u2014 surfacing as failure signal`);
     paired.replyReceivedDuringTurn = true;
     emitToChat(paired, systemMessage("system_codex_turn_completed_no_output", "[system] Codex turn completed without any agentMessage \u2014 likely a failure or empty response."));
   } else {
@@ -2420,7 +2420,9 @@ codex.on("errorItem", (payload) => {
     return;
   paired.replyReceivedDuringTurn = true;
   emitToChat(paired, systemMessage("system_codex_error", `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
+  paired.pairedTurnSawAgentMessage = true;
   paired.replyRequired = false;
+  paired.replyReceivedDuringTurn = false;
 });
 codex.on("sessionRestoreStart", () => {
   if (!proxyTuiSlot)
@@ -2480,8 +2482,64 @@ function pairChat(state) {
     emitToChat(state, systemMessage("system_paired_provisioning", "\u2705 This Claude session is paired with the right-pane Codex TUI. Waiting for the shared thread to finish provisioning before replies can flow."));
   }
 }
+var ISOLATED_BOOTSTRAP_MAX_ATTEMPTS = parseInt(process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_MAX_ATTEMPTS ?? "2", 10);
+var ISOLATED_BOOTSTRAP_RETRY_DELAY_MS = parseInt(process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_RETRY_DELAY_MS ?? "2000", 10);
+function bootstrapIsolatedThread(state, attempt = 1) {
+  state.thread.bootstrap().then((threadId) => {
+    state.ready = true;
+    emitToChat(state, systemMessage("system_isolated_ready", `\u2705 Fresh isolated Codex thread ready (threadId=${threadId}).`));
+  }).catch((err) => {
+    const errMsg = err?.message ?? String(err);
+    log(`[${state.chatId}] Isolated bootstrap attempt ${attempt}/${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS} failed: ${errMsg}`);
+    if (attempt < ISOLATED_BOOTSTRAP_MAX_ATTEMPTS) {
+      emitToChat(state, systemMessage("system_isolated_retry", `\u26A0\uFE0F Bootstrap of isolated Codex thread failed (attempt ${attempt}/${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS}): ${errMsg}. Retrying in ${ISOLATED_BOOTSTRAP_RETRY_DELAY_MS}ms.`));
+      setTimeout(() => {
+        try {
+          state.thread.close();
+        } catch {}
+        state.thread = new ClaudeThread({
+          appServerUrl: codex.appServerUrl,
+          chatId: state.chatId,
+          logFile: stateDir.logFile,
+          cwd: process.cwd()
+        });
+        wireClaudeThreadEvents(state);
+        bootstrapIsolatedThread(state, attempt + 1);
+      }, ISOLATED_BOOTSTRAP_RETRY_DELAY_MS);
+    } else {
+      emitToChat(state, systemMessage("system_isolated_failed", `\u274C Failed to bootstrap isolated Codex thread after ${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS} attempts: ${errMsg}. Closing this chat \u2014 please reconnect Claude (close the window and re-attach) to start a fresh attempt.`));
+      reapChatState(state, "isolated bootstrap exhausted");
+    }
+  });
+}
+function reapChatState(state, reason) {
+  log(`Reaping chat state: chatId=${state.chatId} (${reason})`);
+  if (state.ws) {
+    try {
+      state.ws.close(1011, `chat reaped: ${reason}`);
+    } catch {}
+    state.ws = null;
+  }
+  if (state.attentionWindowTimer)
+    clearTimeout(state.attentionWindowTimer);
+  if (state.disconnectTimer)
+    clearTimeout(state.disconnectTimer);
+  if (state.reaperTimer)
+    clearTimeout(state.reaperTimer);
+  try {
+    state.statusBuffer.dispose();
+  } catch {}
+  try {
+    state.thread.close();
+  } catch {}
+  chats.delete(state.chatId);
+  broadcastStatus();
+}
 function transitionToIsolated(state, reason) {
   state.paired = false;
+  state.replyRequired = false;
+  state.replyReceivedDuringTurn = false;
+  state.pairedTurnSawAgentMessage = false;
   emitToChat(state, systemMessage("system_pair_torn_down", `[system] ${reason}. Future replies will use a fresh isolated Codex thread (no prior shared-TUI context carried over).`));
   state.thread = new ClaudeThread({
     appServerUrl: codex.appServerUrl,
@@ -2491,12 +2549,7 @@ function transitionToIsolated(state, reason) {
   });
   state.ready = false;
   wireClaudeThreadEvents(state);
-  state.thread.bootstrap().then((threadId) => {
-    state.ready = true;
-    emitToChat(state, systemMessage("system_isolated_ready", `\u2705 Fresh isolated Codex thread ready (threadId=${threadId}).`));
-  }).catch((err) => {
-    emitToChat(state, systemMessage("system_isolated_failed", `\u274C Failed to bootstrap isolated Codex thread: ${err?.message ?? err}.`));
-  });
+  bootstrapIsolatedThread(state);
 }
 codex.on("error", (err) => {
   log(`Codex error: ${err.message}`);
@@ -3082,10 +3135,68 @@ function log(msg) {
     appendFileSync3(stateDir.logFile, line);
   } catch {}
 }
-if (daemonLifecycle.wasKilled()) {
-  log("Killed sentinel found \u2014 daemon was intentionally stopped. Exiting immediately.");
-  process.exit(0);
+function startDaemon() {
+  if (daemonLifecycle.wasKilled()) {
+    log("Killed sentinel found \u2014 daemon was intentionally stopped. Exiting immediately.");
+    process.exit(0);
+  }
+  writePidFile();
+  startControlServer();
+  bootCodex();
 }
-writePidFile();
-startControlServer();
-bootCodex();
+if (import.meta.main) {
+  startDaemon();
+}
+var __testing = {
+  get proxyTuiSlot() {
+    return proxyTuiSlot;
+  },
+  setProxyTuiSlot(next) {
+    proxyTuiSlot = next;
+  },
+  chats,
+  codex,
+  fns: {
+    pairChat,
+    transitionToIsolated,
+    bootstrapIsolatedThread,
+    getPairedChatState,
+    createChatState,
+    detachClaudeWs,
+    emitToChat
+  },
+  config: {
+    PAIR_REAP_MS,
+    CLAUDE_REAP_AFTER_MS,
+    ISOLATED_BOOTSTRAP_MAX_ATTEMPTS,
+    ISOLATED_BOOTSTRAP_RETRY_DELAY_MS
+  },
+  reset() {
+    if (proxyTuiSlot?.pairReapTimer) {
+      clearTimeout(proxyTuiSlot.pairReapTimer);
+    }
+    for (const state of chats.values()) {
+      if (state.attentionWindowTimer)
+        clearTimeout(state.attentionWindowTimer);
+      if (state.disconnectTimer)
+        clearTimeout(state.disconnectTimer);
+      if (state.reaperTimer)
+        clearTimeout(state.reaperTimer);
+      try {
+        state.statusBuffer.dispose();
+      } catch {}
+      try {
+        state.thread.close();
+      } catch {}
+    }
+    chats.clear();
+    proxyTuiSlot = null;
+    try {
+      codex.setPairedChat(null);
+    } catch {}
+  },
+  reapChatState
+};
+export {
+  __testing
+};

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3380,10 +3380,13 @@ function wireClaudeThreadEvents(state) {
     emitToChat(state, systemMessage("system_turn_completed", "\u2705 Codex finished the current turn. You can reply now if needed."));
     startAttentionWindow(state);
   });
+  const threadAtRegistration = state.thread;
   state.thread.on("close", () => {
     log(`[${chatId}] ClaudeThread WS closed`);
     state.ready = false;
     if (shuttingDown)
+      return;
+    if (state.thread !== threadAtRegistration)
       return;
     if (chats.get(chatId) !== state)
       return;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3525,9 +3525,12 @@ function handleClaudeToCodex(ws, message) {
   if (!state.ready) {
     let errorMsg;
     if (state.paired) {
-      if (codex.isSessionRestoreInProgress) {
+      const homePair2 = state.homePairId ? pairs.get(state.homePairId) : undefined;
+      const homeCodex = homePair2?.codex;
+      const homeSlot = homePair2?.proxyTuiSlot;
+      if (homeCodex?.isSessionRestoreInProgress) {
         errorMsg = "Restoring shared Codex TUI session, retry shortly.";
-      } else if (proxyTuiSlot) {
+      } else if (homeSlot) {
         errorMsg = "Shared Codex TUI thread is still provisioning. Retry shortly.";
       } else {
         errorMsg = "Shared Codex TUI is no longer connected. Wait for transition to isolated mode.";

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3279,6 +3279,7 @@ async function attachClaude(ws, requestedChatId, requestedPairId, requestId) {
   } catch (err) {
     log(`ClaudeThread bootstrap failed for chatId=${chatId}: ${err?.message ?? err}`);
     emitToChat(state, systemMessage("system_thread_failed", `\u274C Failed to provision Codex thread: ${err?.message ?? err}. Reconnect to retry.`));
+    reapChatState(state, `bootstrap failed: ${err?.message ?? err}`);
   }
 }
 function createChatState(chatId) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3413,20 +3413,26 @@ function detachClaudeWs(state, reason) {
   scheduleReaperTimer(state);
   const homePair = state.paired && state.homePairId ? pairs.get(state.homePairId) : undefined;
   if (state.paired && homePair && homePair.proxyTuiSlot && homePair.proxyTuiSlot.pairedChatId === state.chatId) {
+    const scheduledPairId = state.homePairId;
     const slot = homePair.proxyTuiSlot;
     if (slot.pairReapTimer)
       clearTimeout(slot.pairReapTimer);
     slot.pairReapTimer = setTimeout(() => {
-      const currentPair = pairs.get(state.homePairId);
+      const currentPair = pairs.get(scheduledPairId);
       const currentSlot = currentPair?.proxyTuiSlot;
       if (!currentSlot)
         return;
       const currentState = chats.get(state.chatId);
       if (currentState?.ws) {
-        log(`[pair=${state.homePairId}] Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
+        log(`[pair=${scheduledPairId}] Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
         return;
       }
-      log(`[pair=${state.homePairId}] Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms \u2014 clearing pair slot and reaping chat state`);
+      if (currentSlot.pairedChatId !== state.chatId) {
+        log(`[pair=${scheduledPairId}] reap-timer fired for ${state.chatId} but slot now holds ${currentSlot.pairedChatId ?? "<unpaired>"} \u2014 skipping clear`);
+        currentSlot.pairReapTimer = null;
+        return;
+      }
+      log(`[pair=${scheduledPairId}] Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms \u2014 clearing pair slot and reaping chat state`);
       currentSlot.pairedChatId = null;
       currentSlot.pairReapTimer = null;
       currentPair.codex.setPairedChat(null);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3538,6 +3538,9 @@ function handleClaudeToCodex(ws, message) {
   log(`[${chatId}] Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply}, paired=${state.paired}, homePair=${state.homePairId})`);
   const homePair = state.paired && state.homePairId ? pairs.get(state.homePairId) : undefined;
   if (state.paired && (!homePair || !homePair.isLive)) {
+    if (requireReply) {
+      state.replyRequired = false;
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2337,152 +2337,181 @@ var defaultPairState = {
   },
   set proxyTuiSlot(v) {
     proxyTuiSlot = v;
-  }
+  },
+  handlerRefs: [],
+  isLive: false
 };
 var pairs = new Map([["default", defaultPairState]]);
-codex.on("ready", (threadId) => {
-  tuiConnectionState.markBridgeReady();
-  log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
-  if (proxyTuiSlot) {
-    proxyTuiSlot.readiness = "ready";
-    if (proxyTuiSlot.pairedChatId) {
-      const state = chats.get(proxyTuiSlot.pairedChatId);
-      if (state && !state.ready) {
-        state.ready = true;
-        emitToChat(state, systemMessage("system_pair_ready", `\u2705 Shared Codex TUI thread is now ready (threadId=${threadId}). Replies sent via the reply tool will appear in the right pane's TUI.`));
+function attachPairHandlers(pair) {
+  if (pair.handlerRefs.length > 0) {
+    log(`[pair=${pair.pairId}] attachPairHandlers called but ${pair.handlerRefs.length} handler(s) already attached \u2014 no-op`);
+    return;
+  }
+  const on = (eventName, handler) => {
+    pair.codex.on(eventName, handler);
+    pair.handlerRefs.push({ eventName, handler });
+  };
+  on("ready", (threadId) => {
+    pair.tuiConnectionState.markBridgeReady();
+    log(`[pair=${pair.pairId}] Codex TUI thread ready: ${threadId} (bridge fully operational)`);
+    if (pair.proxyTuiSlot) {
+      pair.proxyTuiSlot.readiness = "ready";
+      if (pair.proxyTuiSlot.pairedChatId) {
+        const state = chats.get(pair.proxyTuiSlot.pairedChatId);
+        if (state && !state.ready) {
+          state.ready = true;
+          emitToChat(state, systemMessage("system_pair_ready", `\u2705 Shared Codex TUI thread is now ready (threadId=${threadId}). Replies sent via the reply tool will appear in the right pane's TUI.`));
+        }
       }
     }
-  }
-});
-codex.on("tuiConnected", (connId, token = "") => {
-  tuiConnectionState.handleTuiConnected(connId);
-  cancelIdleShutdown();
-  log(`Codex TUI connected (conn #${connId}, token=${token ? token.slice(0, 8) + "\u2026" : "<none>"})`);
-  if (token && !proxyTuiSlot) {
-    proxyTuiSlot = {
-      token,
-      pairedChatId: null,
-      readiness: "not-ready",
-      attachedAt: Date.now(),
-      pairReapTimer: null
-    };
-    log(`Proxy TUI slot allocated (token=${token.slice(0, 8)}\u2026)`);
-  }
-  broadcastStatus();
-});
-codex.on("tuiDisconnected", (connId) => {
-  tuiConnectionState.handleTuiDisconnected(connId);
-  log(`Codex TUI disconnected (conn #${connId})`);
-  if (proxyTuiSlot) {
-    const wasPairedChat = proxyTuiSlot.pairedChatId;
-    if (proxyTuiSlot.pairReapTimer)
-      clearTimeout(proxyTuiSlot.pairReapTimer);
-    proxyTuiSlot = null;
-    codex.setPairedChat(null);
-    if (wasPairedChat) {
-      const state = chats.get(wasPairedChat);
-      if (state) {
-        log(`Transitioning paired chat ${wasPairedChat} to isolated (TUI disconnect)`);
-        transitionToIsolated(state, "Shared Codex TUI thread is gone");
-      }
-    }
-  }
-  broadcastStatus();
-  scheduleIdleShutdown();
-});
-codex.on("agentMessage", (msg) => {
-  const paired = getPairedChatState();
-  if (!paired)
-    return;
-  log(`[${paired.chatId}] CodexAdapter \u2192 paired Claude (agentMessage, ${msg.content.length} chars)`);
-  paired.pairedTurnSawAgentMessage = true;
-  paired.replyReceivedDuringTurn = true;
-  emitToChat(paired, msg);
-});
-codex.on("userMessage", (payload) => {
-  const paired = getPairedChatState();
-  if (!paired)
-    return;
-  if (!payload.content)
-    return;
-  log(`[${paired.chatId}] CodexAdapter \u2192 paired Claude (userMessage from TUI, ${payload.content.length} chars)`);
-  paired.replyReceivedDuringTurn = true;
-  emitToChat(paired, {
-    id: payload.id ?? `tui_user_${Date.now()}`,
-    source: "codex",
-    content: `[IMPORTANT] Human typed in the paired Codex TUI:
-${payload.content}`,
-    timestamp: Date.now()
   });
-});
-codex.on("turnStarted", () => {
-  const paired = getPairedChatState();
-  if (!paired)
-    return;
-  paired.pairedTurnSawAgentMessage = false;
-  emitToChat(paired, systemMessage("system_codex_turn_started", "[system] Codex turn started"));
-});
-codex.on("turnCompleted", () => {
-  const paired = getPairedChatState();
-  if (!paired)
-    return;
-  if (!paired.pairedTurnSawAgentMessage && paired.replyRequired) {
-    log(`[${paired.chatId}] Codex turn completed with no agentMessage while replyRequired \u2014 surfacing as failure signal`);
-    paired.replyReceivedDuringTurn = true;
-    emitToChat(paired, systemMessage("system_codex_turn_completed_no_output", "[system] Codex turn completed without any agentMessage \u2014 likely a failure or empty response."));
-  } else {
-    emitToChat(paired, systemMessage("system_codex_turn_completed", "[system] Codex turn completed"));
-  }
-  paired.replyRequired = false;
-  paired.replyReceivedDuringTurn = false;
-});
-codex.on("errorItem", (payload) => {
-  const paired = getPairedChatState();
-  if (!paired)
-    return;
-  paired.replyReceivedDuringTurn = true;
-  emitToChat(paired, systemMessage("system_codex_error", `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
-  paired.pairedTurnSawAgentMessage = true;
-  paired.replyRequired = false;
-  paired.replyReceivedDuringTurn = false;
-});
-codex.on("sessionRestoreStart", () => {
-  if (!proxyTuiSlot)
-    return;
-  log(`Shared Codex session restore started \u2014 flipping paired readiness to not-ready`);
-  proxyTuiSlot.readiness = "not-ready";
-  const paired = getPairedChatState();
-  if (paired)
-    paired.ready = false;
-});
-codex.on("sessionRestoreEnd", (payload = {}) => {
-  if (!proxyTuiSlot)
-    return;
-  if (payload.ok === false) {
-    log(`Shared Codex session restore FAILED \u2014 keeping paired readiness=not-ready, awaiting TUI tear-down`);
-    return;
-  }
-  log(`Shared Codex session restore succeeded \u2014 flipping paired readiness back to ready`);
-  proxyTuiSlot.readiness = "ready";
-  const paired = getPairedChatState();
-  if (paired) {
-    paired.ready = true;
-    emitToChat(paired, systemMessage("system_pair_restored", "\u2705 Shared Codex TUI session restored. Replies can flow again."));
-  }
-});
-codex.on("threadClosed", () => {
-  const paired = getPairedChatState();
-  log(`Codex emitted thread/closed`);
-  if (proxyTuiSlot) {
-    const wasPairedChat = proxyTuiSlot.pairedChatId;
-    proxyTuiSlot = null;
-    codex.setPairedChat(null);
-    if (wasPairedChat && paired) {
-      log(`Transitioning paired chat ${wasPairedChat} to isolated (thread/closed)`);
-      transitionToIsolated(paired, "Shared Codex thread closed");
+  on("tuiConnected", (connId, token = "") => {
+    pair.tuiConnectionState.handleTuiConnected(connId);
+    cancelIdleShutdown();
+    log(`[pair=${pair.pairId}] Codex TUI connected (conn #${connId}, token=${token ? token.slice(0, 8) + "\u2026" : "<none>"})`);
+    if (token && !pair.proxyTuiSlot) {
+      pair.proxyTuiSlot = {
+        token,
+        pairedChatId: null,
+        readiness: "not-ready",
+        attachedAt: Date.now(),
+        pairReapTimer: null
+      };
+      log(`[pair=${pair.pairId}] Proxy TUI slot allocated (token=${token.slice(0, 8)}\u2026)`);
     }
-  }
-});
+    broadcastStatus();
+  });
+  on("tuiDisconnected", (connId) => {
+    pair.tuiConnectionState.handleTuiDisconnected(connId);
+    log(`[pair=${pair.pairId}] Codex TUI disconnected (conn #${connId})`);
+    if (pair.proxyTuiSlot) {
+      const wasPairedChat = pair.proxyTuiSlot.pairedChatId;
+      if (pair.proxyTuiSlot.pairReapTimer)
+        clearTimeout(pair.proxyTuiSlot.pairReapTimer);
+      pair.proxyTuiSlot = null;
+      pair.codex.setPairedChat(null);
+      if (wasPairedChat) {
+        const state = chats.get(wasPairedChat);
+        if (state) {
+          log(`[pair=${pair.pairId}] Transitioning paired chat ${wasPairedChat} to isolated (TUI disconnect)`);
+          transitionToIsolated(state, "Shared Codex TUI thread is gone");
+        }
+      }
+    }
+    broadcastStatus();
+    scheduleIdleShutdown();
+  });
+  on("agentMessage", (msg) => {
+    const paired = getPairedChatState();
+    if (!paired)
+      return;
+    log(`[${paired.chatId}] CodexAdapter \u2192 paired Claude (agentMessage, ${msg.content.length} chars)`);
+    paired.pairedTurnSawAgentMessage = true;
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, msg);
+  });
+  on("userMessage", (payload) => {
+    const paired = getPairedChatState();
+    if (!paired)
+      return;
+    if (!payload.content)
+      return;
+    log(`[${paired.chatId}] CodexAdapter \u2192 paired Claude (userMessage from TUI, ${payload.content.length} chars)`);
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, {
+      id: payload.id ?? `tui_user_${Date.now()}`,
+      source: "codex",
+      content: `[IMPORTANT] Human typed in the paired Codex TUI:
+${payload.content}`,
+      timestamp: Date.now()
+    });
+  });
+  on("turnStarted", () => {
+    const paired = getPairedChatState();
+    if (!paired)
+      return;
+    paired.pairedTurnSawAgentMessage = false;
+    emitToChat(paired, systemMessage("system_codex_turn_started", "[system] Codex turn started"));
+  });
+  on("turnCompleted", () => {
+    const paired = getPairedChatState();
+    if (!paired)
+      return;
+    if (!paired.pairedTurnSawAgentMessage && paired.replyRequired) {
+      log(`[${paired.chatId}] Codex turn completed with no agentMessage while replyRequired \u2014 surfacing as failure signal`);
+      paired.replyReceivedDuringTurn = true;
+      emitToChat(paired, systemMessage("system_codex_turn_completed_no_output", "[system] Codex turn completed without any agentMessage \u2014 likely a failure or empty response."));
+    } else {
+      emitToChat(paired, systemMessage("system_codex_turn_completed", "[system] Codex turn completed"));
+    }
+    paired.replyRequired = false;
+    paired.replyReceivedDuringTurn = false;
+  });
+  on("errorItem", (payload) => {
+    const paired = getPairedChatState();
+    if (!paired)
+      return;
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, systemMessage("system_codex_error", `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
+    paired.pairedTurnSawAgentMessage = true;
+    paired.replyRequired = false;
+    paired.replyReceivedDuringTurn = false;
+  });
+  on("sessionRestoreStart", () => {
+    if (!pair.proxyTuiSlot)
+      return;
+    log(`[pair=${pair.pairId}] Shared Codex session restore started \u2014 flipping paired readiness to not-ready`);
+    pair.proxyTuiSlot.readiness = "not-ready";
+    const paired = getPairedChatState();
+    if (paired)
+      paired.ready = false;
+  });
+  on("sessionRestoreEnd", (payload = {}) => {
+    if (!pair.proxyTuiSlot)
+      return;
+    if (payload.ok === false) {
+      log(`[pair=${pair.pairId}] Shared Codex session restore FAILED \u2014 keeping readiness=not-ready, awaiting TUI tear-down`);
+      return;
+    }
+    log(`[pair=${pair.pairId}] Shared Codex session restore succeeded \u2014 flipping readiness back to ready`);
+    pair.proxyTuiSlot.readiness = "ready";
+    const paired = getPairedChatState();
+    if (paired) {
+      paired.ready = true;
+      emitToChat(paired, systemMessage("system_pair_restored", "\u2705 Shared Codex TUI session restored. Replies can flow again."));
+    }
+  });
+  on("threadClosed", () => {
+    const paired = getPairedChatState();
+    log(`[pair=${pair.pairId}] Codex emitted thread/closed`);
+    if (pair.proxyTuiSlot) {
+      const wasPairedChat = pair.proxyTuiSlot.pairedChatId;
+      pair.proxyTuiSlot = null;
+      pair.codex.setPairedChat(null);
+      if (wasPairedChat && paired) {
+        log(`[pair=${pair.pairId}] Transitioning paired chat ${wasPairedChat} to isolated (thread/closed)`);
+        transitionToIsolated(paired, "Shared Codex thread closed");
+      }
+    }
+  });
+  on("error", (err) => {
+    log(`[pair=${pair.pairId}] Codex error: ${err.message}`);
+  });
+  on("exit", (code) => {
+    log(`[pair=${pair.pairId}] Codex app-server process exited (code ${code})`);
+    codexBootstrapped = false;
+    pair.tuiConnectionState.handleCodexExit();
+    broadcastToAllClaudes(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`));
+    for (const state of chats.values()) {
+      try {
+        state.thread.close();
+      } catch {}
+      state.ready = false;
+    }
+    broadcastStatus();
+  });
+}
+attachPairHandlers(defaultPairState);
 function getPairedChatState() {
   if (!proxyTuiSlot?.pairedChatId)
     return null;
@@ -2573,22 +2602,6 @@ function transitionToIsolated(state, reason) {
   wireClaudeThreadEvents(state);
   bootstrapIsolatedThread(state);
 }
-codex.on("error", (err) => {
-  log(`Codex error: ${err.message}`);
-});
-codex.on("exit", (code) => {
-  log(`Codex app-server process exited (code ${code})`);
-  codexBootstrapped = false;
-  tuiConnectionState.handleCodexExit();
-  broadcastToAllClaudes(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`));
-  for (const state of chats.values()) {
-    try {
-      state.thread.close();
-    } catch {}
-    state.ready = false;
-  }
-  broadcastStatus();
-});
 function startControlServer() {
   controlServer = Bun.serve({
     port: CONTROL_PORT,
@@ -3096,13 +3109,28 @@ function writeStatusFile() {
 function removeStatusFile() {
   daemonLifecycle.removeStatusFile();
 }
+async function ensurePair(pairId) {
+  if (pairId !== "default") {
+    throw new Error(`ensurePair: pairId="${pairId}" not yet supported in P2 (default only)`);
+  }
+  const pair = pairs.get(pairId);
+  if (!pair) {
+    throw new Error(`ensurePair: pair "${pairId}" missing from registry (P2 invariant violated)`);
+  }
+  if (pair.isLive)
+    return pair;
+  log(`[pair=${pair.pairId}] ensurePair: starting codex app-server (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl})`);
+  await pair.codex.start();
+  pair.isLive = true;
+  return pair;
+}
 async function bootCodex() {
   log("Starting AgentBridge daemon (multi-Claude variant)...");
   log(`Codex app-server: ${codex.appServerUrl}`);
   log(`Codex proxy: ${codex.proxyUrl}`);
   log(`Control server: ws://127.0.0.1:${CONTROL_PORT}/ws`);
   try {
-    await codex.start();
+    await ensurePair("default");
     codexBootstrapped = true;
     writeStatusFile();
     broadcastStatus();

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -9,6 +9,7 @@ import { spawn, execSync } from "child_process";
 import { createInterface } from "readline";
 import { EventEmitter } from "events";
 import { appendFileSync } from "fs";
+import { createHash } from "crypto";
 
 // src/state-dir.ts
 import { mkdirSync, existsSync } from "fs";
@@ -78,7 +79,9 @@ var APP_SERVER_NOTIFICATION_METHODS = [
   "turn/completed",
   "item/started",
   "item/agentMessage/delta",
-  "item/completed"
+  "item/completed",
+  "error",
+  "thread/closed"
 ];
 var TRACKED_REQUEST_METHOD_SET = new Set(APP_SERVER_TRACKED_REQUEST_METHODS);
 var SERVER_REQUEST_METHOD_SET = new Set(APP_SERVER_SERVER_REQUEST_METHODS);
@@ -145,6 +148,12 @@ class CodexAdapter extends EventEmitter {
   sessionRestoreInProgress = false;
   replayPending = new Map;
   static SESSION_REPLAY_TIMEOUT_MS = 5000;
+  pairedChatId = null;
+  injectedTurnIds = new Map;
+  pendingInjectionHashes = new Map;
+  pendingInjectionByReqId = new Map;
+  static ECHO_DEDUP_TTL_MS = 60000;
+  static PENDING_HASH_TTL_MS = 5000;
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
     this.appPort = appPort;
@@ -222,6 +231,10 @@ class CodexAdapter extends EventEmitter {
       this.log("Cannot inject: app-server WebSocket not connected");
       return false;
     }
+    if (this.sessionRestoreInProgress) {
+      this.log(`Rejected injection: shared Codex TUI session restore in progress`);
+      return false;
+    }
     if (this.turnInProgress) {
       this.log(`Rejected injection: Codex turn is in progress (thread ${this.threadId})`);
       return false;
@@ -229,6 +242,9 @@ class CodexAdapter extends EventEmitter {
     this.log(`Injecting message into Codex (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
     this.trackBridgeRequestId(requestId);
+    const contentHash = this.hashInjectionContent(text);
+    this.pendingInjectionHashes.set(contentHash, Date.now() + CodexAdapter.PENDING_HASH_TTL_MS);
+    this.pendingInjectionByReqId.set(requestId, contentHash);
     try {
       this.appServerWs.send(JSON.stringify({
         method: "turn/start",
@@ -238,9 +254,49 @@ class CodexAdapter extends EventEmitter {
       return true;
     } catch (err) {
       this.untrackBridgeRequestId(requestId);
+      this.pendingInjectionByReqId.delete(requestId);
+      this.pendingInjectionHashes.delete(contentHash);
       this.log(`Injection send failed: ${err.message}`);
       return false;
     }
+  }
+  setPairedChat(chatId) {
+    this.pairedChatId = chatId;
+    this.log(`Paired chat set to: ${chatId ?? "<none>"}`);
+  }
+  isPaired(chatId) {
+    return this.pairedChatId !== null && this.pairedChatId === chatId;
+  }
+  get currentPairedChatId() {
+    return this.pairedChatId;
+  }
+  hashInjectionContent(text) {
+    return createHash("sha1").update(text).digest("hex").slice(0, 16);
+  }
+  isEchoOfInjection(content, turnId) {
+    if (typeof turnId === "string" && turnId.length > 0) {
+      const expiresAt = this.injectedTurnIds.get(turnId);
+      if (expiresAt !== undefined) {
+        if (Date.now() <= expiresAt)
+          return true;
+        this.injectedTurnIds.delete(turnId);
+      }
+    }
+    const hash = this.hashInjectionContent(content);
+    const hashExpiresAt = this.pendingInjectionHashes.get(hash);
+    if (hashExpiresAt !== undefined) {
+      if (Date.now() <= hashExpiresAt) {
+        this.pendingInjectionHashes.delete(hash);
+        return true;
+      }
+      this.pendingInjectionHashes.delete(hash);
+    }
+    return false;
+  }
+  recordInjectedTurnId(turnId, contentHash) {
+    this.injectedTurnIds.set(turnId, Date.now() + CodexAdapter.ECHO_DEDUP_TTL_MS);
+    if (contentHash)
+      this.pendingInjectionHashes.delete(contentHash);
   }
   async waitForHealthy(maxRetries = 20, delayMs = 500) {
     for (let i = 0;i < maxRetries; i++) {
@@ -436,6 +492,8 @@ class CodexAdapter extends EventEmitter {
       return;
     }
     this.sessionRestoreInProgress = true;
+    this.emit("sessionRestoreStart", { threadId: this.threadId });
+    let restoreSucceeded = false;
     try {
       this.log(`DIAGNOSTIC: replaying cached initialize to restore session (threadId=${this.threadId ?? "none"})`);
       await this.sendReplayAndAwait(this.lastInitializeRaw, "initialize");
@@ -453,6 +511,7 @@ class CodexAdapter extends EventEmitter {
         await this.sendReplayAndAwait(resumeRaw, "thread/resume");
       }
       this.log(`DIAGNOSTIC: session restored after unintentional reconnect (threadId=${this.threadId ?? "none"})`);
+      restoreSucceeded = true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log(`ERROR: session restore failed (${msg}) \u2014 closing TUI with 1011`);
@@ -467,7 +526,11 @@ class CodexAdapter extends EventEmitter {
       }
     } finally {
       this.sessionRestoreInProgress = false;
+      this.emit("sessionRestoreEnd", { threadId: this.threadId, ok: restoreSucceeded });
     }
+  }
+  get isSessionRestoreInProgress() {
+    return this.sessionRestoreInProgress;
   }
   sendReplayAndAwait(raw, method) {
     if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
@@ -550,11 +613,16 @@ class CodexAdapter extends EventEmitter {
       fetch(req, server) {
         const url = new URL(req.url);
         const isUpgrade = req.headers.get("upgrade")?.toLowerCase() === "websocket";
-        self.log(`HTTP ${req.method} ${url.pathname} (upgrade=${isUpgrade})`);
+        const queryToken = url.searchParams.get("abg_token") ?? "";
+        const authHeader = req.headers.get("authorization") ?? "";
+        const bearerToken = authHeader.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? "";
+        const token = bearerToken || queryToken;
+        const tokenSource = bearerToken ? "authorization" : queryToken ? "query" : "none";
+        self.log(`HTTP ${req.method} ${url.pathname} (upgrade=${isUpgrade}, token=${token ? token.slice(0, 8) + "\u2026" : "<none>"}, tokenSource=${tokenSource})`);
         if (url.pathname === "/healthz" || url.pathname === "/readyz") {
           return fetch(`http://127.0.0.1:${self.appPort}${url.pathname}`);
         }
-        if (server.upgrade(req, { data: { connId: 0 } }))
+        if (server.upgrade(req, { data: { connId: 0, token } }))
           return;
         self.log(`WARNING: non-upgrade HTTP request not handled: ${req.method} ${url.pathname}`);
         return new Response("AgentBridge Codex Proxy");
@@ -573,7 +641,18 @@ class CodexAdapter extends EventEmitter {
     const connId = ++this.connIdCounter;
     ws.data.connId = connId;
     if (this.tuiWs) {
-      this.log(`Secondary TUI connected (conn #${connId}, primary is #${this.tuiConnId})`);
+      const primaryToken = this.tuiWs.data.token;
+      const newToken = ws.data.token;
+      if (primaryToken !== newToken) {
+        this.log(`Rejecting second proxy TUI: token mismatch (primary conn #${this.tuiConnId} token=${primaryToken ? primaryToken.slice(0, 8) + "\u2026" : "<none>"}, new conn #${connId} token=${newToken ? newToken.slice(0, 8) + "\u2026" : "<none>"})`);
+        try {
+          ws.close(4002, "another --via-proxy TUI is already connected");
+        } catch (err) {
+          this.log(`Failed to close rejected second TUI cleanly: ${err.message}`);
+        }
+        return;
+      }
+      this.log(`Secondary TUI connected (conn #${connId}, primary is #${this.tuiConnId}, token matches)`);
       this.setupSecondaryConnection(ws, connId);
       return;
     }
@@ -581,8 +660,8 @@ class CodexAdapter extends EventEmitter {
     this.tuiConnId = connId;
     this.tuiWs = ws;
     this.threadId = null;
-    this.log(`TUI connected (conn #${this.tuiConnId})`);
-    this.emit("tuiConnected", this.tuiConnId);
+    this.log(`TUI connected (conn #${this.tuiConnId}, token=${ws.data.token ? ws.data.token.slice(0, 8) + "\u2026" : "<none>"})`);
+    this.emit("tuiConnected", this.tuiConnId, ws.data.token);
     if (previousConnId !== null) {
       this.retireConnectionState(previousConnId);
     }
@@ -924,8 +1003,22 @@ class CodexAdapter extends EventEmitter {
     if (!isNaN(numericId) && this.consumeBridgeRequestId(numericId)) {
       if (parsed.error) {
         this.log(`Bridge-originated request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
+        const contentHash = this.pendingInjectionByReqId.get(numericId);
+        if (contentHash) {
+          this.pendingInjectionHashes.delete(contentHash);
+          this.pendingInjectionByReqId.delete(numericId);
+        }
       } else {
-        this.log(`Bridge-originated request completed (id ${responseId})`);
+        const result = parsed.result ?? {};
+        const turnId = result.turn?.id;
+        const contentHash = this.pendingInjectionByReqId.get(numericId);
+        this.pendingInjectionByReqId.delete(numericId);
+        if (typeof turnId === "string" && turnId.length > 0) {
+          this.recordInjectedTurnId(turnId, contentHash);
+          this.log(`Bridge-originated request completed (id ${responseId}, turnId=${turnId} dedup)`);
+        } else {
+          this.log(`Bridge-originated request completed (id ${responseId}, no turnId \u2014 falling back to content-hash dedup)`);
+        }
       }
       return null;
     }
@@ -968,9 +1061,10 @@ class CodexAdapter extends EventEmitter {
   handleServerNotification(msg) {
     const { method, params } = msg;
     switch (method) {
-      case "turn/started":
+      case "turn/started": {
         this.markTurnStarted(params?.turn?.id);
         break;
+      }
       case "item/started": {
         const item = params?.item;
         if (item?.type === "agentMessage")
@@ -1000,15 +1094,46 @@ class CodexAdapter extends EventEmitter {
               timestamp: Date.now()
             });
           }
+        } else if (item?.type === "userMessage") {
+          const content = this.extractContent(item);
+          if (content) {
+            const turnIdFromParams = typeof params?.turnId === "string" ? params.turnId : undefined;
+            if (this.isEchoOfInjection(content, turnIdFromParams)) {
+              this.log(`Suppressed userMessage echo (item ${item.id}, ${content.length} chars)`);
+            } else {
+              this.log(`User message from TUI (${content.length} chars)`);
+              this.emit("userMessage", {
+                id: item.id,
+                source: "codex",
+                content,
+                timestamp: Date.now(),
+                turnId: turnIdFromParams
+              });
+            }
+          }
         }
         break;
       }
       case "turn/completed": {
         const wasInProgress = this.turnInProgress;
-        this.markTurnCompleted(params?.turn?.id);
+        const turnId = params?.turn?.id;
+        this.markTurnCompleted(turnId);
         if (wasInProgress && !this.turnInProgress) {
-          this.emit("turnCompleted");
+          this.emit("turnCompleted", { turnId });
         }
+        break;
+      }
+      case "error": {
+        const errorParams = params ?? {};
+        const detail = errorParams.error?.message ?? "(no error message)";
+        const code = errorParams.error?.code;
+        this.log(`App-server error notification: ${detail}${code !== undefined ? ` (code ${code})` : ""}`);
+        this.emit("errorItem", { code, message: detail, data: errorParams.error?.data });
+        break;
+      }
+      case "thread/closed": {
+        const closedThreadId = params ?? {};
+        this.emit("threadClosed", { threadId: closedThreadId.threadId });
         break;
       }
     }
@@ -1108,7 +1233,7 @@ class CodexAdapter extends EventEmitter {
     }
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
-      this.emit("turnStarted");
+      this.emit("turnStarted", { turnId });
     }
   }
   markTurnCompleted(turnId) {
@@ -2168,6 +2293,7 @@ var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 var CLAUDE_DISCONNECT_GRACE_MS = 5000;
 var CLAUDE_REAP_AFTER_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_REAP_MS ?? "600000", 10);
+var PAIR_REAP_MS = parseInt(process.env.AGENTBRIDGE_PAIR_REAP_MS ?? "30000", 10);
 var MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 var FILTER_MODE = process.env.AGENTBRIDGE_FILTER_MODE === "full" ? "full" : "filtered";
 var IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
@@ -2181,6 +2307,7 @@ var codexBootstrapped = false;
 var shuttingDown = false;
 var idleShutdownTimer = null;
 var chats = new Map;
+var proxyTuiSlot = null;
 var tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
   log,
@@ -2194,19 +2321,183 @@ var tuiConnectionState = new TuiConnectionState({
 codex.on("ready", (threadId) => {
   tuiConnectionState.markBridgeReady();
   log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
+  if (proxyTuiSlot) {
+    proxyTuiSlot.readiness = "ready";
+    if (proxyTuiSlot.pairedChatId) {
+      const state = chats.get(proxyTuiSlot.pairedChatId);
+      if (state && !state.ready) {
+        state.ready = true;
+        emitToChat(state, systemMessage("system_pair_ready", `\u2705 Shared Codex TUI thread is now ready (threadId=${threadId}). Replies sent via the reply tool will appear in the right pane's TUI.`));
+      }
+    }
+  }
 });
-codex.on("tuiConnected", (connId) => {
+codex.on("tuiConnected", (connId, token = "") => {
   tuiConnectionState.handleTuiConnected(connId);
   cancelIdleShutdown();
-  log(`Codex TUI connected (conn #${connId})`);
+  log(`Codex TUI connected (conn #${connId}, token=${token ? token.slice(0, 8) + "\u2026" : "<none>"})`);
+  if (token && !proxyTuiSlot) {
+    proxyTuiSlot = {
+      token,
+      pairedChatId: null,
+      readiness: "not-ready",
+      attachedAt: Date.now(),
+      pairReapTimer: null
+    };
+    log(`Proxy TUI slot allocated (token=${token.slice(0, 8)}\u2026)`);
+  }
   broadcastStatus();
 });
 codex.on("tuiDisconnected", (connId) => {
   tuiConnectionState.handleTuiDisconnected(connId);
   log(`Codex TUI disconnected (conn #${connId})`);
+  if (proxyTuiSlot) {
+    const wasPairedChat = proxyTuiSlot.pairedChatId;
+    if (proxyTuiSlot.pairReapTimer)
+      clearTimeout(proxyTuiSlot.pairReapTimer);
+    proxyTuiSlot = null;
+    codex.setPairedChat(null);
+    if (wasPairedChat) {
+      const state = chats.get(wasPairedChat);
+      if (state) {
+        log(`Transitioning paired chat ${wasPairedChat} to isolated (TUI disconnect)`);
+        transitionToIsolated(state, "Shared Codex TUI thread is gone");
+      }
+    }
+  }
   broadcastStatus();
   scheduleIdleShutdown();
 });
+codex.on("agentMessage", (msg) => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  log(`[${paired.chatId}] CodexAdapter \u2192 paired Claude (agentMessage, ${msg.content.length} chars)`);
+  paired.pairedTurnSawAgentMessage = true;
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, msg);
+});
+codex.on("userMessage", (payload) => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  if (!payload.content)
+    return;
+  log(`[${paired.chatId}] CodexAdapter \u2192 paired Claude (userMessage from TUI, ${payload.content.length} chars)`);
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, {
+    id: payload.id ?? `tui_user_${Date.now()}`,
+    source: "codex",
+    content: `[IMPORTANT] Human typed in the paired Codex TUI:
+${payload.content}`,
+    timestamp: Date.now()
+  });
+});
+codex.on("turnStarted", () => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  paired.pairedTurnSawAgentMessage = false;
+  emitToChat(paired, systemMessage("system_codex_turn_started", "[system] Codex turn started"));
+});
+codex.on("turnCompleted", () => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  if (!paired.pairedTurnSawAgentMessage) {
+    log(`[${paired.chatId}] Codex turn completed with no agentMessage \u2014 surfacing as failure signal`);
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, systemMessage("system_codex_turn_completed_no_output", "[system] Codex turn completed without any agentMessage \u2014 likely a failure or empty response."));
+  } else {
+    emitToChat(paired, systemMessage("system_codex_turn_completed", "[system] Codex turn completed"));
+  }
+  paired.replyRequired = false;
+  paired.replyReceivedDuringTurn = false;
+});
+codex.on("errorItem", (payload) => {
+  const paired = getPairedChatState();
+  if (!paired)
+    return;
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, systemMessage("system_codex_error", `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
+  paired.replyRequired = false;
+});
+codex.on("sessionRestoreStart", () => {
+  if (!proxyTuiSlot)
+    return;
+  log(`Shared Codex session restore started \u2014 flipping paired readiness to not-ready`);
+  proxyTuiSlot.readiness = "not-ready";
+  const paired = getPairedChatState();
+  if (paired)
+    paired.ready = false;
+});
+codex.on("sessionRestoreEnd", (payload = {}) => {
+  if (!proxyTuiSlot)
+    return;
+  if (payload.ok === false) {
+    log(`Shared Codex session restore FAILED \u2014 keeping paired readiness=not-ready, awaiting TUI tear-down`);
+    return;
+  }
+  log(`Shared Codex session restore succeeded \u2014 flipping paired readiness back to ready`);
+  proxyTuiSlot.readiness = "ready";
+  const paired = getPairedChatState();
+  if (paired) {
+    paired.ready = true;
+    emitToChat(paired, systemMessage("system_pair_restored", "\u2705 Shared Codex TUI session restored. Replies can flow again."));
+  }
+});
+codex.on("threadClosed", () => {
+  const paired = getPairedChatState();
+  log(`Codex emitted thread/closed`);
+  if (proxyTuiSlot) {
+    const wasPairedChat = proxyTuiSlot.pairedChatId;
+    proxyTuiSlot = null;
+    codex.setPairedChat(null);
+    if (wasPairedChat && paired) {
+      log(`Transitioning paired chat ${wasPairedChat} to isolated (thread/closed)`);
+      transitionToIsolated(paired, "Shared Codex thread closed");
+    }
+  }
+});
+function getPairedChatState() {
+  if (!proxyTuiSlot?.pairedChatId)
+    return null;
+  return chats.get(proxyTuiSlot.pairedChatId) ?? null;
+}
+function pairChat(state) {
+  if (!proxyTuiSlot)
+    return;
+  if (proxyTuiSlot.pairedChatId)
+    return;
+  proxyTuiSlot.pairedChatId = state.chatId;
+  state.paired = true;
+  codex.setPairedChat(state.chatId);
+  state.ready = proxyTuiSlot.readiness === "ready";
+  log(`Paired chat ${state.chatId} with proxy TUI (readiness=${proxyTuiSlot.readiness})`);
+  if (state.ready) {
+    emitToChat(state, systemMessage("system_paired_ready", "\u2705 This Claude session is paired with the right-pane Codex TUI. Replies will appear there; user typing in the TUI will be forwarded to you with an [IMPORTANT] prefix."));
+  } else {
+    emitToChat(state, systemMessage("system_paired_provisioning", "\u2705 This Claude session is paired with the right-pane Codex TUI. Waiting for the shared thread to finish provisioning before replies can flow."));
+  }
+}
+function transitionToIsolated(state, reason) {
+  state.paired = false;
+  emitToChat(state, systemMessage("system_pair_torn_down", `[system] ${reason}. Future replies will use a fresh isolated Codex thread (no prior shared-TUI context carried over).`));
+  state.thread = new ClaudeThread({
+    appServerUrl: codex.appServerUrl,
+    chatId: state.chatId,
+    logFile: stateDir.logFile,
+    cwd: process.cwd()
+  });
+  state.ready = false;
+  wireClaudeThreadEvents(state);
+  state.thread.bootstrap().then((threadId) => {
+    state.ready = true;
+    emitToChat(state, systemMessage("system_isolated_ready", `\u2705 Fresh isolated Codex thread ready (threadId=${threadId}).`));
+  }).catch((err) => {
+    emitToChat(state, systemMessage("system_isolated_failed", `\u274C Failed to bootstrap isolated Codex thread: ${err?.message ?? err}.`));
+  });
+}
 codex.on("error", (err) => {
   log(`Codex error: ${err.message}`);
 });
@@ -2321,6 +2612,12 @@ async function attachClaude(ws, requestedChatId) {
   cancelIdleShutdown();
   log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
   sendStatus(ws);
+  if (proxyTuiSlot && proxyTuiSlot.pairedChatId === null) {
+    emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Pairing with the right-pane Codex TUI for shared-thread mode..."));
+    pairChat(state);
+    broadcastStatus();
+    return;
+  }
   emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
   try {
     const threadId = await state.thread.bootstrap();
@@ -2344,6 +2641,8 @@ function createChatState(chatId) {
       cwd: process.cwd()
     }),
     ready: false,
+    paired: false,
+    pairedTurnSawAgentMessage: false,
     inAttentionWindow: false,
     attentionWindowTimer: null,
     replyRequired: false,
@@ -2357,6 +2656,11 @@ function createChatState(chatId) {
     nextSystemMessageId: 0
   };
   state.statusBuffer = new StatusBuffer((summary) => emitToChat(state, summary));
+  wireClaudeThreadEvents(state);
+  return state;
+}
+function wireClaudeThreadEvents(state) {
+  const chatId = state.chatId;
   state.thread.on("agentMessage", (msg) => {
     if (msg.source !== "codex")
       return;
@@ -2415,15 +2719,45 @@ function createChatState(chatId) {
   state.thread.on("error", (err) => {
     log(`[${chatId}] ClaudeThread error: ${err?.message ?? err}`);
   });
-  return state;
 }
 function detachClaudeWs(state, reason) {
   if (!state.ws)
     return;
-  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason})`);
+  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason}, paired=${state.paired})`);
   state.ws = null;
   scheduleDisconnectTimer(state);
   scheduleReaperTimer(state);
+  if (state.paired && proxyTuiSlot && proxyTuiSlot.pairedChatId === state.chatId) {
+    if (proxyTuiSlot.pairReapTimer)
+      clearTimeout(proxyTuiSlot.pairReapTimer);
+    proxyTuiSlot.pairReapTimer = setTimeout(() => {
+      if (!proxyTuiSlot)
+        return;
+      const currentState = chats.get(state.chatId);
+      if (currentState?.ws) {
+        log(`Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
+        return;
+      }
+      log(`Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms \u2014 clearing pair slot and reaping chat state`);
+      proxyTuiSlot.pairedChatId = null;
+      proxyTuiSlot.pairReapTimer = null;
+      codex.setPairedChat(null);
+      if (currentState) {
+        try {
+          currentState.thread.close();
+        } catch {}
+        currentState.statusBuffer.dispose();
+        if (currentState.attentionWindowTimer)
+          clearTimeout(currentState.attentionWindowTimer);
+        if (currentState.disconnectTimer)
+          clearTimeout(currentState.disconnectTimer);
+        if (currentState.reaperTimer)
+          clearTimeout(currentState.reaperTimer);
+        chats.delete(state.chatId);
+        broadcastStatus();
+      }
+    }, PAIR_REAP_MS);
+  }
   scheduleIdleShutdown();
 }
 function scheduleReaperTimer(state) {
@@ -2495,11 +2829,23 @@ function handleClaudeToCodex(ws, message) {
     });
   }
   if (!state.ready) {
+    let errorMsg;
+    if (state.paired) {
+      if (codex.isSessionRestoreInProgress) {
+        errorMsg = "Restoring shared Codex TUI session, retry shortly.";
+      } else if (proxyTuiSlot) {
+        errorMsg = "Shared Codex TUI thread is still provisioning. Retry shortly.";
+      } else {
+        errorMsg = "Shared Codex TUI is no longer connected. Wait for transition to isolated mode.";
+      }
+    } else {
+      errorMsg = "Your Codex thread is still provisioning. Wait for system_thread_ready.";
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,
       success: false,
-      error: "Your Codex thread is still provisioning. Wait for system_thread_ready."
+      error: errorMsg
     });
   }
   const requireReply = !!message.requireReply;
@@ -2512,10 +2858,13 @@ function handleClaudeToCodex(ws, message) {
     state.replyReceivedDuringTurn = false;
     log(`[${chatId}] Reply required flag set`);
   }
-  log(`[${chatId}] Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-  const injected = state.thread.injectMessage(contentWithReminder);
+  log(`[${chatId}] Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply}, paired=${state.paired})`);
+  const injected = state.paired ? codex.injectMessage(contentWithReminder) : state.thread.injectMessage(contentWithReminder);
   if (!injected) {
-    const reason = state.thread.isTurnInProgress ? "Codex is busy executing a turn on your thread. Wait for it to finish." : "Injection failed: thread WS not connected.";
+    const reason = state.paired ? "Shared Codex TUI is busy with another turn. Retry." : state.thread.isTurnInProgress ? "Codex is busy executing a turn on your thread. Wait for it to finish." : "Injection failed: thread WS not connected.";
+    if (requireReply) {
+      state.replyRequired = false;
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,
@@ -2621,7 +2970,8 @@ function currentStatus() {
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
     pid: process.pid,
-    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length
+    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length,
+    proxyTuiConnected: proxyTuiSlot !== null
   };
 }
 function systemMessage(idPrefix, content) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1324,7 +1324,7 @@ class ClaudeThread extends EventEmitter2 {
       clientInfo: { name: "agentbridge-claude-thread", version: "0.1.0" },
       capabilities: { experimentalApi: false }
     });
-    const params = {};
+    const params = { approvalPolicy: "never" };
     if (this.cwd)
       params.cwd = this.cwd;
     const startRes = await this.callRpc("thread/start", params);
@@ -1449,13 +1449,7 @@ class ClaudeThread extends EventEmitter2 {
       const tid = parsed.params?.threadId;
       if (tid && this.threadId && tid !== this.threadId)
         return;
-      try {
-        this.ws?.send(JSON.stringify({
-          jsonrpc: "2.0",
-          id: parsed.id,
-          error: { code: -32601, message: "auto-denied by ClaudeThread (no UI to approve)" }
-        }));
-      } catch {}
+      this.respondToServerRequest(parsed.id, parsed.method, parsed.params);
       return;
     }
     if (typeof parsed.method === "string" && parsed.id === undefined) {
@@ -1552,6 +1546,46 @@ class ClaudeThread extends EventEmitter2 {
         reject(err);
       }
     });
+  }
+  respondToServerRequest(id, method, _params) {
+    let result;
+    let error;
+    switch (method) {
+      case "item/commandExecution/requestApproval":
+        result = { decision: "accept" };
+        this.log(`auto-accepted ${method} (id=${id})`);
+        break;
+      case "item/fileChange/requestApproval":
+        result = { decision: "accept" };
+        this.log(`auto-accepted ${method} (id=${id})`);
+        break;
+      case "applyPatchApproval":
+      case "execCommandApproval":
+        result = { decision: "approved" };
+        this.log(`auto-approved ${method} (id=${id})`);
+        break;
+      case "item/permissions/requestApproval":
+        result = { permissions: {} };
+        this.log(`auto-denied permission widening for ${method} (id=${id})`);
+        break;
+      default:
+        error = {
+          code: -32601,
+          message: `ClaudeThread received unknown server request method '${method}' with no handler`
+        };
+        this.log(`unknown server request method: ${method} (id=${id}) \u2014 replying -32601`);
+        break;
+    }
+    const payload = { jsonrpc: "2.0", id };
+    if (result !== undefined)
+      payload.result = result;
+    if (error !== undefined)
+      payload.error = error;
+    try {
+      this.ws?.send(JSON.stringify(payload));
+    } catch (err) {
+      this.log(`failed to send server-request response: ${err?.message ?? err}`);
+    }
   }
   log(s) {
     const line = `[${new Date().toISOString()}] [ClaudeThread:${this.chatId}] ${s}

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3383,13 +3383,13 @@ function wireClaudeThreadEvents(state) {
   const threadAtRegistration = state.thread;
   state.thread.on("close", () => {
     log(`[${chatId}] ClaudeThread WS closed`);
-    state.ready = false;
     if (shuttingDown)
       return;
     if (state.thread !== threadAtRegistration)
       return;
     if (chats.get(chatId) !== state)
       return;
+    state.ready = false;
     emitToChat(state, systemMessage("system_thread_failed", "\u274C Lost connection to Codex app-server. Reconnect to retry \u2014 bridge will provision a fresh thread."));
     reapChatState(state, "ClaudeThread WS closed unexpectedly (app-server crash or upstream failure)");
   });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -154,11 +154,16 @@ class CodexAdapter extends EventEmitter {
   pendingInjectionByReqId = new Map;
   static ECHO_DEDUP_TTL_MS = 60000;
   static PENDING_HASH_TTL_MS = 5000;
-  constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
+  _pairId;
+  constructor(opts) {
     super();
-    this.appPort = appPort;
-    this.proxyPort = proxyPort;
-    this.logFile = logFile;
+    this._pairId = opts.pairId ?? "default";
+    this.appPort = opts.appPort;
+    this.proxyPort = opts.proxyPort;
+    this.logFile = opts.logFile ?? new StateDirResolver().logFile;
+  }
+  get pairId() {
+    return this._pairId;
   }
   get appServerUrl() {
     return `ws://127.0.0.1:${this.appPort}`;
@@ -2299,7 +2304,12 @@ var FILTER_MODE = process.env.AGENTBRIDGE_FILTER_MODE === "full" ? "full" : "fil
 var IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
 var ATTENTION_WINDOW_MS = parseInt(process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS ?? String(config.turnCoordination.attentionWindowSeconds * 1000), 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
-var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
+var codex = new CodexAdapter({
+  pairId: "default",
+  appPort: CODEX_APP_PORT,
+  proxyPort: CODEX_PROXY_PORT,
+  logFile: stateDir.logFile
+});
 var attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 var controlServer = null;
 var nextControlClientId = 0;
@@ -2318,6 +2328,18 @@ var tuiConnectionState = new TuiConnectionState({
     broadcastToAllClaudes(systemMessage("system_tui_reconnected", `\u2705 Codex TUI reconnected (conn #${connId}). Bridge restored.`));
   }
 });
+var defaultPairState = {
+  pairId: "default",
+  codex,
+  tuiConnectionState,
+  get proxyTuiSlot() {
+    return proxyTuiSlot;
+  },
+  set proxyTuiSlot(v) {
+    proxyTuiSlot = v;
+  }
+};
+var pairs = new Map([["default", defaultPairState]]);
 codex.on("ready", (threadId) => {
   tuiConnectionState.markBridgeReady();
   log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
@@ -2686,6 +2708,7 @@ async function attachClaude(ws, requestedChatId) {
 function createChatState(chatId) {
   const state = {
     chatId,
+    homePairId: "default",
     ws: null,
     thread: new ClaudeThread({
       appServerUrl: codex.appServerUrl,
@@ -3156,6 +3179,7 @@ var __testing = {
   },
   chats,
   codex,
+  pairs,
   fns: {
     pairChat,
     transitionToIsolated,

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2574,6 +2574,11 @@ function attachPairHandlers(pair) {
     pair.codex.on(eventName, handler);
     pair.handlerRefs.push({ eventName, handler });
   };
+  const getPaired = () => {
+    if (!pair.proxyTuiSlot?.pairedChatId)
+      return null;
+    return chats.get(pair.proxyTuiSlot.pairedChatId) ?? null;
+  };
   on("ready", (threadId) => {
     pair.tuiConnectionState.markBridgeReady();
     log(`[pair=${pair.pairId}] Codex TUI thread ready: ${threadId} (bridge fully operational)`);
@@ -2625,7 +2630,7 @@ function attachPairHandlers(pair) {
     scheduleIdleShutdown();
   });
   on("agentMessage", (msg) => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired)
       return;
     log(`[${paired.chatId}] CodexAdapter \u2192 paired Claude (agentMessage, ${msg.content.length} chars)`);
@@ -2634,7 +2639,7 @@ function attachPairHandlers(pair) {
     emitToChat(paired, msg);
   });
   on("userMessage", (payload) => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired)
       return;
     if (!payload.content)
@@ -2650,14 +2655,14 @@ ${payload.content}`,
     });
   });
   on("turnStarted", () => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired)
       return;
     paired.pairedTurnSawAgentMessage = false;
     emitToChat(paired, systemMessage("system_codex_turn_started", "[system] Codex turn started"));
   });
   on("turnCompleted", () => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired)
       return;
     if (!paired.pairedTurnSawAgentMessage && paired.replyRequired) {
@@ -2671,7 +2676,7 @@ ${payload.content}`,
     paired.replyReceivedDuringTurn = false;
   });
   on("errorItem", (payload) => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired)
       return;
     paired.replyReceivedDuringTurn = true;
@@ -2685,7 +2690,7 @@ ${payload.content}`,
       return;
     log(`[pair=${pair.pairId}] Shared Codex session restore started \u2014 flipping paired readiness to not-ready`);
     pair.proxyTuiSlot.readiness = "not-ready";
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (paired)
       paired.ready = false;
   });
@@ -2698,14 +2703,14 @@ ${payload.content}`,
     }
     log(`[pair=${pair.pairId}] Shared Codex session restore succeeded \u2014 flipping readiness back to ready`);
     pair.proxyTuiSlot.readiness = "ready";
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (paired) {
       paired.ready = true;
       emitToChat(paired, systemMessage("system_pair_restored", "\u2705 Shared Codex TUI session restored. Replies can flow again."));
     }
   });
   on("threadClosed", () => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     log(`[pair=${pair.pairId}] Codex emitted thread/closed`);
     if (pair.proxyTuiSlot) {
       const wasPairedChat = pair.proxyTuiSlot.pairedChatId;
@@ -2818,6 +2823,7 @@ function reapChatState(state, reason) {
 }
 function transitionToIsolated(state, reason) {
   state.paired = false;
+  state.homePairId = "default";
   state.replyRequired = false;
   state.replyReceivedDuringTurn = false;
   state.pairedTurnSawAgentMessage = false;
@@ -2912,54 +2918,8 @@ function handleControlMessage(ws, raw) {
 }
 async function handleEnsurePair(ws, message) {
   const { requestId, pairId } = message;
-  if (!isValidPairName(pairId)) {
-    sendProtocolMessage(ws, {
-      type: "pair_error",
-      requestId,
-      pairId,
-      code: "INVALID_PAIR_NAME",
-      message: `pair name "${pairId}" fails validation`
-    });
-    return;
-  }
-  const allocResult = await runUnderRegistryMutex(async () => {
-    if (pairRegistry.has(pairId)) {
-      return { ok: true, entry: pairRegistry.get(pairId) };
-    }
-    const result = pairRegistry.allocate(pairId);
-    if (result.ok) {
-      try {
-        pairRegistry.save();
-      } catch (err) {
-        log(`[ensure_pair=${pairId}] registry save failed: ${err?.message ?? err}`);
-      }
-    }
-    return result;
-  });
-  if (!allocResult.ok) {
-    sendProtocolMessage(ws, {
-      type: "pair_error",
-      requestId,
-      pairId,
-      code: allocResult.error.code,
-      message: allocResult.error.message
-    });
-    return;
-  }
-  const { appPort, proxyPort } = allocResult.entry;
-  if (pairId !== "default") {
-    log(`[ensure_pair=${pairId}] registry entry allocated (appPort=${appPort}, proxyPort=${proxyPort}); activation deferred to P3c`);
-    sendProtocolMessage(ws, {
-      type: "pair_error",
-      requestId,
-      pairId,
-      code: "ALLOCATION_FAILED",
-      message: `pair "${pairId}" registry entry allocated (appPort=${appPort}, proxyPort=${proxyPort}) but non-default pair activation is not implemented in P3b \u2014 lands in P3c`
-    });
-    return;
-  }
   try {
-    const pair = await ensurePair("default");
+    const pair = await ensurePair(pairId);
     sendProtocolMessage(ws, {
       type: "pair_ensured",
       requestId,
@@ -2969,12 +2929,23 @@ async function handleEnsurePair(ws, message) {
       isLive: true
     });
   } catch (err) {
+    if (err instanceof PairError) {
+      sendProtocolMessage(ws, {
+        type: "pair_error",
+        requestId,
+        pairId,
+        code: err.code,
+        message: err.message
+      });
+      return;
+    }
+    log(`[ensure_pair=${pairId}] unexpected error: ${err?.stack ?? err?.message ?? err}`);
     sendProtocolMessage(ws, {
       type: "pair_error",
       requestId,
       pairId,
       code: "ALLOCATION_FAILED",
-      message: `ensurePair("default") failed: ${err?.message ?? err}`
+      message: `ensurePair("${pairId}") failed: ${err?.message ?? err}`
     });
   }
 }
@@ -3530,23 +3501,71 @@ function removeStatusFile() {
   daemonLifecycle.removeStatusFile();
 }
 async function ensurePair(pairId) {
-  if (pairId !== "default") {
-    throw new Error(`ensurePair: pairId="${pairId}" not yet supported in P2 (default only)`);
+  if (!isValidPairName(pairId)) {
+    throw new PairError("INVALID_PAIR_NAME", `pair name "${pairId}" fails validation`);
   }
-  const pair = pairs.get(pairId);
+  const existing = pairs.get(pairId);
+  if (existing?.isLive)
+    return existing;
+  const entry = await runUnderRegistryMutex(async () => {
+    if (pairRegistry.has(pairId))
+      return pairRegistry.get(pairId);
+    const result = pairRegistry.allocate(pairId);
+    if (!result.ok) {
+      throw new PairError(result.error.code, result.error.message);
+    }
+    try {
+      pairRegistry.save();
+    } catch (err) {
+      log(`[pair-registry] ensurePair("${pairId}"): persist failed: ${err?.message ?? err}`);
+    }
+    return result.entry;
+  });
+  let pair = pairs.get(pairId);
   if (!pair) {
-    throw new Error(`ensurePair: pair "${pairId}" missing from registry (P2 invariant violated)`);
+    const newCodex = new CodexAdapter({
+      pairId,
+      appPort: entry.appPort,
+      proxyPort: entry.proxyPort,
+      logFile: stateDir.logFile
+    });
+    const newTuiState = new TuiConnectionState({
+      disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
+      log,
+      onDisconnectPersisted: (connId) => {
+        broadcastToAllClaudes(systemMessage("system_tui_disconnected", `\u26A0\uFE0F Codex TUI disconnected (pair=${pairId}, conn #${connId}). Codex is still running in the background \u2014 reconnect the TUI to resume.`));
+      },
+      onReconnectAfterNotice: (connId) => {
+        broadcastToAllClaudes(systemMessage("system_tui_reconnected", `\u2705 Codex TUI reconnected (pair=${pairId}, conn #${connId}). Bridge restored.`));
+      }
+    });
+    pair = {
+      pairId,
+      codex: newCodex,
+      tuiConnectionState: newTuiState,
+      proxyTuiSlot: null,
+      handlerRefs: [],
+      isLive: false
+    };
+    pairs.set(pairId, pair);
+    log(`[pair=${pairId}] constructed new PairState (appPort=${entry.appPort}, proxyPort=${entry.proxyPort})`);
   }
-  if (pair.isLive)
-    return pair;
   if (pair.handlerRefs.length === 0) {
-    log(`[pair=${pair.pairId}] ensurePair: reattaching handlers before start`);
     attachPairHandlers(pair);
   }
   log(`[pair=${pair.pairId}] ensurePair: starting codex app-server (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl})`);
   await pair.codex.start();
   pair.isLive = true;
   return pair;
+}
+
+class PairError extends Error {
+  code;
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+    this.name = "PairError";
+  }
 }
 async function destroyPair(pairId) {
   const pair = pairs.get(pairId);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2903,7 +2903,7 @@ function handleControlMessage(ws, raw) {
   }
   switch (message.type) {
     case "claude_connect":
-      attachClaude(ws, message.chatId);
+      attachClaude(ws, message.chatId, message.pairId, message.requestId);
       return;
     case "claude_disconnect": {
       const chatId = message.chatId ?? ws.data.chatId;
@@ -3066,9 +3066,42 @@ function handleListPairs(ws, message) {
     pairs: result
   });
 }
-async function attachClaude(ws, requestedChatId) {
+async function attachClaude(ws, requestedChatId, requestedPairId, requestId) {
   const chatId = requestedChatId ?? `auto_${ws.data.clientId}_${Date.now()}`;
   ws.data.chatId = chatId;
+  if (requestedPairId !== undefined) {
+    if (!isValidPairName(requestedPairId)) {
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: false,
+        error: "INVALID_PAIR_NAME",
+        message: `pair name "${requestedPairId}" fails validation`
+      });
+      return;
+    }
+    const targetPair2 = pairs.get(requestedPairId);
+    if (!targetPair2?.isLive) {
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: false,
+        error: "PAIR_NOT_FOUND",
+        message: `pair "${requestedPairId}" is not live; start it with abg codex --pair ${requestedPairId} --via-proxy first`
+      });
+      return;
+    }
+    if (targetPair2.proxyTuiSlot?.pairedChatId && targetPair2.proxyTuiSlot.pairedChatId !== chatId) {
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: false,
+        error: "PAIR_BUSY",
+        message: `pair "${requestedPairId}" already has paired chat "${targetPair2.proxyTuiSlot.pairedChatId}"`
+      });
+      return;
+    }
+  }
   let state = chats.get(chatId);
   if (state) {
     if (state.ws && state.ws !== ws && state.ws.readyState !== WebSocket.CLOSED) {
@@ -3086,6 +3119,14 @@ async function attachClaude(ws, requestedChatId) {
     statusBufferFlushIfPaused(state, "claude resumed");
     flushBufferedMessages(state);
     sendStatus(ws);
+    sendProtocolMessage(ws, {
+      type: "claude_connect_result",
+      requestId,
+      ok: true,
+      chatId,
+      homePairId: state.homePairId,
+      paired: state.paired
+    });
     return;
   }
   state = createChatState(chatId);
@@ -3093,15 +3134,51 @@ async function attachClaude(ws, requestedChatId) {
   state.ws = ws;
   ws.data.attached = true;
   cancelIdleShutdown();
-  log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
+  log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size}, requestedPair=${requestedPairId ?? "-"})`);
   sendStatus(ws);
+  const targetPair = requestedPairId ? pairs.get(requestedPairId) : null;
+  if (targetPair?.isLive && !targetPair.proxyTuiSlot?.pairedChatId && targetPair.proxyTuiSlot) {
+    state.homePairId = requestedPairId;
+    targetPair.proxyTuiSlot.pairedChatId = chatId;
+    state.paired = true;
+    targetPair.codex.setPairedChat(chatId);
+    state.ready = targetPair.proxyTuiSlot.readiness === "ready";
+    log(`[${chatId}] Paired with pair="${requestedPairId}" via explicit attach (readiness=${targetPair.proxyTuiSlot.readiness})`);
+    emitToChat(state, systemMessage(state.ready ? "system_paired_ready" : "system_paired_provisioning", state.ready ? `\u2705 This Claude session is paired with the right-pane Codex TUI on pair "${requestedPairId}". Replies will appear there.` : `\u2705 This Claude session is paired with the right-pane Codex TUI on pair "${requestedPairId}". Waiting for shared-thread provisioning.`));
+    sendProtocolMessage(ws, {
+      type: "claude_connect_result",
+      requestId,
+      ok: true,
+      chatId,
+      homePairId: state.homePairId,
+      paired: state.paired
+    });
+    broadcastStatus();
+    return;
+  }
   if (proxyTuiSlot && proxyTuiSlot.pairedChatId === null) {
     emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Pairing with the right-pane Codex TUI for shared-thread mode..."));
     pairChat(state);
     broadcastStatus();
+    sendProtocolMessage(ws, {
+      type: "claude_connect_result",
+      requestId,
+      ok: true,
+      chatId,
+      homePairId: state.homePairId,
+      paired: state.paired
+    });
     return;
   }
   emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
+  sendProtocolMessage(ws, {
+    type: "claude_connect_result",
+    requestId,
+    ok: true,
+    chatId,
+    homePairId: state.homePairId,
+    paired: state.paired
+  });
   try {
     const threadId = await state.thread.bootstrap();
     state.ready = true;
@@ -3515,10 +3592,24 @@ function writeStatusFile() {
 function removeStatusFile() {
   daemonLifecycle.removeStatusFile();
 }
+var ensurePairInFlight = new Map;
 async function ensurePair(pairId) {
   if (!isValidPairName(pairId)) {
     throw new PairError("INVALID_PAIR_NAME", `pair name "${pairId}" fails validation`);
   }
+  const existingFast = pairs.get(pairId);
+  if (existingFast?.isLive)
+    return existingFast;
+  const inFlight = ensurePairInFlight.get(pairId);
+  if (inFlight)
+    return inFlight;
+  const promise = ensurePairCore(pairId).finally(() => {
+    ensurePairInFlight.delete(pairId);
+  });
+  ensurePairInFlight.set(pairId, promise);
+  return promise;
+}
+async function ensurePairCore(pairId) {
   const existing = pairs.get(pairId);
   if (existing?.isLive)
     return existing;
@@ -3586,14 +3677,32 @@ async function destroyPair(pairId) {
   const pair = pairs.get(pairId);
   if (!pair)
     return;
-  log(`[pair=${pair.pairId}] destroyPair: stopping codex + detaching handlers`);
+  log(`[pair=${pair.pairId}] destroyPair: full teardown (isLive=${pair.isLive})`);
+  if (pair.proxyTuiSlot?.pairReapTimer) {
+    clearTimeout(pair.proxyTuiSlot.pairReapTimer);
+    pair.proxyTuiSlot.pairReapTimer = null;
+  }
   detachPairHandlers(pair);
+  const pairedChatId = pair.proxyTuiSlot?.pairedChatId ?? null;
+  if (pairedChatId) {
+    const state = chats.get(pairedChatId);
+    if (state) {
+      log(`[pair=${pair.pairId}] destroyPair: transitioning paired chat "${pairedChatId}" to isolated`);
+      transitionToIsolated(state, `Pair "${pair.pairId}" destroyed`);
+    }
+  }
+  pair.proxyTuiSlot = null;
   try {
     pair.codex.stop();
   } catch (err) {
     log(`[pair=${pair.pairId}] destroyPair: codex.stop() threw \u2014 ${err?.message ?? err}`);
   }
   pair.isLive = false;
+  if (pairId !== "default") {
+    pairs.delete(pairId);
+    log(`[pair=${pair.pairId}] destroyPair: removed from pairs Map`);
+  }
+  broadcastStatus();
 }
 async function bootCodex() {
   log("Starting AgentBridge daemon (multi-Claude variant)...");

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3383,6 +3383,12 @@ function wireClaudeThreadEvents(state) {
   state.thread.on("close", () => {
     log(`[${chatId}] ClaudeThread WS closed`);
     state.ready = false;
+    if (shuttingDown)
+      return;
+    if (chats.get(chatId) !== state)
+      return;
+    emitToChat(state, systemMessage("system_thread_failed", "\u274C Lost connection to Codex app-server. Reconnect to retry \u2014 bridge will provision a fresh thread."));
+    reapChatState(state, "ClaudeThread WS closed unexpectedly (app-server crash or upstream failure)");
   });
   state.thread.on("error", (err) => {
     log(`[${chatId}] ClaudeThread error: ${err?.message ?? err}`);
@@ -3956,7 +3962,11 @@ var __testing = {
     handleDestroyPair,
     handleListPairs,
     attachClaude,
-    log
+    log,
+    wireClaudeThreadEvents,
+    setShuttingDownForTest(value) {
+      shuttingDown = value;
+    }
   },
   pairRegistry,
   runUnderRegistryMutex,

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3092,7 +3092,17 @@ async function attachClaude(ws, requestedChatId, requestedPairId, requestId) {
       });
       return;
     }
-    if (targetPair2.proxyTuiSlot?.pairedChatId && targetPair2.proxyTuiSlot.pairedChatId !== chatId) {
+    if (!targetPair2.proxyTuiSlot) {
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: false,
+        error: "PAIR_NOT_FOUND",
+        message: `pair "${requestedPairId}" has no proxy TUI connected yet; start \`abg codex --pair ${requestedPairId} --via-proxy\` first, then attach Claude`
+      });
+      return;
+    }
+    if (targetPair2.proxyTuiSlot.pairedChatId && targetPair2.proxyTuiSlot.pairedChatId !== chatId) {
       sendProtocolMessage(ws, {
         type: "claude_connect_result",
         requestId,
@@ -3822,7 +3832,8 @@ var __testing = {
     destroyPair,
     handleEnsurePair,
     handleDestroyPair,
-    handleListPairs
+    handleListPairs,
+    attachClaude
   },
   pairRegistry,
   runUnderRegistryMutex,

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2379,10 +2379,10 @@ import { readFileSync as readFileSync3, writeFileSync as writeFileSync3, renameS
 import { dirname as dirname2 } from "path";
 import { randomBytes } from "crypto";
 var DEFAULT_PAIR_PORTS = { appPort: 4500, proxyPort: 4501 };
-var STRIDE_BASE = parseInt(process.env.AGENTBRIDGE_PAIR_STRIDE_BASE ?? "4510", 10);
-var STRIDE_STEP_DEFAULT = parseInt(process.env.AGENTBRIDGE_PAIR_STRIDE_STEP ?? "10", 10);
-var STRIDE_MAX_DEFAULT = parseInt(process.env.AGENTBRIDGE_PAIR_STRIDE_MAX ?? "20", 10);
-var MAX_PAIRS_DEFAULT = parseInt(process.env.AGENTBRIDGE_PAIR_MAX_PAIRS ?? "8", 10);
+var STRIDE_BASE = 4510;
+var STRIDE_STEP_DEFAULT = 10;
+var STRIDE_MAX_DEFAULT = 20;
+var MAX_PAIRS_DEFAULT = 8;
 var PAIR_NAME_REGEX = /^[a-z0-9][a-z0-9_-]{0,31}$/;
 function isValidPairName(name) {
   if (typeof name !== "string")
@@ -2824,7 +2824,9 @@ ${payload.content}`,
   });
   on("exit", (code) => {
     log(`[pair=${pair.pairId}] Codex app-server process exited (code ${code})`);
-    codexBootstrapped = false;
+    if (pair.pairId === "default") {
+      codexBootstrapped = false;
+    }
     pair.isLive = false;
     pair.tuiConnectionState.handleCodexExit();
     const affectedChats = [];

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2,7 +2,7 @@
 // @bun
 
 // src/daemon.ts
-import { appendFileSync as appendFileSync2 } from "fs";
+import { appendFileSync as appendFileSync3 } from "fs";
 
 // src/codex-adapter.ts
 import { spawn, execSync } from "child_process";
@@ -1282,6 +1282,287 @@ class CodexAdapter extends EventEmitter {
   }
 }
 
+// src/claude-thread.ts
+import { EventEmitter as EventEmitter2 } from "events";
+import { appendFileSync as appendFileSync2 } from "fs";
+var RPC_TIMEOUT_MS = 30000;
+
+class ClaudeThread extends EventEmitter2 {
+  chatId;
+  appServerUrl;
+  logFile;
+  cwd;
+  ws = null;
+  threadId = null;
+  nextId = 1;
+  pending = new Map;
+  turnInProgress = false;
+  agentMessageBuffers = new Map;
+  bootstrapped = false;
+  closed = false;
+  constructor(opts) {
+    super();
+    this.chatId = opts.chatId;
+    this.appServerUrl = opts.appServerUrl;
+    this.logFile = opts.logFile;
+    this.cwd = opts.cwd;
+  }
+  get activeThreadId() {
+    return this.threadId;
+  }
+  get isTurnInProgress() {
+    return this.turnInProgress;
+  }
+  get isReady() {
+    return this.bootstrapped && this.threadId !== null;
+  }
+  async bootstrap() {
+    if (this.bootstrapped && this.threadId)
+      return this.threadId;
+    await this.openSocket();
+    await this.callRpc("initialize", {
+      clientInfo: { name: "agentbridge-claude-thread", version: "0.1.0" },
+      capabilities: { experimentalApi: false }
+    });
+    const params = {};
+    if (this.cwd)
+      params.cwd = this.cwd;
+    const startRes = await this.callRpc("thread/start", params);
+    const tid = startRes?.thread?.id ?? startRes?.threadId ?? null;
+    if (typeof tid !== "string" || tid.length === 0) {
+      throw new Error("thread/start did not return a threadId");
+    }
+    this.threadId = tid;
+    this.bootstrapped = true;
+    this.log(`bootstrap ok threadId=${tid}`);
+    this.emit("ready", tid);
+    return tid;
+  }
+  injectMessage(text) {
+    if (!this.threadId) {
+      this.log("inject rejected: not bootstrapped");
+      return false;
+    }
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.log("inject rejected: ws not open");
+      return false;
+    }
+    if (this.turnInProgress) {
+      this.log(`inject rejected: turn already in progress`);
+      return false;
+    }
+    const id = this.nextId++;
+    const msg = {
+      jsonrpc: "2.0",
+      id,
+      method: "turn/start",
+      params: {
+        threadId: this.threadId,
+        input: [{ type: "text", text }]
+      }
+    };
+    try {
+      this.ws.send(JSON.stringify(msg));
+      return true;
+    } catch (err) {
+      this.log(`inject send failed: ${err.message}`);
+      return false;
+    }
+  }
+  close() {
+    if (this.closed)
+      return;
+    this.closed = true;
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {}
+      this.ws = null;
+    }
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(new Error("ClaudeThread closed"));
+    }
+    this.pending.clear();
+  }
+  openSocket() {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.appServerUrl);
+      let settled = false;
+      ws.onopen = () => {
+        if (settled)
+          return;
+        settled = true;
+        this.ws = ws;
+        this.attachHandlers(ws);
+        resolve();
+      };
+      ws.onerror = (e) => {
+        if (settled)
+          return;
+        settled = true;
+        reject(new Error(`ws connect failed: ${e?.message ?? "unknown"}`));
+      };
+      ws.onclose = (e) => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(`ws closed during handshake (code=${e?.code})`));
+          return;
+        }
+      };
+    });
+  }
+  attachHandlers(ws) {
+    ws.onmessage = (event) => {
+      const raw = typeof event.data === "string" ? event.data : event.data.toString();
+      this.handlePayload(raw);
+    };
+    ws.onclose = () => {
+      this.log(`ws closed (chatId=${this.chatId}, threadId=${this.threadId})`);
+      this.ws = null;
+      this.emit("close");
+    };
+    ws.onerror = (e) => {
+      this.log(`ws error: ${e?.message ?? "unknown"}`);
+      this.emit("error", e);
+    };
+  }
+  handlePayload(raw) {
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (typeof parsed.id === "number" && this.pending.has(parsed.id) && (parsed.result !== undefined || parsed.error !== undefined)) {
+      const pending = this.pending.get(parsed.id);
+      this.pending.delete(parsed.id);
+      clearTimeout(pending.timer);
+      if (parsed.error) {
+        pending.reject(new Error(`${pending.method} failed: ${JSON.stringify(parsed.error).slice(0, 200)}`));
+      } else {
+        pending.resolve(parsed.result);
+      }
+      return;
+    }
+    if (parsed.id !== undefined && typeof parsed.method === "string") {
+      const tid = parsed.params?.threadId;
+      if (tid && this.threadId && tid !== this.threadId)
+        return;
+      try {
+        this.ws?.send(JSON.stringify({
+          jsonrpc: "2.0",
+          id: parsed.id,
+          error: { code: -32601, message: "auto-denied by ClaudeThread (no UI to approve)" }
+        }));
+      } catch {}
+      return;
+    }
+    if (typeof parsed.method === "string" && parsed.id === undefined) {
+      const tid = parsed.params?.threadId;
+      if (tid && this.threadId && tid !== this.threadId) {
+        return;
+      }
+      this.handleNotification(parsed.method, parsed.params ?? {});
+    }
+  }
+  handleNotification(method, params) {
+    switch (method) {
+      case "turn/started": {
+        if (!this.turnInProgress) {
+          this.turnInProgress = true;
+          this.emit("turnStarted");
+        }
+        break;
+      }
+      case "item/started": {
+        const item = params?.item;
+        if (item?.type === "agentMessage")
+          this.agentMessageBuffers.set(item.id, []);
+        break;
+      }
+      case "item/agentMessage/delta": {
+        const itemId = params?.itemId;
+        const delta = params?.delta;
+        if (typeof itemId === "string") {
+          const buf = this.agentMessageBuffers.get(itemId);
+          if (buf && typeof delta === "string")
+            buf.push(delta);
+        }
+        break;
+      }
+      case "item/completed": {
+        const item = params?.item;
+        if (item?.type === "agentMessage") {
+          const content = this.extractContent(item);
+          this.agentMessageBuffers.delete(item.id);
+          if (content) {
+            const bridgeMsg = {
+              id: item.id,
+              source: "codex",
+              content,
+              timestamp: Date.now()
+            };
+            this.emit("agentMessage", bridgeMsg);
+          }
+        }
+        break;
+      }
+      case "turn/completed": {
+        if (this.turnInProgress) {
+          this.turnInProgress = false;
+          this.emit("turnCompleted");
+        }
+        break;
+      }
+      case "turn/failed": {
+        if (this.turnInProgress) {
+          this.turnInProgress = false;
+          this.emit("turnCompleted");
+        }
+        this.emit("turnFailed", params);
+        break;
+      }
+    }
+  }
+  extractContent(item) {
+    if (item.content?.length) {
+      return item.content.filter((c) => c.type === "text" && c.text).map((c) => c.text).join("");
+    }
+    return this.agentMessageBuffers.get(item.id)?.join("") ?? "";
+  }
+  callRpc(method, params) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("callRpc: ws not open"));
+    }
+    const id = this.nextId++;
+    const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(new Error(`${method} timed out after ${RPC_TIMEOUT_MS}ms`));
+        }
+      }, RPC_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, method, timer });
+      try {
+        this.ws.send(msg);
+      } catch (err) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+  log(s) {
+    const line = `[${new Date().toISOString()}] [ClaudeThread:${this.chatId}] ${s}
+`;
+    process.stderr.write(line);
+    try {
+      appendFileSync2(this.logFile, line);
+    } catch {}
+  }
+}
+
 // src/message-filter.ts
 var MARKER_REGEX = /^\s*\[(IMPORTANT|STATUS|FYI)\]\s*/i;
 function parseMarker(content) {
@@ -1852,6 +2133,7 @@ var CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.co
 var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 var CLAUDE_DISCONNECT_GRACE_MS = 5000;
+var CLAUDE_REAP_AFTER_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_REAP_MS ?? "600000", 10);
 var MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 var FILTER_MODE = process.env.AGENTBRIDGE_FILTER_MODE === "full" ? "full" : "filtered";
 var IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
@@ -1860,98 +2142,24 @@ var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT,
 var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
 var attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 var controlServer = null;
-var attachedClaude = null;
 var nextControlClientId = 0;
-var nextSystemMessageId = 0;
 var codexBootstrapped = false;
-var attentionWindowTimer = null;
-var inAttentionWindow = false;
-var replyRequired = false;
-var replyReceivedDuringTurn = false;
 var shuttingDown = false;
 var idleShutdownTimer = null;
-var claudeDisconnectTimer = null;
-var claudeOnlineNoticeSent = false;
-var claudeOfflineNoticeShown = false;
-var codexCollaborationKickoffSent = false;
-var lastAttachStatusSentTs = 0;
-var ATTACH_STATUS_COOLDOWN_MS = 30000;
-var bufferedMessages = [];
+var chats = new Map;
 var tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
   log,
   onDisconnectPersisted: (connId) => {
-    emitToClaude(systemMessage("system_tui_disconnected", `\u26A0\uFE0F Codex TUI disconnected (conn #${connId}). Codex is still running in the background \u2014 reconnect the TUI to resume.`));
+    broadcastToAllClaudes(systemMessage("system_tui_disconnected", `\u26A0\uFE0F Codex TUI disconnected (conn #${connId}). Codex is still running in the background \u2014 reconnect the TUI to resume.`));
   },
   onReconnectAfterNotice: (connId) => {
-    emitToClaude(systemMessage("system_tui_reconnected", `\u2705 Codex TUI reconnected (conn #${connId}). Bridge restored, communication can continue.`));
-    codex.injectMessage("\u2705 Claude Code is still online, bridge restored. Bidirectional communication can continue.");
-  }
-});
-var statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
-codex.on("turnStarted", () => {
-  log("Codex turn started");
-  emitToClaude(systemMessage("system_turn_started", "\u23F3 Codex is working on the current task. Wait for completion before sending a reply."));
-});
-codex.on("agentMessage", (msg) => {
-  if (msg.source !== "codex")
-    return;
-  const result = classifyMessage(msg.content, FILTER_MODE);
-  if (replyRequired) {
-    log(`Codex \u2192 Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
-    replyReceivedDuringTurn = true;
-    if (statusBuffer.size > 0) {
-      statusBuffer.flush("reply-required message arrived");
-    }
-    emitToClaude(msg);
-    return;
-  }
-  if (inAttentionWindow && result.marker === "status") {
-    log(`Codex \u2192 Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
-    statusBuffer.add(msg);
-    return;
-  }
-  log(`Codex \u2192 Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
-  switch (result.action) {
-    case "forward":
-      if (result.marker === "important" && statusBuffer.size > 0) {
-        statusBuffer.flush("important message arrived");
-      }
-      emitToClaude(msg);
-      if (result.marker === "important") {
-        startAttentionWindow();
-      }
-      break;
-    case "buffer":
-      statusBuffer.add(msg);
-      break;
-    case "drop":
-      break;
-  }
-});
-codex.on("turnCompleted", () => {
-  log("Codex turn completed");
-  statusBuffer.flush("turn completed");
-  if (replyRequired && !replyReceivedDuringTurn) {
-    log("\u26A0\uFE0F Reply was required but Codex did not send any agentMessage");
-    emitToClaude(systemMessage("system_reply_missing", "\u26A0\uFE0F Codex completed the turn without sending a reply (require_reply was set). Codex may not have generated an agentMessage. You may want to retry or rephrase."));
-  }
-  replyRequired = false;
-  replyReceivedDuringTurn = false;
-  emitToClaude(systemMessage("system_turn_completed", "\u2705 Codex finished the current turn. You can reply now if needed."));
-  startAttentionWindow();
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
+    broadcastToAllClaudes(systemMessage("system_tui_reconnected", `\u2705 Codex TUI reconnected (conn #${connId}). Bridge restored.`));
   }
 });
 codex.on("ready", (threadId) => {
   tuiConnectionState.markBridgeReady();
-  log(`Codex ready \u2014 thread ${threadId}`);
-  log("Bridge fully operational");
-  emitToClaude(systemMessage("system_ready", currentReadyMessage()));
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
+  log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
 });
 codex.on("tuiConnected", (connId) => {
   tuiConnectionState.handleTuiConnected(connId);
@@ -1969,14 +2177,16 @@ codex.on("error", (err) => {
   log(`Codex error: ${err.message}`);
 });
 codex.on("exit", (code) => {
-  log(`Codex process exited (code ${code})`);
+  log(`Codex app-server process exited (code ${code})`);
   codexBootstrapped = false;
-  statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
-  clearPendingClaudeDisconnect("Codex process exited");
-  claudeOnlineNoticeSent = false;
-  claudeOfflineNoticeShown = false;
-  emitToClaude(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running, but the Codex side needs to be restarted.`));
+  broadcastToAllClaudes(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`));
+  for (const state of chats.values()) {
+    try {
+      state.thread.close();
+    } catch {}
+    state.ready = false;
+  }
   broadcastStatus();
 });
 function startControlServer() {
@@ -1985,13 +2195,12 @@ function startControlServer() {
     hostname: "127.0.0.1",
     fetch(req, server) {
       const url = new URL(req.url);
-      if (url.pathname === "/healthz") {
+      if (url.pathname === "/healthz")
         return Response.json(currentStatus());
-      }
       if (url.pathname === "/readyz") {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false } })) {
+      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, chatId: null } })) {
         return;
       }
       return new Response("AgentBridge daemon");
@@ -2004,9 +2213,13 @@ function startControlServer() {
         log(`Frontend socket opened (#${ws.data.clientId})`);
       },
       close: (ws, code, reason) => {
-        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
-        if (attachedClaude === ws) {
-          detachClaude(ws, "frontend socket closed");
+        const chatId = ws.data.chatId;
+        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, chatId=${chatId ?? "-"})`);
+        if (chatId) {
+          const state = chats.get(chatId);
+          if (state && state.ws === ws) {
+            detachClaudeWs(state, "frontend socket closed");
+          }
         }
       },
       message: (ws, raw) => {
@@ -2026,195 +2239,301 @@ function handleControlMessage(ws, raw) {
   }
   switch (message.type) {
     case "claude_connect":
-      attachClaude(ws);
+      attachClaude(ws, message.chatId);
       return;
-    case "claude_disconnect":
-      detachClaude(ws, "frontend requested disconnect");
+    case "claude_disconnect": {
+      const chatId = message.chatId ?? ws.data.chatId;
+      if (!chatId)
+        return;
+      const state = chats.get(chatId);
+      if (state)
+        detachClaudeWs(state, "frontend requested disconnect");
       return;
+    }
     case "status":
       sendStatus(ws);
       return;
-    case "claude_to_codex": {
-      if (message.message.source !== "claude") {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Invalid message source"
-        });
-        return;
-      }
-      if (!tuiConnectionState.canReply()) {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Codex is not ready. Wait for TUI to connect and create a thread."
-        });
-        return;
-      }
-      const requireReply = !!message.requireReply;
-      let contentWithReminder = message.message.content + `
-
-` + BRIDGE_CONTRACT_REMINDER;
-      if (requireReply) {
-        contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
-        replyRequired = true;
-        replyReceivedDuringTurn = false;
-        log(`Reply required flag set for this message`);
-      }
-      log(`Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-      const injected = codex.injectMessage(contentWithReminder);
-      if (!injected) {
-        const reason = codex.turnInProgress ? "Codex is busy executing a turn. Wait for it to finish before sending another message." : "Injection failed: no active thread or WebSocket not connected.";
-        log(`Injection rejected: ${reason}`);
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: reason
-        });
-        return;
-      }
-      clearAttentionWindow();
-      sendProtocolMessage(ws, {
-        type: "claude_to_codex_result",
-        requestId: message.requestId,
-        success: true
-      });
+    case "claude_to_codex":
+      handleClaudeToCodex(ws, message);
       return;
-    }
   }
 }
-function attachClaude(ws) {
-  if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
-    log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 another session (#${attachedClaude.data.clientId}) is already attached (readyState=${attachedClaude.readyState})`);
-    ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
+async function attachClaude(ws, requestedChatId) {
+  const chatId = requestedChatId ?? `auto_${ws.data.clientId}_${Date.now()}`;
+  ws.data.chatId = chatId;
+  let state = chats.get(chatId);
+  if (state) {
+    if (state.ws && state.ws !== ws && state.ws.readyState !== WebSocket.CLOSED) {
+      log(`Replacing prior WS for chatId=${chatId} (#${state.ws.data.clientId} \u2192 #${ws.data.clientId})`);
+      try {
+        state.ws.close(CLOSE_CODE_REPLACED, "replaced by newer connection for same chatId");
+      } catch {}
+    }
+    state.ws = ws;
+    ws.data.attached = true;
+    clearDisconnectTimer(state, "claude resumed");
+    clearReaperTimer(state, "claude resumed");
+    cancelIdleShutdown();
+    log(`Claude resumed chatId=${chatId} (#${ws.data.clientId})`);
+    statusBufferFlushIfPaused(state, "claude resumed");
+    flushBufferedMessages(state);
+    sendStatus(ws);
     return;
   }
-  clearPendingClaudeDisconnect("Claude frontend attached");
-  attachedClaude = ws;
+  state = createChatState(chatId);
+  chats.set(chatId, state);
+  state.ws = ws;
   ws.data.attached = true;
   cancelIdleShutdown();
-  log(`Claude frontend attached (#${ws.data.clientId})`);
-  statusBuffer.flush("claude reconnected");
+  log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
   sendStatus(ws);
-  const now = Date.now();
-  const isRapidReattach = now - lastAttachStatusSentTs < ATTACH_STATUS_COOLDOWN_MS;
-  if (bufferedMessages.length > 0) {
-    flushBufferedMessages(ws);
-  } else if (!isRapidReattach) {
-    if (tuiConnectionState.canReply()) {
-      sendBridgeMessage(ws, systemMessage("system_ready", currentReadyMessage()));
-    } else if (codexBootstrapped) {
-      sendBridgeMessage(ws, systemMessage("system_waiting", currentWaitingMessage()));
-    }
-  }
-  lastAttachStatusSentTs = now;
-  if (tuiConnectionState.canReply() && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
+  emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
+  try {
+    const threadId = await state.thread.bootstrap();
+    state.ready = true;
+    log(`ClaudeThread ready: chatId=${chatId} threadId=${threadId}`);
+    emitToChat(state, systemMessage("system_thread_ready", `\u2705 Your Codex thread is ready (threadId=${threadId}). You can now send messages via the reply tool.`));
+    broadcastStatus();
+  } catch (err) {
+    log(`ClaudeThread bootstrap failed for chatId=${chatId}: ${err?.message ?? err}`);
+    emitToChat(state, systemMessage("system_thread_failed", `\u274C Failed to provision Codex thread: ${err?.message ?? err}. Reconnect to retry.`));
   }
 }
-function detachClaude(ws, reason) {
-  if (attachedClaude !== ws)
+function createChatState(chatId) {
+  const state = {
+    chatId,
+    ws: null,
+    thread: new ClaudeThread({
+      appServerUrl: codex.appServerUrl,
+      chatId,
+      logFile: stateDir.logFile,
+      cwd: process.cwd()
+    }),
+    ready: false,
+    inAttentionWindow: false,
+    attentionWindowTimer: null,
+    replyRequired: false,
+    replyReceivedDuringTurn: false,
+    bufferedMessages: [],
+    statusBuffer: null,
+    disconnectTimer: null,
+    reaperTimer: null,
+    lastAttachStatusSentTs: 0,
+    onlineNoticeSent: false,
+    nextSystemMessageId: 0
+  };
+  state.statusBuffer = new StatusBuffer((summary) => emitToChat(state, summary));
+  state.thread.on("agentMessage", (msg) => {
+    if (msg.source !== "codex")
+      return;
+    const result = classifyMessage(msg.content, FILTER_MODE);
+    if (state.replyRequired) {
+      log(`[${chatId}] Codex \u2192 Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
+      state.replyReceivedDuringTurn = true;
+      if (state.statusBuffer.size > 0) {
+        state.statusBuffer.flush("reply-required message arrived");
+      }
+      emitToChat(state, msg);
+      return;
+    }
+    if (state.inAttentionWindow && result.marker === "status") {
+      log(`[${chatId}] Codex \u2192 Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
+      state.statusBuffer.add(msg);
+      return;
+    }
+    log(`[${chatId}] Codex \u2192 Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
+    switch (result.action) {
+      case "forward":
+        if (result.marker === "important" && state.statusBuffer.size > 0) {
+          state.statusBuffer.flush("important message arrived");
+        }
+        emitToChat(state, msg);
+        if (result.marker === "important")
+          startAttentionWindow(state);
+        break;
+      case "buffer":
+        state.statusBuffer.add(msg);
+        break;
+      case "drop":
+        break;
+    }
+  });
+  state.thread.on("turnStarted", () => {
+    log(`[${chatId}] Codex turn started`);
+    emitToChat(state, systemMessage("system_turn_started", "\u23F3 Codex is working on the current task. Wait for completion before sending a reply."));
+  });
+  state.thread.on("turnCompleted", () => {
+    log(`[${chatId}] Codex turn completed`);
+    state.statusBuffer.flush("turn completed");
+    if (state.replyRequired && !state.replyReceivedDuringTurn) {
+      log(`[${chatId}] \u26A0\uFE0F Reply was required but Codex did not send any agentMessage`);
+      emitToChat(state, systemMessage("system_reply_missing", "\u26A0\uFE0F Codex completed the turn without sending a reply (require_reply was set)."));
+    }
+    state.replyRequired = false;
+    state.replyReceivedDuringTurn = false;
+    emitToChat(state, systemMessage("system_turn_completed", "\u2705 Codex finished the current turn. You can reply now if needed."));
+    startAttentionWindow(state);
+  });
+  state.thread.on("close", () => {
+    log(`[${chatId}] ClaudeThread WS closed`);
+    state.ready = false;
+  });
+  state.thread.on("error", (err) => {
+    log(`[${chatId}] ClaudeThread error: ${err?.message ?? err}`);
+  });
+  return state;
+}
+function detachClaudeWs(state, reason) {
+  if (!state.ws)
     return;
-  attachedClaude = null;
-  ws.data.attached = false;
-  log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
-  scheduleClaudeDisconnectNotification(ws.data.clientId);
+  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason})`);
+  state.ws = null;
+  scheduleDisconnectTimer(state);
+  scheduleReaperTimer(state);
   scheduleIdleShutdown();
 }
-function startAttentionWindow() {
-  clearAttentionWindow();
-  inAttentionWindow = true;
-  statusBuffer.pause();
-  log(`Attention window started (${ATTENTION_WINDOW_MS}ms)`);
-  attentionWindowTimer = setTimeout(() => {
-    attentionWindowTimer = null;
-    inAttentionWindow = false;
-    statusBuffer.resume();
-    log("Attention window ended");
-  }, ATTENTION_WINDOW_MS);
-}
-function clearAttentionWindow() {
-  if (attentionWindowTimer) {
-    clearTimeout(attentionWindowTimer);
-    attentionWindowTimer = null;
-  }
-  if (inAttentionWindow) {
-    statusBuffer.resume();
-  }
-  inAttentionWindow = false;
-}
-function scheduleIdleShutdown() {
-  cancelIdleShutdown();
-  if (attachedClaude)
-    return;
-  const snapshot = tuiConnectionState.snapshot();
-  if (snapshot.tuiConnected)
-    return;
-  log(`No clients connected. Daemon will shut down in ${IDLE_SHUTDOWN_MS}ms if no one reconnects.`);
-  idleShutdownTimer = setTimeout(() => {
-    if (attachedClaude || tuiConnectionState.snapshot().tuiConnected) {
-      log("Idle shutdown cancelled: client reconnected during grace period");
+function scheduleReaperTimer(state) {
+  if (state.reaperTimer)
+    clearTimeout(state.reaperTimer);
+  state.reaperTimer = setTimeout(() => {
+    state.reaperTimer = null;
+    if (state.ws)
       return;
-    }
-    shutdown("idle \u2014 no clients connected");
-  }, IDLE_SHUTDOWN_MS);
+    log(`Reaping idle chat: chatId=${state.chatId} (no WS for ${CLAUDE_REAP_AFTER_MS}ms)`);
+    try {
+      state.thread.close();
+    } catch {}
+    state.statusBuffer.dispose();
+    if (state.attentionWindowTimer)
+      clearTimeout(state.attentionWindowTimer);
+    chats.delete(state.chatId);
+    broadcastStatus();
+  }, CLAUDE_REAP_AFTER_MS);
 }
-function cancelIdleShutdown() {
-  if (idleShutdownTimer) {
-    clearTimeout(idleShutdownTimer);
-    idleShutdownTimer = null;
+function clearReaperTimer(state, _reason) {
+  if (state.reaperTimer) {
+    clearTimeout(state.reaperTimer);
+    state.reaperTimer = null;
   }
 }
-function clearPendingClaudeDisconnect(reason) {
-  if (!claudeDisconnectTimer)
-    return;
-  clearTimeout(claudeDisconnectTimer);
-  claudeDisconnectTimer = null;
-  if (reason) {
-    log(`Cleared pending Claude disconnect notification (${reason})`);
-  }
-}
-function scheduleClaudeDisconnectNotification(clientId) {
-  clearPendingClaudeDisconnect("rescheduled");
-  claudeDisconnectTimer = setTimeout(() => {
-    claudeDisconnectTimer = null;
-    if (attachedClaude) {
-      log(`Skipping Claude disconnect notification for client #${clientId} because Claude already reconnected`);
-      return;
-    }
-    if (!tuiConnectionState.canReply()) {
-      log(`Suppressing Claude disconnect notification for client #${clientId} because Codex cannot reply`);
-      return;
-    }
-    if (!claudeOnlineNoticeSent) {
-      log(`Suppressing Claude disconnect notification for client #${clientId} because Claude was never announced online`);
-      return;
-    }
-    codex.injectMessage("\u26A0\uFE0F Claude Code went offline. AgentBridge is still running in the background; it will reconnect automatically when Claude reopens.");
-    claudeOnlineNoticeSent = false;
-    claudeOfflineNoticeShown = true;
-    log(`Claude disconnect persisted past grace window (client #${clientId})`);
+function scheduleDisconnectTimer(state) {
+  if (state.disconnectTimer)
+    clearTimeout(state.disconnectTimer);
+  state.disconnectTimer = setTimeout(() => {
+    state.disconnectTimer = null;
   }, CLAUDE_DISCONNECT_GRACE_MS);
 }
-function emitToClaude(message) {
-  if (attachedClaude && attachedClaude.readyState === WebSocket.OPEN) {
-    if (trySendBridgeMessage(attachedClaude, message))
-      return;
-    log("Send to Claude failed, buffering message for retry on reconnect");
-  }
-  bufferedMessages.push(message);
-  if (bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
-    const dropped = bufferedMessages.length - MAX_BUFFERED_MESSAGES;
-    bufferedMessages.splice(0, dropped);
-    log(`Message buffer overflow: dropped ${dropped} oldest message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
+function clearDisconnectTimer(state, _reason) {
+  if (state.disconnectTimer) {
+    clearTimeout(state.disconnectTimer);
+    state.disconnectTimer = null;
   }
 }
-function trySendBridgeMessage(ws, message) {
+function statusBufferFlushIfPaused(state, reason) {
+  if (state.statusBuffer.size > 0)
+    state.statusBuffer.flush(reason);
+}
+function handleClaudeToCodex(ws, message) {
+  const chatId = message.chatId ?? ws.data.chatId;
+  if (!chatId) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "No chatId \u2014 claude_connect was never sent."
+    });
+  }
+  const state = chats.get(chatId);
+  if (!state) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: `Unknown chatId ${chatId}. Reattach via claude_connect.`
+    });
+  }
+  if (message.message.source !== "claude") {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "Invalid message source"
+    });
+  }
+  if (!state.ready) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "Your Codex thread is still provisioning. Wait for system_thread_ready."
+    });
+  }
+  const requireReply = !!message.requireReply;
+  let contentWithReminder = message.message.content + `
+
+` + BRIDGE_CONTRACT_REMINDER;
+  if (requireReply) {
+    contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
+    state.replyRequired = true;
+    state.replyReceivedDuringTurn = false;
+    log(`[${chatId}] Reply required flag set`);
+  }
+  log(`[${chatId}] Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
+  const injected = state.thread.injectMessage(contentWithReminder);
+  if (!injected) {
+    const reason = state.thread.isTurnInProgress ? "Codex is busy executing a turn on your thread. Wait for it to finish." : "Injection failed: thread WS not connected.";
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: reason
+    });
+  }
+  clearAttentionWindow(state);
+  sendProtocolMessage(ws, {
+    type: "claude_to_codex_result",
+    requestId: message.requestId,
+    success: true
+  });
+}
+function startAttentionWindow(state) {
+  clearAttentionWindow(state);
+  state.inAttentionWindow = true;
+  state.statusBuffer.pause();
+  log(`[${state.chatId}] Attention window started (${ATTENTION_WINDOW_MS}ms)`);
+  state.attentionWindowTimer = setTimeout(() => {
+    state.attentionWindowTimer = null;
+    state.inAttentionWindow = false;
+    state.statusBuffer.resume();
+    log(`[${state.chatId}] Attention window ended`);
+  }, ATTENTION_WINDOW_MS);
+}
+function clearAttentionWindow(state) {
+  if (state.attentionWindowTimer) {
+    clearTimeout(state.attentionWindowTimer);
+    state.attentionWindowTimer = null;
+  }
+  if (state.inAttentionWindow)
+    state.statusBuffer.resume();
+  state.inAttentionWindow = false;
+}
+function emitToChat(state, message) {
+  if (state.ws && state.ws.readyState === WebSocket.OPEN) {
+    if (trySendBridgeMessage(state.ws, message, state.chatId))
+      return;
+    log(`[${state.chatId}] Send to Claude failed, buffering`);
+  }
+  state.bufferedMessages.push(message);
+  if (state.bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
+    const dropped = state.bufferedMessages.length - MAX_BUFFERED_MESSAGES;
+    state.bufferedMessages.splice(0, dropped);
+    log(`[${state.chatId}] Message buffer overflow: dropped ${dropped} oldest`);
+  }
+}
+function trySendBridgeMessage(ws, message, chatId) {
   try {
-    const result = ws.send(JSON.stringify({ type: "codex_to_claude", message }));
+    const payload = { type: "codex_to_claude", chatId, message };
+    const result = ws.send(JSON.stringify(payload));
     if (typeof result === "number" && result <= 0) {
       log(`Bridge message send returned ${result} (0=dropped, -1=backpressure)`);
       return false;
@@ -2225,28 +2544,31 @@ function trySendBridgeMessage(ws, message) {
     return false;
   }
 }
-function flushBufferedMessages(ws) {
-  const messages = bufferedMessages.splice(0, bufferedMessages.length);
+function flushBufferedMessages(state) {
+  if (!state.ws || state.bufferedMessages.length === 0)
+    return;
+  const messages = state.bufferedMessages.splice(0, state.bufferedMessages.length);
   for (const message of messages) {
-    if (!trySendBridgeMessage(ws, message)) {
-      const failedIndex = messages.indexOf(message);
-      const remaining = messages.slice(failedIndex);
-      bufferedMessages.unshift(...remaining);
-      log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
+    if (!trySendBridgeMessage(state.ws, message, state.chatId)) {
+      const idx = messages.indexOf(message);
+      state.bufferedMessages.unshift(...messages.slice(idx));
+      log(`[${state.chatId}] Flush interrupted: re-buffered ${messages.length - idx} message(s)`);
       return;
     }
   }
 }
-function sendBridgeMessage(ws, message) {
-  trySendBridgeMessage(ws, message);
+function broadcastToAllClaudes(message) {
+  for (const state of chats.values())
+    emitToChat(state, message);
 }
 function sendStatus(ws) {
   sendProtocolMessage(ws, { type: "status", status: currentStatus() });
 }
 function broadcastStatus() {
-  if (!attachedClaude)
-    return;
-  sendStatus(attachedClaude);
+  for (const state of chats.values()) {
+    if (state.ws && state.ws.readyState === WebSocket.OPEN)
+      sendStatus(state.ws);
+  }
 }
 function sendProtocolMessage(ws, message) {
   try {
@@ -2258,51 +2580,44 @@ function sendProtocolMessage(ws, message) {
 function currentStatus() {
   const snapshot = tuiConnectionState.snapshot();
   return {
-    bridgeReady: tuiConnectionState.canReply(),
+    bridgeReady: tuiConnectionState.canReply() || codexBootstrapped,
     tuiConnected: snapshot.tuiConnected,
     threadId: codex.activeThreadId,
-    queuedMessageCount: bufferedMessages.length + statusBuffer.size,
+    queuedMessageCount: [...chats.values()].reduce((n, s) => n + s.bufferedMessages.length + s.statusBuffer.size, 0),
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
-    pid: process.pid
+    pid: process.pid,
+    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length
   };
-}
-function currentWaitingMessage() {
-  return `\u23F3 Waiting for Codex TUI to connect. Run in another terminal:
-${attachCmd}`;
-}
-function currentReadyMessage() {
-  return `\u2705 Codex TUI connected (${codex.activeThreadId}). Bridge ready.`;
-}
-function notifyCodexClaudeOnline() {
-  const message = !codexCollaborationKickoffSent ? [
-    "\uD83E\uDD1D Claude Code has connected via AgentBridge.",
-    "You are now in a multi-agent collaboration session.",
-    "When you receive a complex task, propose a division of labor to Claude.",
-    "Claude can send you messages \u2014 they will appear as injected user messages.",
-    "Respond naturally and Claude will receive your output via AgentBridge."
-  ].join(`
-`) : "\u2705 AgentBridge connected to Claude Code.";
-  const delivered = codex.injectMessage(message);
-  if (!delivered) {
-    log("Deferred Claude-online notice to Codex \u2014 will retry after current turn completes");
-    return false;
-  }
-  claudeOnlineNoticeSent = true;
-  claudeOfflineNoticeShown = false;
-  codexCollaborationKickoffSent = true;
-  return true;
-}
-function shouldNotifyCodexClaudeOnline() {
-  return !claudeOnlineNoticeSent || claudeOfflineNoticeShown;
 }
 function systemMessage(idPrefix, content) {
   return {
-    id: `${idPrefix}_${++nextSystemMessageId}`,
+    id: `${idPrefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
     source: "codex",
     content,
     timestamp: Date.now()
   };
+}
+function scheduleIdleShutdown() {
+  cancelIdleShutdown();
+  if ([...chats.values()].some((s) => s.ws !== null))
+    return;
+  if (tuiConnectionState.snapshot().tuiConnected)
+    return;
+  log(`No clients connected. Daemon will shut down in ${IDLE_SHUTDOWN_MS}ms if no one reconnects.`);
+  idleShutdownTimer = setTimeout(() => {
+    if ([...chats.values()].some((s) => s.ws !== null) || tuiConnectionState.snapshot().tuiConnected) {
+      log("Idle shutdown cancelled: client reconnected during grace period");
+      return;
+    }
+    shutdown("idle \u2014 no clients connected");
+  }, IDLE_SHUTDOWN_MS);
+}
+function cancelIdleShutdown() {
+  if (idleShutdownTimer) {
+    clearTimeout(idleShutdownTimer);
+    idleShutdownTimer = null;
+  }
 }
 function writePidFile() {
   daemonLifecycle.writePid();
@@ -2322,7 +2637,7 @@ function removeStatusFile() {
   daemonLifecycle.removeStatusFile();
 }
 async function bootCodex() {
-  log("Starting AgentBridge daemon...");
+  log("Starting AgentBridge daemon (multi-Claude variant)...");
   log(`Codex app-server: ${codex.appServerUrl}`);
   log(`Codex proxy: ${codex.proxyUrl}`);
   log(`Control server: ws://127.0.0.1:${CONTROL_PORT}/ws`);
@@ -2330,11 +2645,10 @@ async function bootCodex() {
     await codex.start();
     codexBootstrapped = true;
     writeStatusFile();
-    emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));
     broadcastStatus();
   } catch (err) {
     log(`Failed to start Codex: ${err.message}`);
-    emitToClaude(systemMessage("system_codex_start_failed", `\u274C AgentBridge failed to start Codex app-server: ${err.message}`));
+    broadcastToAllClaudes(systemMessage("system_codex_start_failed", `\u274C AgentBridge failed to start Codex app-server: ${err.message}`));
     broadcastStatus();
   }
 }
@@ -2344,7 +2658,19 @@ function shutdown(reason) {
   shuttingDown = true;
   log(`Shutting down daemon (${reason})...`);
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);
-  clearPendingClaudeDisconnect(`daemon shutdown (${reason})`);
+  for (const state of chats.values()) {
+    if (state.attentionWindowTimer)
+      clearTimeout(state.attentionWindowTimer);
+    if (state.disconnectTimer)
+      clearTimeout(state.disconnectTimer);
+    if (state.reaperTimer)
+      clearTimeout(state.reaperTimer);
+    state.statusBuffer.dispose();
+    try {
+      state.thread.close();
+    } catch {}
+  }
+  chats.clear();
   controlServer?.stop();
   controlServer = null;
   codex.stop();
@@ -2369,7 +2695,7 @@ function log(msg) {
 `;
   process.stderr.write(line);
   try {
-    appendFileSync2(stateDir.logFile, line);
+    appendFileSync3(stateDir.logFile, line);
   } catch {}
 }
 if (daemonLifecycle.wasKilled()) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2950,7 +2950,8 @@ async function handleEnsurePair(ws, message) {
         requestId,
         pairId,
         code: err.code,
-        message: err.message
+        message: err.message,
+        ...err.details ? { details: err.details } : {}
       });
       return;
     }
@@ -3660,16 +3661,35 @@ async function ensurePairCore(pairId) {
     attachPairHandlers(pair);
   }
   log(`[pair=${pair.pairId}] ensurePair: starting codex app-server (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl})`);
-  await pair.codex.start();
+  try {
+    await pair.codex.start();
+  } catch (err) {
+    const errCode = err?.code ?? "";
+    const errMsg = err?.message ?? String(err);
+    const looksLikePortBusy = errCode === "EADDRINUSE" || /EADDRINUSE/i.test(errMsg) || /address already in use/i.test(errMsg) || /port.*in use/i.test(errMsg);
+    if (looksLikePortBusy) {
+      let conflictPort;
+      const portMatch = errMsg.match(/(?::|port[\s=]+|address[\s=]+[\w:.]+:)(\d{2,5})/i);
+      if (portMatch) {
+        const candidate = parseInt(portMatch[1], 10);
+        if (Number.isFinite(candidate))
+          conflictPort = candidate;
+      }
+      throw new PairError("PAIR_PORTS_BUSY", `pair "${pair.pairId}" ports (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl}) are held by another process: ${errMsg}`, { conflictPort });
+    }
+    throw err;
+  }
   pair.isLive = true;
   return pair;
 }
 
 class PairError extends Error {
   code;
-  constructor(code, message) {
+  details;
+  constructor(code, message, details) {
     super(message);
     this.code = code;
+    this.details = details;
     this.name = "PairError";
   }
 }

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2379,10 +2379,10 @@ import { readFileSync as readFileSync3, writeFileSync as writeFileSync3, renameS
 import { dirname as dirname2 } from "path";
 import { randomBytes } from "crypto";
 var DEFAULT_PAIR_PORTS = { appPort: 4500, proxyPort: 4501 };
-var STRIDE_BASE = 4510;
-var STRIDE_STEP_DEFAULT = 10;
-var STRIDE_MAX_DEFAULT = 20;
-var MAX_PAIRS_DEFAULT = 8;
+var STRIDE_BASE = parseInt(process.env.AGENTBRIDGE_PAIR_STRIDE_BASE ?? "4510", 10);
+var STRIDE_STEP_DEFAULT = parseInt(process.env.AGENTBRIDGE_PAIR_STRIDE_STEP ?? "10", 10);
+var STRIDE_MAX_DEFAULT = parseInt(process.env.AGENTBRIDGE_PAIR_STRIDE_MAX ?? "20", 10);
+var MAX_PAIRS_DEFAULT = parseInt(process.env.AGENTBRIDGE_PAIR_MAX_PAIRS ?? "8", 10);
 var PAIR_NAME_REGEX = /^[a-z0-9][a-z0-9_-]{0,31}$/;
 function isValidPairName(name) {
   if (typeof name !== "string")
@@ -2827,8 +2827,15 @@ ${payload.content}`,
     codexBootstrapped = false;
     pair.isLive = false;
     pair.tuiConnectionState.handleCodexExit();
-    broadcastToAllClaudes(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`));
+    const affectedChats = [];
     for (const state of chats.values()) {
+      if (state.homePairId !== pair.pairId)
+        continue;
+      affectedChats.push(state);
+    }
+    log(`[pair=${pair.pairId}] codex exit affects ${affectedChats.length}/${chats.size} chats (homed on this pair)`);
+    for (const state of affectedChats) {
+      emitToChat(state, systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server on pair "${pair.pairId}" exited (code ${code ?? "unknown"}). Your thread on this pair was terminated.`));
       try {
         state.thread.close();
       } catch {}

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3167,19 +3167,32 @@ async function attachClaude(ws, requestedChatId, requestedPairId, requestId) {
     broadcastStatus();
     return;
   }
-  if (proxyTuiSlot && proxyTuiSlot.pairedChatId === null) {
-    emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Pairing with the right-pane Codex TUI for shared-thread mode..."));
-    pairChat(state);
-    broadcastStatus();
-    sendProtocolMessage(ws, {
-      type: "claude_connect_result",
-      requestId,
-      ok: true,
-      chatId,
-      homePairId: state.homePairId,
-      paired: state.paired
-    });
-    return;
+  if (!requestedPairId) {
+    for (const [iterPairId, iterPair] of pairs.entries()) {
+      if (!iterPair.isLive)
+        continue;
+      if (!iterPair.proxyTuiSlot)
+        continue;
+      if (iterPair.proxyTuiSlot.pairedChatId !== null)
+        continue;
+      state.homePairId = iterPairId;
+      iterPair.proxyTuiSlot.pairedChatId = chatId;
+      state.paired = true;
+      iterPair.codex.setPairedChat(chatId);
+      state.ready = iterPair.proxyTuiSlot.readiness === "ready";
+      log(`[${chatId}] FIFO-claimed pair "${iterPairId}" (readiness=${iterPair.proxyTuiSlot.readiness})`);
+      emitToChat(state, systemMessageForChat(state, state.ready ? "system_paired_ready" : "system_paired_provisioning", state.ready ? `\u2705 This Claude session is paired with the right-pane Codex TUI on pair "${iterPairId}". Replies will appear there; user typing in the TUI will be forwarded to you with an [IMPORTANT] prefix.` : `\u2705 This Claude session is paired with the right-pane Codex TUI on pair "${iterPairId}". Waiting for the shared thread to finish provisioning before replies can flow.`));
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: true,
+        chatId,
+        homePairId: state.homePairId,
+        paired: state.paired
+      });
+      broadcastStatus();
+      return;
+    }
   }
   emitToChat(state, systemMessage("system_bridge_provisioning", "\u2705 AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
   sendProtocolMessage(ws, {
@@ -3556,6 +3569,15 @@ function currentStatus() {
       attachedClaudes: [...chats.values()].filter((s) => s.homePairId === pair.pairId).map((s) => ({ chatId: s.chatId, paired: s.paired }))
     }))
   };
+}
+function systemMessageForChat(state, idPrefix, content) {
+  if (state.homePairId) {
+    const livePairCount = [...pairs.values()].filter((p) => p.isLive).length;
+    if (livePairCount > 1) {
+      return systemMessage(idPrefix, `[pair: ${state.homePairId}] ${content}`);
+    }
+  }
+  return systemMessage(idPrefix, content);
 }
 function systemMessage(idPrefix, content) {
   return {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3701,13 +3701,24 @@ async function ensurePairCore(pairId) {
     const looksLikePortBusy = errCode === "EADDRINUSE" || /EADDRINUSE/i.test(errMsg) || /address already in use/i.test(errMsg) || /port.*in use/i.test(errMsg);
     if (looksLikePortBusy) {
       let conflictPort;
-      const portMatch = errMsg.match(/(?::|port[\s=]+|address[\s=]+[\w:.]+:)(\d{2,5})/i);
-      if (portMatch) {
-        const candidate = parseInt(portMatch[1], 10);
-        if (Number.isFinite(candidate))
-          conflictPort = candidate;
+      let conflictPid;
+      const checkPortsMatch = errMsg.match(/Port (\d{2,5}) is already in use[^:]*:\s*PID\(s\)\s*([\d,\s]+)/i);
+      if (checkPortsMatch) {
+        const portCandidate = parseInt(checkPortsMatch[1], 10);
+        if (Number.isFinite(portCandidate))
+          conflictPort = portCandidate;
+        const pidCandidate = parseInt(checkPortsMatch[2].split(",")[0]?.trim() ?? "", 10);
+        if (Number.isFinite(pidCandidate))
+          conflictPid = pidCandidate;
+      } else {
+        const portMatch = errMsg.match(/(?::|port[\s=]+|address[\s=]+[\w:.]+:)(\d{2,5})/i);
+        if (portMatch) {
+          const candidate = parseInt(portMatch[1], 10);
+          if (Number.isFinite(candidate))
+            conflictPort = candidate;
+        }
       }
-      throw new PairError("PAIR_PORTS_BUSY", `pair "${pair.pairId}" ports (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl}) are held by another process: ${errMsg}`, { conflictPort });
+      throw new PairError("PAIR_PORTS_BUSY", `pair "${pair.pairId}" ports (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl}) are held by another process: ${errMsg}`, { conflictPort, conflictPid });
     }
     throw err;
   }

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2500,6 +2500,7 @@ ${payload.content}`,
   on("exit", (code) => {
     log(`[pair=${pair.pairId}] Codex app-server process exited (code ${code})`);
     codexBootstrapped = false;
+    pair.isLive = false;
     pair.tuiConnectionState.handleCodexExit();
     broadcastToAllClaudes(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`));
     for (const state of chats.values()) {
@@ -2510,6 +2511,12 @@ ${payload.content}`,
     }
     broadcastStatus();
   });
+}
+function detachPairHandlers(pair) {
+  for (const { eventName, handler } of pair.handlerRefs) {
+    pair.codex.off(eventName, handler);
+  }
+  pair.handlerRefs = [];
 }
 attachPairHandlers(defaultPairState);
 function getPairedChatState() {
@@ -3119,10 +3126,27 @@ async function ensurePair(pairId) {
   }
   if (pair.isLive)
     return pair;
+  if (pair.handlerRefs.length === 0) {
+    log(`[pair=${pair.pairId}] ensurePair: reattaching handlers before start`);
+    attachPairHandlers(pair);
+  }
   log(`[pair=${pair.pairId}] ensurePair: starting codex app-server (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl})`);
   await pair.codex.start();
   pair.isLive = true;
   return pair;
+}
+async function destroyPair(pairId) {
+  const pair = pairs.get(pairId);
+  if (!pair)
+    return;
+  log(`[pair=${pair.pairId}] destroyPair: stopping codex + detaching handlers`);
+  detachPairHandlers(pair);
+  try {
+    pair.codex.stop();
+  } catch (err) {
+    log(`[pair=${pair.pairId}] destroyPair: codex.stop() threw \u2014 ${err?.message ?? err}`);
+  }
+  pair.isLive = false;
 }
 async function bootCodex() {
   log("Starting AgentBridge daemon (multi-Claude variant)...");
@@ -3215,7 +3239,11 @@ var __testing = {
     getPairedChatState,
     createChatState,
     detachClaudeWs,
-    emitToChat
+    emitToChat,
+    attachPairHandlers,
+    detachPairHandlers,
+    ensurePair,
+    destroyPair
   },
   config: {
     PAIR_REAP_MS,

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2284,6 +2284,196 @@ class ConfigService {
   }
 }
 
+// src/pair-registry.ts
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync3, renameSync, mkdirSync as mkdirSync3, existsSync as existsSync4, unlinkSync as unlinkSync2 } from "fs";
+import { dirname } from "path";
+import { randomBytes } from "crypto";
+var DEFAULT_PAIR_PORTS = { appPort: 4500, proxyPort: 4501 };
+var STRIDE_BASE = 4510;
+var STRIDE_STEP_DEFAULT = 10;
+var STRIDE_MAX_DEFAULT = 20;
+var MAX_PAIRS_DEFAULT = 8;
+var PAIR_NAME_REGEX = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+function isValidPairName(name) {
+  if (typeof name !== "string")
+    return false;
+  if (!PAIR_NAME_REGEX.test(name))
+    return false;
+  if (name === "." || name === "..")
+    return false;
+  return true;
+}
+
+class PairRegistry {
+  entries = new Map;
+  filePath;
+  log;
+  strideStep;
+  strideMax;
+  maxPairs;
+  constructor(opts) {
+    this.filePath = opts.filePath;
+    this.log = opts.log ?? (() => {});
+    this.strideStep = opts.strideStep ?? STRIDE_STEP_DEFAULT;
+    this.strideMax = opts.strideMax ?? STRIDE_MAX_DEFAULT;
+    this.maxPairs = opts.maxPairs ?? MAX_PAIRS_DEFAULT;
+  }
+  load() {
+    this.entries.clear();
+    if (!existsSync4(this.filePath)) {
+      this.log(`[pair-registry] no registry file at ${this.filePath} \u2014 starting empty`);
+      return;
+    }
+    let raw;
+    try {
+      raw = readFileSync3(this.filePath, "utf8");
+    } catch (err) {
+      this.log(`[pair-registry] failed to read ${this.filePath}: ${err?.message ?? err} \u2014 starting empty`);
+      return;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      this.log(`[pair-registry] invalid JSON in ${this.filePath}: ${err?.message ?? err} \u2014 starting empty`);
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+      this.log(`[pair-registry] unexpected registry shape (missing version/entries) \u2014 starting empty`);
+      return;
+    }
+    for (const candidate of parsed.entries) {
+      if (this.isValidEntry(candidate)) {
+        this.entries.set(candidate.pairId, candidate);
+      } else {
+        this.log(`[pair-registry] dropping invalid entry: ${JSON.stringify(candidate)}`);
+      }
+    }
+    this.log(`[pair-registry] loaded ${this.entries.size} entries from ${this.filePath}`);
+  }
+  isValidEntry(e) {
+    return e !== null && typeof e === "object" && typeof e.pairId === "string" && isValidPairName(e.pairId) && typeof e.appPort === "number" && typeof e.proxyPort === "number" && Number.isInteger(e.appPort) && Number.isInteger(e.proxyPort) && e.appPort > 0 && e.proxyPort > 0 && e.appPort < 65536 && e.proxyPort < 65536 && typeof e.allocatedAt === "number";
+  }
+  save() {
+    const dir = dirname(this.filePath);
+    if (!existsSync4(dir))
+      mkdirSync3(dir, { recursive: true });
+    const tmp = `${this.filePath}.tmp.${randomBytes(6).toString("hex")}`;
+    const snapshot = {
+      version: 1,
+      entries: [...this.entries.values()]
+    };
+    try {
+      writeFileSync3(tmp, JSON.stringify(snapshot, null, 2), "utf8");
+      renameSync(tmp, this.filePath);
+    } catch (err) {
+      try {
+        if (existsSync4(tmp))
+          unlinkSync2(tmp);
+      } catch {}
+      throw new Error(`[pair-registry] save failed: ${err?.message ?? err}`);
+    }
+  }
+  get(pairId) {
+    return this.entries.get(pairId) ?? null;
+  }
+  list() {
+    return [...this.entries.values()];
+  }
+  has(pairId) {
+    return this.entries.has(pairId);
+  }
+  allocate(pairId) {
+    if (!isValidPairName(pairId)) {
+      return {
+        ok: false,
+        error: {
+          code: "INVALID_PAIR_NAME",
+          message: `pair name "${pairId}" fails validation (regex ${PAIR_NAME_REGEX.source})`
+        }
+      };
+    }
+    const existing = this.entries.get(pairId);
+    if (existing)
+      return { ok: true, entry: existing };
+    if (this.entries.size >= this.maxPairs) {
+      return {
+        ok: false,
+        error: {
+          code: "MAX_PAIRS",
+          message: `pair registry is at the ${this.maxPairs}-entry limit; destroy an unused pair (--forget) before allocating a new one`
+        }
+      };
+    }
+    let appPort;
+    let proxyPort;
+    if (pairId === "default") {
+      appPort = DEFAULT_PAIR_PORTS.appPort;
+      proxyPort = DEFAULT_PAIR_PORTS.proxyPort;
+      for (const other of this.entries.values()) {
+        if (other.appPort === appPort || other.proxyPort === proxyPort) {
+          return {
+            ok: false,
+            error: {
+              code: "ALLOCATION_FAILED",
+              message: `default pair's reserved ports (${appPort}, ${proxyPort}) collide with registry entry "${other.pairId}"`
+            }
+          };
+        }
+      }
+    } else {
+      const usedPorts = new Set;
+      for (const e of this.entries.values()) {
+        usedPorts.add(e.appPort);
+        usedPorts.add(e.proxyPort);
+      }
+      usedPorts.add(DEFAULT_PAIR_PORTS.appPort);
+      usedPorts.add(DEFAULT_PAIR_PORTS.proxyPort);
+      let found = false;
+      appPort = 0;
+      proxyPort = 0;
+      for (let i = 1;i <= this.strideMax; i++) {
+        const candidateApp = STRIDE_BASE + this.strideStep * (i - 1);
+        const candidateProxy = candidateApp + 1;
+        if (!usedPorts.has(candidateApp) && !usedPorts.has(candidateProxy)) {
+          appPort = candidateApp;
+          proxyPort = candidateProxy;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        return {
+          ok: false,
+          error: {
+            code: "ALLOCATION_FAILED",
+            message: `no free stride within ${this.strideMax} positions starting at ${STRIDE_BASE} (step ${this.strideStep})`
+          }
+        };
+      }
+    }
+    const entry = {
+      pairId,
+      appPort,
+      proxyPort,
+      allocatedAt: Date.now()
+    };
+    this.entries.set(pairId, entry);
+    this.log(`[pair-registry] allocated pair="${pairId}" appPort=${appPort} proxyPort=${proxyPort}`);
+    return { ok: true, entry };
+  }
+  remove(pairId) {
+    if (!this.entries.has(pairId))
+      return false;
+    this.entries.delete(pairId);
+    this.log(`[pair-registry] removed pair="${pairId}"`);
+    return true;
+  }
+  size() {
+    return this.entries.size;
+  }
+}
+
 // src/control-protocol.ts
 var CLOSE_CODE_REPLACED = 4001;
 
@@ -2342,6 +2532,39 @@ var defaultPairState = {
   isLive: false
 };
 var pairs = new Map([["default", defaultPairState]]);
+var pairRegistry = new PairRegistry({
+  filePath: `${stateDir.dir}/pairs/registry.json`,
+  log: (msg) => log(msg)
+});
+pairRegistry.load();
+var registryWriteMutex = Promise.resolve();
+async function runUnderRegistryMutex(fn) {
+  const prev = registryWriteMutex;
+  let release;
+  registryWriteMutex = new Promise((resolve) => {
+    release = resolve;
+  });
+  try {
+    await prev.catch(() => {});
+    return await fn();
+  } finally {
+    release(undefined);
+  }
+}
+runUnderRegistryMutex(async () => {
+  if (!pairRegistry.has("default")) {
+    const result = pairRegistry.allocate("default");
+    if (result.ok) {
+      try {
+        pairRegistry.save();
+      } catch (err) {
+        log(`[pair-registry] failed to persist default entry: ${err?.message ?? err}`);
+      }
+    } else {
+      log(`[pair-registry] failed to materialize default entry: ${result.error.code} \u2014 ${result.error.message}`);
+    }
+  }
+});
 function attachPairHandlers(pair) {
   if (pair.handlerRefs.length > 0) {
     log(`[pair=${pair.pairId}] attachPairHandlers called but ${pair.handlerRefs.length} handler(s) already attached \u2014 no-op`);
@@ -2676,7 +2899,186 @@ function handleControlMessage(ws, raw) {
     case "claude_to_codex":
       handleClaudeToCodex(ws, message);
       return;
+    case "ensure_pair":
+      handleEnsurePair(ws, message);
+      return;
+    case "destroy_pair":
+      handleDestroyPair(ws, message);
+      return;
+    case "list_pairs":
+      handleListPairs(ws, message);
+      return;
   }
+}
+async function handleEnsurePair(ws, message) {
+  const { requestId, pairId } = message;
+  if (!isValidPairName(pairId)) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "INVALID_PAIR_NAME",
+      message: `pair name "${pairId}" fails validation`
+    });
+    return;
+  }
+  const allocResult = await runUnderRegistryMutex(async () => {
+    if (pairRegistry.has(pairId)) {
+      return { ok: true, entry: pairRegistry.get(pairId) };
+    }
+    const result = pairRegistry.allocate(pairId);
+    if (result.ok) {
+      try {
+        pairRegistry.save();
+      } catch (err) {
+        log(`[ensure_pair=${pairId}] registry save failed: ${err?.message ?? err}`);
+      }
+    }
+    return result;
+  });
+  if (!allocResult.ok) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: allocResult.error.code,
+      message: allocResult.error.message
+    });
+    return;
+  }
+  const { appPort, proxyPort } = allocResult.entry;
+  if (pairId !== "default") {
+    log(`[ensure_pair=${pairId}] registry entry allocated (appPort=${appPort}, proxyPort=${proxyPort}); activation deferred to P3c`);
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "ALLOCATION_FAILED",
+      message: `pair "${pairId}" registry entry allocated (appPort=${appPort}, proxyPort=${proxyPort}) but non-default pair activation is not implemented in P3b \u2014 lands in P3c`
+    });
+    return;
+  }
+  try {
+    const pair = await ensurePair("default");
+    sendProtocolMessage(ws, {
+      type: "pair_ensured",
+      requestId,
+      pairId,
+      appServerUrl: pair.codex.appServerUrl,
+      proxyUrl: pair.codex.proxyUrl,
+      isLive: true
+    });
+  } catch (err) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "ALLOCATION_FAILED",
+      message: `ensurePair("default") failed: ${err?.message ?? err}`
+    });
+  }
+}
+async function handleDestroyPair(ws, message) {
+  const { requestId, pairId, forget, force } = message;
+  if (!isValidPairName(pairId)) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "INVALID_PAIR_NAME",
+      message: `pair name "${pairId}" fails validation`
+    });
+    return;
+  }
+  const pair = pairs.get(pairId);
+  const inRegistry = pairRegistry.has(pairId);
+  if (!pair && !inRegistry) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "PAIR_NOT_FOUND",
+      message: `pair "${pairId}" not found (neither live nor registered)`
+    });
+    return;
+  }
+  if (pair?.proxyTuiSlot?.pairedChatId && !force) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "PAIR_BUSY_NOT_FORCED",
+      message: `pair "${pairId}" has paired chat "${pair.proxyTuiSlot.pairedChatId}"; pass force:true to tear down anyway`
+    });
+    return;
+  }
+  let wasLive = false;
+  if (pair?.isLive) {
+    wasLive = true;
+    try {
+      await destroyPair(pairId);
+    } catch (err) {
+      log(`[destroy_pair=${pairId}] internal destroyPair threw: ${err?.message ?? err}`);
+    }
+  }
+  let registryEntryRemoved = false;
+  if (forget) {
+    await runUnderRegistryMutex(async () => {
+      if (pairRegistry.remove(pairId)) {
+        registryEntryRemoved = true;
+        try {
+          pairRegistry.save();
+        } catch (err) {
+          log(`[destroy_pair=${pairId}] registry save failed: ${err?.message ?? err}`);
+        }
+      }
+    });
+  }
+  sendProtocolMessage(ws, {
+    type: "pair_destroyed",
+    requestId,
+    pairId,
+    wasLive,
+    registryEntryRemoved
+  });
+}
+function handleListPairs(ws, message) {
+  const seen = new Set;
+  const result = [];
+  for (const pair of pairs.values()) {
+    seen.add(pair.pairId);
+    result.push({
+      pairId: pair.pairId,
+      isLive: pair.isLive,
+      appServerUrl: pair.codex.appServerUrl,
+      proxyUrl: pair.codex.proxyUrl,
+      tuiConnected: pair.tuiConnectionState.snapshot().tuiConnected,
+      proxyTuiConnected: pair.proxyTuiSlot !== null,
+      pairedChatId: pair.proxyTuiSlot?.pairedChatId ?? null,
+      threadId: pair.codex.activeThreadId,
+      attachedClaudes: [...chats.values()].filter((s) => s.homePairId === pair.pairId).map((s) => ({ chatId: s.chatId, paired: s.paired }))
+    });
+  }
+  for (const entry of pairRegistry.list()) {
+    if (seen.has(entry.pairId))
+      continue;
+    result.push({
+      pairId: entry.pairId,
+      isLive: false,
+      appServerUrl: `ws://127.0.0.1:${entry.appPort}`,
+      proxyUrl: `ws://127.0.0.1:${entry.proxyPort}`,
+      tuiConnected: false,
+      proxyTuiConnected: false,
+      pairedChatId: null,
+      threadId: null,
+      attachedClaudes: []
+    });
+  }
+  sendProtocolMessage(ws, {
+    type: "pair_list",
+    requestId: message.requestId,
+    pairs: result
+  });
 }
 async function attachClaude(ws, requestedChatId) {
   const chatId = requestedChatId ?? `auto_${ws.data.clientId}_${Date.now()}`;
@@ -3254,8 +3656,13 @@ var __testing = {
     attachPairHandlers,
     detachPairHandlers,
     ensurePair,
-    destroyPair
+    destroyPair,
+    handleEnsurePair,
+    handleDestroyPair,
+    handleListPairs
   },
+  pairRegistry,
+  runUnderRegistryMutex,
   config: {
     PAIR_REAP_MS,
     CLAUDE_REAP_AFTER_MS,

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1,18 +1,72 @@
 #!/usr/bin/env bun
 // @bun
 
-// src/daemon.ts
-import { appendFileSync as appendFileSync3 } from "fs";
+// src/log-writer.ts
+import { createWriteStream, mkdirSync, existsSync } from "fs";
+import { dirname } from "path";
+var writers = new Map;
+function getStream(filePath) {
+  const existing = writers.get(filePath);
+  if (existing && !existing.destroyed)
+    return existing;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    try {
+      mkdirSync(dir, { recursive: true });
+    } catch {}
+  }
+  const stream = createWriteStream(filePath, { flags: "a" });
+  stream.on("error", (err) => {
+    process.stderr.write(`[log-writer] write error on ${filePath}: ${err.message}
+`);
+  });
+  writers.set(filePath, stream);
+  return stream;
+}
+function getAsyncFileLogger(filePath) {
+  return {
+    write(line) {
+      const stream = getStream(filePath);
+      try {
+        stream.write(line);
+      } catch (err) {
+        process.stderr.write(`[log-writer] sync write failed on ${filePath}: ${err?.message ?? err}
+`);
+      }
+    },
+    close() {
+      return new Promise((resolve) => {
+        const stream = writers.get(filePath);
+        if (!stream || stream.destroyed) {
+          resolve();
+          return;
+        }
+        writers.delete(filePath);
+        stream.end(() => resolve());
+      });
+    }
+  };
+}
+async function closeAllAsyncFileLoggers() {
+  const all = [...writers.entries()];
+  writers.clear();
+  await Promise.all(all.map(([_path, stream]) => new Promise((resolve) => {
+    if (stream.destroyed) {
+      resolve();
+      return;
+    }
+    stream.end(() => resolve());
+  })));
+}
 
 // src/codex-adapter.ts
 import { spawn, execSync } from "child_process";
 import { createInterface } from "readline";
 import { EventEmitter } from "events";
-import { appendFileSync } from "fs";
 import { createHash } from "crypto";
 
 // src/state-dir.ts
-import { mkdirSync, existsSync } from "fs";
+import { mkdirSync as mkdirSync2, existsSync as existsSync2 } from "fs";
 import { join } from "path";
 import { homedir, platform } from "os";
 
@@ -30,8 +84,8 @@ class StateDirResolver {
     }
   }
   ensure() {
-    if (!existsSync(this.stateDir)) {
-      mkdirSync(this.stateDir, { recursive: true });
+    if (!existsSync2(this.stateDir)) {
+      mkdirSync2(this.stateDir, { recursive: true });
     }
   }
   get dir() {
@@ -72,8 +126,8 @@ class StateDirResolver {
   }
   ensurePairDir(pairId) {
     const dir = this.pairDir(pairId);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
+    if (!existsSync2(dir)) {
+      mkdirSync2(dir, { recursive: true });
     }
   }
 }
@@ -846,7 +900,7 @@ class CodexAdapter extends EventEmitter {
           try {
             this.appServerWs.send(forwardedResponse);
             this.serverRequestToProxy.delete(normalizedId);
-            this.log(`TUI \u2192 app-server: ${pending.method} response (proxy id=${normalizedId} \u2192 server id=${pending.serverId})`);
+            this.proxyLog(`TUI \u2192 app-server: ${pending.method} response (proxy id=${normalizedId} \u2192 server id=${pending.serverId})`);
           } catch (e) {
             this.bufferPendingServerResponse(normalizedId, pending, forwardedResponse, `send failed: ${e.message}`);
           }
@@ -888,7 +942,7 @@ class CodexAdapter extends EventEmitter {
     try {
       const parsed = JSON.parse(data);
       const method = parsed.method ?? `response:${parsed.id}`;
-      this.log(`TUI \u2192 app-server: ${method}`);
+      this.proxyLog(`TUI \u2192 app-server: ${method}`);
       if (parsed.id !== undefined && parsed.method) {
         const proxyId = this.nextProxyId++;
         this.upstreamToClient.set(proxyId, { connId, clientId: parsed.id });
@@ -899,7 +953,7 @@ class CodexAdapter extends EventEmitter {
         this.trackPendingRequest(parsed, connId);
       }
     } catch {
-      this.log(`TUI \u2192 app-server: (unparseable)`);
+      this.proxyLog(`TUI \u2192 app-server: (unparseable)`);
     }
     if (this.appServerWs?.readyState === WebSocket.OPEN) {
       this.appServerWs.send(forwarded);
@@ -1015,7 +1069,7 @@ class CodexAdapter extends EventEmitter {
         return null;
       }
       parsed.id = mapping.clientId;
-      this.log(`app-server \u2192 TUI: response (proxy id=${numericId} \u2192 client id=${String(mapping.clientId)}, conn #${mapping.connId})`);
+      this.proxyLog(`app-server \u2192 TUI: response (proxy id=${numericId} \u2192 client id=${String(mapping.clientId)}, conn #${mapping.connId})`);
       const forwarded = this.patchResponse(parsed, JSON.stringify(parsed));
       this.interceptServerMessage(parsed, mapping.connId);
       return forwarded;
@@ -1035,9 +1089,9 @@ class CodexAdapter extends EventEmitter {
         this.pendingInjectionByReqId.delete(numericId);
         if (typeof turnId === "string" && turnId.length > 0) {
           this.recordInjectedTurnId(turnId, contentHash);
-          this.log(`Bridge-originated request completed (id ${responseId}, turnId=${turnId} dedup)`);
+          this.proxyLog(`Bridge-originated request completed (id ${responseId}, turnId=${turnId} dedup)`);
         } else {
-          this.log(`Bridge-originated request completed (id ${responseId}, no turnId \u2014 falling back to content-hash dedup)`);
+          this.proxyLog(`Bridge-originated request completed (id ${responseId}, no turnId \u2014 falling back to content-hash dedup)`);
         }
       }
       return null;
@@ -1417,19 +1471,27 @@ class CodexAdapter extends EventEmitter {
       }
     }
   }
+  _logger = null;
+  get logger() {
+    if (!this._logger)
+      this._logger = getAsyncFileLogger(this.logFile);
+    return this._logger;
+  }
   log(msg) {
     const line = `[${new Date().toISOString()}] [CodexAdapter] ${msg}
 `;
     process.stderr.write(line);
-    try {
-      appendFileSync(this.logFile, line);
-    } catch {}
+    this.logger.write(line);
   }
+  proxyLog(msg) {
+    if (CodexAdapter.DEBUG_PROXY)
+      this.log(msg);
+  }
+  static DEBUG_PROXY = process.env.AGENTBRIDGE_DEBUG_PROXY === "1";
 }
 
 // src/claude-thread.ts
 import { EventEmitter as EventEmitter2 } from "events";
-import { appendFileSync as appendFileSync2 } from "fs";
 var RPC_TIMEOUT_MS = 30000;
 
 class ClaudeThread extends EventEmitter2 {
@@ -1732,13 +1794,17 @@ class ClaudeThread extends EventEmitter2 {
       this.log(`failed to send server-request response: ${err?.message ?? err}`);
     }
   }
+  _logger = null;
+  get logger() {
+    if (!this._logger)
+      this._logger = getAsyncFileLogger(this.logFile);
+    return this._logger;
+  }
   log(s) {
     const line = `[${new Date().toISOString()}] [ClaudeThread:${this.chatId}] ${s}
 `;
     process.stderr.write(line);
-    try {
-      appendFileSync2(this.logFile, line);
-    } catch {}
+    this.logger.write(line);
   }
 }
 
@@ -1945,7 +2011,7 @@ class TuiConnectionState {
 
 // src/daemon-lifecycle.ts
 import { spawn as spawn2, execFileSync } from "child_process";
-import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
+import { existsSync as existsSync3, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
@@ -2083,7 +2149,7 @@ class DaemonLifecycle {
     } catch {}
   }
   wasKilled() {
-    return existsSync2(this.stateDir.killedFile);
+    return existsSync3(this.stateDir.killedFile);
   }
   launch() {
     this.stateDir.ensure();
@@ -2205,7 +2271,7 @@ function isProcessAlive(pid) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, existsSync as existsSync3 } from "fs";
+import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, existsSync as existsSync4 } from "fs";
 import { join as join2 } from "path";
 var DEFAULT_CONFIG = {
   version: "1.0",
@@ -2262,7 +2328,7 @@ class ConfigService {
     this.configPath = join2(this.configDir, CONFIG_FILE);
   }
   hasConfig() {
-    return existsSync3(this.configPath);
+    return existsSync4(this.configPath);
   }
   load() {
     try {
@@ -2283,7 +2349,7 @@ class ConfigService {
   initDefaults() {
     this.ensureConfigDir();
     const created = [];
-    if (!existsSync3(this.configPath)) {
+    if (!existsSync4(this.configPath)) {
       this.save(DEFAULT_CONFIG);
       created.push(this.configPath);
     }
@@ -2293,15 +2359,15 @@ class ConfigService {
     return this.configPath;
   }
   ensureConfigDir() {
-    if (!existsSync3(this.configDir)) {
-      mkdirSync2(this.configDir, { recursive: true });
+    if (!existsSync4(this.configDir)) {
+      mkdirSync3(this.configDir, { recursive: true });
     }
   }
 }
 
 // src/pair-registry.ts
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync3, renameSync, mkdirSync as mkdirSync3, existsSync as existsSync4, unlinkSync as unlinkSync2 } from "fs";
-import { dirname } from "path";
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync3, renameSync, mkdirSync as mkdirSync4, existsSync as existsSync5, unlinkSync as unlinkSync2 } from "fs";
+import { dirname as dirname2 } from "path";
 import { randomBytes } from "crypto";
 var DEFAULT_PAIR_PORTS = { appPort: 4500, proxyPort: 4501 };
 var STRIDE_BASE = 4510;
@@ -2335,7 +2401,7 @@ class PairRegistry {
   }
   load() {
     this.entries.clear();
-    if (!existsSync4(this.filePath)) {
+    if (!existsSync5(this.filePath)) {
       this.log(`[pair-registry] no registry file at ${this.filePath} \u2014 starting empty`);
       return;
     }
@@ -2370,9 +2436,9 @@ class PairRegistry {
     return e !== null && typeof e === "object" && typeof e.pairId === "string" && isValidPairName(e.pairId) && typeof e.appPort === "number" && typeof e.proxyPort === "number" && Number.isInteger(e.appPort) && Number.isInteger(e.proxyPort) && e.appPort > 0 && e.proxyPort > 0 && e.appPort < 65536 && e.proxyPort < 65536 && typeof e.allocatedAt === "number";
   }
   save() {
-    const dir = dirname(this.filePath);
-    if (!existsSync4(dir))
-      mkdirSync3(dir, { recursive: true });
+    const dir = dirname2(this.filePath);
+    if (!existsSync5(dir))
+      mkdirSync4(dir, { recursive: true });
     const tmp = `${this.filePath}.tmp.${randomBytes(6).toString("hex")}`;
     const snapshot = {
       version: 1,
@@ -2383,7 +2449,7 @@ class PairRegistry {
       renameSync(tmp, this.filePath);
     } catch (err) {
       try {
-        if (existsSync4(tmp))
+        if (existsSync5(tmp))
           unlinkSync2(tmp);
       } catch {}
       throw new Error(`[pair-registry] save failed: ${err?.message ?? err}`);
@@ -2495,6 +2561,7 @@ var CLOSE_CODE_REPLACED = 4001;
 // src/daemon.ts
 var stateDir = new StateDirResolver;
 stateDir.ensure();
+var daemonLogger = getAsyncFileLogger(stateDir.logFile);
 var configService = new ConfigService;
 var config = configService.loadOrDefault();
 var CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.codex.appPort), 10);
@@ -3807,7 +3874,7 @@ function shutdown(reason) {
   codex.stop();
   removePidFile();
   removeStatusFile();
-  process.exit(0);
+  closeAllAsyncFileLoggers().then(() => process.exit(0)).catch(() => process.exit(0));
 }
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
@@ -3825,9 +3892,7 @@ function log(msg) {
   const line = `[${new Date().toISOString()}] [AgentBridgeDaemon] ${msg}
 `;
   process.stderr.write(line);
-  try {
-    appendFileSync3(stateDir.logFile, line);
-  } catch {}
+  daemonLogger.write(line);
 }
 function startDaemon() {
   if (daemonLifecycle.wasKilled()) {

--- a/probes/multi-pair/README.md
+++ b/probes/multi-pair/README.md
@@ -1,0 +1,174 @@
+# Multi-pair probes (STM v2.3 §10)
+
+Manual end-to-end probe scripts for verifying STM v2.3 multi-pair
+behavior against a live daemon. Run each probe against a fresh
+`abg kill && bun src/daemon.ts` daemon.
+
+**Status**: spec drafted, implementation pending. The harness work
+(spawning daemon + multiple codex app-servers + control-WS coordination)
+is substantial — likely a follow-up effort modeled after
+`probes/shared-thread/lib.ts` (686 lines).
+
+This README freezes the probe specs so the implementation work has a
+concrete target.
+
+## Probes
+
+### M01 — two pairs, two Claudes, independent communication
+
+Setup:
+- `abg codex --pair work --via-proxy`
+- `abg codex --pair side --via-proxy`
+- Claude #1 attaches with no pairId → FIFO claims `work`
+- Claude #2 attaches with no pairId → FIFO claims `side`
+
+Asserts:
+- Each pair has its own threadId (different from the other)
+- Message sent in Claude #1's reply appears in `work`'s TUI but NOT
+  in `side`'s TUI
+- User typed in `side`'s TUI reaches Claude #2 but NOT Claude #1
+- `abg pairs ls` shows both as live + paired
+
+### M02 — kill one pair's codex, other survives (crash isolation)
+
+Setup: M01 setup, both pairs healthy.
+
+Action: `kill -9` work's codex app-server PID directly.
+
+Asserts:
+- `work`'s chats see `system_codex_exit`
+- `side`'s chats keep responding to messages
+- `abg pairs ls` shows `work` isLive=false, `side` isLive=true
+- Subsequent `abg codex --pair work --via-proxy` re-spawns work
+  cleanly using the same registered ports
+
+### M03 — `abg codex --pair work --via-proxy` rejects second invocation
+
+Action: run `abg codex --pair work --via-proxy` twice in series.
+
+Asserts:
+- Second invocation exits 1 with message scoped to pair "work"
+- First TUI keeps running
+- `abg codex --pair side --via-proxy` (different pair) succeeds in
+  parallel
+
+### M04 — explicit pair attach when not live
+
+Setup: daemon up, no pairs ensured yet.
+
+Action: Claude attaches with `AGENTBRIDGE_PAIR=ghost-pair`.
+
+Asserts:
+- `claude_connect_result { ok:false, error: "PAIR_NOT_FOUND" }`
+- Bridge enters disabled state with `daemon_rejected_attach`
+- System message includes the pair name + actionable instruction
+
+### M05 — 3 Claudes, 2 pairs live, FIFO claim
+
+Setup:
+- Two pairs ensured (`default`, `work`) with `--via-proxy` TUIs.
+- Three Claudes attach in sequence WITHOUT `AGENTBRIDGE_PAIR`.
+
+Asserts:
+- Claude #1 claims `default` (insertion order first)
+- Claude #2 claims `work`
+- Claude #3 attaches as isolated (no free pair) against default's
+  app-server, with own thread
+
+### M06 — destroy_pair --force on a paired-live pair mid-turn
+
+Setup: pair "work" live with paired Claude mid-turn.
+
+Action: `abg pairs rm work --force --forget`
+
+Asserts:
+- Paired Claude receives `system_pair_torn_down`
+- transitionToIsolated runs → fresh ClaudeThread on default's
+  app-server (or reap with "reconnect" instruction if default is
+  also gone)
+- Pair removed from `pairs` Map; registry entry removed
+- `abg pairs ls` no longer shows `work`
+
+### M07 — PAIR_PORTS_BUSY recovery
+
+Setup: pair "work" was previously live, then `abg kill` killed daemon
++ codex. Start an unrelated process on port 4510 (`work`'s registered
+appPort).
+
+Action: `abg codex --pair work --via-proxy`
+
+Asserts:
+- CLI exits with `PAIR_PORTS_BUSY` message
+- `conflictPort: 4510` shown
+- `conflictPid: <unrelated process PID>` shown (per P5c)
+- Recovery: `abg pairs rm work --forget` succeeds, then
+  `abg codex --pair work --via-proxy` allocates new ports and works
+
+### M08 — daemon restart with registry persisted
+
+Setup: pairs `default`, `work`, `side` previously ensured. Run
+`abg kill && bun src/daemon.ts` to restart daemon.
+
+Asserts:
+- Registry survives in `pairs/registry.json`
+- After restart, `abg pairs ls` shows all 3 with isLive=false
+  (registry-only entries)
+- `abg codex --pair work --via-proxy` rehydrates `work` using the
+  SAME ports as before (registry reused)
+
+### M09 — concurrent ensure_pair("work") dedup
+
+Setup: daemon up, no pairs live yet.
+
+Action: from two separate processes, simultaneously open control WS
+and send `ensure_pair("work")` with different requestIds.
+
+Asserts:
+- Both receive `pair_ensured` with the same URLs
+- daemon spawns work's CodexAdapter exactly once (verified via
+  `ps` count — should be 1, not 2)
+
+### M10 — `abg pairs ls` output formatting
+
+Setup: 3 pairs live with various paired/isolated chat counts.
+
+Asserts:
+- Table renders with proper column alignment
+- LIVE column shows ● vs ○ correctly
+- PAIRED-CHAT column shows chatId or `-`
+- CHATS column reflects attachedClaudes count
+
+### M11 — `abg pairs rm work --force` while paired
+
+Setup: pair "work" live with paired Claude.
+
+Action: `abg pairs rm work` (no `--force`)
+
+Asserts:
+- Exits with `PAIR_BUSY_NOT_FORCED` message
+- Pair untouched
+
+Action: `abg pairs rm work --force`
+
+Asserts: same as M06.
+
+### M12 — crash isolation smoke (any code path throws)
+
+Setup: 3 live pairs.
+
+Action: inject a thrown exception into one pair's `agentMessage` handler.
+
+Asserts:
+- Daemon's `uncaughtException` handler logs but doesn't crash
+- Other 2 pairs continue serving messages
+
+## Implementation notes
+
+When implementing, reuse the v2.2 `probes/shared-thread/lib.ts` harness
+pattern. Specifically:
+
+- `ProbeOptions` with `basePort` offset to avoid colliding with the
+  developer's running daemon
+- `startManagedDaemon()` spawn + `await waitForHealth()` synchronization
+- Cleanup hook that walks every pair's codex.pid and kills the lot
+- Per-probe state dir under `/tmp/agentbridge-multi-pair-probe-<name>`

--- a/probes/shared-thread/README.md
+++ b/probes/shared-thread/README.md
@@ -1,0 +1,39 @@
+# Shared-thread probes
+
+These probes target `docs/shared-thread-mode-spec.md` v2.2.
+
+Run from the package root:
+
+```bash
+bun probes/shared-thread/p05-secondary-picker-token.ts
+```
+
+`p08b-same-chat-after-pair-reap.ts` is the regression probe for reconnecting
+with the same `chatId` after `AGENTBRIDGE_PAIR_REAP_MS` expires. Expected
+behavior: the old paired chat state was reaped, so the reconnect is treated as a
+fresh attach and can claim the open proxy TUI slot again.
+
+Defaults:
+
+- daemon entry: `plugins/agentbridge/server/daemon.js`
+- ports: `4820`, `4821`, `4822`
+- state dir: `/tmp/agentbridge-shared-thread-<probe>-<pid>`
+
+Useful overrides:
+
+```bash
+AGENTBRIDGE_DAEMON_ENTRY=src/daemon.ts bun probes/shared-thread/p05-secondary-picker-token.ts
+ABG_PROBE_BASE_PORT=4920 bun probes/shared-thread/p01-tui-first-claude-pairs.ts
+```
+
+P5 is the gating discriminator probe. It verifies the daemon accepts a same-token
+secondary connection and rejects a foreign token using the same bearer-token path
+that `agentbridge codex --via-proxy` passes to codex-rs through
+`--remote-auth-token-env`. It does not itself drive the interactive codex-rs
+picker UI.
+
+P12 and P13 are best-effort live fault probes because codex-rs does not expose a
+test-only way to synthesize `turn/completed` without output or a top-level
+`error` notification. P14 is intentionally a source-level micro-probe for the
+pre-response echo race, which is not deterministic enough to force through a
+real app-server.

--- a/probes/shared-thread/lib.ts
+++ b/probes/shared-thread/lib.ts
@@ -1,0 +1,686 @@
+#!/usr/bin/env bun
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+
+export type Json = Record<string, any>;
+
+export interface BridgeMessage {
+  id: string;
+  source: "claude" | "codex";
+  content: string;
+  timestamp: number;
+}
+
+export interface ControlResult {
+  requestId: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface ProbeOptions {
+  name: string;
+  basePort?: number;
+  pairReapMs?: number;
+  daemonEntry?: string;
+  extraEnv?: Record<string, string>;
+}
+
+const DEFAULT_BASE_PORT = Number(process.env.ABG_PROBE_BASE_PORT ?? "4820");
+const DEFAULT_TIMEOUT_MS = Number(process.env.ABG_PROBE_TIMEOUT_MS ?? "120000");
+const DEFAULT_CWD = process.env.ABG_PROBE_CWD ?? "/tmp/agentbridge-shared-thread-cwd";
+
+export class ProbeFailure extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProbeFailure";
+  }
+}
+
+export function makeToken(prefix = "abg"): string {
+  return `${prefix}_${randomBytes(8).toString("hex")}`;
+}
+
+export function sha1_16(text: string): string {
+  return createHash("sha1").update(text).digest("hex").slice(0, 16);
+}
+
+export function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new ProbeFailure(message);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new ProbeFailure(`${label} timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export function rawDataToString(data: unknown): string {
+  if (typeof data === "string") return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf-8");
+  if (ArrayBuffer.isView(data)) return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf-8");
+  return String(data);
+}
+
+export function parseMaybeJson(data: unknown): Json | null {
+  try {
+    const value = JSON.parse(rawDataToString(data));
+    return value && typeof value === "object" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function extractItemText(item: any): string {
+  if (!item || typeof item !== "object") return "";
+  if (typeof item.text === "string") return item.text;
+  if (Array.isArray(item.content)) {
+    return item.content
+      .map((part: any) => {
+        if (typeof part?.text === "string") return part.text;
+        if (typeof part?.content === "string") return part.content;
+        return "";
+      })
+      .join("");
+  }
+  return "";
+}
+
+export function marker(name: string): string {
+  return `agentbridge-${name}-${randomBytes(4).toString("hex")}`;
+}
+
+function formatArgs(args: string[]): string {
+  return args.map((arg) => (/\s/.test(arg) ? JSON.stringify(arg) : arg)).join(" ");
+}
+
+export class SharedThreadProbe {
+  readonly name: string;
+  readonly stateDir: string;
+  readonly cwd: string;
+  readonly appPort: number;
+  readonly proxyPort: number;
+  readonly controlPort: number;
+  readonly controlUrl: string;
+  readonly proxyUrl: string;
+  readonly appServerUrl: string;
+  readonly startedAt = Date.now();
+
+  private daemon: ChildProcess | null = null;
+  private daemonLogChunks: string[] = [];
+  private readonly pairReapMs: number;
+  private readonly daemonEntry: string;
+  private readonly extraEnv: Record<string, string>;
+
+  constructor(options: ProbeOptions) {
+    this.name = options.name;
+    const base = options.basePort ?? DEFAULT_BASE_PORT;
+    this.appPort = base;
+    this.proxyPort = base + 1;
+    this.controlPort = base + 2;
+    this.controlUrl = `ws://127.0.0.1:${this.controlPort}/ws`;
+    this.proxyUrl = `ws://127.0.0.1:${this.proxyPort}`;
+    this.appServerUrl = `ws://127.0.0.1:${this.appPort}`;
+    this.stateDir = `/tmp/agentbridge-shared-thread-${this.name}-${process.pid}`;
+    this.cwd = `${DEFAULT_CWD}-${this.name}`;
+    this.pairReapMs = options.pairReapMs ?? Number(process.env.AGENTBRIDGE_PAIR_REAP_MS ?? "30000");
+    this.daemonEntry =
+      options.daemonEntry ??
+      process.env.AGENTBRIDGE_DAEMON_ENTRY ??
+      `${import.meta.dir}/../../plugins/agentbridge/server/daemon.js`;
+    this.extraEnv = options.extraEnv ?? {};
+  }
+
+  log(message: string): void {
+    const elapsed = Date.now() - this.startedAt;
+    process.stderr.write(`[${elapsed.toString().padStart(6)}ms] [${this.name}] ${message}\n`);
+  }
+
+  async startDaemon(): Promise<void> {
+    rmSync(this.stateDir, { recursive: true, force: true });
+    mkdirSync(this.stateDir, { recursive: true });
+    mkdirSync(this.cwd, { recursive: true });
+
+    const env = {
+      ...process.env,
+      AGENTBRIDGE_STATE_DIR: this.stateDir,
+      CODEX_WS_PORT: String(this.appPort),
+      CODEX_PROXY_PORT: String(this.proxyPort),
+      AGENTBRIDGE_CONTROL_PORT: String(this.controlPort),
+      AGENTBRIDGE_IDLE_SHUTDOWN_MS: "300000",
+      AGENTBRIDGE_FILTER_MODE: "full",
+      AGENTBRIDGE_PAIR_REAP_MS: String(this.pairReapMs),
+      AGENTBRIDGE_PAIR_RACE_MS: "0",
+      ...this.extraEnv,
+    };
+
+    this.log(`spawning daemon: bun ${this.daemonEntry}`);
+    this.daemon = spawn("bun", [this.daemonEntry], {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    this.daemon.stdout?.on("data", (chunk: Buffer) => this.captureDaemon("out", chunk));
+    this.daemon.stderr?.on("data", (chunk: Buffer) => this.captureDaemon("err", chunk));
+    this.daemon.on("exit", (code, signal) => {
+      this.log(`daemon exited code=${code ?? "null"} signal=${signal ?? "null"}`);
+    });
+
+    await this.waitReady();
+  }
+
+  private captureDaemon(stream: "out" | "err", chunk: Buffer): void {
+    const text = chunk.toString("utf-8");
+    this.daemonLogChunks.push(text);
+    for (const line of text.split("\n")) {
+      if (line.trim()) process.stderr.write(`[daemon:${stream}] ${line}\n`);
+    }
+  }
+
+  async waitReady(timeoutMs = 60_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(`http://127.0.0.1:${this.controlPort}/readyz`);
+        if (res.ok) {
+          this.log("daemon /readyz ok");
+          return;
+        }
+      } catch {}
+      await sleep(300);
+    }
+    throw new ProbeFailure(`daemon did not become ready on ${this.controlPort} within ${timeoutMs}ms`);
+  }
+
+  async status(): Promise<Json> {
+    const res = await fetch(`http://127.0.0.1:${this.controlPort}/healthz`);
+    assert(res.ok, `/healthz returned ${res.status}`);
+    return await res.json();
+  }
+
+  async connectTui(token: string, name = "tui", options?: TuiOptions): Promise<TuiClient> {
+    const client = new TuiClient(this, name, this.proxyUrl, options, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    await client.connect();
+    return client;
+  }
+
+  async connectProxyRaw(url: string, name = "raw", options?: RawWsOptions): Promise<RawWsClient> {
+    const client = new RawWsClient(this, name, url, options);
+    await client.connect();
+    return client;
+  }
+
+  async connectClaude(chatId: string): Promise<ClaudeClient> {
+    const client = new ClaudeClient(this, chatId);
+    await client.connect();
+    return client;
+  }
+
+  daemonLog(): string {
+    const fromMemory = this.daemonLogChunks.join("");
+    const logPath = `${this.stateDir}/agentbridge.log`;
+    if (!existsSync(logPath)) return fromMemory;
+    return `${fromMemory}\n${readFileSync(logPath, "utf-8")}`;
+  }
+
+  async stop(): Promise<void> {
+    const proc = this.daemon;
+    this.daemon = null;
+    if (!proc) return;
+    this.log("stopping daemon");
+    try { proc.kill("SIGTERM"); } catch {}
+    await sleep(1200);
+    try { proc.kill("SIGKILL"); } catch {}
+  }
+}
+
+export class RawWsClient {
+  readonly messages: Json[] = [];
+  readonly closes: Array<{ code: number; reason: string }> = [];
+  ws: WebSocket | null = null;
+
+  constructor(
+    protected readonly probe: SharedThreadProbe,
+    readonly name: string,
+    readonly url: string,
+    private readonly wsOptions: RawWsOptions = {},
+  ) {}
+
+  connect(timeoutMs = 20_000): Promise<void> {
+    return withTimeout(new Promise<void>((resolve, reject) => {
+      const ws = this.wsOptions.headers
+        ? new WebSocket(this.url, { headers: this.wsOptions.headers } as any)
+        : new WebSocket(this.url);
+      this.ws = ws;
+      let settled = false;
+      ws.onopen = () => {
+        settled = true;
+        this.probe.log(`[${this.name}] WS open ${this.url}`);
+        resolve();
+      };
+      ws.onerror = () => {
+        if (!settled) reject(new ProbeFailure(`[${this.name}] WS error during connect`));
+      };
+      ws.onclose = (event) => {
+        this.closes.push({ code: event.code, reason: event.reason });
+        this.probe.log(`[${this.name}] WS closed code=${event.code} reason=${event.reason || "-"}`);
+        if (!settled) {
+          settled = true;
+          reject(new ProbeFailure(`[${this.name}] WS closed during connect code=${event.code} reason=${event.reason}`));
+        }
+      };
+      ws.onmessage = (event) => {
+        const parsed = parseMaybeJson(event.data);
+        if (parsed) this.messages.push(parsed);
+        this.onMessage(parsed, rawDataToString(event.data));
+      };
+    }), timeoutMs, `${this.name} connect`);
+  }
+
+  protected onMessage(_message: Json | null, _raw: string): void {}
+
+  send(message: Json): void {
+    assert(this.ws?.readyState === WebSocket.OPEN, `[${this.name}] socket is not open`);
+    this.ws.send(JSON.stringify(message));
+  }
+
+  close(): void {
+    try { this.ws?.close(); } catch {}
+  }
+
+  async waitForClose(timeoutMs = 10_000): Promise<{ code: number; reason: string }> {
+    if (this.closes.length > 0) return this.closes[this.closes.length - 1];
+    return withTimeout(new Promise((resolve) => {
+      const old = this.ws?.onclose;
+      if (!this.ws) return;
+      this.ws.onclose = (event) => {
+        old?.call(this.ws, event);
+        const close = { code: event.code, reason: event.reason };
+        this.closes.push(close);
+        resolve(close);
+      };
+    }), timeoutMs, `${this.name} close`);
+  }
+}
+
+export interface TuiOptions {
+  approvalPolicy?: string;
+  autoApprove?: boolean;
+}
+
+export interface RawWsOptions {
+  headers?: Record<string, string>;
+}
+
+export class TuiClient extends RawWsClient {
+  readonly notifications: Json[] = [];
+  readonly responses = new Map<number | string, Json>();
+  readonly requests: Json[] = [];
+  readonly agentMessages: string[] = [];
+  readonly userMessages: string[] = [];
+  readonly itemTypes: string[] = [];
+  threadId: string | null = null;
+  private nextId = 1;
+  private readonly options: Required<TuiOptions>;
+
+  constructor(probe: SharedThreadProbe, name: string, url: string, options?: TuiOptions, rawOptions?: RawWsOptions) {
+    super(probe, name, url, rawOptions);
+    this.options = {
+      approvalPolicy: options?.approvalPolicy ?? "never",
+      autoApprove: options?.autoApprove ?? false,
+    };
+  }
+
+  protected override onMessage(message: Json | null, raw: string): void {
+    if (!message) return;
+    if (message.id !== undefined && message.method === undefined) {
+      this.responses.set(message.id, message);
+      return;
+    }
+    if (typeof message.method === "string" && message.id === undefined) {
+      this.notifications.push(message);
+      const item = message.params?.item;
+      if (item?.type) this.itemTypes.push(item.type);
+      if (message.method !== "item/agentMessage/delta") {
+        this.probe.log(`[${this.name}] ${message.method}${item?.type ? ` (${item.type})` : ""}`);
+      }
+      if (message.method === "item/completed" && item?.type === "agentMessage") {
+        this.agentMessages.push(extractItemText(item));
+      }
+      if (message.method === "item/completed" && item?.type === "userMessage") {
+        this.userMessages.push(extractItemText(item));
+      }
+      return;
+    }
+    if (typeof message.method === "string" && message.id !== undefined) {
+      this.requests.push(message);
+      this.probe.log(`[${this.name}] server request ${message.method} id=${String(message.id)}`);
+      if (this.options.autoApprove) this.respondToServerRequest(message, raw);
+    }
+  }
+
+  private respondToServerRequest(message: Json, _raw: string): void {
+    let result: Json | null = null;
+    switch (message.method) {
+      case "item/commandExecution/requestApproval":
+        result = { decision: "accept" };
+        break;
+      case "item/fileChange/requestApproval":
+        result = { decision: "accept" };
+        break;
+      case "item/permissions/requestApproval":
+        result = { permissions: {}, scope: "turn" };
+        break;
+      case "execCommandApproval":
+        result = { decision: "approved" };
+        break;
+      case "applyPatchApproval":
+        result = { decision: "denied" };
+        break;
+    }
+    if (!result) return;
+    this.send({ jsonrpc: "2.0", id: message.id, result });
+  }
+
+  async initializeAndStartThread(options?: {
+    approvalPolicy?: string;
+    cwd?: string;
+    sandbox?: string;
+  }): Promise<string> {
+    const initId = this.nextId++;
+    this.send({
+      jsonrpc: "2.0",
+      id: initId,
+      method: "initialize",
+      params: { clientInfo: { name: `agentbridge-probe-${this.name}`, version: "0.0.1" } },
+    });
+    await this.waitForResponse(initId, 30_000);
+    this.send({ jsonrpc: "2.0", method: "initialized", params: {} });
+
+    const threadIdReq = this.nextId++;
+    this.send({
+      jsonrpc: "2.0",
+      id: threadIdReq,
+      method: "thread/start",
+      params: {
+        cwd: options?.cwd ?? this.probe.cwd,
+        approvalPolicy: options?.approvalPolicy ?? this.options.approvalPolicy,
+        ...(options?.sandbox ? { sandbox: options.sandbox } : {}),
+      },
+    });
+    const response = await this.waitForResponse(threadIdReq, 45_000);
+    const threadId = response.result?.thread?.id;
+    assert(typeof threadId === "string" && threadId.length > 0, `[${this.name}] thread/start did not return thread.id`);
+    this.threadId = threadId;
+    this.probe.log(`[${this.name}] threadId=${threadId}`);
+    return threadId;
+  }
+
+  async sendRequest(method: string, params?: Json, timeoutMs = 30_000): Promise<Json> {
+    const id = this.nextId++;
+    this.send({ jsonrpc: "2.0", id, method, params });
+    return this.waitForResponse(id, timeoutMs);
+  }
+
+  async sendTurn(text: string, options?: {
+    approvalPolicy?: string;
+    sandboxPolicy?: Json;
+    effort?: string;
+  }): Promise<string | null> {
+    assert(this.threadId, `[${this.name}] no threadId`);
+    const response = await this.sendRequest("turn/start", {
+      threadId: this.threadId,
+      input: [{ type: "text", text }],
+      effort: options?.effort ?? "minimal",
+      ...(options?.approvalPolicy ? { approvalPolicy: options.approvalPolicy } : {}),
+      ...(options?.sandboxPolicy ? { sandboxPolicy: options.sandboxPolicy } : {}),
+    }, 30_000);
+    return response.result?.turn?.id ?? null;
+  }
+
+  async interrupt(turnId: string): Promise<Json> {
+    assert(this.threadId, `[${this.name}] no threadId`);
+    return this.sendRequest("turn/interrupt", { threadId: this.threadId, turnId }, 20_000);
+  }
+
+  async waitForResponse(id: number | string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<Json> {
+    return withTimeout(new Promise<Json>((resolve, reject) => {
+      const poll = () => {
+        const response = this.responses.get(id);
+        if (!response) {
+          setTimeout(poll, 50);
+          return;
+        }
+        if (response.error) reject(new ProbeFailure(`[${this.name}] response ${String(id)} error: ${response.error.message ?? JSON.stringify(response.error)}`));
+        else resolve(response);
+      };
+      poll();
+    }), timeoutMs, `${this.name} response ${String(id)}`);
+  }
+
+  async waitForNotification(
+    method: string,
+    predicate: (message: Json) => boolean = () => true,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<Json> {
+    return withTimeout(new Promise<Json>((resolve) => {
+      const poll = () => {
+        const found = this.notifications.find((message) => message.method === method && predicate(message));
+        if (found) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} notification ${method}`);
+  }
+
+  waitForAgentMessage(contains: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<string> {
+    return withTimeout(new Promise<string>((resolve) => {
+      const poll = () => {
+        const found = this.agentMessages.find((text) => text.includes(contains));
+        if (found !== undefined) resolve(found);
+        else setTimeout(poll, 100);
+      };
+      poll();
+    }), timeoutMs, `${this.name} agentMessage containing ${contains}`);
+  }
+
+  waitForUserMessage(contains: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<string> {
+    return withTimeout(new Promise<string>((resolve) => {
+      const poll = () => {
+        const found = this.userMessages.find((text) => text.includes(contains));
+        if (found !== undefined) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} userMessage containing ${contains}`);
+  }
+
+  async expectNoAgentMessage(contains: string, windowMs: number): Promise<void> {
+    await sleep(windowMs);
+    assert(!this.agentMessages.some((text) => text.includes(contains)), `[${this.name}] unexpected agentMessage containing ${contains}`);
+  }
+
+  async waitForServerRequest(
+    methodIncludes: string,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<Json> {
+    return withTimeout(new Promise<Json>((resolve) => {
+      const poll = () => {
+        const found = this.requests.find((req) => String(req.method).includes(methodIncludes));
+        if (found) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} server request ${methodIncludes}`);
+  }
+}
+
+export class ClaudeClient extends RawWsClient {
+  readonly bridgeMessages: BridgeMessage[] = [];
+  readonly results: ControlResult[] = [];
+  readonly statuses: Json[] = [];
+
+  constructor(probe: SharedThreadProbe, readonly chatId: string) {
+    super(probe, `claude:${chatId}`, probe.controlUrl);
+  }
+
+  override async connect(timeoutMs = 20_000): Promise<void> {
+    await super.connect(timeoutMs);
+    this.send({ type: "claude_connect", chatId: this.chatId });
+  }
+
+  protected override onMessage(message: Json | null, _raw: string): void {
+    if (!message) return;
+    if (message.type === "codex_to_claude") {
+      const msg = message.message as BridgeMessage;
+      this.bridgeMessages.push(msg);
+      this.probe.log(`[${this.name}] codex_to_claude ${msg.id} ${msg.content.slice(0, 96).replace(/\n/g, " ")}`);
+      return;
+    }
+    if (message.type === "claude_to_codex_result") {
+      this.results.push(message as ControlResult);
+      this.probe.log(`[${this.name}] result ${message.requestId} success=${message.success}${message.error ? ` error=${message.error}` : ""}`);
+      return;
+    }
+    if (message.type === "status") this.statuses.push(message.status);
+  }
+
+  async sendReply(text: string, options?: { requireReply?: boolean; timeoutMs?: number }): Promise<ControlResult> {
+    const requestId = `${this.chatId}_${Date.now()}_${randomBytes(2).toString("hex")}`;
+    this.send({
+      type: "claude_to_codex",
+      requestId,
+      chatId: this.chatId,
+      message: {
+        id: `${this.chatId}_msg_${Date.now()}`,
+        source: "claude",
+        content: text,
+        timestamp: Date.now(),
+      },
+      ...(options?.requireReply ? { requireReply: true } : {}),
+    });
+    return this.waitForResult(requestId, options?.timeoutMs ?? 20_000);
+  }
+
+  async waitForResult(requestId: string, timeoutMs = 20_000): Promise<ControlResult> {
+    return withTimeout(new Promise<ControlResult>((resolve) => {
+      const poll = () => {
+        const found = this.results.find((result) => result.requestId === requestId);
+        if (found) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} result ${requestId}`);
+  }
+
+  waitForBridgeMessage(
+    predicate: (message: BridgeMessage) => boolean,
+    label: string,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<BridgeMessage> {
+    return withTimeout(new Promise<BridgeMessage>((resolve) => {
+      const poll = () => {
+        const found = this.bridgeMessages.find(predicate);
+        if (found) resolve(found);
+        else setTimeout(poll, 50);
+      };
+      poll();
+    }), timeoutMs, `${this.name} bridge message ${label}`);
+  }
+
+  waitForContent(contains: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<BridgeMessage> {
+    return this.waitForBridgeMessage((msg) => msg.content.includes(contains), contains, timeoutMs);
+  }
+
+  waitForDedicatedThreadReady(timeoutMs = 90_000): Promise<string> {
+    return withTimeout(new Promise<string>((resolve) => {
+      const poll = () => {
+        for (const msg of this.bridgeMessages) {
+          const match = msg.content.match(/Your Codex thread is ready \(threadId=([0-9a-f-]+)\)/);
+          if (match) return resolve(match[1]);
+        }
+        setTimeout(poll, 100);
+      };
+      poll();
+    }), timeoutMs, `${this.name} dedicated thread ready`);
+  }
+
+  async expectNoContent(contains: string, windowMs: number): Promise<void> {
+    await sleep(windowMs);
+    assert(
+      !this.bridgeMessages.some((message) => message.content.includes(contains)),
+      `[${this.name}] unexpected bridge message containing ${contains}`,
+    );
+  }
+
+  async expectNoDedicatedThreadReady(windowMs: number): Promise<void> {
+    await sleep(windowMs);
+    assert(
+      !this.bridgeMessages.some((message) => message.content.includes("Your Codex thread is ready")),
+      `[${this.name}] unexpectedly received isolated ClaudeThread ready notice`,
+    );
+  }
+}
+
+export async function runProbe(
+  name: string,
+  fn: (probe: SharedThreadProbe) => Promise<void>,
+  options?: Omit<ProbeOptions, "name">,
+): Promise<void> {
+  const probe = new SharedThreadProbe({ name, ...options });
+  let failed = false;
+  try {
+    await probe.startDaemon();
+    await fn(probe);
+  } catch (err: any) {
+    failed = true;
+    probe.log(`ERROR: ${err?.stack ?? err}`);
+  } finally {
+    await probe.stop();
+  }
+  probe.log(failed ? "RESULT: FAILED" : "RESULT: PASSED");
+  process.exit(failed ? 1 : 0);
+}
+
+export async function expectForeignProxyRejected(
+  probe: SharedThreadProbe,
+  url: string,
+  label: string,
+  expectedCode = 4002,
+  options?: RawWsOptions,
+): Promise<void> {
+  const client = new RawWsClient(probe, label, url, options);
+  let opened = false;
+  try {
+    await client.connect(5_000);
+    opened = true;
+  } catch {
+    // Upgrade rejection before open is also acceptable.
+  }
+  if (opened) {
+    const close = await client.waitForClose(5_000);
+    assert(close.code === expectedCode, `${label} expected close ${expectedCode}, got ${close.code} (${close.reason})`);
+  }
+}

--- a/probes/shared-thread/p01-tui-first-claude-pairs.ts
+++ b/probes/shared-thread/p01-tui-first-claude-pairs.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe } from "./lib";
+
+void runProbe("p01", async (probe) => {
+  const token = makeToken("p01");
+  const tui = await probe.connectTui(token, "primary");
+  const tuiThreadId = await tui.initializeAndStartThread();
+
+  const claude = await probe.connectClaude("p01_pair");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const ok = marker("p01-ok");
+  const result = await claude.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `paired Claude reply was rejected: ${result.error ?? "unknown"}`);
+
+  await tui.waitForNotification("turn/started", undefined, 45_000);
+  await tui.waitForAgentMessage(ok, 180_000);
+  await claude.waitForContent(ok, 30_000);
+
+  const status = await probe.status();
+  assert(status.threadId === tuiThreadId, `daemon status threadId ${status.threadId} != TUI threadId ${tuiThreadId}`);
+});
+

--- a/probes/shared-thread/p02-claude-first-isolated.ts
+++ b/probes/shared-thread/p02-claude-first-isolated.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe } from "./lib";
+
+void runProbe("p02", async (probe) => {
+  const claude = await probe.connectClaude("p02_isolated");
+  const isolatedThreadId = await claude.waitForDedicatedThreadReady();
+
+  const tui = await probe.connectTui(makeToken("p02"), "late-tui");
+  const tuiThreadId = await tui.initializeAndStartThread();
+  assert(isolatedThreadId !== tuiThreadId, "Claude-first session reused the later TUI thread");
+
+  const isolatedMarker = marker("p02-claude");
+  const result = await claude.sendReply(
+    `Reply with exactly this marker and nothing else: ${isolatedMarker}`,
+    { requireReply: true },
+  );
+  assert(result.success, `isolated Claude reply failed: ${result.error ?? "unknown"}`);
+  await claude.waitForContent(isolatedMarker, 180_000);
+  await tui.expectNoAgentMessage(isolatedMarker, 5_000);
+
+  const tuiMarker = marker("p02-tui");
+  await tui.sendTurn(`Reply with exactly this marker and nothing else: ${tuiMarker}`);
+  await tui.waitForAgentMessage(tuiMarker, 180_000);
+  await claude.expectNoContent("Human typed in the paired Codex TUI", 5_000);
+});
+

--- a/probes/shared-thread/p03-one-tui-two-claudes.ts
+++ b/probes/shared-thread/p03-one-tui-two-claudes.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe } from "./lib";
+
+void runProbe("p03", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p03"), "primary");
+  await tui.initializeAndStartThread();
+
+  const paired = await probe.connectClaude("p03_paired");
+  await paired.expectNoDedicatedThreadReady(8_000);
+
+  const isolated = await probe.connectClaude("p03_isolated");
+  const isolatedThreadId = await isolated.waitForDedicatedThreadReady();
+  assert(isolatedThreadId.length > 0, "second Claude did not provision an isolated thread");
+
+  const pairMarker = marker("p03-pair");
+  let result = await paired.sendReply(
+    `Reply with exactly this marker and nothing else: ${pairMarker}`,
+    { requireReply: true },
+  );
+  assert(result.success, `paired reply failed: ${result.error ?? "unknown"}`);
+  await tui.waitForAgentMessage(pairMarker, 180_000);
+  await paired.waitForContent(pairMarker, 30_000);
+  await isolated.expectNoContent(pairMarker, 5_000);
+
+  const isolatedMarker = marker("p03-isolated");
+  result = await isolated.sendReply(
+    `Reply with exactly this marker and nothing else: ${isolatedMarker}`,
+    { requireReply: true },
+  );
+  assert(result.success, `isolated reply failed: ${result.error ?? "unknown"}`);
+  await isolated.waitForContent(isolatedMarker, 180_000);
+  await tui.expectNoAgentMessage(isolatedMarker, 5_000);
+  await paired.expectNoContent(isolatedMarker, 5_000);
+});
+

--- a/probes/shared-thread/p04-second-proxy-tui-rejected.ts
+++ b/probes/shared-thread/p04-second-proxy-tui-rejected.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env bun
+import { expectForeignProxyRejected, makeToken, runProbe } from "./lib";
+
+void runProbe("p04", async (probe) => {
+  const primary = await probe.connectTui(makeToken("p04_primary"), "primary");
+  await primary.initializeAndStartThread();
+
+  const foreignToken = makeToken("p04_foreign");
+  await expectForeignProxyRejected(
+    probe,
+    probe.proxyUrl,
+    "foreign-proxy-tui",
+    4002,
+    { headers: { authorization: `Bearer ${foreignToken}` } },
+  );
+
+  // The first TUI should still be usable after rejection.
+  await primary.sendRequest("thread/list", {}, 30_000);
+});

--- a/probes/shared-thread/p05-secondary-picker-token.ts
+++ b/probes/shared-thread/p05-secondary-picker-token.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+import { assert, expectForeignProxyRejected, makeToken, runProbe } from "./lib";
+
+void runProbe("p05", async (probe) => {
+  const token = makeToken("p05");
+  const primary = await probe.connectTui(token, "primary");
+  await primary.initializeAndStartThread();
+
+  const secondary = await probe.connectTui(token, "secondary-picker");
+  await secondary.sendRequest("initialize", {
+    clientInfo: { name: "agentbridge-probe-secondary-picker", version: "0.0.1" },
+  }, 30_000);
+  secondary.send({ jsonrpc: "2.0", method: "initialized", params: {} });
+  const listResponse = await secondary.sendRequest("thread/list", {}, 30_000);
+  assert(listResponse.result !== undefined, "same-token secondary picker did not receive thread/list response");
+
+  const foreignToken = makeToken("p05_foreign");
+  await expectForeignProxyRejected(
+    probe,
+    probe.proxyUrl,
+    "foreign-token-after-secondary",
+    4002,
+    { headers: { authorization: `Bearer ${foreignToken}` } },
+  );
+
+  const log = probe.daemonLog();
+  probe.log(
+    log.includes("Secondary") || log.includes("secondary")
+      ? "daemon log contains secondary-connection evidence"
+      : "daemon log did not include a secondary marker; WS behavior still proved same-token acceptance",
+  );
+});

--- a/probes/shared-thread/p06-user-message-routing-and-echo-dedup.ts
+++ b/probes/shared-thread/p06-user-message-routing-and-echo-dedup.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p06", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p06"), "primary");
+  await tui.initializeAndStartThread();
+  const claude = await probe.connectClaude("p06_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const humanMarker = marker("p06-human");
+  await tui.sendTurn(`Reply with exactly this marker and nothing else: ${humanMarker}`);
+  const routed = await claude.waitForBridgeMessage(
+    (msg) =>
+      msg.source === "codex" &&
+      msg.content.includes("[IMPORTANT] Human typed in the paired Codex TUI:") &&
+      msg.content.includes(humanMarker),
+    "prefixed TUI userMessage",
+    30_000,
+  );
+  assert(routed.source === "codex", `expected source=codex, got ${routed.source}`);
+  await tui.waitForAgentMessage(humanMarker, 180_000);
+
+  const echoMarker = marker("p06-echo");
+  const result = await claude.sendReply(
+    `Reply with exactly this marker and nothing else: ${echoMarker}`,
+    { requireReply: true },
+  );
+  assert(result.success, `paired reply failed: ${result.error ?? "unknown"}`);
+  await tui.waitForUserMessage(echoMarker, 30_000);
+  await tui.waitForAgentMessage(echoMarker, 180_000);
+  await claude.waitForContent(echoMarker, 30_000);
+  await sleep(2_000);
+  assert(
+    !claude.bridgeMessages.some((msg) =>
+      msg.content.includes("[IMPORTANT] Human typed in the paired Codex TUI:") &&
+      msg.content.includes(echoMarker),
+    ),
+    "Claude-originated injected text echoed back as a TUI userMessage",
+  );
+});
+

--- a/probes/shared-thread/p07-paired-claude-reconnect-within-grace.ts
+++ b/probes/shared-thread/p07-paired-claude-reconnect-within-grace.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p07", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p07"), "primary");
+  await tui.initializeAndStartThread();
+
+  const chatId = "p07_paired";
+  const first = await probe.connectClaude(chatId);
+  await first.expectNoDedicatedThreadReady(8_000);
+  first.close();
+  await sleep(1_000);
+
+  const resumed = await probe.connectClaude(chatId);
+  await resumed.expectNoDedicatedThreadReady(5_000);
+  const ok = marker("p07-ok");
+  const result = await resumed.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `reconnected paired reply failed: ${result.error ?? "unknown"}`);
+  await tui.waitForAgentMessage(ok, 180_000);
+  await resumed.waitForContent(ok, 30_000);
+});
+

--- a/probes/shared-thread/p08-paired-claude-reap-after-grace.ts
+++ b/probes/shared-thread/p08-paired-claude-reap-after-grace.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p08", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p08"), "primary");
+  await tui.initializeAndStartThread();
+
+  const first = await probe.connectClaude("p08_first");
+  await first.expectNoDedicatedThreadReady(8_000);
+  first.close();
+  await sleep(1_800);
+
+  const second = await probe.connectClaude("p08_second");
+  await second.expectNoDedicatedThreadReady(5_000);
+  const ok = marker("p08-ok");
+  const result = await second.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `new paired Claude reply failed after reap: ${result.error ?? "unknown"}`);
+  await tui.waitForAgentMessage(ok, 180_000);
+  await second.waitForContent(ok, 30_000);
+}, { pairReapMs: 1000 });
+

--- a/probes/shared-thread/p08b-same-chat-after-pair-reap.ts
+++ b/probes/shared-thread/p08b-same-chat-after-pair-reap.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p08b", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p08b"), "primary");
+  await tui.initializeAndStartThread();
+
+  const chatId = "p08b_same_chat";
+  const first = await probe.connectClaude(chatId);
+  await first.expectNoDedicatedThreadReady(8_000);
+  first.close();
+
+  // Probe runs with a shortened pair reap window. After expiry, daemon should
+  // fully delete the old ChatState; reconnecting with the same chatId should
+  // behave like a fresh attach and claim the still-open proxy TUI slot.
+  await sleep(1_800);
+
+  const second = await probe.connectClaude(chatId);
+  await second.expectNoDedicatedThreadReady(5_000);
+
+  const ok = marker("p08b-ok");
+  const result = await second.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `same-chat reattach after pair reap failed: ${result.error ?? "unknown"}`);
+  await tui.waitForAgentMessage(ok, 180_000);
+  await second.waitForContent(ok, 30_000);
+}, { pairReapMs: 1000 });
+

--- a/probes/shared-thread/p09-tui-disconnect-transitions-claude-isolated.ts
+++ b/probes/shared-thread/p09-tui-disconnect-transitions-claude-isolated.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p09", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p09"), "primary");
+  await tui.initializeAndStartThread();
+  const claude = await probe.connectClaude("p09_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  tui.close();
+  await claude.waitForContent("Shared Codex TUI thread is gone", 30_000);
+  const threadId = await claude.waitForDedicatedThreadReady(90_000);
+  assert(threadId.length > 0, "paired Claude did not transition to a fresh isolated thread");
+
+  const ok = marker("p09-ok");
+  const result = await claude.sendReply(
+    `Reply with exactly this marker and nothing else: ${ok}`,
+    { requireReply: true },
+  );
+  assert(result.success, `isolated reply after TUI disconnect failed: ${result.error ?? "unknown"}`);
+  await claude.waitForContent(ok, 180_000);
+  await sleep(500);
+});
+

--- a/probes/shared-thread/p10-approval-isolation.ts
+++ b/probes/shared-thread/p10-approval-isolation.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+import { assert, makeToken, runProbe, sleep } from "./lib";
+
+void runProbe("p10", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p10"), "primary", {
+    approvalPolicy: "on-request",
+    autoApprove: false,
+  });
+  await tui.initializeAndStartThread({ approvalPolicy: "on-request" });
+  const claude = await probe.connectClaude("p10_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  await tui.sendTurn(
+    "Run this shell command: echo agentbridge-p10-approval-isolation. Ask for approval if required, and do not skip the command.",
+    { approvalPolicy: "on-request" },
+  );
+  await tui.waitForServerRequest("requestApproval", 180_000);
+  await sleep(2_000);
+
+  assert(
+    !claude.bridgeMessages.some((msg) => /requestApproval|approval request|agentbridge-p10-approval-isolation/i.test(msg.content)),
+    "approval request leaked to paired Claude",
+  );
+});
+

--- a/probes/shared-thread/p11-tool-whitelist.ts
+++ b/probes/shared-thread/p11-tool-whitelist.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+import { assert, makeToken, marker, runProbe, sleep } from "./lib";
+
+void runProbe("p11", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p11"), "primary", { autoApprove: true });
+  await tui.initializeAndStartThread({ approvalPolicy: "never" });
+  const claude = await probe.connectClaude("p11_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const commandMarker = marker("p11-shell");
+  await tui.sendTurn(
+    `Run the shell command: echo ${commandMarker}. Then reply with exactly "${commandMarker} done".`,
+    { approvalPolicy: "never" },
+  );
+  await tui.waitForNotification("item/completed", (msg) => msg.params?.item?.type === "commandExecution", 180_000);
+  await tui.waitForAgentMessage(`${commandMarker} done`, 180_000);
+  await sleep(2_000);
+
+  assert(
+    !claude.bridgeMessages.some((msg) => /commandExecution|shellCommand|requestApproval|aggregatedOutput/.test(msg.content)),
+    "internal tool/shell item leaked to paired Claude",
+  );
+});
+

--- a/probes/shared-thread/p12-require-reply-turn-completed-no-output.ts
+++ b/probes/shared-thread/p12-require-reply-turn-completed-no-output.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+import { assert, makeToken, runProbe } from "./lib";
+
+void runProbe("p12", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p12"), "primary");
+  await tui.initializeAndStartThread();
+  const claude = await probe.connectClaude("p12_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const result = await claude.sendReply(
+    "Begin a long-running task and do not produce a final answer until tools complete. This turn will be interrupted by the probe.",
+    { requireReply: true },
+  );
+  assert(result.success, `paired reply failed: ${result.error ?? "unknown"}`);
+
+  const started = await tui.waitForNotification("turn/started", undefined, 60_000);
+  const turnId = started.params?.turn?.id;
+  assert(typeof turnId === "string" && turnId.length > 0, "turn/started did not include turn.id");
+  await tui.interrupt(turnId);
+
+  await claude.waitForBridgeMessage(
+    (msg) => msg.content.includes("[system] Codex turn completed") || msg.content.includes("completed the turn without sending a reply"),
+    "turnCompleted no-output release",
+    60_000,
+  );
+
+  assert(
+    !claude.bridgeMessages.some((msg) => msg.content.includes("[system] Codex turn started") && msg.content.includes("satisfies")),
+    "turnStarted appeared to satisfy requireReply; check daemon release accounting",
+  );
+});
+

--- a/probes/shared-thread/p13-require-reply-error-release.ts
+++ b/probes/shared-thread/p13-require-reply-error-release.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env bun
+import { assert, makeToken, runProbe } from "./lib";
+
+void runProbe("p13", async (probe) => {
+  const tui = await probe.connectTui(makeToken("p13"), "primary");
+  await tui.initializeAndStartThread({ approvalPolicy: "never", sandbox: "read-only" });
+  const claude = await probe.connectClaude("p13_paired");
+  await claude.expectNoDedicatedThreadReady(8_000);
+
+  const result = await claude.sendReply(
+    "Try to create /tmp/agentbridge-p13-should-be-denied.txt using a shell command. If the environment denies it, report the exact error.",
+    { requireReply: true },
+  );
+  assert(result.success, `paired reply failed: ${result.error ?? "unknown"}`);
+
+  await claude.waitForBridgeMessage(
+    (msg) => msg.content.startsWith("[error]") || msg.content.includes("[error]") || msg.content.includes("permission") || msg.content.includes("denied"),
+    "error release",
+    180_000,
+  );
+});
+

--- a/probes/shared-thread/p14-echo-race-pre-response.ts
+++ b/probes/shared-thread/p14-echo-race-pre-response.ts
@@ -3,7 +3,7 @@ import { assert, sha1_16 } from "./lib";
 import { CodexAdapter } from "../../src/codex-adapter";
 
 const text = `agentbridge-p14-echo-race-${Date.now()}`;
-const adapter = new CodexAdapter(1, 2, "/tmp/agentbridge-p14-no-daemon.log") as any;
+const adapter = new CodexAdapter({ appPort: 1, proxyPort: 2, logFile: "/tmp/agentbridge-p14-no-daemon.log" }) as any;
 
 let emittedUserMessages = 0;
 adapter.on("userMessage", () => {

--- a/probes/shared-thread/p14-echo-race-pre-response.ts
+++ b/probes/shared-thread/p14-echo-race-pre-response.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+import { assert, sha1_16 } from "./lib";
+import { CodexAdapter } from "../../src/codex-adapter";
+
+const text = `agentbridge-p14-echo-race-${Date.now()}`;
+const adapter = new CodexAdapter(1, 2, "/tmp/agentbridge-p14-no-daemon.log") as any;
+
+let emittedUserMessages = 0;
+adapter.on("userMessage", () => {
+  emittedUserMessages++;
+});
+
+if (!(adapter.pendingInjectionHashes instanceof Map)) {
+  throw new Error("CodexAdapter.pendingInjectionHashes Map is missing; implement §4.5 race dedup before running P14.");
+}
+if (typeof adapter.handleServerNotification !== "function") {
+  throw new Error("CodexAdapter.handleServerNotification is not reachable for the P14 micro-probe.");
+}
+
+adapter.pendingInjectionHashes.set(sha1_16(text), Date.now() + 5_000);
+adapter.handleServerNotification({
+  method: "item/completed",
+  params: {
+    threadId: "thread_p14",
+    turnId: "turn_p14_pre_response",
+    item: {
+      type: "userMessage",
+      id: "item_p14_user",
+      content: [{ type: "text", text }],
+    },
+  },
+});
+
+assert(emittedUserMessages === 0, "pre-response userMessage echo was emitted despite pendingInjectionHashes match");
+assert(!adapter.pendingInjectionHashes.has(sha1_16(text)), "pending hash was not consumed one-shot");
+
+adapter.handleServerNotification({
+  method: "item/completed",
+  params: {
+    threadId: "thread_p14",
+    turnId: "turn_p14_human",
+    item: {
+      type: "userMessage",
+      id: "item_p14_human",
+      content: [{ type: "text", text: `${text}-human` }],
+    },
+  },
+});
+
+assert(emittedUserMessages === 1, "non-echo userMessage was not emitted after the one-shot hash was consumed");
+process.stderr.write("RESULT: PASSED\n");
+

--- a/probes/shell-approval.ts
+++ b/probes/shell-approval.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env bun
+/**
+ * Approval-policy probe.
+ *
+ * Spawns the daemon on isolated ports, attaches one simulated Claude, and
+ * sends a turn that explicitly asks Codex to execute a shell command
+ * (`echo agentbridge-multi-fix-probe`). Pre-fix, the daemon's ClaudeThread
+ * auto-denied every server-initiated approval request with `-32601`,
+ * which made `exec_command` impossible. Post-fix, we set
+ * `approvalPolicy: "never"` at thread/start AND auto-accept any approval
+ * server-request that still arrives.
+ *
+ * The probe passes when:
+ *   1. The turn completes (turn/completed event observed).
+ *   2. Codex echoes the marker string back inside an agentMessage.
+ *   3. The bridge log shows no `auto-denied ... no UI to approve` lines for
+ *      this chat (pre-fix signature). Auto-accepts are OK to see.
+ *
+ * Cost: one short Codex turn that runs a single `echo`.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+
+const STATE_DIR = "/tmp/agentbridge-shell-approval-probe";
+const CTRL_PORT = 4702;
+const CODEX_WS_PORT = 4700;
+const CODEX_PROXY_PORT = 4701;
+const CONTROL_URL = `ws://127.0.0.1:${CTRL_PORT}/ws`;
+const MARKER = "agentbridge-multi-fix-probe-marker-9f1c4e";
+const CHAT_ID = "shell_probe_a";
+
+function elapsed(start: number) {
+  return Date.now() - start;
+}
+
+async function waitReady(timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${CTRL_PORT}/readyz`);
+      if (res.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`daemon /readyz not ready within ${timeoutMs}ms`);
+}
+
+async function main() {
+  rmSync(STATE_DIR, { recursive: true, force: true });
+  mkdirSync(STATE_DIR, { recursive: true });
+
+  const daemonJs = `${import.meta.dir}/../plugins/agentbridge/server/daemon.js`;
+  const env = {
+    ...process.env,
+    AGENTBRIDGE_STATE_DIR: STATE_DIR,
+    CODEX_WS_PORT: String(CODEX_WS_PORT),
+    CODEX_PROXY_PORT: String(CODEX_PROXY_PORT),
+    AGENTBRIDGE_CONTROL_PORT: String(CTRL_PORT),
+    AGENTBRIDGE_IDLE_SHUTDOWN_MS: "300000",
+  };
+
+  const start = Date.now();
+  const log = (s: string) => process.stderr.write(`[${elapsed(start).toString().padStart(6)}ms] ${s}\n`);
+
+  log(`spawning daemon: bun ${daemonJs}`);
+  const daemon = spawn("bun", [daemonJs], { env, stdio: ["ignore", "pipe", "pipe"] });
+  daemon.stderr.on("data", (b: Buffer) => process.stderr.write(`[daemon] ${b}`));
+  daemon.stdout.on("data", (b: Buffer) => process.stderr.write(`[daemon:out] ${b}`));
+  daemon.on("exit", (code) => log(`daemon exited code=${code}`));
+
+  let failed = false;
+  let threadReady = false;
+  let turnCompleted = false;
+  let echoSeen = false;
+  const agentMessages: string[] = [];
+
+  try {
+    await waitReady(45_000);
+    log("daemon /readyz ok");
+
+    const ws = new WebSocket(CONTROL_URL);
+    let resolveReady!: () => void;
+    let resolveDone!: () => void;
+    const readyP = new Promise<void>((r) => (resolveReady = r));
+    const doneP = new Promise<void>((r) => (resolveDone = r));
+
+    ws.onopen = () => {
+      log(`WS open → claude_connect chatId=${CHAT_ID}`);
+      ws.send(JSON.stringify({ type: "claude_connect", chatId: CHAT_ID }));
+    };
+
+    ws.onmessage = (ev) => {
+      let msg: any;
+      try { msg = JSON.parse(typeof ev.data === "string" ? ev.data : (ev.data as Buffer).toString()); }
+      catch { return; }
+
+      if (msg.type === "codex_to_claude") {
+        const content: string = msg.message?.content ?? "";
+        const idPrefix = (msg.message?.id ?? "").split("_").slice(0, 2).join("_");
+        log(`recv ${idPrefix} (${content.length} chars): ${content.slice(0, 80).replace(/\n/g, " ")}…`);
+
+        if (content.startsWith("✅ Your Codex thread is ready")) {
+          threadReady = true;
+          resolveReady();
+        }
+        if (content.startsWith("✅ Codex finished")) {
+          turnCompleted = true;
+          resolveDone();
+        }
+        if (!content.startsWith("⏳") && !content.startsWith("✅") && !content.startsWith("⚠️") && !content.startsWith("[STATUS")) {
+          agentMessages.push(content);
+          if (content.includes(MARKER)) echoSeen = true;
+        }
+      }
+    };
+
+    ws.onerror = (e: any) => log(`WS error: ${e?.message ?? e}`);
+    ws.onclose = (e) => log(`WS closed code=${e.code} reason=${e.reason || "-"}`);
+
+    log("waiting for thread ready...");
+    await Promise.race([
+      readyP,
+      new Promise<void>((_, rej) => setTimeout(() => rej(new Error("thread never ready in 45s")), 45_000)),
+    ]);
+
+    const prompt = `Run the shell command exactly: echo ${MARKER}\n\nAfter running, reply [IMPORTANT] with one short line confirming you saw the output containing the marker. No further commentary.`;
+    log(`firing turn with shell command...`);
+    ws.send(JSON.stringify({
+      type: "claude_to_codex",
+      requestId: `req_${Date.now()}`,
+      chatId: CHAT_ID,
+      message: { id: `${CHAT_ID}_msg`, source: "claude", content: prompt, timestamp: Date.now() },
+      requireReply: true,
+    }));
+
+    log("waiting up to 120s for turn completion...");
+    await Promise.race([
+      doneP,
+      new Promise<void>((_, rej) => setTimeout(() => rej(new Error("turn never completed in 120s")), 120_000)),
+    ]);
+
+    log(`turn done: turnCompleted=${turnCompleted} echoSeen=${echoSeen} msgCount=${agentMessages.length}`);
+    log(`agentMessages preview: ${agentMessages.map((m) => m.slice(0, 100)).join("  ||  ").slice(0, 400)}`);
+
+    ws.close();
+    await new Promise((r) => setTimeout(r, 400));
+  } catch (err: any) {
+    log(`ERROR: ${err?.stack ?? err}`);
+    failed = true;
+  } finally {
+    log("stopping daemon");
+    try { daemon.kill("SIGTERM"); } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+    try { daemon.kill("SIGKILL"); } catch {}
+  }
+
+  // Inspect the bridge log file for telltale pre-fix lines.
+  const logPath = `${STATE_DIR}/agentbridge.log`;
+  let autoDeniedNoUi = 0;
+  let autoAccepted = 0;
+  if (existsSync(logPath)) {
+    const text = readFileSync(logPath, "utf-8");
+    for (const line of text.split("\n")) {
+      if (line.includes("auto-denied by ClaudeThread (no UI to approve)")) autoDeniedNoUi++;
+      if (line.includes("auto-accepted item/")) autoAccepted++;
+    }
+  } else {
+    log(`(no daemon log at ${logPath})`);
+  }
+  log(`Log scan: pre-fix-auto-denies=${autoDeniedNoUi}  post-fix-auto-accepts=${autoAccepted}`);
+
+  const passed = threadReady && turnCompleted && echoSeen && autoDeniedNoUi === 0;
+  log(passed ? "RESULT: PASSED ✅" : "RESULT: FAILED ❌");
+  log(`  threadReady=${threadReady}  turnCompleted=${turnCompleted}  echoSeen=${echoSeen}  autoDeniedNoUi=${autoDeniedNoUi}`);
+  process.exit(passed && !failed ? 0 : 1);
+}
+
+void main();

--- a/probes/two-claudes.ts
+++ b/probes/two-claudes.ts
@@ -1,0 +1,229 @@
+#!/usr/bin/env bun
+/**
+ * End-to-end probe: two simulated Claude clients on one daemon.
+ *
+ * Spawns the multi-Claude daemon on isolated ports + state dir, then opens
+ * two control-port WebSockets pretending to be two Claude MCP instances.
+ * Each registers a different chatId, gets its own Codex thread, and sends a
+ * tiny turn concurrently. We check that:
+ *
+ *   1. Both `system_thread_ready` notifications arrive (provisioning OK).
+ *   2. After firing `claude_to_codex` on both, both `turn/started` (or our
+ *      proxy "system_turn_started") notifications arrive before either
+ *      `turn/completed` — i.e. the daemon executes them in parallel.
+ *   3. Each chat only receives its own thread's notifications.
+ *
+ * Cost: two minimal-effort turns against Codex's configured model.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+
+const STATE_DIR = "/tmp/agentbridge-multi-probe";
+const CTRL_PORT = 4702;
+const CODEX_WS_PORT = 4700;
+const CODEX_PROXY_PORT = 4701;
+const CONTROL_URL = `ws://127.0.0.1:${CTRL_PORT}/ws`;
+
+interface RecordedEvent {
+  ts: number;
+  chatId: string;
+  method: string;
+  content?: string;
+}
+
+const events: RecordedEvent[] = [];
+const startTs = Date.now();
+
+function elapsed() {
+  return Date.now() - startTs;
+}
+
+function log(s: string) {
+  process.stderr.write(`[${elapsed().toString().padStart(6)}ms] ${s}\n`);
+}
+
+async function waitHealthz(timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${CTRL_PORT}/readyz`);
+      if (res.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`daemon did not become ready at /readyz within ${timeoutMs}ms`);
+}
+
+interface Claude {
+  chatId: string;
+  ws: WebSocket;
+  ready: Promise<void>;
+  threadId: Promise<string | null>;
+  turnStarted: Promise<number>;
+  turnCompleted: Promise<number>;
+  agentMessages: string[];
+}
+
+function startClaude(chatId: string): Claude {
+  let resolveReady!: () => void;
+  let resolveThreadId!: (id: string | null) => void;
+  let resolveStarted!: (ts: number) => void;
+  let resolveCompleted!: (ts: number) => void;
+  const ready = new Promise<void>((r) => (resolveReady = r));
+  const threadIdP = new Promise<string | null>((r) => (resolveThreadId = r));
+  const turnStarted = new Promise<number>((r) => (resolveStarted = r));
+  const turnCompleted = new Promise<number>((r) => (resolveCompleted = r));
+
+  const ws = new WebSocket(CONTROL_URL);
+  const agentMessages: string[] = [];
+
+  ws.onopen = () => {
+    log(`[${chatId}] WS open → claude_connect`);
+    ws.send(JSON.stringify({ type: "claude_connect", chatId }));
+  };
+  ws.onmessage = (ev) => {
+    let msg: any;
+    try {
+      msg = JSON.parse(typeof ev.data === "string" ? ev.data : (ev.data as Buffer).toString());
+    } catch {
+      return;
+    }
+    if (msg.type === "codex_to_claude") {
+      const content: string = msg.message?.content ?? "";
+      const idPrefix = (msg.message?.id ?? "").split("_")[0] + "_" + ((msg.message?.id ?? "").split("_")[1] ?? "");
+      events.push({ ts: elapsed(), chatId, method: idPrefix, content: content.slice(0, 80) });
+      log(`[${chatId}] codex_to_claude id=${msg.message?.id} (${content.length} chars): ${content.slice(0, 60).replace(/\n/g, " ")}…`);
+      if (content.startsWith("✅ Your Codex thread is ready")) {
+        const match = content.match(/threadId=([0-9a-f-]+)\)/);
+        resolveThreadId(match ? match[1] : null);
+        resolveReady();
+      }
+      if (content.startsWith("⏳ Codex is working")) resolveStarted(elapsed());
+      if (content.startsWith("✅ Codex finished")) resolveCompleted(elapsed());
+      if (!content.startsWith("[STATUS") && !content.startsWith("⏳") && !content.startsWith("✅") && !content.startsWith("⚠️")) {
+        agentMessages.push(content);
+      }
+    } else if (msg.type === "claude_to_codex_result") {
+      log(`[${chatId}] claude_to_codex_result reqId=${msg.requestId} success=${msg.success}${msg.error ? " error=" + msg.error : ""}`);
+    } else if (msg.type === "status") {
+      // ignore for brevity
+    }
+  };
+  ws.onerror = (e: any) => log(`[${chatId}] WS error: ${e?.message ?? e}`);
+  ws.onclose = (e) => log(`[${chatId}] WS closed code=${e.code} reason=${e.reason || "-"}`);
+
+  return { chatId, ws, ready, threadId: threadIdP, turnStarted, turnCompleted, agentMessages };
+}
+
+function sendTurn(c: Claude, text: string): Promise<void> {
+  const reqId = `${c.chatId}_${Date.now()}`;
+  c.ws.send(JSON.stringify({
+    type: "claude_to_codex",
+    requestId: reqId,
+    chatId: c.chatId,
+    message: {
+      id: `${c.chatId}_msg`,
+      source: "claude",
+      content: text,
+      timestamp: Date.now(),
+    },
+  }));
+  return Promise.resolve();
+}
+
+async function main() {
+  rmSync(STATE_DIR, { recursive: true, force: true });
+  mkdirSync(STATE_DIR, { recursive: true });
+
+  // Spawn daemon directly via bun on the built bundle.
+  const daemonJs = `${import.meta.dir}/../plugins/agentbridge/server/daemon.js`;
+  const env = {
+    ...process.env,
+    AGENTBRIDGE_STATE_DIR: STATE_DIR,
+    CODEX_WS_PORT: String(CODEX_WS_PORT),
+    CODEX_PROXY_PORT: String(CODEX_PROXY_PORT),
+    AGENTBRIDGE_CONTROL_PORT: String(CTRL_PORT),
+    AGENTBRIDGE_IDLE_SHUTDOWN_MS: "300000",
+  };
+
+  log(`spawning daemon: bun ${daemonJs}`);
+  const daemon = spawn("bun", [daemonJs], { env, stdio: ["ignore", "pipe", "pipe"] });
+  daemon.stderr.on("data", (b: Buffer) => process.stderr.write(`[daemon] ${b}`));
+  daemon.stdout.on("data", (b: Buffer) => process.stderr.write(`[daemon:out] ${b}`));
+  daemon.on("exit", (code) => log(`daemon exited code=${code}`));
+
+  let failed = false;
+  try {
+    await waitHealthz(45_000);
+    log("daemon /readyz ok");
+
+    const a = startClaude("probe_a");
+    const b = startClaude("probe_b");
+
+    log("waiting for both threads ready...");
+    await Promise.all([a.ready, b.ready]);
+    const [tidA, tidB] = await Promise.all([a.threadId, b.threadId]);
+    log(`thread A=${tidA} / thread B=${tidB} (must differ)`);
+    if (!tidA || !tidB || tidA === tidB) {
+      log(`FAIL: thread IDs not distinct (${tidA} vs ${tidB})`);
+      failed = true;
+    }
+
+    const fireAt = elapsed();
+    log(`fire turn on both at ${fireAt}ms`);
+    const prompt = "Reply with exactly the two characters OK and absolutely nothing else. No reasoning, no tool calls.";
+    await Promise.all([sendTurn(a, prompt + " --A"), sendTurn(b, prompt + " --B")]);
+
+    log("waiting for both turn completions (timeout 90s)...");
+    const completedTimer = setTimeout(() => log("⏰ 90s timeout reached"), 90_000);
+    try {
+      const startedA = await Promise.race([a.turnStarted, new Promise<number>((_, rej) => setTimeout(() => rej(new Error("A turn never started")), 60_000))]);
+      const startedB = await Promise.race([b.turnStarted, new Promise<number>((_, rej) => setTimeout(() => rej(new Error("B turn never started")), 60_000))]);
+      const completedA = await Promise.race([a.turnCompleted, new Promise<number>((_, rej) => setTimeout(() => rej(new Error("A turn never completed")), 120_000))]);
+      const completedB = await Promise.race([b.turnCompleted, new Promise<number>((_, rej) => setTimeout(() => rej(new Error("B turn never completed")), 120_000))]);
+
+      log(`startedA=${startedA} startedB=${startedB} completedA=${completedA} completedB=${completedB}`);
+      const maxStart = Math.max(startedA, startedB);
+      const minComplete = Math.min(completedA, completedB);
+      const verdict = maxStart < minComplete ? "PARALLEL ✅" : "SERIALIZED ❌";
+      log(`Concurrency verdict: ${verdict}  (maxStart=${maxStart}ms < minComplete=${minComplete}ms ?)`);
+
+      log(`A agentMessages: ${JSON.stringify(a.agentMessages)}`);
+      log(`B agentMessages: ${JSON.stringify(b.agentMessages)}`);
+      // Cross-leak check
+      const aLeaked = a.agentMessages.some((m) => m.includes("--B"));
+      const bLeaked = b.agentMessages.some((m) => m.includes("--A"));
+      if (aLeaked || bLeaked) {
+        log(`FAIL: cross-chat leakage detected (a got --B? ${aLeaked}, b got --A? ${bLeaked})`);
+        failed = true;
+      } else {
+        log("Isolation: each chat only saw its own messages ✅");
+      }
+    } finally {
+      clearTimeout(completedTimer);
+    }
+
+    // Close cleanly
+    a.ws.close();
+    b.ws.close();
+    await new Promise((r) => setTimeout(r, 500));
+  } catch (err: any) {
+    log(`ERROR: ${err?.stack ?? err}`);
+    failed = true;
+  } finally {
+    log("stopping daemon");
+    try { daemon.kill("SIGTERM"); } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+    try { daemon.kill("SIGKILL"); } catch {}
+  }
+
+  log("=== EVENT TRACE ===");
+  for (const e of events) {
+    log(`  +${e.ts}ms  [${e.chatId}]  ${e.method}  ${e.content ?? ""}`);
+  }
+  log(failed ? "RESULT: FAILED" : "RESULT: PASSED");
+  process.exit(failed ? 1 : 0);
+}
+
+void main();

--- a/probes/two-tui-direct.ts
+++ b/probes/two-tui-direct.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+/**
+ * Multi-TUI viability probe.
+ *
+ * Question: can two independent WebSocket clients connect directly to a
+ * single `codex app-server` and each maintain their OWN stable thread —
+ * simulating two separate Codex TUI windows talking to the same backend?
+ *
+ * Setup:
+ *   1. Spawn a fresh `codex app-server` on an isolated port.
+ *   2. Open WS A, initialize, thread/start → thread_A.
+ *   3. Open WS B, initialize, thread/start → thread_B.
+ *   4. Both fire `turn/start` with a tiny prompt at the same time.
+ *   5. Watch for `thread/closed` notifications (the smoking gun for the
+ *      silent-TUI-exit bug we saw with the bridge proxy's secondaries) and
+ *      for turn completion on each side.
+ *
+ * Verdict:
+ *   - PASS if both threadIds remain valid, no thread/closed for either,
+ *     and both turns complete with assistant output containing the marker.
+ *   - FAIL if either thread is closed, or either turn fails to complete.
+ *
+ * This is the empirical evidence underpinning the "Path B" decision —
+ * pointing `agentbridge codex` straight at port 4500 is only safe if
+ * codex-rs handles two independent TUI-like clients without complaint.
+ *
+ * Cost: two minimal-effort Codex turns against the configured model.
+ */
+
+import { spawn } from "node:child_process";
+
+const APP_PORT = 4720;
+const APP_URL = `ws://127.0.0.1:${APP_PORT}`;
+const PROBE_CWD = "/tmp/agentbridge-two-tui-probe";
+const PROMPT_A = "Reply with exactly the marker probeA-OK-3jf and nothing else.";
+const PROMPT_B = "Reply with exactly the marker probeB-OK-9qx and nothing else.";
+
+interface Client {
+  name: string;
+  prompt: string;
+  marker: string;
+  ws: WebSocket;
+  ready: Promise<void>;
+  threadId: string | null;
+  turnDone: Promise<{ completed: boolean; closed: boolean; gotMarker: boolean }>;
+  events: string[];
+}
+
+const startTs = Date.now();
+function ms() { return Date.now() - startTs; }
+function log(s: string) { process.stderr.write(`[${ms().toString().padStart(6)}ms] ${s}\n`); }
+
+async function waitHealth(url: string, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`http://127.0.0.1:${APP_PORT}/healthz`);
+      if (r.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`app-server /healthz not ready within ${timeoutMs}ms`);
+}
+
+function startClient(name: string, prompt: string, marker: string): Client {
+  let resolveReady!: () => void;
+  let resolveDone!: (v: { completed: boolean; closed: boolean; gotMarker: boolean }) => void;
+  const ready = new Promise<void>((r) => (resolveReady = r));
+  const turnDone = new Promise<{ completed: boolean; closed: boolean; gotMarker: boolean }>((r) => (resolveDone = r));
+  const events: string[] = [];
+  let threadId: string | null = null;
+  let nextId = 1;
+  let completed = false;
+  let closed = false;
+  let gotMarker = false;
+
+  const ws = new WebSocket(APP_URL);
+
+  ws.onopen = async () => {
+    // initialize
+    ws.send(JSON.stringify({
+      jsonrpc: "2.0", id: nextId++, method: "initialize",
+      params: { clientInfo: { name: `probe-${name}`, version: "0.0.1" } },
+    }));
+  };
+
+  ws.onmessage = (ev) => {
+    let m: any;
+    try { m = JSON.parse(typeof ev.data === "string" ? ev.data : (ev.data as Buffer).toString()); }
+    catch { return; }
+    const tag = m.method ?? (m.result ? "result" : (m.error ? "error" : "?"));
+    events.push(`${ms()}ms ${tag}`);
+    if (m.method && m.method !== "item/agentMessage/delta") {
+      // log everything except the noisy delta stream
+      const itemType = m.params?.item?.type ?? "";
+      log(`[${name}] ${m.method}${itemType ? ` (${itemType})` : ""}`);
+    }
+
+    if (m.id && m.result && tag === "result") {
+      // initialize response → start thread
+      if (!threadId && m.id === 1) {
+        ws.send(JSON.stringify({
+          jsonrpc: "2.0", id: nextId++, method: "thread/start",
+          params: { cwd: PROBE_CWD, approvalPolicy: "never" },
+        }));
+        return;
+      }
+      // thread/start response → record threadId, mark ready
+      if (!threadId && m.id === 2) {
+        threadId = m.result?.thread?.id ?? null;
+        log(`[${name}] threadId=${threadId}`);
+        resolveReady();
+        return;
+      }
+    }
+
+    if (m.method === "thread/closed" && m.params?.threadId === threadId) {
+      log(`[${name}] ⚠️ thread/closed (threadId=${threadId})`);
+      closed = true;
+      resolveDone({ completed, closed, gotMarker });
+    }
+
+    if (m.method === "turn/started" && m.params?.threadId === threadId) {
+      log(`[${name}] turn/started`);
+    }
+    // item/* notifications are routed per-WS (each TUI has its own connection),
+    // so we don't filter by threadId — we trust the WS isolation.
+    if (m.method === "item/completed") {
+      const item = m.params?.item;
+      if (item?.type === "agentMessage") {
+        const text = (item.content ?? []).filter((c: any) => c.type === "text").map((c: any) => c.text).join("");
+        if (text.includes(marker)) gotMarker = true;
+        log(`[${name}] item/completed agentMessage (${text.length} chars): ${text.slice(0, 80)}`);
+      }
+    }
+    if (m.method === "turn/completed" && m.params?.threadId === threadId) {
+      completed = true;
+      log(`[${name}] turn/completed`);
+      resolveDone({ completed, closed, gotMarker });
+    }
+  };
+
+  ws.onerror = (e: any) => log(`[${name}] WS error: ${e?.message ?? e}`);
+  ws.onclose = (e) => log(`[${name}] WS closed code=${e.code}`);
+
+  return { name, prompt, marker, ws, ready, get threadId() { return threadId; }, turnDone, events } as any;
+}
+
+function fireTurn(c: Client) {
+  c.ws.send(JSON.stringify({
+    jsonrpc: "2.0", id: 100 + Math.floor(Math.random() * 1000), method: "turn/start",
+    params: {
+      threadId: c.threadId,
+      input: [{ type: "text", text: c.prompt }],
+      effort: "minimal",
+    },
+  }));
+}
+
+async function main() {
+  // ensure cwd exists
+  try { (await import("node:fs")).mkdirSync(PROBE_CWD, { recursive: true }); } catch {}
+
+  log(`spawning codex app-server on ${APP_URL}`);
+  const codex = spawn("codex", ["app-server", "--listen", APP_URL], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  codex.stderr.on("data", (b: Buffer) => process.stderr.write(`[codex] ${b}`));
+
+  let failed = false;
+  try {
+    await waitHealth(APP_URL);
+    log("/healthz ok, connecting two clients");
+
+    const a = startClient("A", PROMPT_A, "probeA-OK-3jf");
+    const b = startClient("B", PROMPT_B, "probeB-OK-9qx");
+
+    await Promise.all([a.ready, b.ready]);
+    log(`both threads ready: A=${a.threadId}  B=${b.threadId}  distinct=${a.threadId !== b.threadId}`);
+
+    // small stagger to avoid same-millisecond storm; not strictly needed
+    fireTurn(a);
+    fireTurn(b);
+    log("fired both turns");
+
+    const [resA, resB] = await Promise.all([
+      Promise.race([a.turnDone, new Promise<any>((_, rej) => setTimeout(() => rej(new Error("A timeout")), 120_000))]),
+      Promise.race([b.turnDone, new Promise<any>((_, rej) => setTimeout(() => rej(new Error("B timeout")), 120_000))]),
+    ]);
+
+    log(`A: completed=${resA.completed} closed=${resA.closed} gotMarker=${resA.gotMarker}`);
+    log(`B: completed=${resB.completed} closed=${resB.closed} gotMarker=${resB.gotMarker}`);
+
+    const ok = a.threadId !== b.threadId
+      && resA.completed && !resA.closed && resA.gotMarker
+      && resB.completed && !resB.closed && resB.gotMarker;
+    if (!ok) failed = true;
+    log(failed ? "RESULT: FAILED ❌" : "RESULT: PASSED ✅ — codex app-server supports 2 independent TUI-like clients");
+
+    a.ws.close(); b.ws.close();
+  } catch (e: any) {
+    log(`ERROR: ${e?.stack ?? e}`);
+    failed = true;
+  } finally {
+    log("stopping codex app-server");
+    try { codex.kill("SIGTERM"); } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+    try { codex.kill("SIGKILL"); } catch {}
+  }
+  process.exit(failed ? 1 : 0);
+}
+
+void main();

--- a/src/app-server-protocol.ts
+++ b/src/app-server-protocol.ts
@@ -33,6 +33,8 @@ export const APP_SERVER_NOTIFICATION_METHODS = [
   "item/started",
   "item/agentMessage/delta",
   "item/completed",
+  "error",
+  "thread/closed",
 ] as const;
 
 export type AppServerNotificationMethod = typeof APP_SERVER_NOTIFICATION_METHODS[number];
@@ -120,12 +122,20 @@ export type AppServerServerRequest =
   | AppServerRequest<"item/fileChange/requestApproval", Record<string, unknown>>
   | AppServerRequest<"item/commandExecution/requestApproval", Record<string, unknown>>;
 
+export interface AppServerErrorPayload {
+  code?: number;
+  message?: string;
+  data?: unknown;
+}
+
 export type AppServerNotification =
   | { jsonrpc?: "2.0"; id?: undefined; method: "turn/started"; params?: { turn?: AppServerTurn; [key: string]: unknown } }
   | { jsonrpc?: "2.0"; id?: undefined; method: "turn/completed"; params?: { turn?: AppServerTurn; [key: string]: unknown } }
   | { jsonrpc?: "2.0"; id?: undefined; method: "item/started"; params?: { item?: AppServerItem; [key: string]: unknown } }
   | { jsonrpc?: "2.0"; id?: undefined; method: "item/completed"; params?: { item?: AppServerItem; [key: string]: unknown } }
-  | { jsonrpc?: "2.0"; id?: undefined; method: "item/agentMessage/delta"; params?: { itemId?: string; delta?: string; [key: string]: unknown } };
+  | { jsonrpc?: "2.0"; id?: undefined; method: "item/agentMessage/delta"; params?: { itemId?: string; delta?: string; [key: string]: unknown } }
+  | { jsonrpc?: "2.0"; id?: undefined; method: "error"; params?: { error?: AppServerErrorPayload; [key: string]: unknown } }
+  | { jsonrpc?: "2.0"; id?: undefined; method: "thread/closed"; params?: { threadId?: string; [key: string]: unknown } };
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/src/bridge-disabled-state.ts
+++ b/src/bridge-disabled-state.ts
@@ -1,4 +1,4 @@
-export type BridgeDisabledReason = "killed" | "rejected";
+export type BridgeDisabledReason = "killed" | "rejected" | "daemon_rejected_attach";
 
 export function disabledReplyError(reason: BridgeDisabledReason): string {
   switch (reason) {
@@ -6,5 +6,12 @@ export function disabledReplyError(reason: BridgeDisabledReason): string {
       return "AgentBridge rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset.";
     case "killed":
       return "AgentBridge is disabled by `agentbridge kill`. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.";
+    case "daemon_rejected_attach":
+      // STM v2.3 §D4 / §D6 P4-cleanup: daemon returned ok=false from
+      // claude_connect_result (PAIR_NOT_FOUND / PAIR_BUSY / INVALID_PAIR_NAME).
+      // The detailed error+message has already been pushed as a system
+      // notification when the rejection happened; this string is the
+      // fallback shown if reply tool is called before the user reads it.
+      return "AgentBridge could not attach this Claude session — the daemon rejected the pair binding. See the most recent system message for the specific error (PAIR_NOT_FOUND / PAIR_BUSY / INVALID_PAIR_NAME). Restart Claude Code after fixing the underlying issue.";
   }
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -293,7 +293,24 @@ async function pollDisabledRecovery() {
     log("Disabled-state recovery conditions met — attempting direct daemon reconnect");
     try {
       await daemonClient.connect();
-      daemonClient.attachClaude();
+      // STM v2.3 §D6 P4-cleanup (Codex P4 final re-pass codex_msg_5753c73beafc_128):
+      // recovery path was also fire-and-forget — could silently claim
+      // "recovered" while the daemon rejected the pair binding. Now
+      // await the typed attach result and respect ok=false the same way
+      // connectToDaemon does.
+      const attachResult = await daemonClient.attachClaude();
+      if (!attachResult.ok) {
+        const pairCtx = PAIR_ID ? ` (requested pair: "${PAIR_ID}")` : "";
+        log(`Recovery attach rejected: ${attachResult.error} — ${attachResult.message}${pairCtx}`);
+        daemonDisabled = true;
+        daemonDisabledReason = "daemon_rejected_attach";
+        stopDisabledRecoveryPoller();
+        await claude.pushNotification(systemMessage(
+          "system_bridge_disabled",
+          `❌ AgentBridge recovery failed: ${attachResult.error}. ${attachResult.message}${pairCtx}`,
+        ));
+        return;
+      }
       daemonDisabled = false;
       daemonDisabledReason = null;
       stopDisabledRecoveryPoller();

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -19,7 +19,7 @@ const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_POR
 const CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 
 const claude = new ClaudeAdapter(stateDir.logFile);
-const daemonClient = new DaemonClient(CONTROL_WS_URL);
+const daemonClient = new DaemonClient(CONTROL_WS_URL, { chatId: claude.chatId });
 
 let shuttingDown = false;
 let daemonDisabled = false;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -19,7 +19,11 @@ const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_POR
 const CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 
 const claude = new ClaudeAdapter(stateDir.logFile);
-const daemonClient = new DaemonClient(CONTROL_WS_URL, { chatId: claude.chatId });
+// STM v2.3 §D4 P4b: AGENTBRIDGE_PAIR env (set by `agentbridge claude --pair NAME`)
+// pre-binds this Claude to a specific pair. Empty / unset → daemon's
+// FIFO claim logic decides (P3-cleanup attachClaude flow).
+const PAIR_ID = process.env.AGENTBRIDGE_PAIR;
+const daemonClient = new DaemonClient(CONTROL_WS_URL, { chatId: claude.chatId, pairId: PAIR_ID });
 
 let shuttingDown = false;
 let daemonDisabled = false;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -139,12 +139,31 @@ async function connectToDaemon(isReconnect = false) {
   try {
     await daemonLifecycle.ensureRunning();
     await daemonClient.connect();
-    daemonClient.attachClaude();
+    // STM v2.3 §D6 P4-cleanup HIGH#2: await the typed claude_connect_result
+    // and surface PAIR_NOT_FOUND / PAIR_BUSY / INVALID_PAIR_NAME as a
+    // disabled state instead of silently claiming "bridge ready".
+    const attachResult = await daemonClient.attachClaude();
+    if (!attachResult.ok) {
+      const pairCtx = PAIR_ID ? ` (requested pair: "${PAIR_ID}")` : "";
+      log(`Daemon rejected claude_connect: ${attachResult.error} — ${attachResult.message}${pairCtx}`);
+      daemonDisabled = true;
+      daemonDisabledReason = "daemon_rejected_attach";
+      await claude.pushNotification(systemMessage(
+        "system_bridge_disabled",
+        `❌ AgentBridge could not attach this Claude session: ${attachResult.error}. ${attachResult.message}${pairCtx}`,
+      ));
+      return;
+    }
     daemonDisabledReason = null;
     if (!isReconnect) {
+      const pairCtx = attachResult.paired && attachResult.homePairId
+        ? ` (paired with pair "${attachResult.homePairId}")`
+        : attachResult.homePairId && attachResult.homePairId !== "default"
+          ? ` (home pair: "${attachResult.homePairId}")`
+          : "";
       void claude.pushNotification(systemMessage(
         "system_bridge_ready",
-        "✅ AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: agentbridge codex",
+        `✅ AgentBridge bridge is ready. Daemon connected${pairCtx}. Start Codex in another terminal with: agentbridge codex`,
       ));
     }
   } catch (err: any) {

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -67,6 +67,13 @@ export class ClaudeAdapter extends EventEmitter {
   private sessionId: string;
   private readonly notificationIdPrefix: string;
   private readonly instanceId: string;
+  /**
+   * `chatId` uniquely identifies THIS MCP/Claude session to the daemon so
+   * the daemon can route messages to the right ClaudeThread. We reuse
+   * `sessionId` (already shown to Claude as `chat_id:` in channel headers)
+   * so the human-visible value and the routing key are the same string.
+   */
+  readonly chatId: string;
   private replySender: ReplySender | null = null;
   private readonly logFile: string;
 
@@ -81,7 +88,8 @@ export class ClaudeAdapter extends EventEmitter {
     super();
     this.logFile = logFile;
     this.instanceId = randomUUID().slice(0, 8);
-    this.sessionId = `codex_${Date.now()}`;
+    this.sessionId = `codex_${Date.now()}_${this.instanceId}`;
+    this.chatId = this.sessionId;
     this.notificationIdPrefix = randomUUID().replace(/-/g, "").slice(0, 12);
     this.log(`ClaudeAdapter created (instance=${this.instanceId})`);
 

--- a/src/claude-thread.ts
+++ b/src/claude-thread.ts
@@ -16,9 +16,9 @@
  */
 
 import { EventEmitter } from "node:events";
-import { appendFileSync } from "node:fs";
 import type { AppServerItem } from "./app-server-protocol";
 import type { BridgeMessage } from "./types";
+import { getAsyncFileLogger, type AsyncFileLogger } from "./log-writer";
 
 export interface ClaudeThreadOptions {
   appServerUrl: string;
@@ -386,9 +386,17 @@ export class ClaudeThread extends EventEmitter {
     }
   }
 
+  // Performance fix (2026-05-17 P0): switch to async file logger to
+  // remove blocking disk IO from the per-message ClaudeThread hot path.
+  private _logger: AsyncFileLogger | null = null;
+  private get logger(): AsyncFileLogger {
+    if (!this._logger) this._logger = getAsyncFileLogger(this.logFile);
+    return this._logger;
+  }
+
   private log(s: string) {
     const line = `[${new Date().toISOString()}] [ClaudeThread:${this.chatId}] ${s}\n`;
     process.stderr.write(line);
-    try { appendFileSync(this.logFile, line); } catch {}
+    this.logger.write(line);
   }
 }

--- a/src/claude-thread.ts
+++ b/src/claude-thread.ts
@@ -1,0 +1,322 @@
+/**
+ * ClaudeThread — one dedicated Codex thread per attached Claude session.
+ *
+ * Each Claude session gets its own WebSocket to the codex app-server and
+ * its own thread. Turns on different threads execute concurrently in the
+ * app-server (verified by `tools/agentbridge-multi/probes/concurrency.ts`).
+ *
+ * Lifecycle: bootstrap() opens the WS, runs initialize + thread/start, then
+ * emits "ready" with the threadId. injectMessage() sends turn/start on this
+ * thread. Notifications from codex are filtered to this threadId and
+ * surfaced via "agentMessage" / "turnStarted" / "turnCompleted" events so
+ * the daemon can route them back to the owning Claude WS by chatId.
+ *
+ * This is intentionally a LEAN adapter — no proxy, no TUI reconnect dance.
+ * For TUI flow see `codex-adapter.ts`.
+ */
+
+import { EventEmitter } from "node:events";
+import { appendFileSync } from "node:fs";
+import type { AppServerItem } from "./app-server-protocol";
+import type { BridgeMessage } from "./types";
+
+export interface ClaudeThreadOptions {
+  appServerUrl: string;
+  chatId: string;
+  logFile: string;
+  cwd?: string;
+}
+
+interface PendingRpc {
+  resolve: (value: any) => void;
+  reject: (err: Error) => void;
+  method: string;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const RPC_TIMEOUT_MS = 30_000;
+
+export class ClaudeThread extends EventEmitter {
+  readonly chatId: string;
+  private readonly appServerUrl: string;
+  private readonly logFile: string;
+  private readonly cwd: string | undefined;
+
+  private ws: WebSocket | null = null;
+  private threadId: string | null = null;
+  private nextId = 1;
+  private pending = new Map<number, PendingRpc>();
+  private turnInProgress = false;
+  private agentMessageBuffers = new Map<string, string[]>();
+  private bootstrapped = false;
+  private closed = false;
+
+  constructor(opts: ClaudeThreadOptions) {
+    super();
+    this.chatId = opts.chatId;
+    this.appServerUrl = opts.appServerUrl;
+    this.logFile = opts.logFile;
+    this.cwd = opts.cwd;
+  }
+
+  get activeThreadId(): string | null { return this.threadId; }
+  get isTurnInProgress(): boolean { return this.turnInProgress; }
+  get isReady(): boolean { return this.bootstrapped && this.threadId !== null; }
+
+  /** Open the WS, initialize, and start a thread. Resolves once ready. */
+  async bootstrap(): Promise<string> {
+    if (this.bootstrapped && this.threadId) return this.threadId;
+    await this.openSocket();
+    await this.callRpc("initialize", {
+      clientInfo: { name: "agentbridge-claude-thread", version: "0.1.0" },
+      capabilities: { experimentalApi: false },
+    });
+    const params: Record<string, unknown> = {};
+    if (this.cwd) params.cwd = this.cwd;
+    const startRes: any = await this.callRpc("thread/start", params);
+    const tid = startRes?.thread?.id ?? startRes?.threadId ?? null;
+    if (typeof tid !== "string" || tid.length === 0) {
+      throw new Error("thread/start did not return a threadId");
+    }
+    this.threadId = tid;
+    this.bootstrapped = true;
+    this.log(`bootstrap ok threadId=${tid}`);
+    this.emit("ready", tid);
+    return tid;
+  }
+
+  /** Send a turn/start on this thread. Returns true on send success. */
+  injectMessage(text: string): boolean {
+    if (!this.threadId) {
+      this.log("inject rejected: not bootstrapped");
+      return false;
+    }
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.log("inject rejected: ws not open");
+      return false;
+    }
+    if (this.turnInProgress) {
+      this.log(`inject rejected: turn already in progress`);
+      return false;
+    }
+    const id = this.nextId++;
+    const msg = {
+      jsonrpc: "2.0",
+      id,
+      method: "turn/start",
+      params: {
+        threadId: this.threadId,
+        input: [{ type: "text", text }],
+      },
+    };
+    try {
+      this.ws.send(JSON.stringify(msg));
+      return true;
+    } catch (err: any) {
+      this.log(`inject send failed: ${err.message}`);
+      return false;
+    }
+  }
+
+  /** Close the WS. Does NOT delete the thread on the server side (could be resumed). */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.ws) {
+      try { this.ws.close(); } catch {}
+      this.ws = null;
+    }
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(new Error("ClaudeThread closed"));
+    }
+    this.pending.clear();
+  }
+
+  // ── internals ──────────────────────────────────────────────
+
+  private openSocket(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.appServerUrl);
+      let settled = false;
+      ws.onopen = () => {
+        if (settled) return;
+        settled = true;
+        this.ws = ws;
+        this.attachHandlers(ws);
+        resolve();
+      };
+      ws.onerror = (e: any) => {
+        if (settled) return;
+        settled = true;
+        reject(new Error(`ws connect failed: ${e?.message ?? "unknown"}`));
+      };
+      ws.onclose = (e: any) => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(`ws closed during handshake (code=${e?.code})`));
+          return;
+        }
+      };
+    });
+  }
+
+  private attachHandlers(ws: WebSocket) {
+    ws.onmessage = (event) => {
+      const raw = typeof event.data === "string" ? event.data : event.data.toString();
+      this.handlePayload(raw);
+    };
+    ws.onclose = () => {
+      this.log(`ws closed (chatId=${this.chatId}, threadId=${this.threadId})`);
+      this.ws = null;
+      this.emit("close");
+    };
+    ws.onerror = (e: any) => {
+      this.log(`ws error: ${e?.message ?? "unknown"}`);
+      this.emit("error", e);
+    };
+  }
+
+  private handlePayload(raw: string) {
+    let parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    // response to one of our rpc requests
+    if (typeof parsed.id === "number" && this.pending.has(parsed.id) && (parsed.result !== undefined || parsed.error !== undefined)) {
+      const pending = this.pending.get(parsed.id)!;
+      this.pending.delete(parsed.id);
+      clearTimeout(pending.timer);
+      if (parsed.error) {
+        pending.reject(new Error(`${pending.method} failed: ${JSON.stringify(parsed.error).slice(0, 200)}`));
+      } else {
+        pending.resolve(parsed.result);
+      }
+      return;
+    }
+
+    // server-initiated request (approvals, fuzzy file, etc.) — auto-deny
+    if (parsed.id !== undefined && typeof parsed.method === "string") {
+      // Only respond if the request targets our thread; otherwise it's
+      // for a different client and we can ignore.
+      const tid = parsed.params?.threadId;
+      if (tid && this.threadId && tid !== this.threadId) return;
+      try {
+        this.ws?.send(JSON.stringify({
+          jsonrpc: "2.0",
+          id: parsed.id,
+          error: { code: -32601, message: "auto-denied by ClaudeThread (no UI to approve)" },
+        }));
+      } catch {}
+      return;
+    }
+
+    // notification (anything with method + no id)
+    if (typeof parsed.method === "string" && parsed.id === undefined) {
+      const tid = parsed.params?.threadId;
+      if (tid && this.threadId && tid !== this.threadId) {
+        // Notification for a different thread — ignore (defense in depth;
+        // each ClaudeThread has its own WS so this should not happen in practice).
+        return;
+      }
+      this.handleNotification(parsed.method as string, parsed.params ?? {});
+    }
+  }
+
+  private handleNotification(method: string, params: any) {
+    switch (method) {
+      case "turn/started": {
+        if (!this.turnInProgress) {
+          this.turnInProgress = true;
+          this.emit("turnStarted");
+        }
+        break;
+      }
+      case "item/started": {
+        const item: AppServerItem | undefined = (params as any)?.item;
+        if (item?.type === "agentMessage") this.agentMessageBuffers.set(item.id, []);
+        break;
+      }
+      case "item/agentMessage/delta": {
+        const itemId = (params as any)?.itemId;
+        const delta = (params as any)?.delta;
+        if (typeof itemId === "string") {
+          const buf = this.agentMessageBuffers.get(itemId);
+          if (buf && typeof delta === "string") buf.push(delta);
+        }
+        break;
+      }
+      case "item/completed": {
+        const item: AppServerItem | undefined = (params as any)?.item;
+        if (item?.type === "agentMessage") {
+          const content = this.extractContent(item);
+          this.agentMessageBuffers.delete(item.id);
+          if (content) {
+            const bridgeMsg: BridgeMessage = {
+              id: item.id,
+              source: "codex",
+              content,
+              timestamp: Date.now(),
+            };
+            this.emit("agentMessage", bridgeMsg);
+          }
+        }
+        break;
+      }
+      case "turn/completed": {
+        if (this.turnInProgress) {
+          this.turnInProgress = false;
+          this.emit("turnCompleted");
+        }
+        break;
+      }
+      case "turn/failed": {
+        if (this.turnInProgress) {
+          this.turnInProgress = false;
+          this.emit("turnCompleted");
+        }
+        this.emit("turnFailed", params);
+        break;
+      }
+    }
+  }
+
+  private extractContent(item: AppServerItem): string {
+    if (item.content?.length) {
+      return item.content.filter((c) => c.type === "text" && c.text).map((c) => c.text!).join("");
+    }
+    return this.agentMessageBuffers.get(item.id)?.join("") ?? "";
+  }
+
+  private callRpc(method: string, params: Record<string, unknown>): Promise<any> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("callRpc: ws not open"));
+    }
+    const id = this.nextId++;
+    const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    return new Promise<any>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(new Error(`${method} timed out after ${RPC_TIMEOUT_MS}ms`));
+        }
+      }, RPC_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, method, timer });
+      try {
+        this.ws!.send(msg);
+      } catch (err: any) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  private log(s: string) {
+    const line = `[${new Date().toISOString()}] [ClaudeThread:${this.chatId}] ${s}\n`;
+    process.stderr.write(line);
+    try { appendFileSync(this.logFile, line); } catch {}
+  }
+}

--- a/src/claude-thread.ts
+++ b/src/claude-thread.ts
@@ -71,7 +71,12 @@ export class ClaudeThread extends EventEmitter {
       clientInfo: { name: "agentbridge-claude-thread", version: "0.1.0" },
       capabilities: { experimentalApi: false },
     });
-    const params: Record<string, unknown> = {};
+    // Use approvalPolicy="never" so Codex never escalates approvals to us.
+    // Sandbox boundaries still apply; if a command can't run under the
+    // configured sandbox it fails as a turn error rather than triggering an
+    // interactive approval flow we have no UI to satisfy. Approval-method
+    // server requests are still handled below as a defense-in-depth fallback.
+    const params: Record<string, unknown> = { approvalPolicy: "never" };
     if (this.cwd) params.cwd = this.cwd;
     const startRes: any = await this.callRpc("thread/start", params);
     const tid = startRes?.thread?.id ?? startRes?.threadId ?? null;
@@ -198,19 +203,24 @@ export class ClaudeThread extends EventEmitter {
       return;
     }
 
-    // server-initiated request (approvals, fuzzy file, etc.) — auto-deny
+    // Server-initiated request (approvals, fuzzy file, etc.). We have no
+    // interactive UI bound to this thread — and we've already set
+    // approvalPolicy="never" at thread/start, so in steady state these
+    // should not arrive. This block is a defense-in-depth fallback:
+    //
+    //   - Approval-like methods (commandExecution / fileChange) → auto-accept,
+    //     since the human-equivalent for this thread is the Claude that
+    //     issued the task. Sandbox boundaries already constrain what can be
+    //     executed; a separate approval handshake adds no security here.
+    //   - Permission-grant requests → auto-deny (grant nothing extra) so the
+    //     sandbox can't be silently widened by Codex.
+    //   - Anything else (future server requests we don't know) → reply with
+    //     -32601 and log; surfacing a clear error is better than silently
+    //     ignoring the id and leaving Codex hung waiting for a response.
     if (parsed.id !== undefined && typeof parsed.method === "string") {
-      // Only respond if the request targets our thread; otherwise it's
-      // for a different client and we can ignore.
       const tid = parsed.params?.threadId;
       if (tid && this.threadId && tid !== this.threadId) return;
-      try {
-        this.ws?.send(JSON.stringify({
-          jsonrpc: "2.0",
-          id: parsed.id,
-          error: { code: -32601, message: "auto-denied by ClaudeThread (no UI to approve)" },
-        }));
-      } catch {}
+      this.respondToServerRequest(parsed.id, parsed.method, parsed.params);
       return;
     }
 
@@ -312,6 +322,68 @@ export class ClaudeThread extends EventEmitter {
         reject(err);
       }
     });
+  }
+
+  /**
+   * Respond to a server-initiated request (Codex asking the client to
+   * approve a command, file change, permission widening, etc.).
+   *
+   * See `ExecCommandApprovalResponse` / `CommandExecutionRequestApprovalResponse`
+   * / `FileChangeRequestApprovalResponse` / `PermissionsRequestApprovalResponse`
+   * in the codex app-server schema for the exact shapes.
+   */
+  private respondToServerRequest(
+    id: number | string,
+    method: string,
+    _params: unknown,
+  ): void {
+    let result: Record<string, unknown> | undefined;
+    let error: { code: number; message: string } | undefined;
+
+    switch (method) {
+      case "item/commandExecution/requestApproval":
+        // CommandExecutionApprovalDecision allowed values:
+        //   "accept" | "acceptForSession" | {acceptWithExecpolicyAmendment} |
+        //   {applyNetworkPolicyAmendment} | "decline" | "cancel"
+        result = { decision: "accept" };
+        this.log(`auto-accepted ${method} (id=${id})`);
+        break;
+      case "item/fileChange/requestApproval":
+        // FileChangeApprovalDecision: accept | acceptForSession | decline | cancel
+        result = { decision: "accept" };
+        this.log(`auto-accepted ${method} (id=${id})`);
+        break;
+      case "applyPatchApproval":
+      case "execCommandApproval":
+        // ReviewDecision: approved | approved_for_session | denied | timed_out | abort
+        result = { decision: "approved" };
+        this.log(`auto-approved ${method} (id=${id})`);
+        break;
+      case "item/permissions/requestApproval":
+        // PermissionsRequestApprovalResponse requires `permissions`. Returning
+        // an empty profile effectively grants nothing additional — the
+        // existing sandbox stays in force. This is the conservative path:
+        // we don't widen what Codex is allowed to do.
+        result = { permissions: {} };
+        this.log(`auto-denied permission widening for ${method} (id=${id})`);
+        break;
+      default:
+        error = {
+          code: -32601,
+          message: `ClaudeThread received unknown server request method '${method}' with no handler`,
+        };
+        this.log(`unknown server request method: ${method} (id=${id}) — replying -32601`);
+        break;
+    }
+
+    const payload: Record<string, unknown> = { jsonrpc: "2.0", id };
+    if (result !== undefined) payload.result = result;
+    if (error !== undefined) payload.error = error;
+    try {
+      this.ws?.send(JSON.stringify(payload));
+    } catch (err: any) {
+      this.log(`failed to send server-request response: ${err?.message ?? err}`);
+    }
   }
 
   private log(s: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,11 @@ async function main() {
       const { runKill } = await import("./cli/kill");
       await runKill();
       break;
+    case "pairs":
+      // STM v2.3 §8.2 P4c — pair management subcommands.
+      const { runPairs } = await import("./cli/pairs");
+      await runPairs(restArgs);
+      break;
     case "--help":
     case "-h":
     case undefined:
@@ -69,7 +74,11 @@ Commands:
   init              Install plugin, check dependencies, generate project config
   dev               Register local marketplace + install plugin (for local dev)
   claude [args...]  Start Claude Code with push channel enabled
+                    Use --pair NAME to pre-bind to a specific pair (STM v2.3)
   codex [args...]   Start Codex TUI connected to AgentBridge daemon
+                    Use --pair NAME to target a specific pair (STM v2.3)
+  pairs <subcmd>    Manage shared-thread pairs (STM v2.3)
+                    Subcommands: ls / rm NAME [--forget] [--force]
   kill              Force kill all AgentBridge processes
 
 Options:

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -10,6 +10,35 @@ export async function runClaude(args: string[]) {
   // Check for owned flag conflicts
   checkOwnedFlagConflicts(args, "agentbridge claude", OWNED_FLAGS);
 
+  // STM v2.3 §8.3 P4b — parse --pair NAME (or --pair=NAME) out of args
+  // and forward it to the spawned Claude via AGENTBRIDGE_PAIR env. The
+  // bridge.ts plugin reads that env at MCP connection time and includes
+  // pairId in the claude_connect control message. Daemon's attachClaude
+  // (P3-cleanup) consumes it for explicit-pair binding.
+  let pairId: string | undefined;
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--pair" && i + 1 < args.length) {
+      pairId = args[i + 1];
+      i++;
+      continue;
+    }
+    if (a.startsWith("--pair=")) {
+      pairId = a.slice("--pair=".length);
+      continue;
+    }
+    rest.push(a);
+  }
+  if (pairId !== undefined) {
+    const { isValidPairName } = await import("../pair-registry");
+    if (!isValidPairName(pairId)) {
+      console.error(`Error: --pair value "${pairId}" is invalid.`);
+      console.error("Allowed: lowercase letters, digits, underscore, hyphen. First char alphanumeric. Length 1-32 chars.");
+      process.exit(1);
+    }
+  }
+
   const stateDir = new StateDirResolver();
   const controlPort = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
   const lifecycle = new DaemonLifecycle({
@@ -31,12 +60,18 @@ export async function runClaude(args: string[]) {
   // Once published to the official marketplace, switch to --channels.
   const fullArgs = [
     "--dangerously-load-development-channels", channelEntry,
-    ...args,
+    ...rest,
   ];
+
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  if (pairId !== undefined) {
+    childEnv.AGENTBRIDGE_PAIR = pairId;
+    console.error(`[agentbridge] Launching Claude pre-bound to pair "${pairId}"`);
+  }
 
   const child = spawn("claude", fullArgs, {
     stdio: "inherit",
-    env: process.env,
+    env: childEnv,
   });
 
   child.on("exit", (code) => {

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -19,13 +19,23 @@ export async function runClaude(args: string[]) {
   const rest: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a === "--pair" && i + 1 < args.length) {
+    if (a === "--pair") {
+      // MEDIUM (Codex P4 review): --pair without a value used to fall
+      // through into native claude args. Now a clear error.
+      if (i + 1 >= args.length) {
+        console.error(`Error: --pair requires a value (e.g. \`--pair work\`).`);
+        process.exit(1);
+      }
       pairId = args[i + 1];
       i++;
       continue;
     }
     if (a.startsWith("--pair=")) {
       pairId = a.slice("--pair=".length);
+      if (!pairId) {
+        console.error(`Error: --pair= requires a value (e.g. \`--pair=work\`).`);
+        process.exit(1);
+      }
       continue;
     }
     rest.push(a);

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -53,7 +53,40 @@ function buildChildEnv(): NodeJS.ProcessEnv {
 /** Flags that AgentBridge owns for codex command. */
 const OWNED_FLAGS = ["--remote"];
 
-export async function runCodex(args: string[]) {
+/**
+ * Connection mode for `agentbridge codex`:
+ *   - "direct" (default): connect each TUI straight to the codex app-server
+ *     so multiple TUI windows can run in parallel, each with its own thread.
+ *     Pre-multi-Claude AgentBridge proxied every TUI through one port, with
+ *     a "primary + secondary picker" assumption that breaks for two
+ *     long-lived TUI windows.
+ *   - "proxy": legacy behavior — route through the daemon's proxy port so
+ *     the proxy can intercept agentMessage events. Useful if you depend on
+ *     the daemon's TUI broadcast (which the multi-Claude daemon no longer
+ *     uses anyway). Opt in with `--via-proxy`.
+ */
+type CodexConnectionMode = "direct" | "proxy";
+
+function extractConnectionMode(args: string[]): { mode: CodexConnectionMode; rest: string[] } {
+  const rest: string[] = [];
+  let mode: CodexConnectionMode = "direct";
+  for (const a of args) {
+    if (a === "--via-proxy") {
+      mode = "proxy";
+      continue;
+    }
+    if (a === "--direct") {
+      mode = "direct";
+      continue;
+    }
+    rest.push(a);
+  }
+  return { mode, rest };
+}
+
+export async function runCodex(rawArgs: string[]) {
+  const { mode, rest: args } = extractConnectionMode(rawArgs);
+
   // Check for owned flag conflicts
   checkOwnedFlagConflicts(args, "agentbridge codex", OWNED_FLAGS);
 
@@ -98,25 +131,40 @@ export async function runCodex(args: string[]) {
     process.exit(1);
   }
 
-  // Read proxyUrl from daemon status or fall back to config
-  let proxyUrl: string;
+  // Resolve the WebSocket URL to hand to codex --remote.
+  //
+  // direct mode → app-server port (each TUI is an independent client of the
+  //               same codex backend; gets its own thread; no proxy).
+  // proxy mode  → daemon's proxy port (legacy; intercepts agentMessage events
+  //               for the multi-Claude broadcast that the multi-Claude daemon
+  //               no longer uses).
+  let remoteUrl: string;
   const status = lifecycle.readStatus();
-  if (status?.proxyUrl) {
-    proxyUrl = status.proxyUrl;
+  if (mode === "direct") {
+    if (status?.appServerUrl) {
+      remoteUrl = status.appServerUrl;
+    } else {
+      remoteUrl = `ws://127.0.0.1:${config.codex.appPort}`;
+      console.error(`[agentbridge] No daemon status found, using config default app-server URL: ${remoteUrl}`);
+    }
   } else {
-    proxyUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
-    console.error(`[agentbridge] No daemon status found, using config default: ${proxyUrl}`);
+    if (status?.proxyUrl) {
+      remoteUrl = status.proxyUrl;
+    } else {
+      remoteUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
+      console.error(`[agentbridge] No daemon status found, using config default proxy URL: ${remoteUrl}`);
+    }
   }
 
   try {
-    await waitForProxyReady(proxyUrl);
+    await waitForProxyReady(remoteUrl);
   } catch (err: any) {
     console.error(`[agentbridge] ${err.message}`);
     process.exit(1);
   }
 
   // Save terminal state and launch Codex with protection
-  console.log(`Connecting Codex TUI to AgentBridge at ${proxyUrl}...`);
+  console.log(`Connecting Codex TUI to AgentBridge at ${remoteUrl} (mode=${mode})...`);
 
   // Save terminal state
   let savedStty: string | null = null;
@@ -170,7 +218,7 @@ export async function runCodex(args: string[]) {
 
   const fullArgs = [
     "--enable", "tui_app_server",
-    "--remote", proxyUrl,
+    "--remote", remoteUrl,
     ...args,
   ];
 

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -216,13 +216,24 @@ function extractCliFlags(args: string[]): {
     // Default is "default" (v2.2-compat). Multiple TUIs on different
     // pairs can coexist; each spawns its own Codex app-server on a
     // separate port via daemon's ensure_pair flow.
-    if (a === "--pair" && i + 1 < args.length) {
+    if (a === "--pair") {
+      // MEDIUM (Codex P4 review): --pair without a value used to fall
+      // through into native codex args (silent breakage). Now a clear
+      // error.
+      if (i + 1 >= args.length) {
+        console.error(`Error: --pair requires a value (e.g. \`--pair work\`).`);
+        process.exit(1);
+      }
       pairId = args[i + 1];
       i++;
       continue;
     }
     if (a.startsWith("--pair=")) {
       pairId = a.slice("--pair=".length);
+      if (!pairId) {
+        console.error(`Error: --pair= requires a value (e.g. \`--pair=work\`).`);
+        process.exit(1);
+      }
       continue;
     }
     rest.push(a);
@@ -348,7 +359,16 @@ export async function runCodex(rawArgs: string[]) {
       process.exit(1);
     }
     console.error(`[agentbridge] Failed to ensure pair "${pairId}": ${err.message ?? err}`);
-    console.error(`  Falling back to status.json URLs.`);
+    // HIGH#1 (Codex P4 review codex_msg_5753c73beafc_123): only fall
+    // back to status.json/config for the default pair. For named pairs
+    // any fallback would mean launching `--pair work` against default's
+    // ports, silently collapsing pair isolation. Hard-fail instead.
+    if (pairId !== "default") {
+      console.error(`  Named pair "${pairId}" requires the daemon's ensure_pair to succeed — refusing to fall back to default ports (would break pair isolation).`);
+      console.error(`  Either start the daemon (\`abg codex\` once succeeds), update the daemon to a build that speaks ensure_pair, or use \`--pair default\` for v2.2-compat behavior.`);
+      process.exit(1);
+    }
+    console.error(`  Default pair: falling back to status.json URLs for v2.2 compatibility.`);
   }
 
   if (mode === "direct") {

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -17,6 +17,25 @@ import { StderrRingBuffer } from "../stderr-ring-buffer";
 import { checkOwnedFlagConflicts } from "./claude";
 
 /**
+ * Spec v2.2 §7: fetch live daemon /healthz JSON for pre-flight checks.
+ * Returns null if the daemon is unreachable (CLI falls through to its normal
+ * "ensure running" flow and surfaces a clearer error elsewhere).
+ */
+async function fetchLiveDaemonStatus(
+  controlPort: number,
+): Promise<{ proxyTuiConnected?: boolean } | null> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${controlPort}/healthz`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as { proxyTuiConnected?: boolean };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Write a timestamped entry to the codex wrapper log.
  *
  * Silent on IO failure — logging must never break the wrapper itself.
@@ -40,9 +59,10 @@ function appendWrapperLog(path: string, entry: string): void {
  * up in `~/.codex/log/codex-tui.log` and on stderr (which we also tee).
  * User-provided values take precedence — we only set defaults.
  */
-function buildChildEnv(): NodeJS.ProcessEnv {
+function buildChildEnv(extraEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
     ...process.env,
+    ...extraEnv,
     RUST_BACKTRACE: process.env.RUST_BACKTRACE ?? "full",
     RUST_LOG:
       process.env.RUST_LOG ??
@@ -51,7 +71,7 @@ function buildChildEnv(): NodeJS.ProcessEnv {
 }
 
 /** Flags that AgentBridge owns for codex command. */
-const OWNED_FLAGS = ["--remote"];
+const OWNED_FLAGS = ["--remote", "--remote-auth-token-env"];
 
 /**
  * Connection mode for `agentbridge codex`:
@@ -135,10 +155,16 @@ export async function runCodex(rawArgs: string[]) {
   //
   // direct mode → app-server port (each TUI is an independent client of the
   //               same codex backend; gets its own thread; no proxy).
-  // proxy mode  → daemon's proxy port (legacy; intercepts agentMessage events
-  //               for the multi-Claude broadcast that the multi-Claude daemon
-  //               no longer uses).
+  // proxy mode  → daemon's proxy port. Spec v2.2 §4.6: `--via-proxy` now
+  //               participates in the shared-thread pairing protocol. A
+  //               unique bearer token is passed via Codex's native
+  //               --remote-auth-token-env option so the daemon can
+  //               distinguish this TUI's secondary picker connection from a
+  //               foreign second instance. codex-cli rejects query strings in
+  //               --remote (accepted forms are ws://host:port / wss://host:port).
   let remoteUrl: string;
+  const childEnv: NodeJS.ProcessEnv = {};
+  const remoteAuthArgs: string[] = [];
   const status = lifecycle.readStatus();
   if (mode === "direct") {
     if (status?.appServerUrl) {
@@ -148,12 +174,31 @@ export async function runCodex(rawArgs: string[]) {
       console.error(`[agentbridge] No daemon status found, using config default app-server URL: ${remoteUrl}`);
     }
   } else {
+    // Spec v2.2 §7: pre-flight check — daemon should only have one proxy TUI
+    // at a time. Hit /healthz for the live state (status.json is stale).
+    const liveStatus = await fetchLiveDaemonStatus(controlPort);
+    if (liveStatus?.proxyTuiConnected) {
+      console.error("");
+      console.error("[agentbridge] Error: another `agentbridge codex --via-proxy` TUI is already connected to the daemon.");
+      console.error("");
+      console.error("Shared-thread mode supports at most one proxy TUI at a time.");
+      console.error("Either close the other TUI window first, or use `agentbridge codex` (direct mode) to run an independent parallel session.");
+      console.error("");
+      process.exit(1);
+    }
+
+    // Spec v2.2 §4.6: generate the token so codex-rs's primary AND secondary
+    // picker connections inherit it via the Authorization header.
+    const abgToken = (await import("node:crypto")).randomBytes(8).toString("hex");
     if (status?.proxyUrl) {
       remoteUrl = status.proxyUrl;
     } else {
       remoteUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
       console.error(`[agentbridge] No daemon status found, using config default proxy URL: ${remoteUrl}`);
     }
+    childEnv.AGENTBRIDGE_PROXY_TOKEN = abgToken;
+    remoteAuthArgs.push("--remote-auth-token-env", "AGENTBRIDGE_PROXY_TOKEN");
+    console.error(`[agentbridge] Shared-thread mode active. Token=${abgToken.slice(0, 8)}…`);
   }
 
   try {
@@ -219,6 +264,7 @@ export async function runCodex(rawArgs: string[]) {
   const fullArgs = [
     "--enable", "tui_app_server",
     "--remote", remoteUrl,
+    ...remoteAuthArgs,
     ...args,
   ];
 
@@ -238,7 +284,7 @@ export async function runCodex(rawArgs: string[]) {
   const child = spawn("codex", fullArgs, {
     // inherit stdin + stdout (TUI needs raw TTY), pipe stderr so we can tee.
     stdio: ["inherit", "inherit", "pipe"],
-    env: buildChildEnv(),
+    env: buildChildEnv(childEnv),
   });
 
   if (typeof child.pid === "number") {

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -270,10 +270,24 @@ export async function runCodex(rawArgs: string[]) {
 
   // Pass sandbox to daemon (read at codex app-server spawn time). Set BEFORE
   // ensureRunning() so the env is in place if the daemon spawn happens now.
-  // Note: if the daemon is already running with a different value, this
-  // export is a no-op for that daemon — kill + restart to switch sandboxes.
+  // Limitation surfaced (Codex batch review 2026-05-17 msg ..._184): if a
+  // daemon is already running, it has already captured its env at spawn
+  // time — this export is a no-op for that daemon. Warn the user instead
+  // of silently dropping the flag.
   if (sandbox) {
-    process.env.AGENTBRIDGE_CODEX_SANDBOX = sandbox;
+    const probeLifecycle = new DaemonLifecycle({
+      stateDir: new StateDirResolver(),
+      controlPort: parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10),
+      log: () => { /* silent probe — we only care about the boolean result */ },
+    });
+    const daemonAlreadyUp = await probeLifecycle.isHealthy();
+    if (daemonAlreadyUp) {
+      console.warn(`[agentbridge] Warning: --sandbox=${sandbox} ignored — daemon is already running.`);
+      console.warn(`[agentbridge]   The codex app-server sandbox was fixed at daemon spawn time.`);
+      console.warn(`[agentbridge]   To switch sandboxes: \`abg kill && abg codex --sandbox=${sandbox}\``);
+    } else {
+      process.env.AGENTBRIDGE_CODEX_SANDBOX = sandbox;
+    }
   }
 
   // STM v2.3 §D1 P4: CLI-side validation of --pair NAME. Reject locally

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -17,22 +17,129 @@ import { StderrRingBuffer } from "../stderr-ring-buffer";
 import { checkOwnedFlagConflicts } from "./claude";
 
 /**
- * Spec v2.2 §7: fetch live daemon /healthz JSON for pre-flight checks.
- * Returns null if the daemon is unreachable (CLI falls through to its normal
- * "ensure running" flow and surfaces a clearer error elsewhere).
+ * STM v2.3 §D6 P4: one-shot control-WS request helper. Opens a short-lived
+ * WebSocket to the daemon, sends a request that carries a unique
+ * `requestId`, and resolves with the first response whose requestId
+ * matches (or the first match by message-type if the request was
+ * untagged). Closes the socket and returns.
+ *
+ * Used by the CLI for `ensure_pair` and `list_pairs` pre-flight calls.
+ * Bun has native WebSocket — no extra dependency.
  */
-async function fetchLiveDaemonStatus(
+async function controlWsRequest<TReq extends { type: string; requestId: string }, TRes>(
   controlPort: number,
-): Promise<{ proxyTuiConnected?: boolean } | null> {
-  try {
-    const res = await fetch(`http://127.0.0.1:${controlPort}/healthz`, {
-      signal: AbortSignal.timeout(2000),
+  request: TReq,
+  matchResponse: (msg: any) => msg is TRes,
+  timeoutMs = 5000,
+): Promise<TRes> {
+  const url = `ws://127.0.0.1:${controlPort}/ws`;
+  return new Promise<TRes>((resolve, reject) => {
+    let settled = false;
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { ws.close(); } catch {}
+      reject(new Error(`control-WS request timed out after ${timeoutMs}ms (type=${request.type})`));
+    }, timeoutMs);
+    ws.addEventListener("open", () => {
+      try { ws.send(JSON.stringify(request)); } catch (err: any) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try { ws.close(); } catch {}
+        reject(new Error(`control-WS send failed: ${err?.message ?? err}`));
+      }
     });
-    if (!res.ok) return null;
-    return (await res.json()) as { proxyTuiConnected?: boolean };
-  } catch {
-    return null;
+    ws.addEventListener("message", (ev) => {
+      if (settled) return;
+      try {
+        const msg = JSON.parse(ev.data.toString());
+        if (matchResponse(msg)) {
+          settled = true;
+          clearTimeout(timer);
+          try { ws.close(); } catch {}
+          resolve(msg);
+        }
+      } catch { /* ignore non-JSON / non-matching */ }
+    });
+    ws.addEventListener("error", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error("control-WS connection error"));
+    });
+    ws.addEventListener("close", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error("control-WS closed before response"));
+    });
+  });
+}
+
+/**
+ * Send `ensure_pair(pairId)` over the control WS. Returns the URLs the
+ * CLI should pass to `codex --remote`, or throws a structured error
+ * carrying the daemon's `pair_error` code.
+ */
+async function ensurePairViaControl(
+  controlPort: number,
+  pairId: string,
+  timeoutMs = 5000,
+): Promise<{ appServerUrl: string; proxyUrl: string }> {
+  const requestId = `cli-ensure-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const response = await controlWsRequest<
+    { type: "ensure_pair"; requestId: string; pairId: string },
+    { type: "pair_ensured" | "pair_error"; requestId: string; [k: string]: any }
+  >(
+    controlPort,
+    { type: "ensure_pair", requestId, pairId },
+    (msg): msg is { type: "pair_ensured" | "pair_error"; requestId: string; [k: string]: any } => {
+      return msg
+        && (msg.type === "pair_ensured" || msg.type === "pair_error")
+        && msg.requestId === requestId;
+    },
+    timeoutMs,
+  );
+  if (response.type === "pair_error") {
+    const err = new Error(response.message ?? "ensure_pair failed") as Error & {
+      code?: string;
+      details?: any;
+    };
+    err.code = response.code;
+    err.details = response.details;
+    throw err;
   }
+  return { appServerUrl: response.appServerUrl, proxyUrl: response.proxyUrl };
+}
+
+/**
+ * Send `list_pairs` over the control WS. Returns the pairs array.
+ */
+async function listPairsViaControl(
+  controlPort: number,
+  timeoutMs = 5000,
+): Promise<Array<{
+  pairId: string;
+  isLive: boolean;
+  proxyTuiConnected: boolean;
+  pairedChatId: string | null;
+  [k: string]: any;
+}>> {
+  const requestId = `cli-list-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const response = await controlWsRequest<
+    { type: "list_pairs"; requestId: string },
+    { type: "pair_list"; requestId: string; pairs: any[] }
+  >(
+    controlPort,
+    { type: "list_pairs", requestId },
+    (msg): msg is { type: "pair_list"; requestId: string; pairs: any[] } => {
+      return msg && msg.type === "pair_list" && msg.requestId === requestId;
+    },
+    timeoutMs,
+  );
+  return response.pairs ?? [];
 }
 
 /**
@@ -87,10 +194,16 @@ const OWNED_FLAGS = ["--remote", "--remote-auth-token-env"];
  */
 type CodexConnectionMode = "direct" | "proxy";
 
-function extractConnectionMode(args: string[]): { mode: CodexConnectionMode; rest: string[] } {
+function extractCliFlags(args: string[]): {
+  mode: CodexConnectionMode;
+  pairId: string;
+  rest: string[];
+} {
   const rest: string[] = [];
   let mode: CodexConnectionMode = "direct";
-  for (const a of args) {
+  let pairId = "default";
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
     if (a === "--via-proxy") {
       mode = "proxy";
       continue;
@@ -99,13 +212,39 @@ function extractConnectionMode(args: string[]): { mode: CodexConnectionMode; res
       mode = "direct";
       continue;
     }
+    // STM v2.3 §8.1 P4: --pair NAME selects which pair this TUI joins.
+    // Default is "default" (v2.2-compat). Multiple TUIs on different
+    // pairs can coexist; each spawns its own Codex app-server on a
+    // separate port via daemon's ensure_pair flow.
+    if (a === "--pair" && i + 1 < args.length) {
+      pairId = args[i + 1];
+      i++;
+      continue;
+    }
+    if (a.startsWith("--pair=")) {
+      pairId = a.slice("--pair=".length);
+      continue;
+    }
     rest.push(a);
   }
-  return { mode, rest };
+  return { mode, pairId, rest };
 }
 
 export async function runCodex(rawArgs: string[]) {
-  const { mode, rest: args } = extractConnectionMode(rawArgs);
+  const { mode, pairId, rest: args } = extractCliFlags(rawArgs);
+
+  // STM v2.3 §D1 P4: CLI-side validation of --pair NAME. Reject locally
+  // with a clear message before any daemon round-trip — the daemon's
+  // INVALID_PAIR_NAME would surface a less ergonomic generic message.
+  const { isValidPairName } = await import("../pair-registry");
+  if (!isValidPairName(pairId)) {
+    console.error(`Error: --pair value "${pairId}" is invalid.`);
+    console.error("");
+    console.error("Allowed: lowercase letters, digits, underscore, hyphen.");
+    console.error("First character must be alphanumeric. Length 1-32 chars.");
+    console.error("Examples: default, work, side, project-2, my_pair");
+    process.exit(1);
+  }
 
   // Check for owned flag conflicts
   checkOwnedFlagConflicts(args, "agentbridge codex", OWNED_FLAGS);
@@ -153,9 +292,16 @@ export async function runCodex(rawArgs: string[]) {
 
   // Resolve the WebSocket URL to hand to codex --remote.
   //
+  // STM v2.3 §8.1 P4: the URL comes from the daemon's `ensure_pair(pairId)`
+  // response, not from `status.json` directly. This makes multi-pair
+  // possible — each pair has its own (appPort, proxyPort) tuple, and the
+  // daemon allocates them under the registry mutex. For backwards-compat
+  // when daemon is not yet reachable for ensure_pair (rare; daemon was
+  // ensured above), falls back to status.json / config.
+  //
   // direct mode → app-server port (each TUI is an independent client of the
   //               same codex backend; gets its own thread; no proxy).
-  // proxy mode  → daemon's proxy port. Spec v2.2 §4.6: `--via-proxy` now
+  // proxy mode  → daemon's proxy port. Spec v2.2 §4.6: `--via-proxy`
   //               participates in the shared-thread pairing protocol. A
   //               unique bearer token is passed via Codex's native
   //               --remote-auth-token-env option so the daemon can
@@ -166,31 +312,82 @@ export async function runCodex(rawArgs: string[]) {
   const childEnv: NodeJS.ProcessEnv = {};
   const remoteAuthArgs: string[] = [];
   const status = lifecycle.readStatus();
+
+  // Ensure the target pair is live and get its URLs. For "default" this
+  // is idempotent against bootCodex's eager ensure; for named pairs it
+  // triggers allocation + spawn in the daemon. Short 2s timeout so an
+  // older v2.2 daemon (or test fake) that doesn't handle ensure_pair
+  // gracefully falls through to status.json URLs.
+  let pairUrls: { appServerUrl: string; proxyUrl: string } | null = null;
+  try {
+    pairUrls = await ensurePairViaControl(controlPort, pairId, 2000);
+    console.error(`[agentbridge] Pair "${pairId}" ready (app=${pairUrls.appServerUrl}, proxy=${pairUrls.proxyUrl})`);
+  } catch (err: any) {
+    if (err.code === "PAIR_PORTS_BUSY") {
+      console.error("");
+      console.error(`[agentbridge] Error: ports for pair "${pairId}" are held by another process.`);
+      console.error(`  ${err.message ?? ""}`);
+      const conflictPort = err.details?.conflictPort;
+      if (conflictPort) {
+        console.error(`  Conflicting port: ${conflictPort}`);
+        console.error(`  Stop that process or use \`abg pairs rm ${pairId} --forget\` to release the registry entry and try again.`);
+      } else {
+        console.error(`  Stop the conflicting process or use \`abg pairs rm ${pairId} --forget\` to release the registry entry.`);
+      }
+      console.error("");
+      process.exit(1);
+    }
+    if (err.code === "INVALID_PAIR_NAME") {
+      console.error(`[agentbridge] Error: pair name "${pairId}" is invalid.`);
+      process.exit(1);
+    }
+    if (err.code === "MAX_PAIRS") {
+      console.error(`[agentbridge] Error: daemon is at the max live pairs limit.`);
+      console.error(`  ${err.message ?? ""}`);
+      console.error(`  Destroy an unused pair with \`abg pairs rm NAME\` and retry.`);
+      process.exit(1);
+    }
+    console.error(`[agentbridge] Failed to ensure pair "${pairId}": ${err.message ?? err}`);
+    console.error(`  Falling back to status.json URLs.`);
+  }
+
   if (mode === "direct") {
-    if (status?.appServerUrl) {
+    if (pairUrls) {
+      remoteUrl = pairUrls.appServerUrl;
+    } else if (status?.appServerUrl) {
       remoteUrl = status.appServerUrl;
     } else {
       remoteUrl = `ws://127.0.0.1:${config.codex.appPort}`;
       console.error(`[agentbridge] No daemon status found, using config default app-server URL: ${remoteUrl}`);
     }
   } else {
-    // Spec v2.2 §7: pre-flight check — daemon should only have one proxy TUI
-    // at a time. Hit /healthz for the live state (status.json is stale).
-    const liveStatus = await fetchLiveDaemonStatus(controlPort);
-    if (liveStatus?.proxyTuiConnected) {
-      console.error("");
-      console.error("[agentbridge] Error: another `agentbridge codex --via-proxy` TUI is already connected to the daemon.");
-      console.error("");
-      console.error("Shared-thread mode supports at most one proxy TUI at a time.");
-      console.error("Either close the other TUI window first, or use `agentbridge codex` (direct mode) to run an independent parallel session.");
-      console.error("");
-      process.exit(1);
+    // Pre-flight check (proxy mode only): is the target pair already
+    // connected to a `--via-proxy` TUI? Each pair allows at most one.
+    // Short timeout so we don't stall on a daemon that doesn't speak
+    // list_pairs (older or stubbed).
+    try {
+      const pairsList = await listPairsViaControl(controlPort, 2000);
+      const target = pairsList.find((p) => p.pairId === pairId);
+      if (target?.proxyTuiConnected) {
+        console.error("");
+        console.error(`[agentbridge] Error: another \`agentbridge codex --pair ${pairId} --via-proxy\` TUI is already connected.`);
+        console.error("");
+        console.error(`Shared-thread mode supports at most one proxy TUI per pair (pair="${pairId}").`);
+        console.error(`Either close the other TUI window for this pair first, or use a different --pair NAME, or use \`agentbridge codex --direct\` to skip pairing.`);
+        console.error("");
+        process.exit(1);
+      }
+    } catch (err: any) {
+      console.error(`[agentbridge] Warning: list_pairs pre-flight check failed: ${err?.message ?? err}`);
+      console.error(`[agentbridge] Proceeding anyway — daemon may reject the second TUI via WS-upgrade token check.`);
     }
 
     // Spec v2.2 §4.6: generate the token so codex-rs's primary AND secondary
     // picker connections inherit it via the Authorization header.
     const abgToken = (await import("node:crypto")).randomBytes(8).toString("hex");
-    if (status?.proxyUrl) {
+    if (pairUrls) {
+      remoteUrl = pairUrls.proxyUrl;
+    } else if (status?.proxyUrl) {
       remoteUrl = status.proxyUrl;
     } else {
       remoteUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
@@ -198,7 +395,7 @@ export async function runCodex(rawArgs: string[]) {
     }
     childEnv.AGENTBRIDGE_PROXY_TOKEN = abgToken;
     remoteAuthArgs.push("--remote-auth-token-env", "AGENTBRIDGE_PROXY_TOKEN");
-    console.error(`[agentbridge] Shared-thread mode active. Token=${abgToken.slice(0, 8)}…`);
+    console.error(`[agentbridge] Shared-thread mode active. pair="${pairId}" token=${abgToken.slice(0, 8)}…`);
   }
 
   try {

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -339,8 +339,14 @@ export async function runCodex(rawArgs: string[]) {
       console.error(`[agentbridge] Error: ports for pair "${pairId}" are held by another process.`);
       console.error(`  ${err.message ?? ""}`);
       const conflictPort = err.details?.conflictPort;
+      const conflictPid = err.details?.conflictPid;
       if (conflictPort) {
         console.error(`  Conflicting port: ${conflictPort}`);
+      }
+      if (conflictPid) {
+        console.error(`  Conflicting PID: ${conflictPid} (inspect with \`ps -p ${conflictPid} -o args=\`)`);
+      }
+      if (conflictPort || conflictPid) {
         console.error(`  Stop that process or use \`abg pairs rm ${pairId} --forget\` to release the registry entry and try again.`);
       } else {
         console.error(`  Stop the conflicting process or use \`abg pairs rm ${pairId} --forget\` to release the registry entry.`);

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -469,10 +469,16 @@ export async function runCodex(rawArgs: string[]) {
   // codex-rs on ExitReason::Fatal survives even when stdio is inherited by
   // a terminal that clears on exit. See codex-rs/cli/src/main.rs:553.
   const stderrTail = new StderrRingBuffer();
-  const wrapperLogPath = stateDir.codexWrapperLogFile;
+  // STM v2.3 §D5 P4d: write per-pair pid + wrapper log so multiple
+  // concurrent `abg codex --pair NAME` invocations don't fight over a
+  // single root-level file. StateDirResolver helpers landed in P3d;
+  // they're now actually used here.
+  stateDir.ensure();
+  stateDir.ensurePairDir(pairId);
+  const wrapperLogPath = stateDir.pairCodexWrapperLogFile(pairId);
+  const tuiPidPath = stateDir.pairCodexPidFile(pairId);
   const startedAt = Date.now();
 
-  stateDir.ensure();
   appendWrapperLog(
     wrapperLogPath,
     `spawn: codex ${fullArgs.map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}`,
@@ -485,7 +491,14 @@ export async function runCodex(rawArgs: string[]) {
   });
 
   if (typeof child.pid === "number") {
-    writeFileSync(stateDir.tuiPidFile, `${child.pid}\n`, "utf-8");
+    writeFileSync(tuiPidPath, `${child.pid}\n`, "utf-8");
+    // Also write the legacy root-level pid for backwards-compat readers
+    // (notably `abg kill` walking the root path; P4d updates kill to
+    // walk pairs/*/codex.pid too, but other tools may still poll the
+    // old location).
+    if (pairId === "default") {
+      try { writeFileSync(stateDir.tuiPidFile, `${child.pid}\n`, "utf-8"); } catch {}
+    }
     appendWrapperLog(wrapperLogPath, `child pid=${child.pid}`);
   }
 
@@ -505,9 +518,12 @@ export async function runCodex(rawArgs: string[]) {
   function cleanupTuiPidFile() {
     if (cleanedTuiPid) return;
     cleanedTuiPid = true;
-    try {
-      unlinkSync(stateDir.tuiPidFile);
-    } catch {}
+    try { unlinkSync(tuiPidPath); } catch {}
+    // P4d: also clean the legacy root-level pid file if this is the
+    // default pair (we wrote it for backwards-compat above).
+    if (pairId === "default") {
+      try { unlinkSync(stateDir.tuiPidFile); } catch {}
+    }
   }
 
   process.on("exit", () => { restoreTerminal(); cleanupTuiPidFile(); });

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -197,11 +197,13 @@ type CodexConnectionMode = "direct" | "proxy";
 function extractCliFlags(args: string[]): {
   mode: CodexConnectionMode;
   pairId: string;
+  sandbox?: string;
   rest: string[];
 } {
   const rest: string[] = [];
   let mode: CodexConnectionMode = "direct";
   let pairId = "default";
+  let sandbox: string | undefined;
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--via-proxy") {
@@ -236,13 +238,43 @@ function extractCliFlags(args: string[]): {
       }
       continue;
     }
+    // Sandbox flag — propagates to the daemon-spawned codex app-server
+    // (not just the TUI). Without this, even `abg codex --via-proxy
+    // --sandbox workspace-write` left the app-server at the default
+    // read-only mode, breaking `apply_patch` end-to-end. Per Codex sprint
+    // ranking 2026-05-17 (msg codex_msg_..._177) #3 ROI item.
+    if (a === "--sandbox") {
+      if (i + 1 >= args.length) {
+        console.error(`Error: --sandbox requires a value (e.g. \`--sandbox workspace-write\`).`);
+        process.exit(1);
+      }
+      sandbox = args[i + 1];
+      i++;
+      continue;
+    }
+    if (a.startsWith("--sandbox=")) {
+      sandbox = a.slice("--sandbox=".length);
+      if (!sandbox) {
+        console.error(`Error: --sandbox= requires a value (e.g. \`--sandbox=workspace-write\`).`);
+        process.exit(1);
+      }
+      continue;
+    }
     rest.push(a);
   }
-  return { mode, pairId, rest };
+  return { mode, pairId, sandbox, rest };
 }
 
 export async function runCodex(rawArgs: string[]) {
-  const { mode, pairId, rest: args } = extractCliFlags(rawArgs);
+  const { mode, pairId, sandbox, rest: args } = extractCliFlags(rawArgs);
+
+  // Pass sandbox to daemon (read at codex app-server spawn time). Set BEFORE
+  // ensureRunning() so the env is in place if the daemon spawn happens now.
+  // Note: if the daemon is already running with a different value, this
+  // export is a no-op for that daemon — kill + restart to switch sandboxes.
+  if (sandbox) {
+    process.env.AGENTBRIDGE_CODEX_SANDBOX = sandbox;
+  }
 
   // STM v2.3 §D1 P4: CLI-side validation of --pair NAME. Reject locally
   // with a clear message before any daemon round-trip — the daemon's

--- a/src/cli/kill.ts
+++ b/src/cli/kill.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync, unlinkSync } from "node:fs";
+import { readFileSync, unlinkSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { StateDirResolver } from "../state-dir";
 import { DaemonLifecycle, isProcessAlive } from "../daemon-lifecycle";
 
@@ -19,16 +20,102 @@ export async function runKill() {
   // This closes the reconnect race where the frontend sees the disconnect
   // before the sentinel is written and relaunches the daemon.
   lifecycle.markKilled();
+
+  // STM v2.3 §8.4 P4d: walk every pair's codex.pid in pairs/*/codex.pid
+  // and SIGTERM the lot before tearing down the daemon. Best-effort —
+  // a malformed pair dir is logged and skipped, not fatal.
+  const pairTuiKills = await killAllPairTuis(stateDir, (msg) => console.log(`  ${msg}`));
+  // Legacy root-level codex-tui.pid for default pair (written for v2.2
+  // backwards-compat). Skip if we already killed via the per-pair path.
   const tuiKilled = await killManagedCodexTui(stateDir, (msg) => console.log(`  ${msg}`));
   const killed = await lifecycle.kill();
 
-  if (killed || tuiKilled) {
+  if (killed || tuiKilled || pairTuiKills > 0) {
     console.log("\nAgentBridge stopped.");
+    if (pairTuiKills > 0) {
+      console.log(`Killed ${pairTuiKills} pair-managed Codex TUI process(es).`);
+    }
     console.log("Please restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to fully disconnect.");
   } else {
     console.log("\nNo running AgentBridge daemon or managed Codex TUI found.");
     console.log("Stale state files cleaned up (if any).");
   }
+}
+
+/**
+ * STM v2.3 §8.4 P4d: walk `<stateDir>/pairs/*\/codex.pid` and SIGTERM
+ * each managed Codex TUI. Best-effort — a malformed pair dir is logged
+ * and skipped, not fatal. Returns the count of successfully killed
+ * processes.
+ */
+async function killAllPairTuis(
+  stateDir: StateDirResolver,
+  log: (msg: string) => void,
+  gracefulTimeoutMs = 3000,
+): Promise<number> {
+  const pairsRoot = join(stateDir.dir, "pairs");
+  if (!existsSync(pairsRoot)) return 0;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(pairsRoot);
+  } catch (err: any) {
+    log(`Failed to read pairs/ dir: ${err?.message ?? err}`);
+    return 0;
+  }
+
+  let killCount = 0;
+  for (const pairId of entries) {
+    if (pairId === "registry.json") continue; // skip the registry file
+    const pidPath = join(pairsRoot, pairId, "codex.pid");
+    if (!existsSync(pidPath)) continue;
+    let pid: number | null = null;
+    try {
+      const raw = readFileSync(pidPath, "utf-8").trim();
+      if (raw) {
+        const parsed = Number.parseInt(raw, 10);
+        if (Number.isFinite(parsed)) pid = parsed;
+      }
+    } catch {}
+    if (pid === null) {
+      log(`Pair "${pairId}": malformed pid file, skipping`);
+      try { unlinkSync(pidPath); } catch {}
+      continue;
+    }
+    if (!isProcessAlive(pid)) {
+      log(`Pair "${pairId}": pid ${pid} not alive, cleaning stale pid file`);
+      try { unlinkSync(pidPath); } catch {}
+      continue;
+    }
+    if (!isManagedCodexTuiProcess(pid)) {
+      log(`Pair "${pairId}": pid ${pid} is alive but NOT a managed AgentBridge Codex TUI — skipping`);
+      try { unlinkSync(pidPath); } catch {}
+      continue;
+    }
+    log(`Pair "${pairId}": sending SIGTERM to pid ${pid}`);
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch (err: any) {
+      log(`Pair "${pairId}": SIGTERM failed: ${err?.message ?? err}`);
+      try { unlinkSync(pidPath); } catch {}
+      continue;
+    }
+
+    const deadline = Date.now() + gracefulTimeoutMs;
+    while (Date.now() < deadline) {
+      if (!isProcessAlive(pid)) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    if (isProcessAlive(pid)) {
+      log(`Pair "${pairId}": pid ${pid} did not stop gracefully, sending SIGKILL`);
+      try { process.kill(pid, "SIGKILL"); } catch {}
+    } else {
+      log(`Pair "${pairId}": pid ${pid} stopped gracefully`);
+    }
+    try { unlinkSync(pidPath); } catch {}
+    killCount++;
+  }
+  return killCount;
 }
 
 async function killManagedCodexTui(

--- a/src/cli/pairs.ts
+++ b/src/cli/pairs.ts
@@ -107,6 +107,7 @@ export async function runPairs(args: string[]): Promise<void> {
 async function runPairsLs(): Promise<void> {
   let response: { pairs: PairListEntry[] };
   try {
+    const lsReqId = `cli-pairs-ls-${Date.now()}`;
     response = await controlWsRequest<
       { type: "list_pairs"; requestId: string },
       { type: "pair_list"; requestId: string; pairs: PairListEntry[] }
@@ -114,10 +115,10 @@ async function runPairsLs(): Promise<void> {
       CONTROL_PORT_DEFAULT,
       {
         type: "list_pairs",
-        requestId: `cli-pairs-ls-${Date.now()}`,
+        requestId: lsReqId,
       },
       (msg): msg is { type: "pair_list"; requestId: string; pairs: PairListEntry[] } => {
-        return msg && msg.type === "pair_list";
+        return msg && msg.type === "pair_list" && msg.requestId === lsReqId;
       },
     );
   } catch (err: any) {
@@ -181,6 +182,7 @@ async function runPairsRm(args: string[]): Promise<void> {
 
   let response: { type: "pair_destroyed" | "pair_error"; [k: string]: any };
   try {
+    const rmReqId = `cli-pairs-rm-${Date.now()}`;
     response = await controlWsRequest<
       { type: "destroy_pair"; requestId: string; pairId: string; forget: boolean; force: boolean },
       { type: "pair_destroyed" | "pair_error"; requestId: string; [k: string]: any }
@@ -188,13 +190,13 @@ async function runPairsRm(args: string[]): Promise<void> {
       CONTROL_PORT_DEFAULT,
       {
         type: "destroy_pair",
-        requestId: `cli-pairs-rm-${Date.now()}`,
+        requestId: rmReqId,
         pairId,
         forget,
         force,
       },
       (msg): msg is { type: "pair_destroyed" | "pair_error"; requestId: string; [k: string]: any } => {
-        return msg && (msg.type === "pair_destroyed" || msg.type === "pair_error");
+        return msg && (msg.type === "pair_destroyed" || msg.type === "pair_error") && msg.requestId === rmReqId;
       },
     );
   } catch (err: any) {

--- a/src/cli/pairs.ts
+++ b/src/cli/pairs.ts
@@ -1,0 +1,243 @@
+/**
+ * STM v2.3 §8.2 P4c — `abg pairs` subcommand surface.
+ *
+ *   abg pairs                  → help / list of pairs (shorthand for `abg pairs ls`)
+ *   abg pairs ls               → list all registered pairs (live + registry-only)
+ *   abg pairs rm NAME [--forget] [--force]
+ *                              → destroy a pair via daemon's destroy_pair RPC
+ *
+ * Implementation: thin wrappers around the control-WS protocol added in
+ * P3b (ensure_pair / destroy_pair / list_pairs). Uses one-shot WS
+ * requests rather than a long-lived DaemonClient since these are
+ * fire-and-exit commands.
+ */
+
+import { isValidPairName } from "../pair-registry";
+
+const CONTROL_PORT_DEFAULT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
+
+interface PairListEntry {
+  pairId: string;
+  isLive: boolean;
+  appServerUrl: string;
+  proxyUrl: string;
+  tuiConnected: boolean;
+  proxyTuiConnected: boolean;
+  pairedChatId: string | null;
+  threadId: string | null;
+  attachedClaudes: { chatId: string; paired: boolean }[];
+}
+
+async function controlWsRequest<TReq extends { type: string; requestId: string }, TRes>(
+  controlPort: number,
+  request: TReq,
+  matchResponse: (msg: any) => msg is TRes,
+  timeoutMs = 5000,
+): Promise<TRes> {
+  const url = `ws://127.0.0.1:${controlPort}/ws`;
+  return new Promise<TRes>((resolve, reject) => {
+    let settled = false;
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { ws.close(); } catch {}
+      reject(new Error(`control-WS request timed out after ${timeoutMs}ms (type=${request.type})`));
+    }, timeoutMs);
+    ws.addEventListener("open", () => {
+      try { ws.send(JSON.stringify(request)); } catch (err: any) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try { ws.close(); } catch {}
+        reject(new Error(`control-WS send failed: ${err?.message ?? err}`));
+      }
+    });
+    ws.addEventListener("message", (ev) => {
+      if (settled) return;
+      try {
+        const msg = JSON.parse(ev.data.toString());
+        if (matchResponse(msg)) {
+          settled = true;
+          clearTimeout(timer);
+          try { ws.close(); } catch {}
+          resolve(msg);
+        }
+      } catch { /* ignore */ }
+    });
+    ws.addEventListener("error", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error("control-WS connection error — is the daemon running?"));
+    });
+    ws.addEventListener("close", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error("control-WS closed before response"));
+    });
+  });
+}
+
+export async function runPairs(args: string[]): Promise<void> {
+  const subcommand = args[0];
+  const subArgs = args.slice(1);
+  switch (subcommand) {
+    case undefined:
+    case "ls":
+    case "list":
+      await runPairsLs();
+      break;
+    case "rm":
+    case "destroy":
+      await runPairsRm(subArgs);
+      break;
+    case "--help":
+    case "-h":
+      printPairsHelp();
+      break;
+    default:
+      console.error(`Unknown subcommand: pairs ${subcommand}`);
+      console.error(`Run \`abg pairs --help\` for usage.`);
+      process.exit(1);
+  }
+}
+
+async function runPairsLs(): Promise<void> {
+  let response: { pairs: PairListEntry[] };
+  try {
+    response = await controlWsRequest<
+      { type: "list_pairs"; requestId: string },
+      { type: "pair_list"; requestId: string; pairs: PairListEntry[] }
+    >(
+      CONTROL_PORT_DEFAULT,
+      {
+        type: "list_pairs",
+        requestId: `cli-pairs-ls-${Date.now()}`,
+      },
+      (msg): msg is { type: "pair_list"; requestId: string; pairs: PairListEntry[] } => {
+        return msg && msg.type === "pair_list";
+      },
+    );
+  } catch (err: any) {
+    console.error(`[agentbridge] Failed to list pairs: ${err?.message ?? err}`);
+    console.error(`[agentbridge] Is the daemon running? Try \`abg codex\` to start it.`);
+    process.exit(1);
+  }
+
+  if (response.pairs.length === 0) {
+    console.log("No pairs registered.");
+    return;
+  }
+
+  // Column widths sized to current pair names; capped so output stays readable.
+  const nameWidth = Math.max(4, ...response.pairs.map((p) => p.pairId.length));
+  const proxyWidth = Math.max(10, ...response.pairs.map((p) => p.proxyUrl.length));
+  const appWidth = Math.max(10, ...response.pairs.map((p) => p.appServerUrl.length));
+  const pairedWidth = Math.max(11, ...response.pairs.map((p) => (p.pairedChatId ?? "-").length));
+
+  const header = `${"PAIR".padEnd(nameWidth)}  ${"LIVE".padEnd(4)}  ${"PROXY".padEnd(proxyWidth)}  ${"APP".padEnd(appWidth)}  ${"TUI".padEnd(3)}  ${"PAIRED-CHAT".padEnd(pairedWidth)}  CHATS`;
+  console.log(header);
+  console.log("-".repeat(header.length));
+  for (const p of response.pairs) {
+    const liveDot = p.isLive ? "●" : "○";
+    const tuiDot = p.proxyTuiConnected ? "●" : "○";
+    const paired = p.pairedChatId ?? "-";
+    const chats = p.attachedClaudes.length;
+    console.log(
+      `${p.pairId.padEnd(nameWidth)}  ${liveDot.padEnd(4)}  ${p.proxyUrl.padEnd(proxyWidth)}  ${p.appServerUrl.padEnd(appWidth)}  ${tuiDot.padEnd(3)}  ${paired.padEnd(pairedWidth)}  ${chats}`,
+    );
+  }
+}
+
+async function runPairsRm(args: string[]): Promise<void> {
+  let pairId: string | undefined;
+  let forget = false;
+  let force = false;
+  for (const a of args) {
+    if (a === "--forget") { forget = true; continue; }
+    if (a === "--force") { force = true; continue; }
+    if (a.startsWith("--")) {
+      console.error(`Unknown flag: ${a}`);
+      console.error(`Usage: abg pairs rm NAME [--forget] [--force]`);
+      process.exit(1);
+    }
+    if (pairId) {
+      console.error(`Error: only one pair name accepted; got "${pairId}" and "${a}".`);
+      process.exit(1);
+    }
+    pairId = a;
+  }
+  if (!pairId) {
+    console.error(`Error: pair name required.`);
+    console.error(`Usage: abg pairs rm NAME [--forget] [--force]`);
+    process.exit(1);
+  }
+  if (!isValidPairName(pairId)) {
+    console.error(`Error: pair name "${pairId}" is invalid.`);
+    process.exit(1);
+  }
+
+  let response: { type: "pair_destroyed" | "pair_error"; [k: string]: any };
+  try {
+    response = await controlWsRequest<
+      { type: "destroy_pair"; requestId: string; pairId: string; forget: boolean; force: boolean },
+      { type: "pair_destroyed" | "pair_error"; requestId: string; [k: string]: any }
+    >(
+      CONTROL_PORT_DEFAULT,
+      {
+        type: "destroy_pair",
+        requestId: `cli-pairs-rm-${Date.now()}`,
+        pairId,
+        forget,
+        force,
+      },
+      (msg): msg is { type: "pair_destroyed" | "pair_error"; requestId: string; [k: string]: any } => {
+        return msg && (msg.type === "pair_destroyed" || msg.type === "pair_error");
+      },
+    );
+  } catch (err: any) {
+    console.error(`[agentbridge] Failed to destroy pair: ${err?.message ?? err}`);
+    process.exit(1);
+  }
+
+  if (response.type === "pair_error") {
+    if (response.code === "PAIR_BUSY_NOT_FORCED") {
+      console.error(`Error: pair "${pairId}" has a paired Claude — pass --force to tear down anyway.`);
+      console.error(`  ${response.message ?? ""}`);
+    } else if (response.code === "PAIR_NOT_FOUND") {
+      console.error(`Error: pair "${pairId}" not found (neither live nor registered).`);
+    } else {
+      console.error(`Error (${response.code}): ${response.message ?? ""}`);
+    }
+    process.exit(1);
+  }
+
+  const parts: string[] = [];
+  if (response.wasLive) parts.push("torn down live pair");
+  else parts.push("no live pair to tear down");
+  if (response.registryEntryRemoved) parts.push("removed registry entry");
+  else if (forget) parts.push("registry entry was not present");
+  else parts.push("kept registry entry (use --forget to remove)");
+  console.log(`Pair "${pairId}" destroyed: ${parts.join("; ")}.`);
+}
+
+function printPairsHelp(): void {
+  console.log(`
+AgentBridge pair management
+
+Usage:
+  abg pairs                          # alias for \`abg pairs ls\`
+  abg pairs ls                       # list all pairs (live + registry-only)
+  abg pairs rm NAME [--forget] [--force]
+                                     # destroy a pair (and optionally remove
+                                     # its registry entry)
+
+Flags:
+  --forget   Remove the registry entry so a future \`ensure_pair\` re-allocates
+             from scratch (use after PAIR_PORTS_BUSY to release stale ports).
+  --force    Tear down the pair even if it has a paired Claude. Without
+             --force, paired-live pairs return PAIR_BUSY_NOT_FORCED.
+`.trim());
+}

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -12,9 +12,9 @@
 import { spawn, execSync, type ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
 import { EventEmitter } from "node:events";
-import { appendFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { StateDirResolver } from "./state-dir";
+import { getAsyncFileLogger, type AsyncFileLogger } from "./log-writer";
 import type { BridgeMessage } from "./types";
 import type { ServerWebSocket } from "bun";
 import {
@@ -1094,7 +1094,7 @@ export class CodexAdapter extends EventEmitter {
           try {
             this.appServerWs.send(forwardedResponse);
             this.serverRequestToProxy.delete(normalizedId);
-            this.log(`TUI → app-server: ${pending.method} response (proxy id=${normalizedId} → server id=${pending.serverId})`);
+            this.proxyLog(`TUI → app-server: ${pending.method} response (proxy id=${normalizedId} → server id=${pending.serverId})`);
           } catch (e: any) {
             this.bufferPendingServerResponse(normalizedId, pending, forwardedResponse, `send failed: ${e.message}`);
           }
@@ -1171,7 +1171,7 @@ export class CodexAdapter extends EventEmitter {
     try {
       const parsed = JSON.parse(data);
       const method = parsed.method ?? `response:${parsed.id}`;
-      this.log(`TUI → app-server: ${method}`);
+      this.proxyLog(`TUI → app-server: ${method}`);
 
       // Rewrite request id to globally unique proxy id
       if (parsed.id !== undefined && parsed.method) {
@@ -1184,7 +1184,7 @@ export class CodexAdapter extends EventEmitter {
         this.trackPendingRequest(parsed, connId);
       }
     } catch {
-      this.log(`TUI → app-server: (unparseable)`);
+      this.proxyLog(`TUI → app-server: (unparseable)`);
     }
 
     // Forward to app-server. The OPEN check above guarantees readyState was
@@ -1344,7 +1344,7 @@ export class CodexAdapter extends EventEmitter {
       }
 
       parsed.id = mapping.clientId;
-      this.log(`app-server → TUI: response (proxy id=${numericId} → client id=${String(mapping.clientId)}, conn #${mapping.connId})`);
+      this.proxyLog(`app-server → TUI: response (proxy id=${numericId} → client id=${String(mapping.clientId)}, conn #${mapping.connId})`);
       const forwarded = this.patchResponse(parsed, JSON.stringify(parsed));
       this.interceptServerMessage(parsed, mapping.connId);
       return forwarded;
@@ -1370,9 +1370,9 @@ export class CodexAdapter extends EventEmitter {
         this.pendingInjectionByReqId.delete(numericId);
         if (typeof turnId === "string" && turnId.length > 0) {
           this.recordInjectedTurnId(turnId, contentHash);
-          this.log(`Bridge-originated request completed (id ${responseId}, turnId=${turnId} dedup)`);
+          this.proxyLog(`Bridge-originated request completed (id ${responseId}, turnId=${turnId} dedup)`);
         } else {
-          this.log(`Bridge-originated request completed (id ${responseId}, no turnId — falling back to content-hash dedup)`);
+          this.proxyLog(`Bridge-originated request completed (id ${responseId}, no turnId — falling back to content-hash dedup)`);
         }
       }
       return null;
@@ -1857,9 +1857,33 @@ export class CodexAdapter extends EventEmitter {
     }
   }
 
+  // Performance fix (2026-05-17 P0): switch from blocking `appendFileSync`
+  // to the shared async WriteStream pool. The proxy hot path called this
+  // log() ~2 times per WS frame; multiplied by streaming Codex deltas,
+  // synchronous disk IO was a measurable bottleneck. Lifecycle / error
+  // logs still flow through here; per-message proxy frame logs are
+  // additionally gated behind AGENTBRIDGE_DEBUG_PROXY (see proxyLog
+  // below) so default operation drops noisy lines entirely.
+  private _logger: AsyncFileLogger | null = null;
+  private get logger(): AsyncFileLogger {
+    if (!this._logger) this._logger = getAsyncFileLogger(this.logFile);
+    return this._logger;
+  }
+
   private log(msg: string) {
     const line = `[${new Date().toISOString()}] [CodexAdapter] ${msg}\n`;
     process.stderr.write(line);
-    try { appendFileSync(this.logFile, line); } catch {}
+    this.logger.write(line);
   }
+
+  /**
+   * Performance fix (2026-05-17 P1): per-frame proxy diagnostics — gated
+   * behind `AGENTBRIDGE_DEBUG_PROXY=1`. Default behavior: no-op (no
+   * stderr write, no file write). Set the env var to bring the verbose
+   * proxy logs back when debugging routing or echo dedup.
+   */
+  private proxyLog(msg: string) {
+    if (CodexAdapter.DEBUG_PROXY) this.log(msg);
+  }
+  private static readonly DEBUG_PROXY = process.env.AGENTBRIDGE_DEBUG_PROXY === "1";
 }

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -168,13 +168,25 @@ export class CodexAdapter extends EventEmitter {
   private static readonly ECHO_DEDUP_TTL_MS = 60_000;
   private static readonly PENDING_HASH_TTL_MS = 5_000;
 
-  constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
+  /**
+   * STM v2.3 P1: pair identifier for this adapter instance. Defaults to
+   * "default" (the only legal value in P1). Surfaced via the `pairId`
+   * getter so daemon-side per-pair event handlers can log correlated
+   * messages without keeping a separate map. Not used by the adapter's
+   * own logic — the adapter does not need to know its pair id to do its
+   * job (see spec v2.3 §5.2).
+   */
+  private readonly _pairId: string;
+
+  constructor(opts: { pairId?: string; appPort: number; proxyPort: number; logFile?: string }) {
     super();
-    this.appPort = appPort;
-    this.proxyPort = proxyPort;
-    this.logFile = logFile;
+    this._pairId = opts.pairId ?? "default";
+    this.appPort = opts.appPort;
+    this.proxyPort = opts.proxyPort;
+    this.logFile = opts.logFile ?? new StateDirResolver().logFile;
   }
 
+  get pairId() { return this._pairId; }
   get appServerUrl() { return `ws://127.0.0.1:${this.appPort}`; }
   get proxyUrl() { return `ws://127.0.0.1:${this.proxyPort}`; }
   get activeThreadId() { return this.threadId; }

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -13,6 +13,7 @@ import { spawn, execSync, type ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
 import { EventEmitter } from "node:events";
 import { appendFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { StateDirResolver } from "./state-dir";
 import type { BridgeMessage } from "./types";
 import type { ServerWebSocket } from "bun";
@@ -32,6 +33,18 @@ import {
 
 interface TuiSocketData {
   connId: number;
+  /**
+   * Spec v2.2 §4.6: bearer token (or legacy `abg_token` query fallback) at
+   * WS upgrade time. Used to distinguish codex-rs's own secondary picker
+   * (same token) from a second unrelated `abg codex --via-proxy` instance
+   * (different token).
+   *
+   * Empty string for legacy connections without a token — backward compat:
+   * legacy mode treats first connection as primary with empty token, and
+   * accepts subsequent legacy (empty-token) connections too. Mixing token
+   * and non-token connections triggers reject (spec §4.6).
+   */
+  token: string;
 }
 
 interface PendingServerRequest {
@@ -140,6 +153,21 @@ export class CodexAdapter extends EventEmitter {
   }>();
   private static readonly SESSION_REPLAY_TIMEOUT_MS = 5000;
 
+  // ── Shared Thread Mode (spec v2.2) ─────────────────────────
+  //
+  // When a Claude session is paired with this CodexAdapter's tuiWs (the
+  // proxy TUI), its replies are injected on the TUI's thread. To prevent
+  // those injections from echoing back to the same Claude as user input,
+  // we track the resulting turnId (primary, 60s TTL) and the injected
+  // content hash (race fallback for the pre-response window, 5s one-shot).
+  // See docs/shared-thread-mode-spec.md §4.5.
+  private pairedChatId: string | null = null;
+  private injectedTurnIds = new Map<string, number>(); // turnId → expiresAt
+  private pendingInjectionHashes = new Map<string, number>(); // contentHash → expiresAt
+  private pendingInjectionByReqId = new Map<number, string>(); // bridge requestId → contentHash
+  private static readonly ECHO_DEDUP_TTL_MS = 60_000;
+  private static readonly PENDING_HASH_TTL_MS = 5_000;
+
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
     this.appPort = appPort;
@@ -221,7 +249,12 @@ export class CodexAdapter extends EventEmitter {
     }
   }
 
-  /** Inject a message into the active Codex thread via turn/start. Returns true if sent. */
+  /**
+   * Inject a message into the active Codex thread via turn/start. Returns
+   * true if sent. Spec v2.2 §8 E8: rejects while `sessionRestoreInProgress`
+   * so paired Claude gets a clear "restoring shared Codex TUI session"
+   * error instead of an inject sent against a not-yet-restored app-server.
+   */
   injectMessage(text: string): boolean {
     if (!this.threadId) {
       this.log("Cannot inject: no active thread");
@@ -231,6 +264,10 @@ export class CodexAdapter extends EventEmitter {
       this.log("Cannot inject: app-server WebSocket not connected");
       return false;
     }
+    if (this.sessionRestoreInProgress) {
+      this.log(`Rejected injection: shared Codex TUI session restore in progress`);
+      return false;
+    }
     if (this.turnInProgress) {
       this.log(`Rejected injection: Codex turn is in progress (thread ${this.threadId})`);
       return false;
@@ -238,6 +275,12 @@ export class CodexAdapter extends EventEmitter {
     this.log(`Injecting message into Codex (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
     this.trackBridgeRequestId(requestId);
+    // Spec v2.2 §4.5 race protection: hash the content + remember expiry so we
+    // can suppress an echo userMessage notification that arrives before the
+    // turn/start response gives us a turnId to dedup on.
+    const contentHash = this.hashInjectionContent(text);
+    this.pendingInjectionHashes.set(contentHash, Date.now() + CodexAdapter.PENDING_HASH_TTL_MS);
+    this.pendingInjectionByReqId.set(requestId, contentHash);
     try {
       this.appServerWs.send(JSON.stringify({
         method: "turn/start",
@@ -247,9 +290,67 @@ export class CodexAdapter extends EventEmitter {
       return true;
     } catch (err: any) {
       this.untrackBridgeRequestId(requestId);
+      this.pendingInjectionByReqId.delete(requestId);
+      this.pendingInjectionHashes.delete(contentHash);
       this.log(`Injection send failed: ${err.message}`);
       return false;
     }
+  }
+
+  // ── Shared Thread Mode API (spec v2.2 §4.1) ────────────────
+
+  /** Set the chatId that this CodexAdapter is currently paired with (or null to clear). */
+  setPairedChat(chatId: string | null): void {
+    this.pairedChatId = chatId;
+    this.log(`Paired chat set to: ${chatId ?? "<none>"}`);
+  }
+
+  /** True if the given chatId is the current paired chat. */
+  isPaired(chatId: string): boolean {
+    return this.pairedChatId !== null && this.pairedChatId === chatId;
+  }
+
+  /** Read-only getter for daemon's pairing state machine. */
+  get currentPairedChatId(): string | null {
+    return this.pairedChatId;
+  }
+
+  private hashInjectionContent(text: string): string {
+    return createHash("sha1").update(text).digest("hex").slice(0, 16);
+  }
+
+  /**
+   * Spec v2.2 §4.5: check if a userMessage notification is an echo of a
+   * bridge-originated injection. Primary check is turnId match; fallback is
+   * content-hash match for the race window before turn/start response lands.
+   */
+  private isEchoOfInjection(content: string, turnId: string | undefined): boolean {
+    if (typeof turnId === "string" && turnId.length > 0) {
+      const expiresAt = this.injectedTurnIds.get(turnId);
+      if (expiresAt !== undefined) {
+        if (Date.now() <= expiresAt) return true;
+        this.injectedTurnIds.delete(turnId);
+      }
+    }
+    const hash = this.hashInjectionContent(content);
+    const hashExpiresAt = this.pendingInjectionHashes.get(hash);
+    if (hashExpiresAt !== undefined) {
+      if (Date.now() <= hashExpiresAt) {
+        this.pendingInjectionHashes.delete(hash); // one-shot consumption
+        return true;
+      }
+      this.pendingInjectionHashes.delete(hash);
+    }
+    return false;
+  }
+
+  private recordInjectedTurnId(turnId: string, contentHash: string | undefined) {
+    this.injectedTurnIds.set(turnId, Date.now() + CodexAdapter.ECHO_DEDUP_TTL_MS);
+    // Once we have a turnId, the content-hash entry is redundant (turnId is
+    // the canonical correlator). Clear it eagerly to free memory and avoid
+    // the rare case where a same-text user message gets falsely suppressed
+    // after the injection's response has landed.
+    if (contentHash) this.pendingInjectionHashes.delete(contentHash);
   }
 
   // ── Health Check ───────────────────────────────────────────
@@ -534,6 +635,8 @@ export class CodexAdapter extends EventEmitter {
     }
 
     this.sessionRestoreInProgress = true;
+    this.emit("sessionRestoreStart", { threadId: this.threadId });
+    let restoreSucceeded = false;
     try {
       this.log(
         `DIAGNOSTIC: replaying cached initialize to restore session (threadId=${this.threadId ?? "none"})`,
@@ -558,6 +661,7 @@ export class CodexAdapter extends EventEmitter {
       this.log(
         `DIAGNOSTIC: session restored after unintentional reconnect (threadId=${this.threadId ?? "none"})`,
       );
+      restoreSucceeded = true;
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log(
@@ -574,7 +678,18 @@ export class CodexAdapter extends EventEmitter {
       }
     } finally {
       this.sessionRestoreInProgress = false;
+      // Spec v2.2 §8 E8: emit ok=false on failure so daemon keeps paired
+      // readiness=not-ready. The TUI is being closed (1011) in the catch
+      // branch; the resulting tuiDisconnected event tears down the pair
+      // cleanly. Without ok=false, daemon would briefly flip to "ready" and
+      // tell paired Claude "session restored" — a lie.
+      this.emit("sessionRestoreEnd", { threadId: this.threadId, ok: restoreSucceeded });
     }
+  }
+
+  /** Spec v2.2 §8 E8: daemon checks this so paired `reply` returns restore error. */
+  get isSessionRestoreInProgress(): boolean {
+    return this.sessionRestoreInProgress;
   }
 
   /**
@@ -695,11 +810,19 @@ export class CodexAdapter extends EventEmitter {
       fetch(req, server) {
         const url = new URL(req.url);
         const isUpgrade = req.headers.get("upgrade")?.toLowerCase() === "websocket";
-        self.log(`HTTP ${req.method} ${url.pathname} (upgrade=${isUpgrade})`);
+        const queryToken = url.searchParams.get("abg_token") ?? "";
+        const authHeader = req.headers.get("authorization") ?? "";
+        const bearerToken = authHeader.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? "";
+        const token = bearerToken || queryToken;
+        const tokenSource = bearerToken ? "authorization" : queryToken ? "query" : "none";
+        self.log(`HTTP ${req.method} ${url.pathname} (upgrade=${isUpgrade}, token=${token ? token.slice(0, 8) + "…" : "<none>"}, tokenSource=${tokenSource})`);
         if (url.pathname === "/healthz" || url.pathname === "/readyz") {
           return fetch(`http://127.0.0.1:${self.appPort}${url.pathname}`);
         }
-        if (server.upgrade(req, { data: { connId: 0 } })) return undefined;
+        // Spec v2.2 §4.6: token discrimination is enforced in onTuiConnect after
+        // upgrade, so we can return a clean WS close with code 4002. Rejecting
+        // at fetch time would surface as a confusing HTTP 4xx to codex-rs.
+        if (server.upgrade(req, { data: { connId: 0, token } })) return undefined;
         self.log(`WARNING: non-upgrade HTTP request not handled: ${req.method} ${url.pathname}`);
         return new Response("AgentBridge Codex Proxy");
       },
@@ -723,7 +846,23 @@ export class CodexAdapter extends EventEmitter {
     // the main session connection stays open. Give the secondary its own
     // app-server WS so the primary is not disturbed.
     if (this.tuiWs) {
-      this.log(`Secondary TUI connected (conn #${connId}, primary is #${this.tuiConnId})`);
+      // Spec v2.2 §4.6: distinguish codex-rs's own secondary picker (carries
+      // the SAME bearer token as the primary) from a second unrelated
+      // `abg codex --via-proxy` instance (different token). Reject the latter
+      // with WS close 4002 so the CLI's pre-flight check surfaces a clear
+      // error rather than the primary getting silently disrupted.
+      const primaryToken = this.tuiWs.data.token;
+      const newToken = ws.data.token;
+      if (primaryToken !== newToken) {
+        this.log(`Rejecting second proxy TUI: token mismatch (primary conn #${this.tuiConnId} token=${primaryToken ? primaryToken.slice(0, 8) + "…" : "<none>"}, new conn #${connId} token=${newToken ? newToken.slice(0, 8) + "…" : "<none>"})`);
+        try {
+          ws.close(4002, "another --via-proxy TUI is already connected");
+        } catch (err: any) {
+          this.log(`Failed to close rejected second TUI cleanly: ${err.message}`);
+        }
+        return;
+      }
+      this.log(`Secondary TUI connected (conn #${connId}, primary is #${this.tuiConnId}, token matches)`);
       this.setupSecondaryConnection(ws, connId);
       return;
     }
@@ -735,8 +874,8 @@ export class CodexAdapter extends EventEmitter {
     // Reset threadId to prevent premature message injection before TUI completes
     // its handshake (initialize → thread/start or thread/resume).
     this.threadId = null;
-    this.log(`TUI connected (conn #${this.tuiConnId})`);
-    this.emit("tuiConnected", this.tuiConnId);
+    this.log(`TUI connected (conn #${this.tuiConnId}, token=${ws.data.token ? ws.data.token.slice(0, 8) + "…" : "<none>"})`);
+    this.emit("tuiConnected", this.tuiConnId, ws.data.token);
     if (previousConnId !== null) {
       this.retireConnectionState(previousConnId);
     }
@@ -1202,8 +1341,27 @@ export class CodexAdapter extends EventEmitter {
     if (!isNaN(numericId) && this.consumeBridgeRequestId(numericId)) {
       if (parsed.error) {
         this.log(`Bridge-originated request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
+        // Clear the pending injection-hash entry so a future legitimate
+        // identical user-typed message isn't suppressed.
+        const contentHash = this.pendingInjectionByReqId.get(numericId);
+        if (contentHash) {
+          this.pendingInjectionHashes.delete(contentHash);
+          this.pendingInjectionByReqId.delete(numericId);
+        }
       } else {
-        this.log(`Bridge-originated request completed (id ${responseId})`);
+        // Spec v2.2 §4.5 primary echo dedup: capture the turnId returned by
+        // codex-rs so subsequent userMessage notifications for this turn can
+        // be recognized as echoes of our own injection.
+        const result = (parsed.result ?? {}) as { turn?: { id?: string } };
+        const turnId = result.turn?.id;
+        const contentHash = this.pendingInjectionByReqId.get(numericId);
+        this.pendingInjectionByReqId.delete(numericId);
+        if (typeof turnId === "string" && turnId.length > 0) {
+          this.recordInjectedTurnId(turnId, contentHash);
+          this.log(`Bridge-originated request completed (id ${responseId}, turnId=${turnId} dedup)`);
+        } else {
+          this.log(`Bridge-originated request completed (id ${responseId}, no turnId — falling back to content-hash dedup)`);
+        }
       }
       return null;
     }
@@ -1255,9 +1413,15 @@ export class CodexAdapter extends EventEmitter {
   private handleServerNotification(msg: AppServerNotification) {
     const { method, params } = msg;
     switch (method) {
-      case "turn/started":
+      case "turn/started": {
+        // markTurnStarted emits "turnStarted" only on idle→busy transition
+        // (symmetric with turnCompleted on busy→idle). Spec v2.2 §4.3
+        // forwards turnStarted as a non-satisfying signal to paired Claude;
+        // daemon listens on that emit. The turnId arg is added so consumers
+        // can track per-turn state (e.g. sawAgentMessage).
         this.markTurnStarted(params?.turn?.id);
         break;
+      }
       case "item/started": {
         const item: AppServerItem | undefined = params?.item;
         if (item?.type === "agentMessage") this.agentMessageBuffers.set(item.id, []);
@@ -1281,16 +1445,57 @@ export class CodexAdapter extends EventEmitter {
               id: item.id, source: "codex" as const, content, timestamp: Date.now(),
             } satisfies BridgeMessage);
           }
+        } else if (item?.type === "userMessage") {
+          // Spec v2.2 §4.3: route human-typed TUI messages to paired Claude,
+          // but suppress echoes of paired Claude's own injection.
+          const content = this.extractContent(item);
+          if (content) {
+            const turnIdFromParams = typeof (params as Record<string, unknown> | undefined)?.turnId === "string"
+              ? ((params as Record<string, unknown>).turnId as string)
+              : undefined;
+            if (this.isEchoOfInjection(content, turnIdFromParams)) {
+              this.log(`Suppressed userMessage echo (item ${item.id}, ${content.length} chars)`);
+            } else {
+              this.log(`User message from TUI (${content.length} chars)`);
+              this.emit("userMessage", {
+                id: item.id,
+                source: "codex" as const,
+                content,
+                timestamp: Date.now(),
+                turnId: turnIdFromParams,
+              } satisfies BridgeMessage & { turnId?: string });
+            }
+          }
         }
         break;
       }
       case "turn/completed": {
         const wasInProgress = this.turnInProgress;
-        this.markTurnCompleted(params?.turn?.id);
-        // Only emit when all turns are done (symmetric with turnStarted)
+        const turnId = params?.turn?.id;
+        this.markTurnCompleted(turnId);
+        // Only emit when all turns are done (symmetric with turnStarted).
+        // Spec v2.2 §4.3: daemon tracks per-turnId sawAgentMessage to decide
+        // satisfiesRequireReply on the forwarded system message.
         if (wasInProgress && !this.turnInProgress) {
-          this.emit("turnCompleted");
+          this.emit("turnCompleted", { turnId });
         }
+        break;
+      }
+      case "error": {
+        // Spec v2.2 §4.3: top-level error notification (NOT a ThreadItem).
+        // Forward to daemon so paired Claude's requireReply releases.
+        const errorParams = (params ?? {}) as { error?: { code?: number; message?: string; data?: unknown } };
+        const detail = errorParams.error?.message ?? "(no error message)";
+        const code = errorParams.error?.code;
+        this.log(`App-server error notification: ${detail}${code !== undefined ? ` (code ${code})` : ""}`);
+        this.emit("errorItem", { code, message: detail, data: errorParams.error?.data });
+        break;
+      }
+      case "thread/closed": {
+        // Spec v2.2 §4.3: top-level thread lifecycle notification. Triggers
+        // daemon's TUI-disconnect-equivalent pair teardown (§5).
+        const closedThreadId = (params ?? {}) as { threadId?: string };
+        this.emit("threadClosed", { threadId: closedThreadId.threadId });
         break;
       }
     }
@@ -1416,7 +1621,7 @@ export class CodexAdapter extends EventEmitter {
 
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
-      this.emit("turnStarted");
+      this.emit("turnStarted", { turnId });
     }
   }
 

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -75,6 +75,17 @@ interface PendingRequest {
   threadId?: string;
 }
 
+/**
+ * Build argv for spawning the codex app-server child process.
+ * Extracted so unit tests can assert sandbox propagation without
+ * touching `spawn`. Used by CodexAdapter.start.
+ */
+export function buildCodexAppServerArgs(appServerUrl: string, sandbox?: string): string[] {
+  const args = ["app-server", "--listen", appServerUrl];
+  if (sandbox) args.push("--sandbox", sandbox);
+  return args;
+}
+
 export class CodexAdapter extends EventEmitter {
   private static readonly RESPONSE_TRACKING_TTL_MS = 30000;
 
@@ -196,8 +207,10 @@ export class CodexAdapter extends EventEmitter {
   async start() {
     this.intentionalDisconnect = false;
     await this.checkPorts();
-    this.log(`Spawning codex app-server on ${this.appServerUrl}`);
-    this.proc = spawn("codex", ["app-server", "--listen", this.appServerUrl], {
+    const sandbox = process.env.AGENTBRIDGE_CODEX_SANDBOX;
+    const args = buildCodexAppServerArgs(this.appServerUrl, sandbox);
+    this.log(`Spawning codex app-server on ${this.appServerUrl}${sandbox ? ` (sandbox=${sandbox})` : ""}`);
+    this.proc = spawn("codex", args, {
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -1,21 +1,98 @@
 import type { BridgeMessage } from "./types";
 
+/**
+ * STM v2.3 §D7 P3: per-pair status snapshot. One entry per pair in
+ * `DaemonStatus.pairs`. v2.2 `proxyUrl` / `appServerUrl` / `tuiConnected`
+ * / `proxyTuiConnected` / `threadId` top-level fields stay populated from
+ * the default pair as a backward-compatibility shim for existing CLI /
+ * test readers.
+ */
+export interface PairStatus {
+  pairId: string;
+  /** True when the pair's CodexAdapter is started (codex.start() completed). */
+  isLive: boolean;
+  appServerUrl: string;
+  proxyUrl: string;
+  /** True when CodexAdapter has a TUI WS attached (any kind, direct or proxy). */
+  tuiConnected: boolean;
+  /** True when a `--via-proxy` TUI is connected to this pair. */
+  proxyTuiConnected: boolean;
+  /** Currently paired chatId, or null. */
+  pairedChatId: string | null;
+  /** Active Codex thread id for this pair, or null when not yet provisioned. */
+  threadId: string | null;
+  /** Chats whose `homePairId === pairId`, with their pair-relationship state. */
+  attachedClaudes: { chatId: string; paired: boolean }[];
+}
+
 export interface DaemonStatus {
   bridgeReady: boolean;
-  tuiConnected: boolean;
-  threadId: string | null;
-  queuedMessageCount: number;
+  pid: number;
+  /**
+   * v2.2-compatible top-level mirror of the default pair's status. The
+   * URL fields are config (always populated from the default pair's
+   * registered ports). The runtime fields reflect actual state — `null`
+   * when not yet known (e.g. threadId before bootstrap, or when default
+   * is destroyed entirely in a future phase).
+   *
+   * Existing CLI and test code that reads these top-level fields keeps
+   * working. New v2.3 code should prefer the `pairs` array below.
+   */
   proxyUrl: string;
   appServerUrl: string;
-  pid: number;
-  attachedClaudeCount?: number;
-  /**
-   * Spec v2.2 §7: true when a `--via-proxy` TUI is currently connected.
-   * CLI uses this for pre-flight check before launching a second
-   * `agentbridge codex --via-proxy` instance.
-   */
-  proxyTuiConnected?: boolean;
+  tuiConnected: boolean;
+  proxyTuiConnected: boolean;
+  threadId: string | null;
+  /** Aggregate count across all pairs + isolated chats. */
+  attachedClaudeCount: number;
+  /** Aggregate count of buffered + status-buffer messages across all chats. */
+  queuedMessageCount: number;
+  /** STM v2.3 §D7: per-pair detail array. */
+  pairs: PairStatus[];
 }
+
+// ── STM v2.3 §D6 P3: pair management error codes ────────────────────────
+
+/**
+ * Error codes returned in `pair_error` and `claude_connect_result` failure
+ * responses. Each code has a corresponding human-readable `message` field
+ * in the payload; the code is the canonical machine-readable identifier.
+ */
+export type PairErrorCode =
+  /** Pair name fails the D1 validation regex (or is empty / reserved misuse). */
+  | "INVALID_PAIR_NAME"
+  /** No registry / live entry for the requested pair name. */
+  | "PAIR_NOT_FOUND"
+  /**
+   * Pair is live and already has a paired Claude (D4 strict semantics:
+   * explicit-pair Claude attaches see this instead of falling back to isolated).
+   */
+  | "PAIR_BUSY"
+  /**
+   * Allocated ports for this pair are held by a foreign process. Recovery
+   * via `destroy_pair --forget` or stopping the conflicting process.
+   * `details.conflictPort` and `details.conflictPid` are populated.
+   */
+  | "PAIR_PORTS_BUSY"
+  /** Daemon reached `AGENTBRIDGE_MAX_PAIRS` live pairs. */
+  | "MAX_PAIRS"
+  /** Port range exhausted within `AGENTBRIDGE_PAIR_PORT_MAX` strides. */
+  | "ALLOCATION_FAILED"
+  /**
+   * `destroy_pair` invoked on a paired-live pair without `force: true`.
+   * CLI maps to a "use --force" message.
+   */
+  | "PAIR_BUSY_NOT_FORCED"
+  /** Daemon is in the middle of SIGTERM-driven shutdown; reject new ensures. */
+  | "DAEMON_SHUTTING_DOWN";
+
+export interface PairErrorDetails {
+  conflictPort?: number;
+  conflictPid?: number;
+  [key: string]: unknown;
+}
+
+// ── Control messages ────────────────────────────────────────────────────
 
 /**
  * `chatId` identifies a logical Claude session. Each Claude MCP instance
@@ -25,9 +102,24 @@ export interface DaemonStatus {
  *
  * When omitted, the daemon falls back to legacy single-session behavior
  * (assigns a synthetic chatId so the routing path still works).
+ *
+ * STM v2.3 P3: `claude_connect` gains an optional `pairId` per D4. The
+ * bridge sources this from `AGENTBRIDGE_PAIR` env (set by `agentbridge
+ * claude --pair NAME`) and forwards it to the daemon for explicit-pair
+ * binding. Absence triggers FIFO claim across pairs.
+ *
+ * `claude_connect` also gains an optional `requestId` so the daemon's
+ * `claude_connect_result` response can be correlated. v2.2 bridges that
+ * omit `requestId` get a result with `requestId: undefined` which they
+ * treat as a fire-and-forget acknowledgement (backwards-compatible).
  */
 export type ControlClientMessage =
-  | { type: "claude_connect"; chatId?: string }
+  | {
+      type: "claude_connect";
+      requestId?: string;
+      chatId?: string;
+      pairId?: string;
+    }
   | { type: "claude_disconnect"; chatId?: string }
   | {
       type: "claude_to_codex";
@@ -36,7 +128,11 @@ export type ControlClientMessage =
       message: BridgeMessage;
       requireReply?: boolean;
     }
-  | { type: "status" };
+  | { type: "status" }
+  // STM v2.3 §D6 P3 — pair management API.
+  | { type: "ensure_pair"; requestId: string; pairId: string }
+  | { type: "destroy_pair"; requestId: string; pairId: string; forget?: boolean; force?: boolean }
+  | { type: "list_pairs"; requestId: string };
 
 export type ControlServerMessage =
   | { type: "codex_to_claude"; chatId?: string; message: BridgeMessage }
@@ -46,7 +142,53 @@ export type ControlServerMessage =
       success: boolean;
       error?: string;
     }
-  | { type: "status"; status: DaemonStatus };
+  | { type: "status"; status: DaemonStatus }
+  // STM v2.3 §D6 P3 — typed claude_connect response so bridges can surface
+  // strict-pair failures as a user-visible disabled state.
+  | {
+      type: "claude_connect_result";
+      requestId?: string;
+      ok: true;
+      chatId: string;
+      homePairId: string | null;
+      paired: boolean;
+    }
+  | {
+      type: "claude_connect_result";
+      requestId?: string;
+      ok: false;
+      error: Extract<PairErrorCode, "INVALID_PAIR_NAME" | "PAIR_NOT_FOUND" | "PAIR_BUSY">;
+      message: string;
+    }
+  // STM v2.3 §D6 P3 — pair management responses.
+  | {
+      type: "pair_ensured";
+      requestId: string;
+      pairId: string;
+      appServerUrl: string;
+      proxyUrl: string;
+      isLive: true;
+    }
+  | {
+      type: "pair_destroyed";
+      requestId: string;
+      pairId: string;
+      wasLive: boolean;
+      registryEntryRemoved: boolean;
+    }
+  | {
+      type: "pair_list";
+      requestId: string;
+      pairs: PairStatus[];
+    }
+  | {
+      type: "pair_error";
+      requestId: string;
+      pairId: string;
+      code: PairErrorCode;
+      message: string;
+      details?: PairErrorDetails;
+    };
 
 /** WebSocket close code sent by the daemon when a newer Claude session replaces the current one. */
 export const CLOSE_CODE_REPLACED = 4001;

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -9,6 +9,12 @@ export interface DaemonStatus {
   appServerUrl: string;
   pid: number;
   attachedClaudeCount?: number;
+  /**
+   * Spec v2.2 §7: true when a `--via-proxy` TUI is currently connected.
+   * CLI uses this for pre-flight check before launching a second
+   * `agentbridge codex --via-proxy` instance.
+   */
+  proxyTuiConnected?: boolean;
 }
 
 /**

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -8,17 +8,38 @@ export interface DaemonStatus {
   proxyUrl: string;
   appServerUrl: string;
   pid: number;
+  attachedClaudeCount?: number;
 }
 
+/**
+ * `chatId` identifies a logical Claude session. Each Claude MCP instance
+ * generates and registers one on `claude_connect`. Subsequent control
+ * messages from that session carry the same id so the daemon can route
+ * inbound/outbound traffic to the correct ClaudeThread + Claude WebSocket.
+ *
+ * When omitted, the daemon falls back to legacy single-session behavior
+ * (assigns a synthetic chatId so the routing path still works).
+ */
 export type ControlClientMessage =
-  | { type: "claude_connect" }
-  | { type: "claude_disconnect" }
-  | { type: "claude_to_codex"; requestId: string; message: BridgeMessage; requireReply?: boolean }
+  | { type: "claude_connect"; chatId?: string }
+  | { type: "claude_disconnect"; chatId?: string }
+  | {
+      type: "claude_to_codex";
+      requestId: string;
+      chatId?: string;
+      message: BridgeMessage;
+      requireReply?: boolean;
+    }
   | { type: "status" };
 
 export type ControlServerMessage =
-  | { type: "codex_to_claude"; message: BridgeMessage }
-  | { type: "claude_to_codex_result"; requestId: string; success: boolean; error?: string }
+  | { type: "codex_to_claude"; chatId?: string; message: BridgeMessage }
+  | {
+      type: "claude_to_codex_result";
+      requestId: string;
+      success: boolean;
+      error?: string;
+    }
   | { type: "status"; status: DaemonStatus };
 
 /** WebSocket close code sent by the daemon when a newer Claude session replaces the current one. */

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -259,6 +259,20 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       pending.resolve({ success: false, error });
       this.pendingReplies.delete(requestId);
     }
+    // STM v2.3 §D6 P4-cleanup (Codex P4 final re-pass codex_msg_5753c73beafc_128):
+    // also drain pending attach promises so a close-before-response does
+    // not silently timeout-to-ok after the daemon is gone. Resolves with
+    // ok=false carrying a synthetic DAEMON_SHUTTING_DOWN code so callers
+    // (bridge.ts) enter the disabled-state path uniformly.
+    for (const [requestId, pending] of this.pendingAttachReplies.entries()) {
+      clearTimeout(pending.timer);
+      pending.resolve({
+        ok: false,
+        error: "DAEMON_SHUTTING_DOWN",
+        message: `claude_connect interrupted: ${error}`,
+      });
+      this.pendingAttachReplies.delete(requestId);
+    }
   }
 
   private send(message: ControlClientMessage) {

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -24,14 +24,30 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     }
   >();
   private chatId: string | undefined;
+  /**
+   * STM v2.3 §D4 P4b: optional explicit pair binding. Read from
+   * `AGENTBRIDGE_PAIR` env at bridge.ts startup and forwarded to the
+   * daemon's `attachClaude` via the `claude_connect` control message.
+   * The daemon validates per D1 / D4 and responds with a typed
+   * `claude_connect_result` (PAIR_NOT_FOUND / PAIR_BUSY / ok=true).
+   */
+  private pairId: string | undefined;
 
-  constructor(private readonly url: string, opts?: { chatId?: string }) {
+  constructor(
+    private readonly url: string,
+    opts?: { chatId?: string; pairId?: string },
+  ) {
     super();
     this.chatId = opts?.chatId;
+    this.pairId = opts?.pairId;
   }
 
   setChatId(chatId: string) {
     this.chatId = chatId;
+  }
+
+  setPairId(pairId: string | undefined) {
+    this.pairId = pairId;
   }
 
   async connect() {
@@ -78,7 +94,9 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   }
 
   attachClaude() {
-    this.send({ type: "claude_connect", chatId: this.chatId });
+    // STM v2.3 §D4 P4b: forward pairId if AGENTBRIDGE_PAIR was set. The
+    // daemon validates and responds with a typed claude_connect_result.
+    this.send({ type: "claude_connect", chatId: this.chatId, pairId: this.pairId });
   }
 
   async disconnect() {

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -23,6 +23,22 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       timer: ReturnType<typeof setTimeout>;
     }
   >();
+  /**
+   * STM v2.3 §D4 / §D6 P4-cleanup: pending attachClaude promises waiting
+   * on `claude_connect_result`. Separate from `pendingReplies` because
+   * the response shape is discriminated (ok=true vs ok=false) and
+   * different from `claude_to_codex_result`.
+   */
+  private pendingAttachReplies = new Map<
+    string,
+    {
+      resolve: (value:
+        | { ok: true; homePairId: string | null; paired: boolean }
+        | { ok: false; error: string; message: string }
+      ) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
   private chatId: string | undefined;
   /**
    * STM v2.3 §D4 P4b: optional explicit pair binding. Read from
@@ -93,10 +109,36 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     });
   }
 
-  attachClaude() {
-    // STM v2.3 §D4 P4b: forward pairId if AGENTBRIDGE_PAIR was set. The
-    // daemon validates and responds with a typed claude_connect_result.
-    this.send({ type: "claude_connect", chatId: this.chatId, pairId: this.pairId });
+  /**
+   * STM v2.3 §D4 / §D6 P4-cleanup: send `claude_connect` and await the
+   * typed `claude_connect_result` (Codex P4 review codex_msg_5753c73beafc_123
+   * HIGH#2). Returns the daemon's verdict so bridge.ts can enter a
+   * disabled state on PAIR_NOT_FOUND / PAIR_BUSY / INVALID_PAIR_NAME
+   * instead of silently claiming "bridge ready" after a fire-and-forget
+   * attach. Falls through to {ok:true} after a short timeout against
+   * an older daemon that doesn't emit the typed result (so v2.2 bridges
+   * keep working).
+   */
+  async attachClaude(timeoutMs = 5000): Promise<
+    | { ok: true; homePairId: string | null; paired: boolean }
+    | { ok: false; error: string; message: string }
+  > {
+    const requestId = `attach_${Date.now()}_${this.nextRequestId++}`;
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingAttachReplies.delete(requestId);
+        // Old daemon (or test fixture) didn't reply with a typed
+        // claude_connect_result — assume success for backwards-compat.
+        resolve({ ok: true, homePairId: null, paired: false });
+      }, timeoutMs);
+      this.pendingAttachReplies.set(requestId, { resolve, timer });
+      this.send({
+        type: "claude_connect",
+        requestId,
+        chatId: this.chatId,
+        pairId: this.pairId,
+      });
+    });
   }
 
   async disconnect() {
@@ -158,6 +200,30 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
           clearTimeout(pending.timer);
           this.pendingReplies.delete(message.requestId);
           pending.resolve({ success: message.success, error: message.error });
+          return;
+        }
+        case "claude_connect_result": {
+          // STM v2.3 §D6 P4-cleanup: resolve the matching pending attach
+          // promise. requestId may be absent for old-style callers (no
+          // pending entry → drop).
+          if (!message.requestId) return;
+          const pending = this.pendingAttachReplies.get(message.requestId);
+          if (!pending) return;
+          clearTimeout(pending.timer);
+          this.pendingAttachReplies.delete(message.requestId);
+          if (message.ok) {
+            pending.resolve({
+              ok: true,
+              homePairId: message.homePairId,
+              paired: message.paired,
+            });
+          } else {
+            pending.resolve({
+              ok: false,
+              error: message.error,
+              message: message.message,
+            });
+          }
           return;
         }
         case "status":

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -23,9 +23,15 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       timer: ReturnType<typeof setTimeout>;
     }
   >();
+  private chatId: string | undefined;
 
-  constructor(private readonly url: string) {
+  constructor(private readonly url: string, opts?: { chatId?: string }) {
     super();
+    this.chatId = opts?.chatId;
+  }
+
+  setChatId(chatId: string) {
+    this.chatId = chatId;
   }
 
   async connect() {
@@ -72,14 +78,14 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   }
 
   attachClaude() {
-    this.send({ type: "claude_connect" });
+    this.send({ type: "claude_connect", chatId: this.chatId });
   }
 
   async disconnect() {
     if (!this.ws) return;
 
     try {
-      this.send({ type: "claude_disconnect" });
+      this.send({ type: "claude_disconnect", chatId: this.chatId });
     } catch {}
 
     try {
@@ -106,6 +112,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       this.send({
         type: "claude_to_codex",
         requestId,
+        chatId: this.chatId,
         message,
         ...(requireReply ? { requireReply: true } : {}),
       });

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -124,7 +124,12 @@ export class DaemonLifecycle {
   }
 
   /** Read daemon status from status.json. */
-  readStatus(): { proxyUrl?: string; controlPort?: number; pid?: number } | null {
+  readStatus(): {
+    proxyUrl?: string;
+    appServerUrl?: string;
+    controlPort?: number;
+    pid?: number;
+  } | null {
     try {
       const raw = readFileSync(this.stateDir.statusFile, "utf-8");
       return JSON.parse(raw);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1489,12 +1489,32 @@ function handleClaudeToCodex(
     log(`[${chatId}] Reply required flag set`);
   }
 
-  log(`[${chatId}] Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply}, paired=${state.paired})`);
+  log(`[${chatId}] Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply}, paired=${state.paired}, homePair=${state.homePairId})`);
 
   // Spec v2.2 §6: paired chats route through CodexAdapter (shared transport);
   // isolated chats keep using their own ClaudeThread.
+  //
+  // STM v2.3 multi-pair bug found by M01 probe (2026-05-17): paired
+  // injects MUST go through the chat's home pair's CodexAdapter, not
+  // the module-level `codex` (which is just the default pair's). For a
+  // Claude paired with the "work" pair, using the default's codex meant
+  // injecting into a TUI/thread that didn't exist — "Cannot inject: no
+  // active thread" was the symptom and "Shared Codex TUI is busy" the
+  // user-facing error. Look up the per-pair adapter via homePairId.
+  const homePair = state.paired && state.homePairId ? pairs.get(state.homePairId) : undefined;
+  if (state.paired && (!homePair || !homePair.isLive)) {
+    // Pair vanished or went down between FIFO claim and this reply
+    // (e.g. concurrent `destroy_pair --force` race). Surface explicitly
+    // rather than silently injecting into the wrong pair.
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: `Home pair "${state.homePairId}" is no longer live; reconnect Claude to re-home.`,
+    });
+  }
   const injected = state.paired
-    ? codex.injectMessage(contentWithReminder)
+    ? homePair!.codex.injectMessage(contentWithReminder)
     : state.thread.injectMessage(contentWithReminder);
 
   if (!injected) {
@@ -2120,6 +2140,10 @@ export const __testing = {
     /** Issue #82 (2026-05-17): exposed so tests can flip `shuttingDown`
      * to assert close-handler guard behavior during shutdown. */
     setShuttingDownForTest(value: boolean) { shuttingDown = value; },
+    /** M01 probe bug regression (2026-05-17): exposed so a unit test
+     * can assert paired-inject routes to the chat's homePair adapter
+     * (not the module-level default `codex`). */
+    handleClaudeToCodex,
   } as const,
   /** STM v2.3 §D2 P3b — registry handle (read for assertions; mutate via handlers). */
   pairRegistry,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -32,8 +32,9 @@ import { TuiConnectionState } from "./tui-connection-state";
 import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
 import { ConfigService } from "./config-service";
+import { PairRegistry, isValidPairName } from "./pair-registry";
 import { CLOSE_CODE_REPLACED } from "./control-protocol";
-import type { ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
+import type { ControlClientMessage, ControlServerMessage, DaemonStatus, PairStatus } from "./control-protocol";
 import type { BridgeMessage } from "./types";
 
 interface ControlSocketData {
@@ -224,6 +225,60 @@ const defaultPairState: PairState = {
   isLive: false, // bootCodex / ensurePair("default") flips this to true on success
 };
 const pairs = new Map<string, PairState>([["default", defaultPairState]]);
+
+// ── STM v2.3 §D2 P3 — pair registry + write mutex ──────────────────────
+
+/**
+ * Pair → port-assignment registry. Persisted at `<stateDir>/pairs/registry.json`.
+ * Loaded at module start; mutations during `ensure_pair` / `destroy_pair`
+ * acquire the daemon-wide `registryWriteMutex` and save atomically via
+ * the PairRegistry class.
+ */
+const pairRegistry = new PairRegistry({
+  filePath: `${stateDir.dir}/pairs/registry.json`,
+  log: (msg) => log(msg),
+});
+pairRegistry.load();
+
+/**
+ * Daemon-wide registry-write mutex. The per-pair `ensurePairInFlight` map
+ * (P3c+) deduplicates concurrent ensures for the SAME pair; this mutex
+ * protects ALL registry writes from racing each other. Implemented as a
+ * promise chain — each acquire awaits the previous release before
+ * proceeding, so two `ensure_pair("work")` + `ensure_pair("side")` calls
+ * cannot interleave their read-modify-write of the registry file.
+ */
+let registryWriteMutex: Promise<unknown> = Promise.resolve();
+
+async function runUnderRegistryMutex<T>(fn: () => Promise<T> | T): Promise<T> {
+  const prev = registryWriteMutex;
+  let release!: (value: unknown) => void;
+  registryWriteMutex = new Promise((resolve) => { release = resolve; });
+  try {
+    await prev.catch(() => {});
+    return await fn();
+  } finally {
+    release(undefined);
+  }
+}
+
+// Ensure the default pair has a registry entry at startup so list_pairs
+// and subsequent ensure_pair("default") calls find it without racing on
+// allocation. This is the only synchronous-at-boot registry mutation —
+// run it under the mutex anyway to keep the contract simple. The mutex
+// is uncontended at this point.
+void runUnderRegistryMutex(async () => {
+  if (!pairRegistry.has("default")) {
+    const result = pairRegistry.allocate("default");
+    if (result.ok) {
+      try { pairRegistry.save(); } catch (err: any) {
+        log(`[pair-registry] failed to persist default entry: ${err?.message ?? err}`);
+      }
+    } else {
+      log(`[pair-registry] failed to materialize default entry: ${result.error.code} — ${result.error.message}`);
+    }
+  }
+});
 
 // ── TUI / app-server event wiring ────────────────────────────────
 // Codex TUI activity is INTENTIONALLY not cross-broadcast to Claude sessions.
@@ -666,7 +721,230 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
     case "claude_to_codex":
       handleClaudeToCodex(ws, message);
       return;
+    // STM v2.3 §D6 P3 — pair management API ──────────────────────
+    case "ensure_pair":
+      void handleEnsurePair(ws, message);
+      return;
+    case "destroy_pair":
+      void handleDestroyPair(ws, message);
+      return;
+    case "list_pairs":
+      handleListPairs(ws, message);
+      return;
   }
+}
+
+// ── STM v2.3 §D6 P3 — pair management control protocol handlers ────────
+//
+// In P3b: `ensure_pair("default")` runs the full P2 ensurePair flow + saves
+// the registry. `ensure_pair("<other>")` validates + allocates a registry
+// entry but does NOT spawn a CodexAdapter — the actual non-default
+// activation lands in P3c once helpers (`getPairedChatState`, `pairChat`,
+// `transitionToIsolated`) become pair-aware. Until then, attaching the
+// shared event handlers on a non-default pair would route work-pair events
+// through default's paired-chat tracking (Codex P2 review warning).
+// `destroy_pair` handles both live default + registry-only entries.
+// `list_pairs` reports every registry entry plus their live status.
+
+async function handleEnsurePair(
+  ws: ServerWebSocket<ControlSocketData>,
+  message: Extract<ControlClientMessage, { type: "ensure_pair" }>,
+): Promise<void> {
+  const { requestId, pairId } = message;
+  if (!isValidPairName(pairId)) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "INVALID_PAIR_NAME",
+      message: `pair name "${pairId}" fails validation`,
+    });
+    return;
+  }
+
+  // Allocate (or get) registry entry under the daemon-wide mutex.
+  const allocResult = await runUnderRegistryMutex(async () => {
+    if (pairRegistry.has(pairId)) {
+      return { ok: true as const, entry: pairRegistry.get(pairId)! };
+    }
+    const result = pairRegistry.allocate(pairId);
+    if (result.ok) {
+      try { pairRegistry.save(); } catch (err: any) {
+        log(`[ensure_pair=${pairId}] registry save failed: ${err?.message ?? err}`);
+      }
+    }
+    return result;
+  });
+
+  if (!allocResult.ok) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: allocResult.error.code,
+      message: allocResult.error.message,
+    });
+    return;
+  }
+
+  const { appPort, proxyPort } = allocResult.entry;
+
+  if (pairId !== "default") {
+    // P3b: registry entry exists, but non-default activation lands in P3c.
+    // Surface this clearly via ALLOCATION_FAILED with a P3-specific message
+    // so users (and tests) know the entry IS in the registry — they can
+    // remove it via destroy_pair --forget if they want.
+    log(`[ensure_pair=${pairId}] registry entry allocated (appPort=${appPort}, proxyPort=${proxyPort}); activation deferred to P3c`);
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "ALLOCATION_FAILED",
+      message: `pair "${pairId}" registry entry allocated (appPort=${appPort}, proxyPort=${proxyPort}) but non-default pair activation is not implemented in P3b — lands in P3c`,
+    });
+    return;
+  }
+
+  try {
+    const pair = await ensurePair("default");
+    sendProtocolMessage(ws, {
+      type: "pair_ensured",
+      requestId,
+      pairId,
+      appServerUrl: pair.codex.appServerUrl,
+      proxyUrl: pair.codex.proxyUrl,
+      isLive: true,
+    });
+  } catch (err: any) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "ALLOCATION_FAILED",
+      message: `ensurePair("default") failed: ${err?.message ?? err}`,
+    });
+  }
+}
+
+async function handleDestroyPair(
+  ws: ServerWebSocket<ControlSocketData>,
+  message: Extract<ControlClientMessage, { type: "destroy_pair" }>,
+): Promise<void> {
+  const { requestId, pairId, forget, force } = message;
+  if (!isValidPairName(pairId)) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "INVALID_PAIR_NAME",
+      message: `pair name "${pairId}" fails validation`,
+    });
+    return;
+  }
+
+  const pair = pairs.get(pairId);
+  const inRegistry = pairRegistry.has(pairId);
+  if (!pair && !inRegistry) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "PAIR_NOT_FOUND",
+      message: `pair "${pairId}" not found (neither live nor registered)`,
+    });
+    return;
+  }
+
+  // PAIR_BUSY_NOT_FORCED: live pair with paired Claude and no --force.
+  if (pair?.proxyTuiSlot?.pairedChatId && !force) {
+    sendProtocolMessage(ws, {
+      type: "pair_error",
+      requestId,
+      pairId,
+      code: "PAIR_BUSY_NOT_FORCED",
+      message: `pair "${pairId}" has paired chat "${pair.proxyTuiSlot.pairedChatId}"; pass force:true to tear down anyway`,
+    });
+    return;
+  }
+
+  let wasLive = false;
+  if (pair?.isLive) {
+    wasLive = true;
+    try {
+      await destroyPair(pairId);
+    } catch (err: any) {
+      log(`[destroy_pair=${pairId}] internal destroyPair threw: ${err?.message ?? err}`);
+    }
+  }
+
+  let registryEntryRemoved = false;
+  if (forget) {
+    await runUnderRegistryMutex(async () => {
+      if (pairRegistry.remove(pairId)) {
+        registryEntryRemoved = true;
+        try { pairRegistry.save(); } catch (err: any) {
+          log(`[destroy_pair=${pairId}] registry save failed: ${err?.message ?? err}`);
+        }
+      }
+    });
+  }
+
+  sendProtocolMessage(ws, {
+    type: "pair_destroyed",
+    requestId,
+    pairId,
+    wasLive,
+    registryEntryRemoved,
+  });
+}
+
+function handleListPairs(
+  ws: ServerWebSocket<ControlSocketData>,
+  message: Extract<ControlClientMessage, { type: "list_pairs" }>,
+): void {
+  // Union of live pairs (pairs Map) + registry entries that aren't currently
+  // live. Live entries take precedence so their runtime state is reported.
+  const seen = new Set<string>();
+  const result: PairStatus[] = [];
+
+  for (const pair of pairs.values()) {
+    seen.add(pair.pairId);
+    result.push({
+      pairId: pair.pairId,
+      isLive: pair.isLive,
+      appServerUrl: pair.codex.appServerUrl,
+      proxyUrl: pair.codex.proxyUrl,
+      tuiConnected: pair.tuiConnectionState.snapshot().tuiConnected,
+      proxyTuiConnected: pair.proxyTuiSlot !== null,
+      pairedChatId: pair.proxyTuiSlot?.pairedChatId ?? null,
+      threadId: pair.codex.activeThreadId,
+      attachedClaudes: [...chats.values()]
+        .filter((s) => s.homePairId === pair.pairId)
+        .map((s) => ({ chatId: s.chatId, paired: s.paired })),
+    });
+  }
+
+  for (const entry of pairRegistry.list()) {
+    if (seen.has(entry.pairId)) continue;
+    // Registry-only entry: no live runtime state, but URLs are config.
+    result.push({
+      pairId: entry.pairId,
+      isLive: false,
+      appServerUrl: `ws://127.0.0.1:${entry.appPort}`,
+      proxyUrl: `ws://127.0.0.1:${entry.proxyPort}`,
+      tuiConnected: false,
+      proxyTuiConnected: false,
+      pairedChatId: null,
+      threadId: null,
+      attachedClaudes: [],
+    });
+  }
+
+  sendProtocolMessage(ws, {
+    type: "pair_list",
+    requestId: message.requestId,
+    pairs: result,
+  });
 }
 
 async function attachClaude(
@@ -1398,7 +1676,15 @@ export const __testing = {
     detachPairHandlers,
     ensurePair,
     destroyPair,
+    /** STM v2.3 §D6 P3b — control-protocol handlers, exposed for unit tests. */
+    handleEnsurePair,
+    handleDestroyPair,
+    handleListPairs,
   } as const,
+  /** STM v2.3 §D2 P3b — registry handle (read for assertions; mutate via handlers). */
+  pairRegistry,
+  /** STM v2.3 §D2 P3b — registry-write mutex bridge for assertions in tests. */
+  runUnderRegistryMutex,
   /** Constants captured at module load — useful for asserting timer behavior. */
   config: {
     PAIR_REAP_MS,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -954,6 +954,12 @@ async function attachClaude(
   // emit a typed claude_connect_result back per spec §D6 — bridges that
   // sent a `requestId` consume the response to surface PAIR_NOT_FOUND /
   // PAIR_BUSY as a user-visible disabled state.
+  //
+  // Strict explicit-pair semantics (Codex P3 close re-pass HIGH#1
+  // codex_msg_5753c73beafc_112): if the user asked for a specific pair,
+  // we never silently fall through to default pairing or isolated
+  // bootstrap. Any reason the requested pair can't accept the chat
+  // surfaces as a typed error and aborts the attach.
   if (requestedPairId !== undefined) {
     if (!isValidPairName(requestedPairId)) {
       sendProtocolMessage(ws, {
@@ -976,7 +982,22 @@ async function attachClaude(
       });
       return;
     }
-    if (targetPair.proxyTuiSlot?.pairedChatId && targetPair.proxyTuiSlot.pairedChatId !== chatId) {
+    if (!targetPair.proxyTuiSlot) {
+      // Live pair without a proxy-TUI slot — codex is running but no
+      // `--via-proxy` TUI has connected yet, so there's nothing for
+      // Claude to pair against. Per Codex P3 close re-pass: do NOT
+      // fall through to default pairing or isolated bootstrap. Surface
+      // as PAIR_NOT_FOUND with a clarifying message.
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: false,
+        error: "PAIR_NOT_FOUND",
+        message: `pair "${requestedPairId}" has no proxy TUI connected yet; start \`abg codex --pair ${requestedPairId} --via-proxy\` first, then attach Claude`,
+      });
+      return;
+    }
+    if (targetPair.proxyTuiSlot.pairedChatId && targetPair.proxyTuiSlot.pairedChatId !== chatId) {
       sendProtocolMessage(ws, {
         type: "claude_connect_result",
         requestId,
@@ -1947,6 +1968,8 @@ export const __testing = {
     handleEnsurePair,
     handleDestroyPair,
     handleListPairs,
+    /** STM v2.3 §D4 / §D6 P3-cleanup — attach flow exposed so tests can verify claude_connect_result. */
+    attachClaude,
   } as const,
   /** STM v2.3 §D2 P3b — registry handle (read for assertions; mutate via handlers). */
   pairRegistry,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1074,20 +1074,41 @@ async function attachClaude(
     return;
   }
 
-  if (proxyTuiSlot && proxyTuiSlot.pairedChatId === null) {
-    emitToChat(state, systemMessage("system_bridge_provisioning",
-      "✅ AgentBridge daemon attached. Pairing with the right-pane Codex TUI for shared-thread mode..."));
-    pairChat(state);
-    broadcastStatus();
-    sendProtocolMessage(ws, {
-      type: "claude_connect_result",
-      requestId,
-      ok: true,
-      chatId,
-      homePairId: state.homePairId,
-      paired: state.paired,
-    });
-    return; // paired chats skip ClaudeThread.bootstrap (shared transport)
+  // STM v2.3 §6.4 / §D4 P5a — FIFO claim across live pairs in registry
+  // insertion order. If any live pair has a `proxyTuiSlot` with no
+  // paired chat, this Claude becomes its paired chat. Iterating the
+  // `pairs` Map honors the spec's "registry insertion order" — default
+  // is inserted first at module load, named pairs append as they
+  // ensure_pair, so default is always preferred when free.
+  if (!requestedPairId) {
+    for (const [iterPairId, iterPair] of pairs.entries()) {
+      if (!iterPair.isLive) continue;
+      if (!iterPair.proxyTuiSlot) continue;            // pair has no --via-proxy TUI yet
+      if (iterPair.proxyTuiSlot.pairedChatId !== null) continue; // already paired
+      // Claim this pair.
+      state.homePairId = iterPairId;
+      iterPair.proxyTuiSlot.pairedChatId = chatId;
+      state.paired = true;
+      iterPair.codex.setPairedChat(chatId);
+      state.ready = iterPair.proxyTuiSlot.readiness === "ready";
+      log(`[${chatId}] FIFO-claimed pair "${iterPairId}" (readiness=${iterPair.proxyTuiSlot.readiness})`);
+      emitToChat(state, systemMessageForChat(state,
+        state.ready ? "system_paired_ready" : "system_paired_provisioning",
+        state.ready
+          ? `✅ This Claude session is paired with the right-pane Codex TUI on pair "${iterPairId}". Replies will appear there; user typing in the TUI will be forwarded to you with an [IMPORTANT] prefix.`
+          : `✅ This Claude session is paired with the right-pane Codex TUI on pair "${iterPairId}". Waiting for the shared thread to finish provisioning before replies can flow.`,
+      ));
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: true,
+        chatId,
+        homePairId: state.homePairId,
+        paired: state.paired,
+      });
+      broadcastStatus();
+      return;
+    }
   }
 
   emitToChat(state, systemMessage("system_bridge_provisioning",
@@ -1548,6 +1569,23 @@ function currentStatus(): DaemonStatus {
         .map((s) => ({ chatId: s.chatId, paired: s.paired })),
     })),
   };
+}
+
+/**
+ * STM v2.3 §7.3 P5a — pair-aware system message.
+ *
+ * Prepends `[pair: NAME] ` to the content when multiple pairs are live
+ * AND the chat is bound to one of them. Single-pair scenarios (the v2.2
+ * baseline) get the unadorned message so existing UX is preserved.
+ */
+function systemMessageForChat(state: ChatState, idPrefix: string, content: string): BridgeMessage {
+  if (state.homePairId) {
+    const livePairCount = [...pairs.values()].filter((p) => p.isLive).length;
+    if (livePairCount > 1) {
+      return systemMessage(idPrefix, `[pair: ${state.homePairId}] ${content}`);
+    }
+  }
+  return systemMessage(idPrefix, content);
 }
 
 function systemMessage(idPrefix: string, content: string): BridgeMessage {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -44,6 +44,13 @@ interface ControlSocketData {
 
 interface ChatState {
   chatId: string;
+  /**
+   * STM v2.3 §6.1 P1: every chat is associated with one pair (its "home
+   * pair"). In P1 this is always `"default"` because only the default
+   * pair exists. P5 introduces FIFO claiming across multiple pairs and
+   * the optional `null` value for isolated chats with no live pair.
+   */
+  homePairId: string;
   ws: ServerWebSocket<ControlSocketData> | null;
   thread: ClaudeThread;
   ready: boolean;
@@ -121,7 +128,12 @@ const ATTENTION_WINDOW_MS = parseInt(
 
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 
-const codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
+const codex = new CodexAdapter({
+  pairId: "default",
+  appPort: CODEX_APP_PORT,
+  proxyPort: CODEX_PROXY_PORT,
+  logFile: stateDir.logFile,
+});
 const attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 
 let controlServer: ReturnType<typeof Bun.serve> | null = null;
@@ -133,7 +145,19 @@ let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
 /** chatId → ChatState. Survives WS disconnects (lazy reap, see CLAUDE_REAP_AFTER_MS). */
 const chats = new Map<string, ChatState>();
 
-/** Spec v2.2 §5: single-slot proxy TUI tracking. null when no `--via-proxy` TUI connected. */
+/**
+ * Spec v2.2 §5: single-slot proxy TUI tracking. null when no `--via-proxy`
+ * TUI connected.
+ *
+ * STM v2.3 P1: this module-level variable is a transitional alias for
+ * `pairs.get("default")!.proxyTuiSlot` — the PairState is the canonical
+ * container per spec v2.3 §6.1, but the existing ~40 reference sites
+ * continue to work unchanged by reading/writing this variable. The
+ * PairState entry below uses getter/setter to delegate to this variable
+ * so direct accesses (e.g. `proxyTuiSlot = null`) and Map-based accesses
+ * (`pairs.get("default")!.proxyTuiSlot = null`) refer to the same slot.
+ * P2+ will phase out the direct accesses.
+ */
 let proxyTuiSlot: ProxyTuiSlot | null = null;
 
 const tuiConnectionState = new TuiConnectionState({
@@ -156,6 +180,33 @@ const tuiConnectionState = new TuiConnectionState({
     );
   },
 });
+
+/**
+ * STM v2.3 §6.1 P1: pairs registry. In P1 there is exactly one entry —
+ * `"default"` — and its fields are proxies for the module-level singletons
+ * declared above. P2 introduces the full PairState shape (per-pair
+ * lifecycle / readiness / reap timers) and P5 admits N pairs.
+ *
+ * The default entry uses property getters/setters for `proxyTuiSlot` so
+ * mutations through either access path (direct variable assignment or
+ * `pairs.get("default")!.proxyTuiSlot = X`) stay in sync.
+ */
+interface PairState {
+  readonly pairId: string;
+  readonly codex: CodexAdapter;
+  readonly tuiConnectionState: TuiConnectionState;
+  proxyTuiSlot: ProxyTuiSlot | null;
+}
+
+const defaultPairState: PairState = {
+  pairId: "default",
+  codex,
+  tuiConnectionState,
+  get proxyTuiSlot() { return proxyTuiSlot; },
+  set proxyTuiSlot(v: ProxyTuiSlot | null) { proxyTuiSlot = v; },
+};
+const pairs = new Map<string, PairState>([["default", defaultPairState]]);
+void pairs; // P1: structure introduced; P2+ migrates daemon code to use it directly.
 
 // ── TUI / app-server event wiring ────────────────────────────────
 // Codex TUI activity is INTENTIONALLY not cross-broadcast to Claude sessions.
@@ -639,6 +690,9 @@ async function attachClaude(
 function createChatState(chatId: string): ChatState {
   const state: ChatState = {
     chatId,
+    // STM v2.3 §6.1 P1: every chat is associated with the default pair.
+    // Multi-pair claim logic arrives in P4/P5.
+    homePairId: "default",
     ws: null,
     thread: new ClaudeThread({
       appServerUrl: codex.appServerUrl,
@@ -1196,6 +1250,13 @@ export const __testing = {
   chats,
   /** Direct handle to the singleton CodexAdapter — tests can emit events on it. */
   codex,
+  /**
+   * STM v2.3 §6.1 P1: pair registry. In P1 contains exactly the default
+   * entry whose fields proxy the module-level singletons (codex /
+   * proxyTuiSlot / tuiConnectionState). Tests can read but should not
+   * mutate the Map shape — use `setProxyTuiSlot` / `chats` for state changes.
+   */
+  pairs,
   /** Daemon-level functions exposed for direct invocation in tests. */
   fns: {
     pairChat,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1287,7 +1287,6 @@ function wireClaudeThreadEvents(state: ChatState): void {
   const threadAtRegistration = state.thread;
   state.thread.on("close", () => {
     log(`[${chatId}] ClaudeThread WS closed`);
-    state.ready = false;
 
     // Issue #82 (2026-05-17): app-server crash / unexpected upstream WS
     // close. Before this guard the chat stayed in `chats` with
@@ -1299,7 +1298,11 @@ function wireClaudeThreadEvents(state: ChatState): void {
     // bootstrap succeeds; if not, the bootstrap-failure reap kicks in
     // and bridge enters disabled state cleanly.
     //
-    // Three guards prevent unwanted re-reaping:
+    // Three guards prevent unwanted re-reaping (and unwanted ready-flip
+    // — Codex batch review re-pass msg ..._188 caught that ready=false
+    // must also be gated, else a stale OLD-thread close after replacement
+    // marks the live new thread not-ready without reaping, recreating a
+    // softer "still provisioning" symptom):
     //  1. shuttingDown — during daemon SIGTERM all ClaudeThread WSs
     //     close in cascade; reaping during shutdown is pointless (state
     //     will be discarded) and writes noise to logs.
@@ -1318,6 +1321,12 @@ function wireClaudeThreadEvents(state: ChatState): void {
     if (shuttingDown) return;
     if (state.thread !== threadAtRegistration) return;
     if (chats.get(chatId) !== state) return;
+
+    // Only flip ready=false once we've confirmed this close is for the
+    // current live thread (not a stale OLD-thread close after intentional
+    // replacement). Otherwise the live chat gets stuck in a soft
+    // "still provisioning" state without being reaped.
+    state.ready = false;
 
     emitToChat(state, systemMessage("system_thread_failed",
       "❌ Lost connection to Codex app-server. Reconnect to retry — bridge will provision a fresh thread."));

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -47,6 +47,20 @@ interface ChatState {
   ws: ServerWebSocket<ControlSocketData> | null;
   thread: ClaudeThread;
   ready: boolean;
+  /**
+   * Spec v2.2 §5: when true, this chat shares the proxy TUI's thread via
+   * CodexAdapter (no own thread/start). Replies route through
+   * codex.injectMessage; outbound is fed by codex.on("agentMessage" etc).
+   * Paired chats skip ClaudeThread.bootstrap() — their `ready` flag flips
+   * when proxyTuiSlot.readiness becomes "ready".
+   */
+  paired: boolean;
+  /**
+   * Spec v2.2 §4.3: per-turn tracking so daemon can decide whether a
+   * `turn/completed` system message satisfies `requireReply`. Resets when
+   * a new turn starts on the shared thread.
+   */
+  pairedTurnSawAgentMessage: boolean;
 
   inAttentionWindow: boolean;
   attentionWindowTimer: ReturnType<typeof setTimeout> | null;
@@ -63,6 +77,23 @@ interface ChatState {
   nextSystemMessageId: number;
 }
 
+/**
+ * Spec v2.2 §5: daemon-wide state tracking the single proxy TUI (if any).
+ * `pairedChatId` is set when a Claude attaches while the slot is open.
+ * `readiness` flips to "ready" when CodexAdapter signals thread is ready.
+ * Only one slot exists at a time (CodexAdapter §4.6 enforces single TUI).
+ */
+type PairReadiness = "not-ready" | "ready";
+
+interface ProxyTuiSlot {
+  token: string;
+  pairedChatId: string | null;
+  readiness: PairReadiness;
+  attachedAt: number;
+  /** Set when paired Claude detaches; clears pairedChatId on expiry. */
+  pairReapTimer: ReturnType<typeof setTimeout> | null;
+}
+
 const stateDir = new StateDirResolver();
 stateDir.ensure();
 const configService = new ConfigService();
@@ -74,6 +105,7 @@ const CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10
 const TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 const CLAUDE_DISCONNECT_GRACE_MS = 5_000;
 const CLAUDE_REAP_AFTER_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_REAP_MS ?? "600000", 10); // 10 min
+const PAIR_REAP_MS = parseInt(process.env.AGENTBRIDGE_PAIR_REAP_MS ?? "30000", 10); // 30s grace for paired Claude reconnect (spec v2.2 §5)
 const MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 const FILTER_MODE: FilterMode =
   (process.env.AGENTBRIDGE_FILTER_MODE as FilterMode) === "full" ? "full" : "filtered";
@@ -100,6 +132,9 @@ let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** chatId → ChatState. Survives WS disconnects (lazy reap, see CLAUDE_REAP_AFTER_MS). */
 const chats = new Map<string, ChatState>();
+
+/** Spec v2.2 §5: single-slot proxy TUI tracking. null when no `--via-proxy` TUI connected. */
+let proxyTuiSlot: ProxyTuiSlot | null = null;
 
 const tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
@@ -130,21 +165,226 @@ const tuiConnectionState = new TuiConnectionState({
 codex.on("ready", (threadId: string) => {
   tuiConnectionState.markBridgeReady();
   log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
+  // Spec v2.2 §5: thread/started observed → flip readiness so paired Claude
+  // replies stop returning the "provisioning" error.
+  if (proxyTuiSlot) {
+    proxyTuiSlot.readiness = "ready";
+    if (proxyTuiSlot.pairedChatId) {
+      const state = chats.get(proxyTuiSlot.pairedChatId);
+      if (state && !state.ready) {
+        state.ready = true;
+        emitToChat(state, systemMessage("system_pair_ready",
+          `✅ Shared Codex TUI thread is now ready (threadId=${threadId}). Replies sent via the reply tool will appear in the right pane's TUI.`));
+      }
+    }
+  }
 });
 
-codex.on("tuiConnected", (connId: number) => {
+codex.on("tuiConnected", (connId: number, token: string = "") => {
   tuiConnectionState.handleTuiConnected(connId);
   cancelIdleShutdown();
-  log(`Codex TUI connected (conn #${connId})`);
+  log(`Codex TUI connected (conn #${connId}, token=${token ? token.slice(0, 8) + "…" : "<none>"})`);
+  // Spec v2.2 §5: a TUI carrying a non-empty shared-mode token is a proxy TUI.
+  // Initialize the slot. Empty token = direct/legacy TUI; no pairing intent.
+  if (token && !proxyTuiSlot) {
+    proxyTuiSlot = {
+      token,
+      pairedChatId: null,
+      readiness: "not-ready",
+      attachedAt: Date.now(),
+      pairReapTimer: null,
+    };
+    log(`Proxy TUI slot allocated (token=${token.slice(0, 8)}…)`);
+    // Spec v2.2 §5.1: PAIR_RACE_MS=0 — Claude-first stays isolated. Do NOT
+    // retroactively pair an already-attached isolated Claude. Only chats that
+    // attach AFTER this point (in attachClaude) can claim the slot.
+  }
   broadcastStatus();
 });
 
 codex.on("tuiDisconnected", (connId: number) => {
   tuiConnectionState.handleTuiDisconnected(connId);
   log(`Codex TUI disconnected (conn #${connId})`);
+  // Spec v2.2 §5: TUI disconnect tears down the proxy slot. Paired Claude (if
+  // any) transitions to isolated mode with a system notice. No prior context
+  // is replayed.
+  if (proxyTuiSlot) {
+    const wasPairedChat = proxyTuiSlot.pairedChatId;
+    if (proxyTuiSlot.pairReapTimer) clearTimeout(proxyTuiSlot.pairReapTimer);
+    proxyTuiSlot = null;
+    codex.setPairedChat(null);
+    if (wasPairedChat) {
+      const state = chats.get(wasPairedChat);
+      if (state) {
+        log(`Transitioning paired chat ${wasPairedChat} to isolated (TUI disconnect)`);
+        transitionToIsolated(state, "Shared Codex TUI thread is gone");
+      }
+    }
+  }
   broadcastStatus();
   scheduleIdleShutdown();
 });
+
+// ── Spec v2.2 §4.3 — shared transport outbound routing ────────
+//
+// When a chat is paired via proxyTuiSlot, CodexAdapter is the transport. All
+// shared-thread events route to the paired chat only.
+
+codex.on("agentMessage", (msg: BridgeMessage) => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  log(`[${paired.chatId}] CodexAdapter → paired Claude (agentMessage, ${msg.content.length} chars)`);
+  paired.pairedTurnSawAgentMessage = true;
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, msg);
+});
+
+codex.on("userMessage", (payload: { content: string; id?: string; turnId?: string }) => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  if (!payload.content) return;
+  log(`[${paired.chatId}] CodexAdapter → paired Claude (userMessage from TUI, ${payload.content.length} chars)`);
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, {
+    id: payload.id ?? `tui_user_${Date.now()}`,
+    source: "codex",
+    content: `[IMPORTANT] Human typed in the paired Codex TUI:\n${payload.content}`,
+    timestamp: Date.now(),
+  });
+});
+
+codex.on("turnStarted", () => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  // Spec v2.2 §4.3: emit as diagnostic, MUST NOT satisfy requireReply.
+  // Reset per-turn agentMessage tracker so turn/completed can detect the
+  // "no-output failure" mode.
+  paired.pairedTurnSawAgentMessage = false;
+  emitToChat(paired, systemMessage("system_codex_turn_started", "[system] Codex turn started"));
+});
+
+codex.on("turnCompleted", () => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  // Spec v2.2 §4.3: satisfies requireReply ONLY if the turn produced no
+  // agentMessage (the "no-output failure" signal). Otherwise the agentMessage
+  // already released requireReply earlier.
+  if (!paired.pairedTurnSawAgentMessage) {
+    log(`[${paired.chatId}] Codex turn completed with no agentMessage — surfacing as failure signal`);
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, systemMessage("system_codex_turn_completed_no_output",
+      "[system] Codex turn completed without any agentMessage — likely a failure or empty response."));
+  } else {
+    emitToChat(paired, systemMessage("system_codex_turn_completed", "[system] Codex turn completed"));
+  }
+  // Cleanup: reset per-turn flags so a future transition to isolated mode
+  // starts from a clean slate.
+  paired.replyRequired = false;
+  paired.replyReceivedDuringTurn = false;
+});
+
+codex.on("errorItem", (payload: { code?: number; message?: string }) => {
+  const paired = getPairedChatState();
+  if (!paired) return;
+  // Spec v2.2 §4.3: error notification satisfies requireReply.
+  paired.replyReceivedDuringTurn = true;
+  emitToChat(paired, systemMessage("system_codex_error",
+    `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
+  // Cleanup paired flags — error is a terminal signal for this turn.
+  paired.replyRequired = false;
+});
+
+// Spec v2.2 §8 E8: app-server reconnect restore flips paired readiness back
+// to not-ready, surfacing "restoring shared Codex TUI session, retry shortly"
+// to paired Claude until restore completes.
+codex.on("sessionRestoreStart", () => {
+  if (!proxyTuiSlot) return;
+  log(`Shared Codex session restore started — flipping paired readiness to not-ready`);
+  proxyTuiSlot.readiness = "not-ready";
+  const paired = getPairedChatState();
+  if (paired) paired.ready = false;
+});
+
+codex.on("sessionRestoreEnd", (payload: { ok?: boolean; threadId?: string } = {}) => {
+  if (!proxyTuiSlot) return;
+  if (payload.ok === false) {
+    // Spec v2.2 §8 E8: restore failure path. Keep paired readiness=not-ready.
+    // CodexAdapter's catch branch closes the TUI with 1011, which will fire
+    // tuiDisconnected and tear down the pair via the normal path. We just
+    // don't lie to paired Claude in the meantime.
+    log(`Shared Codex session restore FAILED — keeping paired readiness=not-ready, awaiting TUI tear-down`);
+    return;
+  }
+  log(`Shared Codex session restore succeeded — flipping paired readiness back to ready`);
+  proxyTuiSlot.readiness = "ready";
+  const paired = getPairedChatState();
+  if (paired) {
+    paired.ready = true;
+    emitToChat(paired, systemMessage("system_pair_restored",
+      "✅ Shared Codex TUI session restored. Replies can flow again."));
+  }
+});
+
+codex.on("threadClosed", () => {
+  const paired = getPairedChatState();
+  log(`Codex emitted thread/closed`);
+  if (proxyTuiSlot) {
+    const wasPairedChat = proxyTuiSlot.pairedChatId;
+    proxyTuiSlot = null;
+    codex.setPairedChat(null);
+    if (wasPairedChat && paired) {
+      log(`Transitioning paired chat ${wasPairedChat} to isolated (thread/closed)`);
+      transitionToIsolated(paired, "Shared Codex thread closed");
+    }
+  }
+});
+
+function getPairedChatState(): ChatState | null {
+  if (!proxyTuiSlot?.pairedChatId) return null;
+  return chats.get(proxyTuiSlot.pairedChatId) ?? null;
+}
+
+function pairChat(state: ChatState): void {
+  if (!proxyTuiSlot) return;
+  if (proxyTuiSlot.pairedChatId) return;
+  proxyTuiSlot.pairedChatId = state.chatId;
+  state.paired = true;
+  codex.setPairedChat(state.chatId);
+  state.ready = proxyTuiSlot.readiness === "ready";
+  log(`Paired chat ${state.chatId} with proxy TUI (readiness=${proxyTuiSlot.readiness})`);
+  if (state.ready) {
+    emitToChat(state, systemMessage("system_paired_ready",
+      "✅ This Claude session is paired with the right-pane Codex TUI. Replies will appear there; user typing in the TUI will be forwarded to you with an [IMPORTANT] prefix."));
+  } else {
+    emitToChat(state, systemMessage("system_paired_provisioning",
+      "✅ This Claude session is paired with the right-pane Codex TUI. Waiting for the shared thread to finish provisioning before replies can flow."));
+  }
+}
+
+function transitionToIsolated(state: ChatState, reason: string): void {
+  state.paired = false;
+  emitToChat(state, systemMessage("system_pair_torn_down",
+    `[system] ${reason}. Future replies will use a fresh isolated Codex thread (no prior shared-TUI context carried over).`));
+  // Re-bootstrap as isolated. Same chatId, new ClaudeThread.
+  state.thread = new ClaudeThread({
+    appServerUrl: codex.appServerUrl,
+    chatId: state.chatId,
+    logFile: stateDir.logFile,
+    cwd: process.cwd(),
+  });
+  state.ready = false;
+  wireClaudeThreadEvents(state);
+  state.thread.bootstrap()
+    .then((threadId) => {
+      state.ready = true;
+      emitToChat(state, systemMessage("system_isolated_ready",
+        `✅ Fresh isolated Codex thread ready (threadId=${threadId}).`));
+    })
+    .catch((err: any) => {
+      emitToChat(state, systemMessage("system_isolated_failed",
+        `❌ Failed to bootstrap isolated Codex thread: ${err?.message ?? err}.`));
+    });
+}
 
 codex.on("error", (err: Error) => {
   log(`Codex error: ${err.message}`);
@@ -267,7 +507,8 @@ async function attachClaude(
     return;
   }
 
-  // New chat: create state + ClaudeThread
+  // New chat: create state. Spec v2.2 §5: if a proxy TUI is connected and
+  // unpaired, this new Claude becomes the paired Claude. Otherwise, isolated.
   state = createChatState(chatId);
   chats.set(chatId, state);
   state.ws = ws;
@@ -276,6 +517,15 @@ async function attachClaude(
   log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
 
   sendStatus(ws);
+
+  if (proxyTuiSlot && proxyTuiSlot.pairedChatId === null) {
+    emitToChat(state, systemMessage("system_bridge_provisioning",
+      "✅ AgentBridge daemon attached. Pairing with the right-pane Codex TUI for shared-thread mode..."));
+    pairChat(state);
+    broadcastStatus();
+    return; // paired chats skip ClaudeThread.bootstrap (shared transport)
+  }
+
   emitToChat(state, systemMessage("system_bridge_provisioning",
     "✅ AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
 
@@ -304,6 +554,8 @@ function createChatState(chatId: string): ChatState {
       cwd: process.cwd(),
     }),
     ready: false,
+    paired: false,
+    pairedTurnSawAgentMessage: false,
     inAttentionWindow: false,
     attentionWindowTimer: null,
     replyRequired: false,
@@ -317,8 +569,16 @@ function createChatState(chatId: string): ChatState {
     nextSystemMessageId: 0,
   };
   state.statusBuffer = new StatusBuffer((summary) => emitToChat(state, summary));
+  wireClaudeThreadEvents(state);
+  return state;
+}
 
-  // Wire ClaudeThread events to per-chat routing.
+/**
+ * Spec v2.2: extracted so it can be called again when a paired chat
+ * transitions to isolated mode (new ClaudeThread instance, fresh event wiring).
+ */
+function wireClaudeThreadEvents(state: ChatState): void {
+  const chatId = state.chatId;
   state.thread.on("agentMessage", (msg: BridgeMessage) => {
     if (msg.source !== "codex") return;
     const result = classifyMessage(msg.content, FILTER_MODE);
@@ -393,16 +653,48 @@ function createChatState(chatId: string): ChatState {
   state.thread.on("error", (err: any) => {
     log(`[${chatId}] ClaudeThread error: ${err?.message ?? err}`);
   });
-
-  return state;
 }
 
 function detachClaudeWs(state: ChatState, reason: string) {
   if (!state.ws) return;
-  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason})`);
+  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason}, paired=${state.paired})`);
   state.ws = null;
   scheduleDisconnectTimer(state);
   scheduleReaperTimer(state);
+
+  // Spec v2.2 §5: paired Claude WS detach starts a grace timer. Same chatId
+  // reconnect within PAIR_REAP_MS keeps the pair alive; otherwise the slot
+  // becomes available for a new Claude to pair AND the orphan chat state is
+  // reaped (it never bootstrapped its own ClaudeThread; without the pair, it
+  // has no transport and cannot serve a future resume meaningfully).
+  if (state.paired && proxyTuiSlot && proxyTuiSlot.pairedChatId === state.chatId) {
+    if (proxyTuiSlot.pairReapTimer) clearTimeout(proxyTuiSlot.pairReapTimer);
+    proxyTuiSlot.pairReapTimer = setTimeout(() => {
+      if (!proxyTuiSlot) return;
+      const currentState = chats.get(state.chatId);
+      if (currentState?.ws) {
+        log(`Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
+        return;
+      }
+      log(`Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms — clearing pair slot and reaping chat state`);
+      proxyTuiSlot.pairedChatId = null;
+      proxyTuiSlot.pairReapTimer = null;
+      codex.setPairedChat(null);
+      // Full reap of the orphaned paired chat (matches the 10-min idle reaper's
+      // cleanup: close any thread WS, dispose buffers, delete from map). A
+      // future Claude with the same chatId gets a fresh chat state.
+      if (currentState) {
+        try { currentState.thread.close(); } catch {}
+        currentState.statusBuffer.dispose();
+        if (currentState.attentionWindowTimer) clearTimeout(currentState.attentionWindowTimer);
+        if (currentState.disconnectTimer) clearTimeout(currentState.disconnectTimer);
+        if (currentState.reaperTimer) clearTimeout(currentState.reaperTimer);
+        chats.delete(state.chatId);
+        broadcastStatus();
+      }
+    }, PAIR_REAP_MS);
+  }
+
   scheduleIdleShutdown();
 }
 
@@ -482,11 +774,26 @@ function handleClaudeToCodex(
   }
 
   if (!state.ready) {
+    // Spec v2.2 §5 + §8 E8: paired-but-not-ready returns a transient error so
+    // paired Claude can retry once the shared thread is provisioned or
+    // session-restored. Distinguish first-time provisioning from restore.
+    let errorMsg: string;
+    if (state.paired) {
+      if (codex.isSessionRestoreInProgress) {
+        errorMsg = "Restoring shared Codex TUI session, retry shortly.";
+      } else if (proxyTuiSlot) {
+        errorMsg = "Shared Codex TUI thread is still provisioning. Retry shortly.";
+      } else {
+        errorMsg = "Shared Codex TUI is no longer connected. Wait for transition to isolated mode.";
+      }
+    } else {
+      errorMsg = "Your Codex thread is still provisioning. Wait for system_thread_ready.";
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,
       success: false,
-      error: "Your Codex thread is still provisioning. Wait for system_thread_ready.",
+      error: errorMsg,
     });
   }
 
@@ -499,12 +806,24 @@ function handleClaudeToCodex(
     log(`[${chatId}] Reply required flag set`);
   }
 
-  log(`[${chatId}] Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-  const injected = state.thread.injectMessage(contentWithReminder);
+  log(`[${chatId}] Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply}, paired=${state.paired})`);
+
+  // Spec v2.2 §6: paired chats route through CodexAdapter (shared transport);
+  // isolated chats keep using their own ClaudeThread.
+  const injected = state.paired
+    ? codex.injectMessage(contentWithReminder)
+    : state.thread.injectMessage(contentWithReminder);
+
   if (!injected) {
-    const reason = state.thread.isTurnInProgress
-      ? "Codex is busy executing a turn on your thread. Wait for it to finish."
-      : "Injection failed: thread WS not connected.";
+    const reason = state.paired
+      ? "Shared Codex TUI is busy with another turn. Retry."
+      : (state.thread.isTurnInProgress
+          ? "Codex is busy executing a turn on your thread. Wait for it to finish."
+          : "Injection failed: thread WS not connected.");
+    if (requireReply) {
+      // Roll back the replyRequired flag since injection didn't happen.
+      state.replyRequired = false;
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,
@@ -625,6 +944,7 @@ function currentStatus(): DaemonStatus {
     appServerUrl: codex.appServerUrl,
     pid: process.pid,
     attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length,
+    proxyTuiConnected: proxyTuiSlot !== null,
   };
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -521,7 +521,14 @@ function attachPairHandlers(pair: PairState): void {
 
   on("exit", (code: number | null) => {
     log(`[pair=${pair.pairId}] Codex app-server process exited (code ${code})`);
-    codexBootstrapped = false;
+    // Issue #84 (2026-05-17): `codexBootstrapped` is a default-pair
+    // bootstrap status flag (consumed by /healthz's `bridgeReady` field
+    // and certain ready-gating logic). Pre-fix this was set false on
+    // ANY pair's exit, leaking non-default crashes into top-level
+    // bridge-readiness reporting. Scope to the default pair only.
+    if (pair.pairId === "default") {
+      codexBootstrapped = false;
+    }
     // Bug fix (Codex P2 review codex_msg_5753c73beafc_95): clear `isLive`
     // so a subsequent `ensurePair(pair.pairId)` re-spawns the app-server
     // rather than no-op'ing on stale liveness state. Without this, ME6

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1145,6 +1145,15 @@ async function attachClaude(
     log(`ClaudeThread bootstrap failed for chatId=${chatId}: ${err?.message ?? err}`);
     emitToChat(state, systemMessage("system_thread_failed",
       `❌ Failed to provision Codex thread: ${err?.message ?? err}. Reconnect to retry.`));
+    // Bug fix (2026-05-17): reap the half-initialized chat so the
+    // advertised "Reconnect to retry" path actually works. Without
+    // this, the chat stays in `chats` with `state.ready=false` forever:
+    // subsequent reply attempts hit the "thread still provisioning"
+    // error, and a bridge reconnect with the same chatId takes the
+    // resume branch and skips bootstrap. Reaping forces the next
+    // attach to construct a fresh ChatState and re-bootstrap. Mirrors
+    // the §6.5 P3c isolated-bootstrap-exhausted reap.
+    reapChatState(state, `bootstrap failed: ${err?.message ?? err}`);
   }
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1506,6 +1506,16 @@ function handleClaudeToCodex(
     // Pair vanished or went down between FIFO claim and this reply
     // (e.g. concurrent `destroy_pair --force` race). Surface explicitly
     // rather than silently injecting into the wrong pair.
+    //
+    // Codex re-review of ebea1d3 (msg ..._197) — must roll back
+    // replyRequired here because we set it above (line 1487) before
+    // attempting the injection. Without rollback, a racing requireReply
+    // reply against pair teardown leaves the chat in stale reply-
+    // required state even though no injection happened, mirroring the
+    // later `!injected` branch's rollback contract.
+    if (requireReply) {
+      state.replyRequired = false;
+    }
     return sendProtocolMessage(ws, {
       type: "claude_to_codex_result",
       requestId: message.requestId,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -46,12 +46,16 @@ interface ControlSocketData {
 interface ChatState {
   chatId: string;
   /**
-   * STM v2.3 §6.1 P1: every chat is associated with one pair (its "home
-   * pair"). In P1 this is always `"default"` because only the default
-   * pair exists. P5 introduces FIFO claiming across multiple pairs and
-   * the optional `null` value for isolated chats with no live pair.
+   * STM v2.3 §6.1 / §6.4: pair this chat is bound to.
+   *
+   * P1/P3 always populate this with `"default"` (the only pair until P5
+   * introduces multi-pair FIFO claiming). The spec allows `null` for
+   * chats with no live home pair — e.g. an isolated chat created after
+   * default has been destroyed, or any chat that hasn't yet successfully
+   * bound to a pair. Type-widening lands here in P3-cleanup so P5 can
+   * use null without a follow-up schema change.
    */
-  homePairId: string;
+  homePairId: string | null;
   ws: ServerWebSocket<ControlSocketData> | null;
   thread: ClaudeThread;
   ready: boolean;
@@ -759,15 +763,23 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
 
 // ── STM v2.3 §D6 P3 — pair management control protocol handlers ────────
 //
-// In P3b: `ensure_pair("default")` runs the full P2 ensurePair flow + saves
-// the registry. `ensure_pair("<other>")` validates + allocates a registry
-// entry but does NOT spawn a CodexAdapter — the actual non-default
-// activation lands in P3c once helpers (`getPairedChatState`, `pairChat`,
-// `transitionToIsolated`) become pair-aware. Until then, attaching the
-// shared event handlers on a non-default pair would route work-pair events
-// through default's paired-chat tracking (Codex P2 review warning).
-// `destroy_pair` handles both live default + registry-only entries.
-// `list_pairs` reports every registry entry plus their live status.
+// `ensure_pair(pairId)` validates the name (D1), allocates / reuses a
+// registry entry under the daemon-wide write mutex, constructs a fresh
+// PairState for non-default pairs (own CodexAdapter + TuiConnectionState,
+// pair-scoped handlers via attachPairHandlers' closure-local getPaired),
+// and starts the Codex app-server. Same-pair concurrent ensures dedupe
+// through `ensurePairInFlight`. Port-binding failures surface as
+// PAIR_PORTS_BUSY with structured details.
+//
+// `destroy_pair(pairId, { forget, force })` performs the full §6.3
+// teardown: cancel timers, detach handlers, transition any paired chat
+// to isolated, stop codex, clear slot, remove non-default pairs from
+// the pairs Map, broadcast status, and optionally remove the registry
+// entry. PAIR_BUSY_NOT_FORCED guards against silent loss of paired
+// work.
+//
+// `list_pairs` reports the union of live pairs (with full runtime state)
+// and registry-only entries (URLs from registry, isLive=false).
 
 async function handleEnsurePair(
   ws: ServerWebSocket<ControlSocketData>,
@@ -792,6 +804,7 @@ async function handleEnsurePair(
         pairId,
         code: err.code,
         message: err.message,
+        ...(err.details ? { details: err.details } : {}),
       });
       return;
     }
@@ -1675,14 +1688,48 @@ async function ensurePairCore(pairId: string): Promise<PairState> {
   }
 
   log(`[pair=${pair.pairId}] ensurePair: starting codex app-server (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl})`);
-  await pair.codex.start();
+  try {
+    await pair.codex.start();
+  } catch (err: any) {
+    // STM v2.3 §D2 P3-cleanup: map port-binding failures to PAIR_PORTS_BUSY
+    // with structured details. CodexAdapter / Bun.serve surface port
+    // conflicts via EADDRINUSE on `error.code` or in the message text.
+    // Other start errors propagate as ALLOCATION_FAILED upstream.
+    const errCode = err?.code ?? "";
+    const errMsg = err?.message ?? String(err);
+    const looksLikePortBusy =
+      errCode === "EADDRINUSE" ||
+      /EADDRINUSE/i.test(errMsg) ||
+      /address already in use/i.test(errMsg) ||
+      /port.*in use/i.test(errMsg);
+    if (looksLikePortBusy) {
+      // Try to extract which port conflicted from the message so the CLI
+      // can surface a specific PID/port pointer. Pattern: `:NNNN` or `port NNNN`.
+      let conflictPort: number | undefined;
+      const portMatch = errMsg.match(/(?::|port[\s=]+|address[\s=]+[\w:.]+:)(\d{2,5})/i);
+      if (portMatch) {
+        const candidate = parseInt(portMatch[1], 10);
+        if (Number.isFinite(candidate)) conflictPort = candidate;
+      }
+      throw new PairError(
+        "PAIR_PORTS_BUSY",
+        `pair "${pair.pairId}" ports (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl}) are held by another process: ${errMsg}`,
+        { conflictPort },
+      );
+    }
+    throw err;
+  }
   pair.isLive = true;
   return pair;
 }
 
 /** STM v2.3 §D6 P3c — error class carrying a pair-protocol error code. */
 class PairError extends Error {
-  constructor(public readonly code: import("./control-protocol").PairErrorCode, message: string) {
+  constructor(
+    public readonly code: import("./control-protocol").PairErrorCode,
+    message: string,
+    public readonly details?: import("./control-protocol").PairErrorDetails,
+  ) {
     super(message);
     this.name = "PairError";
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -433,6 +433,11 @@ function attachPairHandlers(pair: PairState): void {
   on("exit", (code: number | null) => {
     log(`[pair=${pair.pairId}] Codex app-server process exited (code ${code})`);
     codexBootstrapped = false;
+    // Bug fix (Codex P2 review codex_msg_5753c73beafc_95): clear `isLive`
+    // so a subsequent `ensurePair(pair.pairId)` re-spawns the app-server
+    // rather than no-op'ing on stale liveness state. Without this, ME6
+    // "next ensure_pair re-spawns after crash" would silently fail in P3.
+    pair.isLive = false;
     pair.tuiConnectionState.handleCodexExit();
     broadcastToAllClaudes(
       systemMessage(
@@ -1209,6 +1214,16 @@ async function ensurePair(pairId: string): Promise<PairState> {
     throw new Error(`ensurePair: pair "${pairId}" missing from registry (P2 invariant violated)`);
   }
   if (pair.isLive) return pair;
+  // Bug fix (Codex P2 review codex_msg_5753c73beafc_95): if this is a
+  // re-ensure after a prior destroyPair (or after an `exit` cleared
+  // isLive), handler refs were cleared too. Reattach before starting
+  // so the new codex.start() fires `ready` / `tuiConnected` / etc. into
+  // live event listeners. Without this, ensurePair-after-destroyPair
+  // produced a live-but-event-deaf pair.
+  if (pair.handlerRefs.length === 0) {
+    log(`[pair=${pair.pairId}] ensurePair: reattaching handlers before start`);
+    attachPairHandlers(pair);
+  }
   log(`[pair=${pair.pairId}] ensurePair: starting codex app-server (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl})`);
   await pair.codex.start();
   pair.isLive = true;
@@ -1357,6 +1372,11 @@ export const __testing = {
     createChatState,
     detachClaudeWs,
     emitToChat,
+    /** STM v2.3 P2 lifecycle entry points (added 2026-05-16). */
+    attachPairHandlers,
+    detachPairHandlers,
+    ensurePair,
+    destroyPair,
   } as const,
   /** Constants captured at module load — useful for asserting timer behavior. */
   config: {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1371,19 +1371,34 @@ function detachClaudeWs(state: ChatState, reason: string) {
   // pair. Route everything through `pairs.get(state.homePairId)`.
   const homePair = state.paired && state.homePairId ? pairs.get(state.homePairId) : undefined;
   if (state.paired && homePair && homePair.proxyTuiSlot && homePair.proxyTuiSlot.pairedChatId === state.chatId) {
+    // Capture the pairId at schedule time. `state.homePairId` is mutable
+    // (transitionToIsolated flips it to "default"); without capture, a
+    // stale timer firing after a transition would consult the WRONG
+    // pair's slot. Codex M06b re-pass msg ..._214.
+    const scheduledPairId = state.homePairId!;
     const slot = homePair.proxyTuiSlot;
     if (slot.pairReapTimer) clearTimeout(slot.pairReapTimer);
     slot.pairReapTimer = setTimeout(() => {
-      // Re-fetch in case the pair was destroyed during the grace window.
-      const currentPair = pairs.get(state.homePairId!);
+      // Re-fetch via the CAPTURED pairId — not state.homePairId — so
+      // we never clear the wrong pair's slot if state was re-homed
+      // during the grace window.
+      const currentPair = pairs.get(scheduledPairId);
       const currentSlot = currentPair?.proxyTuiSlot;
       if (!currentSlot) return;
       const currentState = chats.get(state.chatId);
       if (currentState?.ws) {
-        log(`[pair=${state.homePairId}] Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
+        log(`[pair=${scheduledPairId}] Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
         return;
       }
-      log(`[pair=${state.homePairId}] Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms — clearing pair slot and reaping chat state`);
+      // Defense in depth: only clear if the slot still references THIS
+      // chat. A different chat may have FIFO-claimed the slot if our
+      // earlier mutation already ran (or if there's a parallel race).
+      if (currentSlot.pairedChatId !== state.chatId) {
+        log(`[pair=${scheduledPairId}] reap-timer fired for ${state.chatId} but slot now holds ${currentSlot.pairedChatId ?? "<unpaired>"} — skipping clear`);
+        currentSlot.pairReapTimer = null;
+        return;
+      }
+      log(`[pair=${scheduledPairId}] Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms — clearing pair slot and reaping chat state`);
       currentSlot.pairedChatId = null;
       currentSlot.pairReapTimer = null;
       currentPair!.codex.setPairedChat(null);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -308,6 +308,15 @@ function attachPairHandlers(pair: PairState): void {
     pair.codex.on(eventName, handler);
     pair.handlerRefs.push({ eventName, handler });
   };
+  // STM v2.3 §6.5 / §6.6 P3c — pair-scoped paired-chat lookup. Replaces the
+  // P2-era module-level `getPairedChatState()` which read the default pair's
+  // proxyTuiSlot via the P1 alias. Now every handler reads from its own
+  // pair's slot, so events on a non-default pair stay routed within that
+  // pair's chat scope.
+  const getPaired = (): ChatState | null => {
+    if (!pair.proxyTuiSlot?.pairedChatId) return null;
+    return chats.get(pair.proxyTuiSlot.pairedChatId) ?? null;
+  };
 
   on("ready", (threadId: string) => {
     pair.tuiConnectionState.markBridgeReady();
@@ -378,7 +387,7 @@ function attachPairHandlers(pair: PairState): void {
   // shared-thread events route to the paired chat only.
 
   on("agentMessage", (msg: BridgeMessage) => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired) return;
     log(`[${paired.chatId}] CodexAdapter → paired Claude (agentMessage, ${msg.content.length} chars)`);
     paired.pairedTurnSawAgentMessage = true;
@@ -387,7 +396,7 @@ function attachPairHandlers(pair: PairState): void {
   });
 
   on("userMessage", (payload: { content: string; id?: string; turnId?: string }) => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired) return;
     if (!payload.content) return;
     log(`[${paired.chatId}] CodexAdapter → paired Claude (userMessage from TUI, ${payload.content.length} chars)`);
@@ -401,7 +410,7 @@ function attachPairHandlers(pair: PairState): void {
   });
 
   on("turnStarted", () => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired) return;
     // Spec v2.2 §4.3: emit as diagnostic, MUST NOT satisfy requireReply.
     // Reset per-turn agentMessage tracker so turn/completed can detect the
@@ -411,7 +420,7 @@ function attachPairHandlers(pair: PairState): void {
   });
 
   on("turnCompleted", () => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired) return;
     // Bug fix (2026-05-16): only surface "no-output failure" when Claude was
     // actually waiting for a reply (replyRequired=true). User-typed TUI turns
@@ -430,7 +439,7 @@ function attachPairHandlers(pair: PairState): void {
   });
 
   on("errorItem", (payload: { code?: number; message?: string }) => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (!paired) return;
     paired.replyReceivedDuringTurn = true;
     emitToChat(paired, systemMessage("system_codex_error",
@@ -447,7 +456,7 @@ function attachPairHandlers(pair: PairState): void {
     if (!pair.proxyTuiSlot) return;
     log(`[pair=${pair.pairId}] Shared Codex session restore started — flipping paired readiness to not-ready`);
     pair.proxyTuiSlot.readiness = "not-ready";
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (paired) paired.ready = false;
   });
 
@@ -459,7 +468,7 @@ function attachPairHandlers(pair: PairState): void {
     }
     log(`[pair=${pair.pairId}] Shared Codex session restore succeeded — flipping readiness back to ready`);
     pair.proxyTuiSlot.readiness = "ready";
-    const paired = getPairedChatState();
+    const paired = getPaired();
     if (paired) {
       paired.ready = true;
       emitToChat(paired, systemMessage("system_pair_restored",
@@ -468,7 +477,7 @@ function attachPairHandlers(pair: PairState): void {
   });
 
   on("threadClosed", () => {
-    const paired = getPairedChatState();
+    const paired = getPaired();
     log(`[pair=${pair.pairId}] Codex emitted thread/closed`);
     if (pair.proxyTuiSlot) {
       const wasPairedChat = pair.proxyTuiSlot.pairedChatId;
@@ -627,6 +636,12 @@ function reapChatState(state: ChatState, reason: string): void {
 
 function transitionToIsolated(state: ChatState, reason: string): void {
   state.paired = false;
+  // STM v2.3 §6.5 P3c: pair teardown is a terminal boundary. Re-home the
+  // chat onto the default pair (Path A) — the ClaudeThread below targets
+  // `codex.appServerUrl` (the default pair's app-server). If default is
+  // not live the bootstrap retries exhaust and reapChatState produces the
+  // explicit "reconnect Claude" instruction (Path B equivalent).
+  state.homePairId = "default";
   // Bug fix (Codex review 2026-05-16): pair teardown is a terminal boundary
   // for the old shared turn. Reset paired-turn flags so they don't bleed
   // into the fresh isolated thread — a stale `replyRequired=true` would
@@ -751,62 +766,8 @@ async function handleEnsurePair(
   message: Extract<ControlClientMessage, { type: "ensure_pair" }>,
 ): Promise<void> {
   const { requestId, pairId } = message;
-  if (!isValidPairName(pairId)) {
-    sendProtocolMessage(ws, {
-      type: "pair_error",
-      requestId,
-      pairId,
-      code: "INVALID_PAIR_NAME",
-      message: `pair name "${pairId}" fails validation`,
-    });
-    return;
-  }
-
-  // Allocate (or get) registry entry under the daemon-wide mutex.
-  const allocResult = await runUnderRegistryMutex(async () => {
-    if (pairRegistry.has(pairId)) {
-      return { ok: true as const, entry: pairRegistry.get(pairId)! };
-    }
-    const result = pairRegistry.allocate(pairId);
-    if (result.ok) {
-      try { pairRegistry.save(); } catch (err: any) {
-        log(`[ensure_pair=${pairId}] registry save failed: ${err?.message ?? err}`);
-      }
-    }
-    return result;
-  });
-
-  if (!allocResult.ok) {
-    sendProtocolMessage(ws, {
-      type: "pair_error",
-      requestId,
-      pairId,
-      code: allocResult.error.code,
-      message: allocResult.error.message,
-    });
-    return;
-  }
-
-  const { appPort, proxyPort } = allocResult.entry;
-
-  if (pairId !== "default") {
-    // P3b: registry entry exists, but non-default activation lands in P3c.
-    // Surface this clearly via ALLOCATION_FAILED with a P3-specific message
-    // so users (and tests) know the entry IS in the registry — they can
-    // remove it via destroy_pair --forget if they want.
-    log(`[ensure_pair=${pairId}] registry entry allocated (appPort=${appPort}, proxyPort=${proxyPort}); activation deferred to P3c`);
-    sendProtocolMessage(ws, {
-      type: "pair_error",
-      requestId,
-      pairId,
-      code: "ALLOCATION_FAILED",
-      message: `pair "${pairId}" registry entry allocated (appPort=${appPort}, proxyPort=${proxyPort}) but non-default pair activation is not implemented in P3b — lands in P3c`,
-    });
-    return;
-  }
-
   try {
-    const pair = await ensurePair("default");
+    const pair = await ensurePair(pairId);
     sendProtocolMessage(ws, {
       type: "pair_ensured",
       requestId,
@@ -816,12 +777,23 @@ async function handleEnsurePair(
       isLive: true,
     });
   } catch (err: any) {
+    if (err instanceof PairError) {
+      sendProtocolMessage(ws, {
+        type: "pair_error",
+        requestId,
+        pairId,
+        code: err.code,
+        message: err.message,
+      });
+      return;
+    }
+    log(`[ensure_pair=${pairId}] unexpected error: ${err?.stack ?? err?.message ?? err}`);
     sendProtocolMessage(ws, {
       type: "pair_error",
       requestId,
       pairId,
       code: "ALLOCATION_FAILED",
-      message: `ensurePair("default") failed: ${err?.message ?? err}`,
+      message: `ensurePair("${pairId}") failed: ${err?.message ?? err}`,
     });
   }
 }
@@ -1488,45 +1460,99 @@ function writeStatusFile() {
 function removeStatusFile() { daemonLifecycle.removeStatusFile(); }
 
 /**
- * STM v2.3 §6.2 P2: bring a pair live — start its Codex app-server.
+ * STM v2.3 §6.2 P3c: bring a pair live — allocate registry entry if
+ * needed, construct a CodexAdapter + TuiConnectionState for non-default
+ * pairs, attach handlers, and start the Codex app-server.
  *
- * In P2 the only legal `pairId` is `"default"` and the PairState is
- * pre-constructed at module load (handlers attached). This function just
- * runs the codex.start() flow and flips `isLive`. Calling it on an
- * already-live pair is idempotent.
+ * Errors thrown here are instances of `PairError` so callers (notably
+ * `handleEnsurePair`) can map them to the right `pair_error` code in
+ * the control protocol.
  *
- * P3 generalizes this to:
- *   - validate pairId per D1
- *   - check `ensurePairInFlight` dedup mutex
- *   - look up / allocate ports via registry
- *   - construct CodexAdapter on demand for non-default pairs
- *   - attachPairHandlers for the new PairState
- *   - await codex.start() and flip isLive
- *   - return URLs to caller
+ * Concurrency: the registry read-modify-write (allocate + save) runs
+ * under `registryWriteMutex` to prevent different-pairId ensures from
+ * racing. PairState construction and codex.start() happen outside the
+ * mutex to avoid serializing all spawns through one chain.
  */
 async function ensurePair(pairId: string): Promise<PairState> {
-  if (pairId !== "default") {
-    throw new Error(`ensurePair: pairId="${pairId}" not yet supported in P2 (default only)`);
+  if (!isValidPairName(pairId)) {
+    throw new PairError("INVALID_PAIR_NAME", `pair name "${pairId}" fails validation`);
   }
-  const pair = pairs.get(pairId);
+
+  // Fast path: pair already constructed and live.
+  const existing = pairs.get(pairId);
+  if (existing?.isLive) return existing;
+
+  // Allocate (or look up) the registry entry for this pair.
+  const entry = await runUnderRegistryMutex(async () => {
+    if (pairRegistry.has(pairId)) return pairRegistry.get(pairId)!;
+    const result = pairRegistry.allocate(pairId);
+    if (!result.ok) {
+      throw new PairError(result.error.code, result.error.message);
+    }
+    try { pairRegistry.save(); } catch (err: any) {
+      log(`[pair-registry] ensurePair("${pairId}"): persist failed: ${err?.message ?? err}`);
+    }
+    return result.entry;
+  });
+
+  // Construct the PairState if we don't have one yet. The default pair is
+  // pre-constructed at module load (uses the P1 alias getter/setter for
+  // proxyTuiSlot); non-default pairs get a fresh PairState with a normal
+  // proxyTuiSlot field.
+  let pair = pairs.get(pairId);
   if (!pair) {
-    throw new Error(`ensurePair: pair "${pairId}" missing from registry (P2 invariant violated)`);
+    const newCodex = new CodexAdapter({
+      pairId,
+      appPort: entry.appPort,
+      proxyPort: entry.proxyPort,
+      logFile: stateDir.logFile,
+    });
+    const newTuiState = new TuiConnectionState({
+      disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
+      log,
+      onDisconnectPersisted: (connId) => {
+        broadcastToAllClaudes(systemMessage(
+          "system_tui_disconnected",
+          `⚠️ Codex TUI disconnected (pair=${pairId}, conn #${connId}). Codex is still running in the background — reconnect the TUI to resume.`,
+        ));
+      },
+      onReconnectAfterNotice: (connId) => {
+        broadcastToAllClaudes(systemMessage(
+          "system_tui_reconnected",
+          `✅ Codex TUI reconnected (pair=${pairId}, conn #${connId}). Bridge restored.`,
+        ));
+      },
+    });
+    pair = {
+      pairId,
+      codex: newCodex,
+      tuiConnectionState: newTuiState,
+      proxyTuiSlot: null,
+      handlerRefs: [],
+      isLive: false,
+    };
+    pairs.set(pairId, pair);
+    log(`[pair=${pairId}] constructed new PairState (appPort=${entry.appPort}, proxyPort=${entry.proxyPort})`);
   }
-  if (pair.isLive) return pair;
-  // Bug fix (Codex P2 review codex_msg_5753c73beafc_95): if this is a
-  // re-ensure after a prior destroyPair (or after an `exit` cleared
-  // isLive), handler refs were cleared too. Reattach before starting
-  // so the new codex.start() fires `ready` / `tuiConnected` / etc. into
-  // live event listeners. Without this, ensurePair-after-destroyPair
-  // produced a live-but-event-deaf pair.
+
+  // Bug fix (Codex P2 review codex_msg_5753c73beafc_95): reattach handlers
+  // if a prior destroyPair cleared them. attachPairHandlers is idempotent.
   if (pair.handlerRefs.length === 0) {
-    log(`[pair=${pair.pairId}] ensurePair: reattaching handlers before start`);
     attachPairHandlers(pair);
   }
+
   log(`[pair=${pair.pairId}] ensurePair: starting codex app-server (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl})`);
   await pair.codex.start();
   pair.isLive = true;
   return pair;
+}
+
+/** STM v2.3 §D6 P3c — error class carrying a pair-protocol error code. */
+class PairError extends Error {
+  constructor(public readonly code: import("./control-protocol").PairErrorCode, message: string) {
+    super(message);
+    this.name = "PairError";
+  }
 }
 
 /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -114,6 +114,21 @@ stateDir.ensure();
 // triggered ReferenceError "Cannot access 'daemonLogger' before
 // initialization" at boot via JS temporal dead zone.
 const daemonLogger = getAsyncFileLogger(stateDir.logFile);
+
+// Bug regression E (2026-05-17) — sticky flag: once stderr breaks (broken
+// pipe, closed by parent, etc.) stop trying to write to it. Without this,
+// EPIPE from stderr.write in log() throws → uncaughtException handler
+// calls log() → log() tries stderr.write → throws EPIPE again → infinite
+// loop. Historical incident: 8.5 GB log file from `bun daemon.js | head`.
+// MUST declare here (above pairRegistry.load() and other module-init code
+// that can call log()) — same TDZ constraint as daemonLogger above.
+let stderrBroken = false;
+process.stderr.on("error", (err: any) => {
+  if (err?.code === "EPIPE" || err?.code === "ERR_STREAM_DESTROYED") {
+    stderrBroken = true;
+  }
+});
+
 const configService = new ConfigService();
 const config = configService.loadOrDefault();
 
@@ -1961,7 +1976,16 @@ process.on("unhandledRejection", (reason: any) => {
 
 function log(msg: string) {
   const line = `[${new Date().toISOString()}] [AgentBridgeDaemon] ${msg}\n`;
-  process.stderr.write(line);
+  if (!stderrBroken) {
+    try {
+      process.stderr.write(line);
+    } catch (err: any) {
+      if (err?.code === "EPIPE" || err?.code === "ERR_STREAM_DESTROYED") {
+        stderrBroken = true;
+      }
+      // Any other stderr write error: silently drop. File log still records.
+    }
+  }
   daemonLogger.write(line);
 }
 
@@ -2036,6 +2060,9 @@ export const __testing = {
     handleListPairs,
     /** STM v2.3 §D4 / §D6 P3-cleanup — attach flow exposed so tests can verify claude_connect_result. */
     attachClaude,
+    /** Bug regression E (2026-05-17): exposed so EPIPE/stderr-broken test
+     * can drive log() directly and verify the sticky-flag short-circuit. */
+    log,
   } as const,
   /** STM v2.3 §D2 P3b — registry handle (read for assertions; mutate via handlers). */
   pairRegistry,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1123,19 +1123,40 @@ function sendProtocolMessage(ws: ServerWebSocket<ControlSocketData>, message: Co
 
 function currentStatus(): DaemonStatus {
   const snapshot = tuiConnectionState.snapshot();
+  // STM v2.3 §D7 P3: aggregate status. v2.2 top-level fields are kept
+  // populated from the default pair (URLs always — they're config; runtime
+  // fields reflect actual state). New v2.3 code reads detail from `pairs`.
   return {
     bridgeReady: tuiConnectionState.canReply() || codexBootstrapped,
+    pid: process.pid,
+    // URLs are config: always populated from the default pair's registered ports.
+    proxyUrl: codex.proxyUrl,
+    appServerUrl: codex.appServerUrl,
     tuiConnected: snapshot.tuiConnected,
+    proxyTuiConnected: proxyTuiSlot !== null,
     threadId: codex.activeThreadId,
+    // Aggregates across all chats / pairs.
+    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length,
     queuedMessageCount: [...chats.values()].reduce(
       (n, s) => n + s.bufferedMessages.length + s.statusBuffer.size,
       0,
     ),
-    proxyUrl: codex.proxyUrl,
-    appServerUrl: codex.appServerUrl,
-    pid: process.pid,
-    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length,
-    proxyTuiConnected: proxyTuiSlot !== null,
+    // P3 sub-commit 1: protocol shape only — wire the array but keep
+    // population trivial (just the default pair) until P3 sub-commit 2
+    // adds the registry / pair-introspection helpers.
+    pairs: [...pairs.values()].map((pair) => ({
+      pairId: pair.pairId,
+      isLive: pair.isLive,
+      appServerUrl: pair.codex.appServerUrl,
+      proxyUrl: pair.codex.proxyUrl,
+      tuiConnected: pair.tuiConnectionState.snapshot().tuiConnected,
+      proxyTuiConnected: pair.proxyTuiSlot !== null,
+      pairedChatId: pair.proxyTuiSlot?.pairedChatId ?? null,
+      threadId: pair.codex.activeThreadId,
+      attachedClaudes: [...chats.values()]
+        .filter((s) => s.homePairId === pair.pairId)
+        .map((s) => ({ chatId: s.chatId, paired: s.paired })),
+    })),
   };
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1277,6 +1277,14 @@ function wireClaudeThreadEvents(state: ChatState): void {
     startAttentionWindow(state);
   });
 
+  // Capture the thread reference at registration time. bootstrapIsolatedThread
+  // retry and transitionToIsolated both intentionally `state.thread.close()`
+  // then assign `state.thread = new ClaudeThread(...)`. The CLOSE event
+  // fires on the OLD thread reference but `state.thread` now points to
+  // the NEW one. Without this capture, the close handler can't tell
+  // "this was an intentional swap" apart from "the active thread crashed".
+  // (Codex cross-review batch #1-#5, 2026-05-17.)
+  const threadAtRegistration = state.thread;
   state.thread.on("close", () => {
     log(`[${chatId}] ClaudeThread WS closed`);
     state.ready = false;
@@ -1291,11 +1299,16 @@ function wireClaudeThreadEvents(state: ChatState): void {
     // bootstrap succeeds; if not, the bootstrap-failure reap kicks in
     // and bridge enters disabled state cleanly.
     //
-    // Two guards prevent unwanted re-reaping:
+    // Three guards prevent unwanted re-reaping:
     //  1. shuttingDown — during daemon SIGTERM all ClaudeThread WSs
     //     close in cascade; reaping during shutdown is pointless (state
     //     will be discarded) and writes noise to logs.
-    //  2. chats.get(chatId) !== state — if reapChatState already removed
+    //  2. state.thread !== threadAtRegistration — if the thread was
+    //     intentionally swapped (bootstrapIsolatedThread retry,
+    //     transitionToIsolated), the close fires on the OLD reference
+    //     but state.thread now points to the NEW one. Skip — the new
+    //     thread is the live one, not the one that closed.
+    //  3. chats.get(chatId) !== state — if reapChatState already removed
     //     this chat (so the close event we're seeing was caused by the
     //     intentional state.thread.close() inside reapChatState), the
     //     guard fails and we skip to avoid recursive re-entry. Also
@@ -1303,6 +1316,7 @@ function wireClaudeThreadEvents(state: ChatState): void {
     //     bridge reconnected and got a fresh ChatState for the same
     //     chatId before this stale handler fired).
     if (shuttingDown) return;
+    if (state.thread !== threadAtRegistration) return;
     if (chats.get(chatId) !== state) return;
 
     emitToChat(state, systemMessage("system_thread_failed",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -528,13 +528,24 @@ function attachPairHandlers(pair: PairState): void {
     // "next ensure_pair re-spawns after crash" would silently fail in P3.
     pair.isLive = false;
     pair.tuiConnectionState.handleCodexExit();
-    broadcastToAllClaudes(
-      systemMessage(
-        "system_codex_exit",
-        `⚠️ Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`,
-      ),
-    );
+
+    // Issue #83 risk #3 (M02 probe found 2026-05-17): the previous code
+    // broadcast system_codex_exit to ALL Claudes and closed EVERY chat
+    // thread + flipped state.ready=false — violating multi-pair crash
+    // isolation. Scope the cascade to chats homed on THIS pair only.
+    // Chats on other pairs (or isolated) are unaffected by this pair's
+    // crash and must continue operating.
+    const affectedChats: ChatState[] = [];
     for (const state of chats.values()) {
+      if (state.homePairId !== pair.pairId) continue;
+      affectedChats.push(state);
+    }
+    log(`[pair=${pair.pairId}] codex exit affects ${affectedChats.length}/${chats.size} chats (homed on this pair)`);
+    for (const state of affectedChats) {
+      emitToChat(state, systemMessage(
+        "system_codex_exit",
+        `⚠️ Codex app-server on pair "${pair.pairId}" exited (code ${code ?? "unknown"}). Your thread on this pair was terminated.`,
+      ));
       try { state.thread.close(); } catch {}
       state.ready = false;
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -266,11 +266,14 @@ codex.on("turnStarted", () => {
 codex.on("turnCompleted", () => {
   const paired = getPairedChatState();
   if (!paired) return;
-  // Spec v2.2 §4.3: satisfies requireReply ONLY if the turn produced no
-  // agentMessage (the "no-output failure" signal). Otherwise the agentMessage
-  // already released requireReply earlier.
-  if (!paired.pairedTurnSawAgentMessage) {
-    log(`[${paired.chatId}] Codex turn completed with no agentMessage — surfacing as failure signal`);
+  // Bug fix (2026-05-16): only surface "no-output failure" when Claude was
+  // actually waiting for a reply (replyRequired=true). User-typed TUI turns
+  // can legitimately complete without an agentMessage (e.g. silent ack) —
+  // emitting failure wording there confused paired Claude. Spec v2.2 §4.3
+  // describes this as the "no-output failure signal" but does not require
+  // it for non-Claude-originated turns.
+  if (!paired.pairedTurnSawAgentMessage && paired.replyRequired) {
+    log(`[${paired.chatId}] Codex turn completed with no agentMessage while replyRequired — surfacing as failure signal`);
     paired.replyReceivedDuringTurn = true;
     emitToChat(paired, systemMessage("system_codex_turn_completed_no_output",
       "[system] Codex turn completed without any agentMessage — likely a failure or empty response."));
@@ -290,8 +293,17 @@ codex.on("errorItem", (payload: { code?: number; message?: string }) => {
   paired.replyReceivedDuringTurn = true;
   emitToChat(paired, systemMessage("system_codex_error",
     `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
-  // Cleanup paired flags — error is a terminal signal for this turn.
+  // Bug fix (2026-05-16): mark the turn as "Claude has been informed" so a
+  // subsequent turn/completed does not fire a spurious no-output failure on
+  // top of the error we already surfaced. Naming is slightly stretched here
+  // ("sawAgentMessage" is now "saw something Claude needs to know about")
+  // but renaming would touch too many call sites for a minor fix.
+  paired.pairedTurnSawAgentMessage = true;
   paired.replyRequired = false;
+  // Symmetric reset (Codex review 2026-05-16): match the cleanup in the
+  // turn/completed handler so an error doesn't leave a stale "received during
+  // turn" flag that could confuse later logic.
+  paired.replyReceivedDuringTurn = false;
 });
 
 // Spec v2.2 §8 E8: app-server reconnect restore flips paired readiness back
@@ -361,8 +373,98 @@ function pairChat(state: ChatState): void {
   }
 }
 
+/**
+ * Bug fix (2026-05-16): isolated-bootstrap retry helper.
+ *
+ * Previously `transitionToIsolated` did a one-shot `bootstrap()` whose catch
+ * branch only emitted a system_isolated_failed message and left state.ready
+ * stuck at false — paired Claude was effectively stranded with no recovery
+ * path. This helper retries up to ISOLATED_BOOTSTRAP_MAX_ATTEMPTS times with
+ * a delay between attempts, and surfaces a definitive "give up" message
+ * only after exhausting them, including explicit instructions for the user.
+ */
+const ISOLATED_BOOTSTRAP_MAX_ATTEMPTS = parseInt(
+  process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_MAX_ATTEMPTS ?? "2",
+  10,
+);
+const ISOLATED_BOOTSTRAP_RETRY_DELAY_MS = parseInt(
+  process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_RETRY_DELAY_MS ?? "2000",
+  10,
+);
+
+function bootstrapIsolatedThread(state: ChatState, attempt = 1): void {
+  state.thread.bootstrap()
+    .then((threadId) => {
+      state.ready = true;
+      emitToChat(state, systemMessage("system_isolated_ready",
+        `✅ Fresh isolated Codex thread ready (threadId=${threadId}).`));
+    })
+    .catch((err: any) => {
+      const errMsg = err?.message ?? String(err);
+      log(`[${state.chatId}] Isolated bootstrap attempt ${attempt}/${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS} failed: ${errMsg}`);
+      if (attempt < ISOLATED_BOOTSTRAP_MAX_ATTEMPTS) {
+        emitToChat(state, systemMessage("system_isolated_retry",
+          `⚠️ Bootstrap of isolated Codex thread failed (attempt ${attempt}/${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS}): ${errMsg}. Retrying in ${ISOLATED_BOOTSTRAP_RETRY_DELAY_MS}ms.`));
+        setTimeout(() => {
+          // Codex review (2026-05-16): close the prior ClaudeThread before
+          // constructing a replacement so a half-open WS / RPC handle from
+          // the failed attempt does not leak.
+          try { state.thread.close(); } catch {}
+          state.thread = new ClaudeThread({
+            appServerUrl: codex.appServerUrl,
+            chatId: state.chatId,
+            logFile: stateDir.logFile,
+            cwd: process.cwd(),
+          });
+          wireClaudeThreadEvents(state);
+          bootstrapIsolatedThread(state, attempt + 1);
+        }, ISOLATED_BOOTSTRAP_RETRY_DELAY_MS);
+      } else {
+        emitToChat(state, systemMessage("system_isolated_failed",
+          `❌ Failed to bootstrap isolated Codex thread after ${ISOLATED_BOOTSTRAP_MAX_ATTEMPTS} attempts: ${errMsg}. Closing this chat — please reconnect Claude (close the window and re-attach) to start a fresh attempt.`));
+        // Bug fix (Codex review 2026-05-16): reap the chat so the advertised
+        // recovery path ("reconnect Claude") actually works. Without this,
+        // attachClaude takes the resume branch for the same chatId, never
+        // re-enters bootstrapIsolatedThread, and the user follows our own
+        // instructions but stays stuck. Reaping forces the next attach to
+        // construct a fresh ChatState with a fresh bootstrap.
+        reapChatState(state, "isolated bootstrap exhausted");
+      }
+    });
+}
+
+/**
+ * Forcefully tear down a chat: close the active WS (clients can reconnect
+ * fresh), clear timers, dispose StatusBuffer, close the ClaudeThread, and
+ * remove the entry from `chats`. Used both for natural reaper expiry paths
+ * and for the isolated-bootstrap final-failure path.
+ */
+function reapChatState(state: ChatState, reason: string): void {
+  log(`Reaping chat state: chatId=${state.chatId} (${reason})`);
+  if (state.ws) {
+    try { state.ws.close(1011, `chat reaped: ${reason}`); } catch {}
+    state.ws = null;
+  }
+  if (state.attentionWindowTimer) clearTimeout(state.attentionWindowTimer);
+  if (state.disconnectTimer) clearTimeout(state.disconnectTimer);
+  if (state.reaperTimer) clearTimeout(state.reaperTimer);
+  try { state.statusBuffer.dispose(); } catch {}
+  try { state.thread.close(); } catch {}
+  chats.delete(state.chatId);
+  broadcastStatus();
+}
+
 function transitionToIsolated(state: ChatState, reason: string): void {
   state.paired = false;
+  // Bug fix (Codex review 2026-05-16): pair teardown is a terminal boundary
+  // for the old shared turn. Reset paired-turn flags so they don't bleed
+  // into the fresh isolated thread — a stale `replyRequired=true` would
+  // otherwise force-forward the first isolated message via the
+  // require-reply path in wireClaudeThreadEvents and could fire a bogus
+  // "missing reply" warning at turn/completed.
+  state.replyRequired = false;
+  state.replyReceivedDuringTurn = false;
+  state.pairedTurnSawAgentMessage = false;
   emitToChat(state, systemMessage("system_pair_torn_down",
     `[system] ${reason}. Future replies will use a fresh isolated Codex thread (no prior shared-TUI context carried over).`));
   // Re-bootstrap as isolated. Same chatId, new ClaudeThread.
@@ -374,16 +476,7 @@ function transitionToIsolated(state: ChatState, reason: string): void {
   });
   state.ready = false;
   wireClaudeThreadEvents(state);
-  state.thread.bootstrap()
-    .then((threadId) => {
-      state.ready = true;
-      emitToChat(state, systemMessage("system_isolated_ready",
-        `✅ Fresh isolated Codex thread ready (threadId=${threadId}).`));
-    })
-    .catch((err: any) => {
-      emitToChat(state, systemMessage("system_isolated_failed",
-        `❌ Failed to bootstrap isolated Codex thread: ${err?.message ?? err}.`));
-    });
+  bootstrapIsolatedThread(state);
 }
 
 codex.on("error", (err: Error) => {
@@ -1059,16 +1152,85 @@ function log(msg: string) {
   } catch {}
 }
 
-// Refuse to start if user intentionally killed the daemon.
-if (daemonLifecycle.wasKilled()) {
-  log("Killed sentinel found — daemon was intentionally stopped. Exiting immediately.");
-  process.exit(0);
+function startDaemon() {
+  // Refuse to start if user intentionally killed the daemon.
+  if (daemonLifecycle.wasKilled()) {
+    log("Killed sentinel found — daemon was intentionally stopped. Exiting immediately.");
+    process.exit(0);
+  }
+
+  writePidFile();
+  startControlServer();
+  void bootCodex();
 }
 
-writePidFile();
-startControlServer();
-void bootCodex();
+// `import.meta.main` is true only when this module is the entrypoint (run via
+// `bun daemon.js` or the bundled CLI). When imported as a library (e.g. by
+// `src/unit-test/daemon.test.ts`), the side-effectful boot is skipped so
+// tests can exercise the state machine without spinning up sockets or
+// spawning the Codex app-server.
+if (import.meta.main) {
+  startDaemon();
+}
 
 // Silence unused-warning for the legacy import; we keep the symbol around in
 // case future tooling wants to surface the attach command in status.
 void attachCmd;
+
+// ── Testing harness ─────────────────────────────────────────────
+//
+// Exported strictly for `src/unit-test/daemon.test.ts`. Not part of any
+// public API; do not import from production code. The shape and guarantees
+// here are subject to change to suit testing needs.
+
+export const __testing = {
+  /** Read current single-slot proxy TUI state. */
+  get proxyTuiSlot(): ProxyTuiSlot | null {
+    return proxyTuiSlot;
+  },
+  /** Overwrite the slot (set to null to clear). Tests use this to seed scenarios. */
+  setProxyTuiSlot(next: ProxyTuiSlot | null): void {
+    proxyTuiSlot = next;
+  },
+  /** Direct handle to the chat registry — tests can read/write/clear. */
+  chats,
+  /** Direct handle to the singleton CodexAdapter — tests can emit events on it. */
+  codex,
+  /** Daemon-level functions exposed for direct invocation in tests. */
+  fns: {
+    pairChat,
+    transitionToIsolated,
+    bootstrapIsolatedThread,
+    getPairedChatState,
+    createChatState,
+    detachClaudeWs,
+    emitToChat,
+  } as const,
+  /** Constants captured at module load — useful for asserting timer behavior. */
+  config: {
+    PAIR_REAP_MS,
+    CLAUDE_REAP_AFTER_MS,
+    ISOLATED_BOOTSTRAP_MAX_ATTEMPTS,
+    ISOLATED_BOOTSTRAP_RETRY_DELAY_MS,
+  } as const,
+  /** Reset every mutable module-level field to its clean state. Call in beforeEach. */
+  reset(): void {
+    if (proxyTuiSlot?.pairReapTimer) {
+      clearTimeout(proxyTuiSlot.pairReapTimer);
+    }
+    for (const state of chats.values()) {
+      if (state.attentionWindowTimer) clearTimeout(state.attentionWindowTimer);
+      if (state.disconnectTimer) clearTimeout(state.disconnectTimer);
+      if (state.reaperTimer) clearTimeout(state.reaperTimer);
+      try { state.statusBuffer.dispose(); } catch {}
+      try { state.thread.close(); } catch {}
+    }
+    chats.clear();
+    proxyTuiSlot = null;
+    // Codex review (2026-05-16): also clear CodexAdapter's internal
+    // pairedChatId so it does not leak across tests.
+    try { codex.setPairedChat(null); } catch {}
+  },
+  /** Direct reap helper exposed for tests that need to assert the reap behavior. */
+  reapChatState,
+};

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1280,6 +1280,34 @@ function wireClaudeThreadEvents(state: ChatState): void {
   state.thread.on("close", () => {
     log(`[${chatId}] ClaudeThread WS closed`);
     state.ready = false;
+
+    // Issue #82 (2026-05-17): app-server crash / unexpected upstream WS
+    // close. Before this guard the chat stayed in `chats` with
+    // ready=false forever — reply attempts hit "thread still provisioning"
+    // and the user had no recovery path short of restarting Claude Code.
+    // Reap drives the bridge through the same recovery loop as the
+    // bootstrap-failure case (commit 18f60d8): close 1011 → bridge auto-
+    // reconnect → fresh bootstrap. If the app-server is back the new
+    // bootstrap succeeds; if not, the bootstrap-failure reap kicks in
+    // and bridge enters disabled state cleanly.
+    //
+    // Two guards prevent unwanted re-reaping:
+    //  1. shuttingDown — during daemon SIGTERM all ClaudeThread WSs
+    //     close in cascade; reaping during shutdown is pointless (state
+    //     will be discarded) and writes noise to logs.
+    //  2. chats.get(chatId) !== state — if reapChatState already removed
+    //     this chat (so the close event we're seeing was caused by the
+    //     intentional state.thread.close() inside reapChatState), the
+    //     guard fails and we skip to avoid recursive re-entry. Also
+    //     covers the case where a new ChatState replaced this one (e.g.
+    //     bridge reconnected and got a fresh ChatState for the same
+    //     chatId before this stale handler fired).
+    if (shuttingDown) return;
+    if (chats.get(chatId) !== state) return;
+
+    emitToChat(state, systemMessage("system_thread_failed",
+      "❌ Lost connection to Codex app-server. Reconnect to retry — bridge will provision a fresh thread."));
+    reapChatState(state, "ClaudeThread WS closed unexpectedly (app-server crash or upstream failure)");
   });
 
   state.thread.on("error", (err: any) => {
@@ -2063,6 +2091,12 @@ export const __testing = {
     /** Bug regression E (2026-05-17): exposed so EPIPE/stderr-broken test
      * can drive log() directly and verify the sticky-flag short-circuit. */
     log,
+    /** Issue #82 (2026-05-17): exposed so tests can wire ClaudeThread
+     * event handlers onto stubbed ChatStates and emit close/error. */
+    wireClaudeThreadEvents,
+    /** Issue #82 (2026-05-17): exposed so tests can flip `shuttingDown`
+     * to assert close-handler guard behavior during shutdown. */
+    setShuttingDownForTest(value: boolean) { shuttingDown = value; },
   } as const,
   /** STM v2.3 §D2 P3b — registry handle (read for assertions; mutate via handlers). */
   pairRegistry,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -729,7 +729,7 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
 
   switch (message.type) {
     case "claude_connect":
-      void attachClaude(ws, message.chatId);
+      void attachClaude(ws, message.chatId, message.pairId, message.requestId);
       return;
     case "claude_disconnect": {
       const chatId = message.chatId ?? ws.data.chatId;
@@ -930,9 +930,50 @@ function handleListPairs(
 async function attachClaude(
   ws: ServerWebSocket<ControlSocketData>,
   requestedChatId?: string,
+  requestedPairId?: string,
+  requestId?: string,
 ) {
   const chatId = requestedChatId ?? `auto_${ws.data.clientId}_${Date.now()}`;
   ws.data.chatId = chatId;
+
+  // STM v2.3 §D4 / §D6 P3-cleanup: validate explicit pair id BEFORE state
+  // mutation so a bad request doesn't side-effect chat creation. Also
+  // emit a typed claude_connect_result back per spec §D6 — bridges that
+  // sent a `requestId` consume the response to surface PAIR_NOT_FOUND /
+  // PAIR_BUSY as a user-visible disabled state.
+  if (requestedPairId !== undefined) {
+    if (!isValidPairName(requestedPairId)) {
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: false,
+        error: "INVALID_PAIR_NAME",
+        message: `pair name "${requestedPairId}" fails validation`,
+      });
+      return;
+    }
+    const targetPair = pairs.get(requestedPairId);
+    if (!targetPair?.isLive) {
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: false,
+        error: "PAIR_NOT_FOUND",
+        message: `pair "${requestedPairId}" is not live; start it with abg codex --pair ${requestedPairId} --via-proxy first`,
+      });
+      return;
+    }
+    if (targetPair.proxyTuiSlot?.pairedChatId && targetPair.proxyTuiSlot.pairedChatId !== chatId) {
+      sendProtocolMessage(ws, {
+        type: "claude_connect_result",
+        requestId,
+        ok: false,
+        error: "PAIR_BUSY",
+        message: `pair "${requestedPairId}" already has paired chat "${targetPair.proxyTuiSlot.pairedChatId}"`,
+      });
+      return;
+    }
+  }
 
   let state = chats.get(chatId);
   if (state) {
@@ -950,6 +991,14 @@ async function attachClaude(
     statusBufferFlushIfPaused(state, "claude resumed");
     flushBufferedMessages(state);
     sendStatus(ws);
+    sendProtocolMessage(ws, {
+      type: "claude_connect_result",
+      requestId,
+      ok: true,
+      chatId,
+      homePairId: state.homePairId,
+      paired: state.paired,
+    });
     return;
   }
 
@@ -960,20 +1009,69 @@ async function attachClaude(
   state.ws = ws;
   ws.data.attached = true;
   cancelIdleShutdown();
-  log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
+  log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size}, requestedPair=${requestedPairId ?? "-"})`);
 
   sendStatus(ws);
+
+  // P3-cleanup: explicit-pair Claude binds to the requested pair's slot if
+  // it's unpaired. Default-only behavior (P1-P3) is preserved when no
+  // pairId is supplied — pair with default's slot via the P1 alias.
+  const targetPair = requestedPairId ? pairs.get(requestedPairId) : null;
+  if (targetPair?.isLive && !targetPair.proxyTuiSlot?.pairedChatId && targetPair.proxyTuiSlot) {
+    state.homePairId = requestedPairId!;
+    targetPair.proxyTuiSlot.pairedChatId = chatId;
+    state.paired = true;
+    targetPair.codex.setPairedChat(chatId);
+    state.ready = targetPair.proxyTuiSlot.readiness === "ready";
+    log(`[${chatId}] Paired with pair="${requestedPairId}" via explicit attach (readiness=${targetPair.proxyTuiSlot.readiness})`);
+    emitToChat(state, systemMessage(state.ready ? "system_paired_ready" : "system_paired_provisioning",
+      state.ready
+        ? `✅ This Claude session is paired with the right-pane Codex TUI on pair "${requestedPairId}". Replies will appear there.`
+        : `✅ This Claude session is paired with the right-pane Codex TUI on pair "${requestedPairId}". Waiting for shared-thread provisioning.`));
+    sendProtocolMessage(ws, {
+      type: "claude_connect_result",
+      requestId,
+      ok: true,
+      chatId,
+      homePairId: state.homePairId,
+      paired: state.paired,
+    });
+    broadcastStatus();
+    return;
+  }
 
   if (proxyTuiSlot && proxyTuiSlot.pairedChatId === null) {
     emitToChat(state, systemMessage("system_bridge_provisioning",
       "✅ AgentBridge daemon attached. Pairing with the right-pane Codex TUI for shared-thread mode..."));
     pairChat(state);
     broadcastStatus();
+    sendProtocolMessage(ws, {
+      type: "claude_connect_result",
+      requestId,
+      ok: true,
+      chatId,
+      homePairId: state.homePairId,
+      paired: state.paired,
+    });
     return; // paired chats skip ClaudeThread.bootstrap (shared transport)
   }
 
   emitToChat(state, systemMessage("system_bridge_provisioning",
     "✅ AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
+
+  // Emit the typed claude_connect_result now — the chat is attached even
+  // if the ClaudeThread bootstrap still has work to do. Bootstrap status
+  // is conveyed by subsequent system_thread_ready / system_thread_failed
+  // messages, not by claude_connect_result. (Per spec §D6, ok=true means
+  // "attached successfully", not "thread fully bootstrapped".)
+  sendProtocolMessage(ws, {
+    type: "claude_connect_result",
+    requestId,
+    ok: true,
+    chatId,
+    homePairId: state.homePairId,
+    paired: state.paired,
+  });
 
   try {
     const threadId = await state.thread.bootstrap();
@@ -1481,12 +1579,39 @@ function removeStatusFile() { daemonLifecycle.removeStatusFile(); }
  * racing. PairState construction and codex.start() happen outside the
  * mutex to avoid serializing all spawns through one chain.
  */
+/**
+ * STM v2.3 §6.2 P3-cleanup: same-pair in-flight dedup mutex. Two concurrent
+ * `ensure_pair("work")` calls subscribe to the same promise instead of
+ * racing into PairState construction / codex.start. The daemon-wide
+ * `registryWriteMutex` only protects registry writes; this Map protects
+ * the broader allocate→construct→start→isLive flow per pair.
+ */
+const ensurePairInFlight = new Map<string, Promise<PairState>>();
+
 async function ensurePair(pairId: string): Promise<PairState> {
+  // Validate upfront so a bad name doesn't get stuck in the dedup map.
   if (!isValidPairName(pairId)) {
     throw new PairError("INVALID_PAIR_NAME", `pair name "${pairId}" fails validation`);
   }
-
   // Fast path: pair already constructed and live.
+  const existingFast = pairs.get(pairId);
+  if (existingFast?.isLive) return existingFast;
+  // Same-pair dedup: if another ensure for this exact pairId is mid-flight,
+  // await it rather than racing.
+  const inFlight = ensurePairInFlight.get(pairId);
+  if (inFlight) return inFlight;
+  const promise = ensurePairCore(pairId).finally(() => {
+    ensurePairInFlight.delete(pairId);
+  });
+  ensurePairInFlight.set(pairId, promise);
+  return promise;
+}
+
+async function ensurePairCore(pairId: string): Promise<PairState> {
+  // Fast path is checked once more inside the core (a same-pair waiter
+  // may have already finished by the time the dedup map handed us the
+  // promise — but since the promise resolves with that result, this
+  // path is effectively unreachable; included for defense-in-depth).
   const existing = pairs.get(pairId);
   if (existing?.isLive) return existing;
 
@@ -1571,16 +1696,77 @@ class PairError extends Error {
  * arrive in P3 with the `destroy_pair` control protocol; P2 just defines
  * the symmetric counterpart of `ensurePair` so the lifecycle is closed.
  */
+/**
+ * STM v2.3 §6.3 P3-cleanup: full live teardown per spec.
+ *
+ * Originally a P2 stub that just detached handlers + stopped codex. Codex
+ * P3-series review (codex_msg_5753c73beafc_107) flagged HIGH gaps:
+ *
+ *   - timers (`tuiReapTimer`, `pairReapTimer`) were not cleared
+ *   - paired chats (if any) were not transitioned to isolated via §6.5
+ *   - non-default pairs were never removed from the `pairs` Map, so
+ *     `list_pairs` would still report a torn-down pair as "registry-only
+ *     entry" with stale isLive=false but a live PairState behind it
+ *   - status was not broadcast to surviving Claude WS clients
+ *
+ * Default pair stays in the Map even after teardown so the v2.2-style
+ * top-level `proxyTuiSlot` alias keeps resolving; only non-default
+ * pairs are dropped. Tests that rely on the default pair entry being
+ * present continue to work.
+ */
 async function destroyPair(pairId: string): Promise<void> {
   const pair = pairs.get(pairId);
   if (!pair) return;
-  log(`[pair=${pair.pairId}] destroyPair: stopping codex + detaching handlers`);
+  log(`[pair=${pair.pairId}] destroyPair: full teardown (isLive=${pair.isLive})`);
+
+  // 1. Cancel any timers attached to this pair's slot before we drop the slot.
+  if (pair.proxyTuiSlot?.pairReapTimer) {
+    clearTimeout(pair.proxyTuiSlot.pairReapTimer);
+    pair.proxyTuiSlot.pairReapTimer = null;
+  }
+
+  // 2. Detach event handlers (D9 targeted off). MUST happen before
+  //    codex.stop() so the exit handler's `pair.isLive = false` doesn't
+  //    fire and confuse downstream observers — we're about to set
+  //    isLive=false explicitly here anyway.
   detachPairHandlers(pair);
+
+  // 3. Transition the paired Claude (if any) to isolated per §6.5
+  //    BEFORE killing the codex app-server, so the new ClaudeThread
+  //    has time to bootstrap against default's app-server (the
+  //    existing transitionToIsolated targets `codex.appServerUrl`).
+  const pairedChatId = pair.proxyTuiSlot?.pairedChatId ?? null;
+  if (pairedChatId) {
+    const state = chats.get(pairedChatId);
+    if (state) {
+      log(`[pair=${pair.pairId}] destroyPair: transitioning paired chat "${pairedChatId}" to isolated`);
+      transitionToIsolated(state, `Pair "${pair.pairId}" destroyed`);
+    }
+  }
+
+  // 4. Clear the slot itself.
+  pair.proxyTuiSlot = null;
+
+  // 5. Stop the Codex app-server child. Wrapped in try/catch because
+  //    stop() can throw if the app-server already exited.
   try { pair.codex.stop(); } catch (err: any) {
     log(`[pair=${pair.pairId}] destroyPair: codex.stop() threw — ${err?.message ?? err}`);
   }
+
   pair.isLive = false;
-  // P3+ will also remove from the pairs Map for non-default pairs.
+
+  // 6. Non-default pairs leave the `pairs` Map entirely so `list_pairs`
+  //    won't keep reporting them and so reallocations don't conflict
+  //    with stale PairState. Default stays in the Map (its P1 alias
+  //    for proxyTuiSlot is consumed by `let proxyTuiSlot` reads
+  //    elsewhere in the daemon — removing it would dangle that alias).
+  if (pairId !== "default") {
+    pairs.delete(pairId);
+    log(`[pair=${pair.pairId}] destroyPair: removed from pairs Map`);
+  }
+
+  // 7. Broadcast so any attached Claude reads the new aggregate status.
+  broadcastStatus();
 }
 
 async function bootCodex() {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -676,7 +676,15 @@ function startControlServer() {
 
       if (url.pathname === "/healthz") return Response.json(currentStatus());
       if (url.pathname === "/readyz") {
-        return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
+        // STM v2.3 §D6 P3d: readiness means "control plane ready" — the
+        // daemon can accept WS connections and answer ensure_pair. Pair
+        // liveness is conveyed by `pair_ensured.isLive` and `status.pairs`
+        // entries, not by /readyz. v2.2 returned 503 until codexBootstrapped
+        // (= default pair's `codex.start` succeeded); that conflated "I'm
+        // up" with "default pair is up". In a lazy / multi-pair world the
+        // daemon may be fully serving with no pair live yet (e.g. before
+        // first `abg codex --via-proxy`), and that's still ready.
+        return Response.json(currentStatus(), { status: 200 });
       }
       if (url.pathname === "/ws" &&
           server.upgrade(req, { data: { clientId: 0, attached: false, chatId: null } })) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,8 +1,26 @@
 #!/usr/bin/env bun
 
+/**
+ * AgentBridge daemon — multi-Claude variant.
+ *
+ * Each attached Claude session gets:
+ *   - A `chatId` (sent by the MCP at `claude_connect` time).
+ *   - A dedicated `ClaudeThread` (own WebSocket to codex app-server, own
+ *     codex thread). Turns on different threads run in parallel — verified
+ *     by the concurrency probe under `probes/`.
+ *   - Per-chat attention window, statusBuffer, replyRequired, and offline
+ *     message buffer.
+ *
+ * Codex TUI continues to use the existing CodexAdapter proxy with its own
+ * thread. TUI activity is NOT cross-broadcast to attached Claudes — every
+ * Claude sees only events from its own ClaudeThread. This keeps the two
+ * surfaces (TUI = human ↔ Codex, Claude = MCP ↔ Codex) isolated.
+ */
+
 import { appendFileSync } from "node:fs";
 import type { ServerWebSocket } from "bun";
 import { CodexAdapter } from "./codex-adapter";
+import { ClaudeThread } from "./claude-thread";
 import {
   BRIDGE_CONTRACT_REMINDER,
   REPLY_REQUIRED_INSTRUCTION,
@@ -21,6 +39,28 @@ import type { BridgeMessage } from "./types";
 interface ControlSocketData {
   clientId: number;
   attached: boolean;
+  chatId: string | null;
+}
+
+interface ChatState {
+  chatId: string;
+  ws: ServerWebSocket<ControlSocketData> | null;
+  thread: ClaudeThread;
+  ready: boolean;
+
+  inAttentionWindow: boolean;
+  attentionWindowTimer: ReturnType<typeof setTimeout> | null;
+  replyRequired: boolean;
+  replyReceivedDuringTurn: boolean;
+
+  bufferedMessages: BridgeMessage[];
+  statusBuffer: StatusBuffer;
+
+  disconnectTimer: ReturnType<typeof setTimeout> | null;
+  reaperTimer: ReturnType<typeof setTimeout> | null;
+  lastAttachStatusSentTs: number;
+  onlineNoticeSent: boolean;
+  nextSystemMessageId: number;
 }
 
 const stateDir = new StateDirResolver();
@@ -33,11 +73,19 @@ const CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.
 const CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 const TUI_DISCONNECT_GRACE_MS = parseInt(process.env.TUI_DISCONNECT_GRACE_MS ?? "2500", 10);
 const CLAUDE_DISCONNECT_GRACE_MS = 5_000;
+const CLAUDE_REAP_AFTER_MS = parseInt(process.env.AGENTBRIDGE_CLAUDE_REAP_MS ?? "600000", 10); // 10 min
 const MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
 const FILTER_MODE: FilterMode =
   (process.env.AGENTBRIDGE_FILTER_MODE as FilterMode) === "full" ? "full" : "filtered";
-const IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
-const ATTENTION_WINDOW_MS = parseInt(process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS ?? String(config.turnCoordination.attentionWindowSeconds * 1000), 10);
+const IDLE_SHUTDOWN_MS = parseInt(
+  process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000),
+  10,
+);
+const ATTENTION_WINDOW_MS = parseInt(
+  process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS ??
+    String(config.turnCoordination.attentionWindowSeconds * 1000),
+  10,
+);
 
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 
@@ -45,30 +93,19 @@ const codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFil
 const attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 
 let controlServer: ReturnType<typeof Bun.serve> | null = null;
-let attachedClaude: ServerWebSocket<ControlSocketData> | null = null;
 let nextControlClientId = 0;
-let nextSystemMessageId = 0;
 let codexBootstrapped = false;
-let attentionWindowTimer: ReturnType<typeof setTimeout> | null = null;
-let inAttentionWindow = false;
-let replyRequired = false;
-let replyReceivedDuringTurn = false;
 let shuttingDown = false;
 let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
-let claudeDisconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let claudeOnlineNoticeSent = false;
-let claudeOfflineNoticeShown = false;
-let codexCollaborationKickoffSent = false;
-let lastAttachStatusSentTs = 0;
-const ATTACH_STATUS_COOLDOWN_MS = 30_000; // Don't re-send status on rapid reattach
 
-const bufferedMessages: BridgeMessage[] = [];
+/** chatId → ChatState. Survives WS disconnects (lazy reap, see CLAUDE_REAP_AFTER_MS). */
+const chats = new Map<string, ChatState>();
 
 const tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
   log,
   onDisconnectPersisted: (connId) => {
-    emitToClaude(
+    broadcastToAllClaudes(
       systemMessage(
         "system_tui_disconnected",
         `⚠️ Codex TUI disconnected (conn #${connId}). Codex is still running in the background — reconnect the TUI to resume.`,
@@ -76,115 +113,23 @@ const tuiConnectionState = new TuiConnectionState({
     );
   },
   onReconnectAfterNotice: (connId) => {
-    emitToClaude(
+    broadcastToAllClaudes(
       systemMessage(
         "system_tui_reconnected",
-        `✅ Codex TUI reconnected (conn #${connId}). Bridge restored, communication can continue.`,
+        `✅ Codex TUI reconnected (conn #${connId}). Bridge restored.`,
       ),
     );
-    codex.injectMessage("✅ Claude Code is still online, bridge restored. Bidirectional communication can continue.");
   },
 });
 
-const statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
-
-codex.on("turnStarted", () => {
-  log("Codex turn started");
-  emitToClaude(
-    systemMessage(
-      "system_turn_started",
-      "⏳ Codex is working on the current task. Wait for completion before sending a reply.",
-    ),
-  );
-});
-
-codex.on("agentMessage", (msg: BridgeMessage) => {
-  if (msg.source !== "codex") return;
-  const result = classifyMessage(msg.content, FILTER_MODE);
-
-  // When replyRequired is active, force-forward ALL messages regardless of marker
-  if (replyRequired) {
-    log(`Codex → Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
-    replyReceivedDuringTurn = true;
-    if (statusBuffer.size > 0) {
-      statusBuffer.flush("reply-required message arrived");
-    }
-    emitToClaude(msg);
-    return;
-  }
-
-  // During attention window, suppress STATUS to give Claude space to respond
-  if (inAttentionWindow && result.marker === "status") {
-    log(`Codex → Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
-    statusBuffer.add(msg);
-    return;
-  }
-
-  log(`Codex → Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
-  switch (result.action) {
-    case "forward":
-      if (result.marker === "important" && statusBuffer.size > 0) {
-        statusBuffer.flush("important message arrived");
-      }
-      emitToClaude(msg);
-      // IMPORTANT message — give Claude an attention window to respond
-      if (result.marker === "important") {
-        startAttentionWindow();
-      }
-      break;
-    case "buffer":
-      statusBuffer.add(msg);
-      break;
-    case "drop":
-      break;
-  }
-});
-
-codex.on("turnCompleted", () => {
-  log("Codex turn completed");
-  statusBuffer.flush("turn completed");
-
-  // Check if reply was required but Codex didn't send any agentMessage
-  if (replyRequired && !replyReceivedDuringTurn) {
-    log("⚠️ Reply was required but Codex did not send any agentMessage");
-    emitToClaude(
-      systemMessage(
-        "system_reply_missing",
-        "⚠️ Codex completed the turn without sending a reply (require_reply was set). Codex may not have generated an agentMessage. You may want to retry or rephrase.",
-      ),
-    );
-  }
-
-  // Reset reply-required state
-  replyRequired = false;
-  replyReceivedDuringTurn = false;
-
-  emitToClaude(
-    systemMessage(
-      "system_turn_completed",
-      "✅ Codex finished the current turn. You can reply now if needed.",
-    ),
-  );
-  startAttentionWindow();
-
-  // Retry Claude-online notice if it was deferred while the turn was in progress.
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
-});
+// ── TUI / app-server event wiring ────────────────────────────────
+// Codex TUI activity is INTENTIONALLY not cross-broadcast to Claude sessions.
+// We only listen for lifecycle events that affect all chats (TUI connected,
+// codex ready, codex exit, etc.).
 
 codex.on("ready", (threadId: string) => {
   tuiConnectionState.markBridgeReady();
-  log(`Codex ready — thread ${threadId}`);
-  log("Bridge fully operational");
-
-  emitToClaude(
-    systemMessage("system_ready", currentReadyMessage()),
-  );
-
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
+  log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
 });
 
 codex.on("tuiConnected", (connId: number) => {
@@ -206,21 +151,23 @@ codex.on("error", (err: Error) => {
 });
 
 codex.on("exit", (code: number | null) => {
-  log(`Codex process exited (code ${code})`);
+  log(`Codex app-server process exited (code ${code})`);
   codexBootstrapped = false;
-  statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
-  clearPendingClaudeDisconnect("Codex process exited");
-  claudeOnlineNoticeSent = false;
-  claudeOfflineNoticeShown = false;
-  emitToClaude(
+  broadcastToAllClaudes(
     systemMessage(
       "system_codex_exit",
-      `⚠️ Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running, but the Codex side needs to be restarted.`,
+      `⚠️ Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`,
     ),
   );
+  for (const state of chats.values()) {
+    try { state.thread.close(); } catch {}
+    state.ready = false;
+  }
   broadcastStatus();
 });
+
+// ── Control server / Claude WS handling ─────────────────────────
 
 function startControlServer() {
   controlServer = Bun.serve({
@@ -229,31 +176,32 @@ function startControlServer() {
     fetch(req, server) {
       const url = new URL(req.url);
 
-      if (url.pathname === "/healthz") {
-        return Response.json(currentStatus());
-      }
-
+      if (url.pathname === "/healthz") return Response.json(currentStatus());
       if (url.pathname === "/readyz") {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
-
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false } })) {
+      if (url.pathname === "/ws" &&
+          server.upgrade(req, { data: { clientId: 0, attached: false, chatId: null } })) {
         return undefined;
       }
 
       return new Response("AgentBridge daemon");
     },
     websocket: {
-      idleTimeout: 960, // 16 minutes — prevent premature idle disconnects
+      idleTimeout: 960,
       sendPings: true,
       open: (ws: ServerWebSocket<ControlSocketData>) => {
         ws.data.clientId = ++nextControlClientId;
         log(`Frontend socket opened (#${ws.data.clientId})`);
       },
       close: (ws: ServerWebSocket<ControlSocketData>, code: number, reason: string) => {
-        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
-        if (attachedClaude === ws) {
-          detachClaude(ws, "frontend socket closed");
+        const chatId = ws.data.chatId;
+        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, chatId=${chatId ?? "-"})`);
+        if (chatId) {
+          const state = chats.get(chatId);
+          if (state && state.ws === ws) {
+            detachClaudeWs(state, "frontend socket closed");
+          }
         }
       },
       message: (ws: ServerWebSocket<ControlSocketData>, raw) => {
@@ -275,157 +223,430 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
 
   switch (message.type) {
     case "claude_connect":
-      attachClaude(ws);
+      void attachClaude(ws, message.chatId);
       return;
-    case "claude_disconnect":
-      detachClaude(ws, "frontend requested disconnect");
+    case "claude_disconnect": {
+      const chatId = message.chatId ?? ws.data.chatId;
+      if (!chatId) return;
+      const state = chats.get(chatId);
+      if (state) detachClaudeWs(state, "frontend requested disconnect");
       return;
+    }
     case "status":
       sendStatus(ws);
       return;
-    case "claude_to_codex": {
-      if (message.message.source !== "claude") {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Invalid message source",
-        });
-        return;
-      }
+    case "claude_to_codex":
+      handleClaudeToCodex(ws, message);
+      return;
+  }
+}
 
-      if (!tuiConnectionState.canReply()) {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Codex is not ready. Wait for TUI to connect and create a thread.",
-        });
-        return;
-      }
+async function attachClaude(
+  ws: ServerWebSocket<ControlSocketData>,
+  requestedChatId?: string,
+) {
+  const chatId = requestedChatId ?? `auto_${ws.data.clientId}_${Date.now()}`;
+  ws.data.chatId = chatId;
 
-      const requireReply = !!message.requireReply;
-      let contentWithReminder = message.message.content + "\n\n" + BRIDGE_CONTRACT_REMINDER;
-      if (requireReply) {
-        contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
-        replyRequired = true;
-        replyReceivedDuringTurn = false;
-        log(`Reply required flag set for this message`);
+  let state = chats.get(chatId);
+  if (state) {
+    // Resume: same chatId reconnecting. If another WS is still bound, replace it.
+    if (state.ws && state.ws !== ws && state.ws.readyState !== WebSocket.CLOSED) {
+      log(`Replacing prior WS for chatId=${chatId} (#${state.ws.data.clientId} → #${ws.data.clientId})`);
+      try { state.ws.close(CLOSE_CODE_REPLACED, "replaced by newer connection for same chatId"); } catch {}
+    }
+    state.ws = ws;
+    ws.data.attached = true;
+    clearDisconnectTimer(state, "claude resumed");
+    clearReaperTimer(state, "claude resumed");
+    cancelIdleShutdown();
+    log(`Claude resumed chatId=${chatId} (#${ws.data.clientId})`);
+    statusBufferFlushIfPaused(state, "claude resumed");
+    flushBufferedMessages(state);
+    sendStatus(ws);
+    return;
+  }
+
+  // New chat: create state + ClaudeThread
+  state = createChatState(chatId);
+  chats.set(chatId, state);
+  state.ws = ws;
+  ws.data.attached = true;
+  cancelIdleShutdown();
+  log(`New Claude session attached: chatId=${chatId} (#${ws.data.clientId}, total=${chats.size})`);
+
+  sendStatus(ws);
+  emitToChat(state, systemMessage("system_bridge_provisioning",
+    "✅ AgentBridge daemon attached. Provisioning your dedicated Codex thread..."));
+
+  try {
+    const threadId = await state.thread.bootstrap();
+    state.ready = true;
+    log(`ClaudeThread ready: chatId=${chatId} threadId=${threadId}`);
+    emitToChat(state, systemMessage("system_thread_ready",
+      `✅ Your Codex thread is ready (threadId=${threadId}). You can now send messages via the reply tool.`));
+    broadcastStatus();
+  } catch (err: any) {
+    log(`ClaudeThread bootstrap failed for chatId=${chatId}: ${err?.message ?? err}`);
+    emitToChat(state, systemMessage("system_thread_failed",
+      `❌ Failed to provision Codex thread: ${err?.message ?? err}. Reconnect to retry.`));
+  }
+}
+
+function createChatState(chatId: string): ChatState {
+  const state: ChatState = {
+    chatId,
+    ws: null,
+    thread: new ClaudeThread({
+      appServerUrl: codex.appServerUrl,
+      chatId,
+      logFile: stateDir.logFile,
+      cwd: process.cwd(),
+    }),
+    ready: false,
+    inAttentionWindow: false,
+    attentionWindowTimer: null,
+    replyRequired: false,
+    replyReceivedDuringTurn: false,
+    bufferedMessages: [],
+    statusBuffer: null as any, // assigned below
+    disconnectTimer: null,
+    reaperTimer: null,
+    lastAttachStatusSentTs: 0,
+    onlineNoticeSent: false,
+    nextSystemMessageId: 0,
+  };
+  state.statusBuffer = new StatusBuffer((summary) => emitToChat(state, summary));
+
+  // Wire ClaudeThread events to per-chat routing.
+  state.thread.on("agentMessage", (msg: BridgeMessage) => {
+    if (msg.source !== "codex") return;
+    const result = classifyMessage(msg.content, FILTER_MODE);
+
+    if (state.replyRequired) {
+      log(`[${chatId}] Codex → Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
+      state.replyReceivedDuringTurn = true;
+      if (state.statusBuffer.size > 0) {
+        state.statusBuffer.flush("reply-required message arrived");
       }
-      log(`Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-      const injected = codex.injectMessage(contentWithReminder);
-      if (!injected) {
-        const reason = codex.turnInProgress
-          ? "Codex is busy executing a turn. Wait for it to finish before sending another message."
-          : "Injection failed: no active thread or WebSocket not connected.";
-        log(`Injection rejected: ${reason}`);
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: reason,
-        });
-        return;
-      }
-      clearAttentionWindow(); // Claude successfully replied, end attention window
-      sendProtocolMessage(ws, {
-        type: "claude_to_codex_result",
-        requestId: message.requestId,
-        success: true,
-      });
+      emitToChat(state, msg);
+      return;
+    }
+
+    if (state.inAttentionWindow && result.marker === "status") {
+      log(`[${chatId}] Codex → Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
+      state.statusBuffer.add(msg);
+      return;
+    }
+
+    log(`[${chatId}] Codex → Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
+    switch (result.action) {
+      case "forward":
+        if (result.marker === "important" && state.statusBuffer.size > 0) {
+          state.statusBuffer.flush("important message arrived");
+        }
+        emitToChat(state, msg);
+        if (result.marker === "important") startAttentionWindow(state);
+        break;
+      case "buffer":
+        state.statusBuffer.add(msg);
+        break;
+      case "drop":
+        break;
+    }
+  });
+
+  state.thread.on("turnStarted", () => {
+    log(`[${chatId}] Codex turn started`);
+    emitToChat(state, systemMessage(
+      "system_turn_started",
+      "⏳ Codex is working on the current task. Wait for completion before sending a reply.",
+    ));
+  });
+
+  state.thread.on("turnCompleted", () => {
+    log(`[${chatId}] Codex turn completed`);
+    state.statusBuffer.flush("turn completed");
+
+    if (state.replyRequired && !state.replyReceivedDuringTurn) {
+      log(`[${chatId}] ⚠️ Reply was required but Codex did not send any agentMessage`);
+      emitToChat(state, systemMessage(
+        "system_reply_missing",
+        "⚠️ Codex completed the turn without sending a reply (require_reply was set).",
+      ));
+    }
+    state.replyRequired = false;
+    state.replyReceivedDuringTurn = false;
+
+    emitToChat(state, systemMessage(
+      "system_turn_completed",
+      "✅ Codex finished the current turn. You can reply now if needed.",
+    ));
+    startAttentionWindow(state);
+  });
+
+  state.thread.on("close", () => {
+    log(`[${chatId}] ClaudeThread WS closed`);
+    state.ready = false;
+  });
+
+  state.thread.on("error", (err: any) => {
+    log(`[${chatId}] ClaudeThread error: ${err?.message ?? err}`);
+  });
+
+  return state;
+}
+
+function detachClaudeWs(state: ChatState, reason: string) {
+  if (!state.ws) return;
+  log(`Claude WS detached: chatId=${state.chatId} (#${state.ws.data.clientId}, ${reason})`);
+  state.ws = null;
+  scheduleDisconnectTimer(state);
+  scheduleReaperTimer(state);
+  scheduleIdleShutdown();
+}
+
+function scheduleReaperTimer(state: ChatState) {
+  if (state.reaperTimer) clearTimeout(state.reaperTimer);
+  state.reaperTimer = setTimeout(() => {
+    state.reaperTimer = null;
+    if (state.ws) return; // reattached
+    log(`Reaping idle chat: chatId=${state.chatId} (no WS for ${CLAUDE_REAP_AFTER_MS}ms)`);
+    try { state.thread.close(); } catch {}
+    state.statusBuffer.dispose();
+    if (state.attentionWindowTimer) clearTimeout(state.attentionWindowTimer);
+    chats.delete(state.chatId);
+    broadcastStatus();
+  }, CLAUDE_REAP_AFTER_MS);
+}
+
+function clearReaperTimer(state: ChatState, _reason: string) {
+  if (state.reaperTimer) {
+    clearTimeout(state.reaperTimer);
+    state.reaperTimer = null;
+  }
+}
+
+function scheduleDisconnectTimer(state: ChatState) {
+  if (state.disconnectTimer) clearTimeout(state.disconnectTimer);
+  state.disconnectTimer = setTimeout(() => {
+    state.disconnectTimer = null;
+    // No-op placeholder for future "tell codex this claude went offline" logic.
+  }, CLAUDE_DISCONNECT_GRACE_MS);
+}
+
+function clearDisconnectTimer(state: ChatState, _reason: string) {
+  if (state.disconnectTimer) {
+    clearTimeout(state.disconnectTimer);
+    state.disconnectTimer = null;
+  }
+}
+
+function statusBufferFlushIfPaused(state: ChatState, reason: string) {
+  if (state.statusBuffer.size > 0) state.statusBuffer.flush(reason);
+}
+
+// ── Claude → Codex injection ────────────────────────────────────
+
+function handleClaudeToCodex(
+  ws: ServerWebSocket<ControlSocketData>,
+  message: Extract<ControlClientMessage, { type: "claude_to_codex" }>,
+) {
+  const chatId = message.chatId ?? ws.data.chatId;
+  if (!chatId) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "No chatId — claude_connect was never sent.",
+    });
+  }
+
+  const state = chats.get(chatId);
+  if (!state) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: `Unknown chatId ${chatId}. Reattach via claude_connect.`,
+    });
+  }
+
+  if (message.message.source !== "claude") {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "Invalid message source",
+    });
+  }
+
+  if (!state.ready) {
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: "Your Codex thread is still provisioning. Wait for system_thread_ready.",
+    });
+  }
+
+  const requireReply = !!message.requireReply;
+  let contentWithReminder = message.message.content + "\n\n" + BRIDGE_CONTRACT_REMINDER;
+  if (requireReply) {
+    contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
+    state.replyRequired = true;
+    state.replyReceivedDuringTurn = false;
+    log(`[${chatId}] Reply required flag set`);
+  }
+
+  log(`[${chatId}] Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
+  const injected = state.thread.injectMessage(contentWithReminder);
+  if (!injected) {
+    const reason = state.thread.isTurnInProgress
+      ? "Codex is busy executing a turn on your thread. Wait for it to finish."
+      : "Injection failed: thread WS not connected.";
+    return sendProtocolMessage(ws, {
+      type: "claude_to_codex_result",
+      requestId: message.requestId,
+      success: false,
+      error: reason,
+    });
+  }
+  clearAttentionWindow(state);
+  sendProtocolMessage(ws, {
+    type: "claude_to_codex_result",
+    requestId: message.requestId,
+    success: true,
+  });
+}
+
+// ── Per-chat helpers ────────────────────────────────────────────
+
+function startAttentionWindow(state: ChatState) {
+  clearAttentionWindow(state);
+  state.inAttentionWindow = true;
+  state.statusBuffer.pause();
+  log(`[${state.chatId}] Attention window started (${ATTENTION_WINDOW_MS}ms)`);
+  state.attentionWindowTimer = setTimeout(() => {
+    state.attentionWindowTimer = null;
+    state.inAttentionWindow = false;
+    state.statusBuffer.resume();
+    log(`[${state.chatId}] Attention window ended`);
+  }, ATTENTION_WINDOW_MS);
+}
+
+function clearAttentionWindow(state: ChatState) {
+  if (state.attentionWindowTimer) {
+    clearTimeout(state.attentionWindowTimer);
+    state.attentionWindowTimer = null;
+  }
+  if (state.inAttentionWindow) state.statusBuffer.resume();
+  state.inAttentionWindow = false;
+}
+
+function emitToChat(state: ChatState, message: BridgeMessage) {
+  if (state.ws && state.ws.readyState === WebSocket.OPEN) {
+    if (trySendBridgeMessage(state.ws, message, state.chatId)) return;
+    log(`[${state.chatId}] Send to Claude failed, buffering`);
+  }
+  state.bufferedMessages.push(message);
+  if (state.bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
+    const dropped = state.bufferedMessages.length - MAX_BUFFERED_MESSAGES;
+    state.bufferedMessages.splice(0, dropped);
+    log(`[${state.chatId}] Message buffer overflow: dropped ${dropped} oldest`);
+  }
+}
+
+function trySendBridgeMessage(
+  ws: ServerWebSocket<ControlSocketData>,
+  message: BridgeMessage,
+  chatId: string,
+): boolean {
+  try {
+    const payload: ControlServerMessage = { type: "codex_to_claude", chatId, message };
+    const result = ws.send(JSON.stringify(payload));
+    if (typeof result === "number" && result <= 0) {
+      log(`Bridge message send returned ${result} (0=dropped, -1=backpressure)`);
+      return false;
+    }
+    return true;
+  } catch (err: any) {
+    log(`Failed to send bridge message: ${err.message}`);
+    return false;
+  }
+}
+
+function flushBufferedMessages(state: ChatState) {
+  if (!state.ws || state.bufferedMessages.length === 0) return;
+  const messages = state.bufferedMessages.splice(0, state.bufferedMessages.length);
+  for (const message of messages) {
+    if (!trySendBridgeMessage(state.ws, message, state.chatId)) {
+      const idx = messages.indexOf(message);
+      state.bufferedMessages.unshift(...messages.slice(idx));
+      log(`[${state.chatId}] Flush interrupted: re-buffered ${messages.length - idx} message(s)`);
       return;
     }
   }
 }
 
-function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
-  if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
-    // Reject the new connection — don't disrupt the existing active session.
-    // Check !== CLOSED (not === OPEN) so that CLOSING state is also treated as
-    // "slot occupied", preventing a race where a new session slips in before
-    // the old one finishes its close handshake.
-    log(`Rejecting Claude frontend #${ws.data.clientId} — another session (#${attachedClaude.data.clientId}) is already attached (readyState=${attachedClaude.readyState})`);
-    ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
-    return;
-  }
+function broadcastToAllClaudes(message: BridgeMessage) {
+  for (const state of chats.values()) emitToChat(state, message);
+}
 
-  clearPendingClaudeDisconnect("Claude frontend attached");
-  attachedClaude = ws;
-  ws.data.attached = true;
-  cancelIdleShutdown();
-  log(`Claude frontend attached (#${ws.data.clientId})`);
+function sendStatus(ws: ServerWebSocket<ControlSocketData>) {
+  sendProtocolMessage(ws, { type: "status", status: currentStatus() });
+}
 
-  statusBuffer.flush("claude reconnected");
-  sendStatus(ws);
-
-  const now = Date.now();
-  const isRapidReattach = now - lastAttachStatusSentTs < ATTACH_STATUS_COOLDOWN_MS;
-
-  if (bufferedMessages.length > 0) {
-    flushBufferedMessages(ws);
-  } else if (!isRapidReattach) {
-    // Only send status messages if this is not a rapid reattach (avoid flooding Claude)
-    if (tuiConnectionState.canReply()) {
-      sendBridgeMessage(ws, systemMessage("system_ready", currentReadyMessage()));
-    } else if (codexBootstrapped) {
-      sendBridgeMessage(ws, systemMessage("system_waiting", currentWaitingMessage()));
-    }
-  }
-
-  lastAttachStatusSentTs = now;
-
-  if (tuiConnectionState.canReply() && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
+function broadcastStatus() {
+  for (const state of chats.values()) {
+    if (state.ws && state.ws.readyState === WebSocket.OPEN) sendStatus(state.ws);
   }
 }
 
-function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
-  if (attachedClaude !== ws) return;
-
-  attachedClaude = null;
-  ws.data.attached = false;
-  log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
-
-  scheduleClaudeDisconnectNotification(ws.data.clientId);
-
-  scheduleIdleShutdown();
-}
-
-function startAttentionWindow() {
-  clearAttentionWindow();
-  inAttentionWindow = true;
-  statusBuffer.pause();
-  log(`Attention window started (${ATTENTION_WINDOW_MS}ms)`);
-  attentionWindowTimer = setTimeout(() => {
-    attentionWindowTimer = null;
-    inAttentionWindow = false;
-    statusBuffer.resume();
-    log("Attention window ended");
-  }, ATTENTION_WINDOW_MS);
-}
-
-function clearAttentionWindow() {
-  if (attentionWindowTimer) {
-    clearTimeout(attentionWindowTimer);
-    attentionWindowTimer = null;
+function sendProtocolMessage(ws: ServerWebSocket<ControlSocketData>, message: ControlServerMessage) {
+  try {
+    ws.send(JSON.stringify(message));
+  } catch (err: any) {
+    log(`Failed to send control message: ${err.message}`);
   }
-  if (inAttentionWindow) {
-    statusBuffer.resume();
-  }
-  inAttentionWindow = false;
 }
+
+function currentStatus(): DaemonStatus {
+  const snapshot = tuiConnectionState.snapshot();
+  return {
+    bridgeReady: tuiConnectionState.canReply() || codexBootstrapped,
+    tuiConnected: snapshot.tuiConnected,
+    threadId: codex.activeThreadId,
+    queuedMessageCount: [...chats.values()].reduce(
+      (n, s) => n + s.bufferedMessages.length + s.statusBuffer.size,
+      0,
+    ),
+    proxyUrl: codex.proxyUrl,
+    appServerUrl: codex.appServerUrl,
+    pid: process.pid,
+    attachedClaudeCount: [...chats.values()].filter((s) => s.ws).length,
+  };
+}
+
+function systemMessage(idPrefix: string, content: string): BridgeMessage {
+  return {
+    id: `${idPrefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    source: "codex",
+    content,
+    timestamp: Date.now(),
+  };
+}
+
+// ── Idle shutdown ───────────────────────────────────────────────
 
 function scheduleIdleShutdown() {
   cancelIdleShutdown();
-  if (attachedClaude) return; // still has a client
-
-  const snapshot = tuiConnectionState.snapshot();
-  if (snapshot.tuiConnected) return; // TUI still connected
+  if ([...chats.values()].some((s) => s.ws !== null)) return; // still have a live claude
+  if (tuiConnectionState.snapshot().tuiConnected) return;
 
   log(`No clients connected. Daemon will shut down in ${IDLE_SHUTDOWN_MS}ms if no one reconnects.`);
   idleShutdownTimer = setTimeout(() => {
-    // Re-check before shutting down
-    if (attachedClaude || tuiConnectionState.snapshot().tuiConnected) {
+    if ([...chats.values()].some((s) => s.ws !== null) || tuiConnectionState.snapshot().tuiConnected) {
       log("Idle shutdown cancelled: client reconnected during grace period");
       return;
     }
@@ -440,178 +661,10 @@ function cancelIdleShutdown() {
   }
 }
 
-function clearPendingClaudeDisconnect(reason?: string) {
-  if (!claudeDisconnectTimer) return;
-  clearTimeout(claudeDisconnectTimer);
-  claudeDisconnectTimer = null;
-  if (reason) {
-    log(`Cleared pending Claude disconnect notification (${reason})`);
-  }
-}
+// ── Lifecycle ───────────────────────────────────────────────────
 
-function scheduleClaudeDisconnectNotification(clientId: number) {
-  clearPendingClaudeDisconnect("rescheduled");
-  claudeDisconnectTimer = setTimeout(() => {
-    claudeDisconnectTimer = null;
-
-    if (attachedClaude) {
-      log(
-        `Skipping Claude disconnect notification for client #${clientId} because Claude already reconnected`,
-      );
-      return;
-    }
-
-    if (!tuiConnectionState.canReply()) {
-      log(
-        `Suppressing Claude disconnect notification for client #${clientId} because Codex cannot reply`,
-      );
-      return;
-    }
-
-    if (!claudeOnlineNoticeSent) {
-      log(
-        `Suppressing Claude disconnect notification for client #${clientId} because Claude was never announced online`,
-      );
-      return;
-    }
-
-    codex.injectMessage(
-      "⚠️ Claude Code went offline. AgentBridge is still running in the background; it will reconnect automatically when Claude reopens.",
-    );
-    claudeOnlineNoticeSent = false;
-    claudeOfflineNoticeShown = true;
-    log(`Claude disconnect persisted past grace window (client #${clientId})`);
-  }, CLAUDE_DISCONNECT_GRACE_MS);
-}
-
-function emitToClaude(message: BridgeMessage) {
-  if (attachedClaude && attachedClaude.readyState === WebSocket.OPEN) {
-    if (trySendBridgeMessage(attachedClaude, message)) return;
-    // Send failed — fall through to buffer
-    log("Send to Claude failed, buffering message for retry on reconnect");
-  }
-
-  bufferedMessages.push(message);
-  if (bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
-    const dropped = bufferedMessages.length - MAX_BUFFERED_MESSAGES;
-    bufferedMessages.splice(0, dropped);
-    log(`Message buffer overflow: dropped ${dropped} oldest message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
-  }
-}
-
-function trySendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: BridgeMessage): boolean {
-  try {
-    const result = ws.send(JSON.stringify({ type: "codex_to_claude", message } satisfies ControlServerMessage));
-    if (typeof result === "number" && result <= 0) {
-      log(`Bridge message send returned ${result} (0=dropped, -1=backpressure)`);
-      return false;
-    }
-    return true;
-  } catch (err: any) {
-    log(`Failed to send bridge message: ${err.message}`);
-    return false;
-  }
-}
-
-function flushBufferedMessages(ws: ServerWebSocket<ControlSocketData>) {
-  const messages = bufferedMessages.splice(0, bufferedMessages.length);
-  for (const message of messages) {
-    if (!trySendBridgeMessage(ws, message)) {
-      // Re-buffer this and all remaining messages on failure
-      const failedIndex = messages.indexOf(message);
-      const remaining = messages.slice(failedIndex);
-      bufferedMessages.unshift(...remaining);
-      log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
-      return;
-    }
-  }
-}
-
-function sendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: BridgeMessage) {
-  trySendBridgeMessage(ws, message);
-}
-
-function sendStatus(ws: ServerWebSocket<ControlSocketData>) {
-  sendProtocolMessage(ws, { type: "status", status: currentStatus() });
-}
-
-function broadcastStatus() {
-  if (!attachedClaude) return;
-  sendStatus(attachedClaude);
-}
-
-function sendProtocolMessage(ws: ServerWebSocket<ControlSocketData>, message: ControlServerMessage) {
-  try {
-    ws.send(JSON.stringify(message));
-  } catch (err: any) {
-    log(`Failed to send control message: ${err.message}`);
-  }
-}
-
-function currentStatus(): DaemonStatus {
-  const snapshot = tuiConnectionState.snapshot();
-  return {
-    bridgeReady: tuiConnectionState.canReply(),
-    tuiConnected: snapshot.tuiConnected,
-    threadId: codex.activeThreadId,
-    queuedMessageCount: bufferedMessages.length + statusBuffer.size,
-    proxyUrl: codex.proxyUrl,
-    appServerUrl: codex.appServerUrl,
-    pid: process.pid,
-  };
-}
-
-function currentWaitingMessage() {
-  return `⏳ Waiting for Codex TUI to connect. Run in another terminal:\n${attachCmd}`;
-}
-
-function currentReadyMessage() {
-  return `✅ Codex TUI connected (${codex.activeThreadId}). Bridge ready.`;
-}
-
-function notifyCodexClaudeOnline(): boolean {
-  const message = !codexCollaborationKickoffSent
-    ? [
-        "🤝 Claude Code has connected via AgentBridge.",
-        "You are now in a multi-agent collaboration session.",
-        "When you receive a complex task, propose a division of labor to Claude.",
-        "Claude can send you messages — they will appear as injected user messages.",
-        "Respond naturally and Claude will receive your output via AgentBridge.",
-      ].join("\n")
-    : "✅ AgentBridge connected to Claude Code.";
-
-  const delivered = codex.injectMessage(message);
-  if (!delivered) {
-    log("Deferred Claude-online notice to Codex — will retry after current turn completes");
-    return false;
-  }
-
-  claudeOnlineNoticeSent = true;
-  claudeOfflineNoticeShown = false;
-  codexCollaborationKickoffSent = true;
-  return true;
-}
-
-function shouldNotifyCodexClaudeOnline() {
-  return !claudeOnlineNoticeSent || claudeOfflineNoticeShown;
-}
-
-function systemMessage(idPrefix: string, content: string): BridgeMessage {
-  return {
-    id: `${idPrefix}_${++nextSystemMessageId}`,
-    source: "codex",
-    content,
-    timestamp: Date.now(),
-  };
-}
-
-function writePidFile() {
-  daemonLifecycle.writePid();
-}
-
-function removePidFile() {
-  daemonLifecycle.removePidFile();
-}
+function writePidFile() { daemonLifecycle.writePid(); }
+function removePidFile() { daemonLifecycle.removePidFile(); }
 
 function writeStatusFile() {
   daemonLifecycle.writeStatus({
@@ -622,12 +675,10 @@ function writeStatusFile() {
   });
 }
 
-function removeStatusFile() {
-  daemonLifecycle.removeStatusFile();
-}
+function removeStatusFile() { daemonLifecycle.removeStatusFile(); }
 
 async function bootCodex() {
-  log("Starting AgentBridge daemon...");
+  log("Starting AgentBridge daemon (multi-Claude variant)...");
   log(`Codex app-server: ${codex.appServerUrl}`);
   log(`Codex proxy: ${codex.proxyUrl}`);
   log(`Control server: ws://127.0.0.1:${CONTROL_PORT}/ws`);
@@ -636,12 +687,10 @@ async function bootCodex() {
     await codex.start();
     codexBootstrapped = true;
     writeStatusFile();
-
-    emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));
     broadcastStatus();
   } catch (err: any) {
     log(`Failed to start Codex: ${err.message}`);
-    emitToClaude(
+    broadcastToAllClaudes(
       systemMessage(
         "system_codex_start_failed",
         `❌ AgentBridge failed to start Codex app-server: ${err.message}`,
@@ -656,7 +705,14 @@ function shutdown(reason: string) {
   shuttingDown = true;
   log(`Shutting down daemon (${reason})...`);
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);
-  clearPendingClaudeDisconnect(`daemon shutdown (${reason})`);
+  for (const state of chats.values()) {
+    if (state.attentionWindowTimer) clearTimeout(state.attentionWindowTimer);
+    if (state.disconnectTimer) clearTimeout(state.disconnectTimer);
+    if (state.reaperTimer) clearTimeout(state.reaperTimer);
+    state.statusBuffer.dispose();
+    try { state.thread.close(); } catch {}
+  }
+  chats.clear();
   controlServer?.stop();
   controlServer = null;
   codex.stop();
@@ -684,8 +740,6 @@ function log(msg: string) {
 }
 
 // Refuse to start if user intentionally killed the daemon.
-// This prevents stale auto-reconnect loops from relaunching us.
-// Only `agentbridge codex` / `ensureRunning` clears the sentinel before launching.
 if (daemonLifecycle.wasKilled()) {
   log("Killed sentinel found — daemon was intentionally stopped. Exiting immediately.");
   process.exit(0);
@@ -694,3 +748,7 @@ if (daemonLifecycle.wasKilled()) {
 writePidFile();
 startControlServer();
 void bootCodex();
+
+// Silence unused-warning for the legacy import; we keep the symbol around in
+// case future tooling wants to surface the attach command in status.
+void attachCmd;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -17,8 +17,8 @@
  * surfaces (TUI = human ↔ Codex, Claude = MCP ↔ Codex) isolated.
  */
 
-import { appendFileSync } from "node:fs";
 import type { ServerWebSocket } from "bun";
+import { getAsyncFileLogger, closeAllAsyncFileLoggers } from "./log-writer";
 import { CodexAdapter } from "./codex-adapter";
 import { ClaudeThread } from "./claude-thread";
 import {
@@ -108,6 +108,12 @@ interface ProxyTuiSlot {
 
 const stateDir = new StateDirResolver();
 stateDir.ensure();
+// Performance fix (2026-05-17 P0): async file logger declared up here so
+// any module-top-level code (e.g. `pairRegistry.load()`) that calls
+// `log()` finds the logger already initialized. Earlier placement
+// triggered ReferenceError "Cannot access 'daemonLogger' before
+// initialization" at boot via JS temporal dead zone.
+const daemonLogger = getAsyncFileLogger(stateDir.logFile);
 const configService = new ConfigService();
 const config = configService.loadOrDefault();
 
@@ -1928,7 +1934,10 @@ function shutdown(reason: string) {
   codex.stop();
   removePidFile();
   removeStatusFile();
-  process.exit(0);
+  // Performance fix (2026-05-17 P0): flush async file loggers before
+  // process.exit so the last few buffered log lines reach disk. The
+  // exit call is sequenced after the flush completes.
+  void closeAllAsyncFileLoggers().then(() => process.exit(0)).catch(() => process.exit(0));
 }
 
 process.on("SIGINT", () => shutdown("SIGINT"));
@@ -1944,9 +1953,7 @@ process.on("unhandledRejection", (reason: any) => {
 function log(msg: string) {
   const line = `[${new Date().toISOString()}] [AgentBridgeDaemon] ${msg}\n`;
   process.stderr.write(line);
-  try {
-    appendFileSync(stateDir.logFile, line);
-  } catch {}
+  daemonLogger.write(line);
 }
 
 function startDaemon() {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1762,18 +1762,30 @@ async function ensurePairCore(pairId: string): Promise<PairState> {
       /address already in use/i.test(errMsg) ||
       /port.*in use/i.test(errMsg);
     if (looksLikePortBusy) {
-      // Try to extract which port conflicted from the message so the CLI
-      // can surface a specific PID/port pointer. Pattern: `:NNNN` or `port NNNN`.
+      // STM v2.3 P5c: parse the canonical CodexAdapter.checkPorts error
+      // first since it carries both port AND PID:
+      //   "Port 4500 is already in use by non-Codex process(es): PID(s) 12345, 67890."
+      // Fall back to generic `:NNNN` port-only patterns if the error came
+      // from somewhere else (e.g. Bun.serve raw EADDRINUSE).
       let conflictPort: number | undefined;
-      const portMatch = errMsg.match(/(?::|port[\s=]+|address[\s=]+[\w:.]+:)(\d{2,5})/i);
-      if (portMatch) {
-        const candidate = parseInt(portMatch[1], 10);
-        if (Number.isFinite(candidate)) conflictPort = candidate;
+      let conflictPid: number | undefined;
+      const checkPortsMatch = errMsg.match(/Port (\d{2,5}) is already in use[^:]*:\s*PID\(s\)\s*([\d,\s]+)/i);
+      if (checkPortsMatch) {
+        const portCandidate = parseInt(checkPortsMatch[1], 10);
+        if (Number.isFinite(portCandidate)) conflictPort = portCandidate;
+        const pidCandidate = parseInt(checkPortsMatch[2].split(",")[0]?.trim() ?? "", 10);
+        if (Number.isFinite(pidCandidate)) conflictPid = pidCandidate;
+      } else {
+        const portMatch = errMsg.match(/(?::|port[\s=]+|address[\s=]+[\w:.]+:)(\d{2,5})/i);
+        if (portMatch) {
+          const candidate = parseInt(portMatch[1], 10);
+          if (Number.isFinite(candidate)) conflictPort = candidate;
+        }
       }
       throw new PairError(
         "PAIR_PORTS_BUSY",
         `pair "${pair.pairId}" ports (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl}) are held by another process: ${errMsg}`,
-        { conflictPort },
+        { conflictPort, conflictPid },
       );
     }
     throw err;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1361,19 +1361,32 @@ function detachClaudeWs(state: ChatState, reason: string) {
   // becomes available for a new Claude to pair AND the orphan chat state is
   // reaped (it never bootstrapped its own ClaudeThread; without the pair, it
   // has no transport and cannot serve a future resume meaningfully).
-  if (state.paired && proxyTuiSlot && proxyTuiSlot.pairedChatId === state.chatId) {
-    if (proxyTuiSlot.pairReapTimer) clearTimeout(proxyTuiSlot.pairReapTimer);
-    proxyTuiSlot.pairReapTimer = setTimeout(() => {
-      if (!proxyTuiSlot) return;
+  //
+  // Issue #83 risk #2 (M06b probe found 2026-05-17): the pair-reap path
+  // was using the module-level `proxyTuiSlot` (default pair's slot) and
+  // `codex.setPairedChat(null)` (default's adapter) regardless of the
+  // chat's homePairId. For a Claude paired with a non-default pair,
+  // detach left the OTHER pair's pairedChatId stuck and the chat's home
+  // pair's slot never reset — subsequent attaches couldn't reclaim that
+  // pair. Route everything through `pairs.get(state.homePairId)`.
+  const homePair = state.paired && state.homePairId ? pairs.get(state.homePairId) : undefined;
+  if (state.paired && homePair && homePair.proxyTuiSlot && homePair.proxyTuiSlot.pairedChatId === state.chatId) {
+    const slot = homePair.proxyTuiSlot;
+    if (slot.pairReapTimer) clearTimeout(slot.pairReapTimer);
+    slot.pairReapTimer = setTimeout(() => {
+      // Re-fetch in case the pair was destroyed during the grace window.
+      const currentPair = pairs.get(state.homePairId!);
+      const currentSlot = currentPair?.proxyTuiSlot;
+      if (!currentSlot) return;
       const currentState = chats.get(state.chatId);
       if (currentState?.ws) {
-        log(`Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
+        log(`[pair=${state.homePairId}] Paired Claude ${state.chatId} reconnected during grace; not clearing pair`);
         return;
       }
-      log(`Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms — clearing pair slot and reaping chat state`);
-      proxyTuiSlot.pairedChatId = null;
-      proxyTuiSlot.pairReapTimer = null;
-      codex.setPairedChat(null);
+      log(`[pair=${state.homePairId}] Paired Claude ${state.chatId} did not reconnect within ${PAIR_REAP_MS}ms — clearing pair slot and reaping chat state`);
+      currentSlot.pairedChatId = null;
+      currentSlot.pairReapTimer = null;
+      currentPair!.codex.setPairedChat(null);
       // Full reap of the orphaned paired chat (matches the 10-min idle reaper's
       // cleanup: close any thread WS, dispose buffers, delete from map). A
       // future Claude with the same chatId gets a fresh chat state.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -191,11 +191,27 @@ const tuiConnectionState = new TuiConnectionState({
  * mutations through either access path (direct variable assignment or
  * `pairs.get("default")!.proxyTuiSlot = X`) stay in sync.
  */
+/**
+ * STM v2.3 §D9 P2: each event handler registered on a pair's CodexAdapter
+ * is tracked here so `detachPairHandlers(pair)` can call `codex.off(name,
+ * ref)` for exactly the handlers `attachPairHandlers(pair)` registered.
+ * Avoids `removeAllListeners()` which would wipe diagnostics/internal
+ * listeners that the daemon does not own.
+ */
+interface PairHandlerRegistration {
+  eventName: string;
+  handler: (...args: any[]) => void;
+}
+
 interface PairState {
   readonly pairId: string;
   readonly codex: CodexAdapter;
   readonly tuiConnectionState: TuiConnectionState;
   proxyTuiSlot: ProxyTuiSlot | null;
+  /** D9 handler refs populated by `attachPairHandlers`. */
+  handlerRefs: PairHandlerRegistration[];
+  /** P2: live = handlers attached + codex started. Toggled by ensurePair/destroyPair. */
+  isLive: boolean;
 }
 
 const defaultPairState: PairState = {
@@ -204,203 +220,247 @@ const defaultPairState: PairState = {
   tuiConnectionState,
   get proxyTuiSlot() { return proxyTuiSlot; },
   set proxyTuiSlot(v: ProxyTuiSlot | null) { proxyTuiSlot = v; },
+  handlerRefs: [],
+  isLive: false, // bootCodex / ensurePair("default") flips this to true on success
 };
 const pairs = new Map<string, PairState>([["default", defaultPairState]]);
-void pairs; // P1: structure introduced; P2+ migrates daemon code to use it directly.
 
 // ── TUI / app-server event wiring ────────────────────────────────
 // Codex TUI activity is INTENTIONALLY not cross-broadcast to Claude sessions.
 // We only listen for lifecycle events that affect all chats (TUI connected,
 // codex ready, codex exit, etc.).
-
-codex.on("ready", (threadId: string) => {
-  tuiConnectionState.markBridgeReady();
-  log(`Codex TUI thread ready: ${threadId} (bridge fully operational)`);
-  // Spec v2.2 §5: thread/started observed → flip readiness so paired Claude
-  // replies stop returning the "provisioning" error.
-  if (proxyTuiSlot) {
-    proxyTuiSlot.readiness = "ready";
-    if (proxyTuiSlot.pairedChatId) {
-      const state = chats.get(proxyTuiSlot.pairedChatId);
-      if (state && !state.ready) {
-        state.ready = true;
-        emitToChat(state, systemMessage("system_pair_ready",
-          `✅ Shared Codex TUI thread is now ready (threadId=${threadId}). Replies sent via the reply tool will appear in the right pane's TUI.`));
-      }
-    }
-  }
-});
-
-codex.on("tuiConnected", (connId: number, token: string = "") => {
-  tuiConnectionState.handleTuiConnected(connId);
-  cancelIdleShutdown();
-  log(`Codex TUI connected (conn #${connId}, token=${token ? token.slice(0, 8) + "…" : "<none>"})`);
-  // Spec v2.2 §5: a TUI carrying a non-empty shared-mode token is a proxy TUI.
-  // Initialize the slot. Empty token = direct/legacy TUI; no pairing intent.
-  if (token && !proxyTuiSlot) {
-    proxyTuiSlot = {
-      token,
-      pairedChatId: null,
-      readiness: "not-ready",
-      attachedAt: Date.now(),
-      pairReapTimer: null,
-    };
-    log(`Proxy TUI slot allocated (token=${token.slice(0, 8)}…)`);
-    // Spec v2.2 §5.1: PAIR_RACE_MS=0 — Claude-first stays isolated. Do NOT
-    // retroactively pair an already-attached isolated Claude. Only chats that
-    // attach AFTER this point (in attachClaude) can claim the slot.
-  }
-  broadcastStatus();
-});
-
-codex.on("tuiDisconnected", (connId: number) => {
-  tuiConnectionState.handleTuiDisconnected(connId);
-  log(`Codex TUI disconnected (conn #${connId})`);
-  // Spec v2.2 §5: TUI disconnect tears down the proxy slot. Paired Claude (if
-  // any) transitions to isolated mode with a system notice. No prior context
-  // is replayed.
-  if (proxyTuiSlot) {
-    const wasPairedChat = proxyTuiSlot.pairedChatId;
-    if (proxyTuiSlot.pairReapTimer) clearTimeout(proxyTuiSlot.pairReapTimer);
-    proxyTuiSlot = null;
-    codex.setPairedChat(null);
-    if (wasPairedChat) {
-      const state = chats.get(wasPairedChat);
-      if (state) {
-        log(`Transitioning paired chat ${wasPairedChat} to isolated (TUI disconnect)`);
-        transitionToIsolated(state, "Shared Codex TUI thread is gone");
-      }
-    }
-  }
-  broadcastStatus();
-  scheduleIdleShutdown();
-});
-
-// ── Spec v2.2 §4.3 — shared transport outbound routing ────────
 //
-// When a chat is paired via proxyTuiSlot, CodexAdapter is the transport. All
-// shared-thread events route to the paired chat only.
+// STM v2.3 §D9 P2: every handler registers on `pair.codex` (currently only
+// the default pair's adapter; multi-pair lifecycle in P3+). Each
+// registration is tracked in `pair.handlerRefs` so `detachPairHandlers`
+// can use targeted `off()` without `removeAllListeners()`-style overreach
+// that would clobber diagnostics listeners we do not own.
+//
+// In P2 the handler bodies still call out to module-level helpers
+// (`getPairedChatState`, `chats`, `transitionToIsolated`, etc.). The
+// handler bodies use `pair.X` for state owned by the PairState (codex,
+// proxyTuiSlot, tuiConnectionState) to make pair scoping explicit even
+// though the P1 alias keeps the module-level names pointed at the same
+// objects. P3+ will progressively migrate the called-out helpers to be
+// pair-aware as well.
 
-codex.on("agentMessage", (msg: BridgeMessage) => {
-  const paired = getPairedChatState();
-  if (!paired) return;
-  log(`[${paired.chatId}] CodexAdapter → paired Claude (agentMessage, ${msg.content.length} chars)`);
-  paired.pairedTurnSawAgentMessage = true;
-  paired.replyReceivedDuringTurn = true;
-  emitToChat(paired, msg);
-});
-
-codex.on("userMessage", (payload: { content: string; id?: string; turnId?: string }) => {
-  const paired = getPairedChatState();
-  if (!paired) return;
-  if (!payload.content) return;
-  log(`[${paired.chatId}] CodexAdapter → paired Claude (userMessage from TUI, ${payload.content.length} chars)`);
-  paired.replyReceivedDuringTurn = true;
-  emitToChat(paired, {
-    id: payload.id ?? `tui_user_${Date.now()}`,
-    source: "codex",
-    content: `[IMPORTANT] Human typed in the paired Codex TUI:\n${payload.content}`,
-    timestamp: Date.now(),
-  });
-});
-
-codex.on("turnStarted", () => {
-  const paired = getPairedChatState();
-  if (!paired) return;
-  // Spec v2.2 §4.3: emit as diagnostic, MUST NOT satisfy requireReply.
-  // Reset per-turn agentMessage tracker so turn/completed can detect the
-  // "no-output failure" mode.
-  paired.pairedTurnSawAgentMessage = false;
-  emitToChat(paired, systemMessage("system_codex_turn_started", "[system] Codex turn started"));
-});
-
-codex.on("turnCompleted", () => {
-  const paired = getPairedChatState();
-  if (!paired) return;
-  // Bug fix (2026-05-16): only surface "no-output failure" when Claude was
-  // actually waiting for a reply (replyRequired=true). User-typed TUI turns
-  // can legitimately complete without an agentMessage (e.g. silent ack) —
-  // emitting failure wording there confused paired Claude. Spec v2.2 §4.3
-  // describes this as the "no-output failure signal" but does not require
-  // it for non-Claude-originated turns.
-  if (!paired.pairedTurnSawAgentMessage && paired.replyRequired) {
-    log(`[${paired.chatId}] Codex turn completed with no agentMessage while replyRequired — surfacing as failure signal`);
-    paired.replyReceivedDuringTurn = true;
-    emitToChat(paired, systemMessage("system_codex_turn_completed_no_output",
-      "[system] Codex turn completed without any agentMessage — likely a failure or empty response."));
-  } else {
-    emitToChat(paired, systemMessage("system_codex_turn_completed", "[system] Codex turn completed"));
-  }
-  // Cleanup: reset per-turn flags so a future transition to isolated mode
-  // starts from a clean slate.
-  paired.replyRequired = false;
-  paired.replyReceivedDuringTurn = false;
-});
-
-codex.on("errorItem", (payload: { code?: number; message?: string }) => {
-  const paired = getPairedChatState();
-  if (!paired) return;
-  // Spec v2.2 §4.3: error notification satisfies requireReply.
-  paired.replyReceivedDuringTurn = true;
-  emitToChat(paired, systemMessage("system_codex_error",
-    `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
-  // Bug fix (2026-05-16): mark the turn as "Claude has been informed" so a
-  // subsequent turn/completed does not fire a spurious no-output failure on
-  // top of the error we already surfaced. Naming is slightly stretched here
-  // ("sawAgentMessage" is now "saw something Claude needs to know about")
-  // but renaming would touch too many call sites for a minor fix.
-  paired.pairedTurnSawAgentMessage = true;
-  paired.replyRequired = false;
-  // Symmetric reset (Codex review 2026-05-16): match the cleanup in the
-  // turn/completed handler so an error doesn't leave a stale "received during
-  // turn" flag that could confuse later logic.
-  paired.replyReceivedDuringTurn = false;
-});
-
-// Spec v2.2 §8 E8: app-server reconnect restore flips paired readiness back
-// to not-ready, surfacing "restoring shared Codex TUI session, retry shortly"
-// to paired Claude until restore completes.
-codex.on("sessionRestoreStart", () => {
-  if (!proxyTuiSlot) return;
-  log(`Shared Codex session restore started — flipping paired readiness to not-ready`);
-  proxyTuiSlot.readiness = "not-ready";
-  const paired = getPairedChatState();
-  if (paired) paired.ready = false;
-});
-
-codex.on("sessionRestoreEnd", (payload: { ok?: boolean; threadId?: string } = {}) => {
-  if (!proxyTuiSlot) return;
-  if (payload.ok === false) {
-    // Spec v2.2 §8 E8: restore failure path. Keep paired readiness=not-ready.
-    // CodexAdapter's catch branch closes the TUI with 1011, which will fire
-    // tuiDisconnected and tear down the pair via the normal path. We just
-    // don't lie to paired Claude in the meantime.
-    log(`Shared Codex session restore FAILED — keeping paired readiness=not-ready, awaiting TUI tear-down`);
+function attachPairHandlers(pair: PairState): void {
+  if (pair.handlerRefs.length > 0) {
+    log(`[pair=${pair.pairId}] attachPairHandlers called but ${pair.handlerRefs.length} handler(s) already attached — no-op`);
     return;
   }
-  log(`Shared Codex session restore succeeded — flipping paired readiness back to ready`);
-  proxyTuiSlot.readiness = "ready";
-  const paired = getPairedChatState();
-  if (paired) {
-    paired.ready = true;
-    emitToChat(paired, systemMessage("system_pair_restored",
-      "✅ Shared Codex TUI session restored. Replies can flow again."));
-  }
-});
+  const on = <E extends string>(eventName: E, handler: (...args: any[]) => void) => {
+    pair.codex.on(eventName, handler);
+    pair.handlerRefs.push({ eventName, handler });
+  };
 
-codex.on("threadClosed", () => {
-  const paired = getPairedChatState();
-  log(`Codex emitted thread/closed`);
-  if (proxyTuiSlot) {
-    const wasPairedChat = proxyTuiSlot.pairedChatId;
-    proxyTuiSlot = null;
-    codex.setPairedChat(null);
-    if (wasPairedChat && paired) {
-      log(`Transitioning paired chat ${wasPairedChat} to isolated (thread/closed)`);
-      transitionToIsolated(paired, "Shared Codex thread closed");
+  on("ready", (threadId: string) => {
+    pair.tuiConnectionState.markBridgeReady();
+    log(`[pair=${pair.pairId}] Codex TUI thread ready: ${threadId} (bridge fully operational)`);
+    // Spec v2.2 §5: thread/started observed → flip readiness so paired Claude
+    // replies stop returning the "provisioning" error.
+    if (pair.proxyTuiSlot) {
+      pair.proxyTuiSlot.readiness = "ready";
+      if (pair.proxyTuiSlot.pairedChatId) {
+        const state = chats.get(pair.proxyTuiSlot.pairedChatId);
+        if (state && !state.ready) {
+          state.ready = true;
+          emitToChat(state, systemMessage("system_pair_ready",
+            `✅ Shared Codex TUI thread is now ready (threadId=${threadId}). Replies sent via the reply tool will appear in the right pane's TUI.`));
+        }
+      }
     }
+  });
+
+  on("tuiConnected", (connId: number, token: string = "") => {
+    pair.tuiConnectionState.handleTuiConnected(connId);
+    cancelIdleShutdown();
+    log(`[pair=${pair.pairId}] Codex TUI connected (conn #${connId}, token=${token ? token.slice(0, 8) + "…" : "<none>"})`);
+    // Spec v2.2 §5: a TUI carrying a non-empty shared-mode token is a proxy TUI.
+    // Initialize the slot. Empty token = direct/legacy TUI; no pairing intent.
+    if (token && !pair.proxyTuiSlot) {
+      pair.proxyTuiSlot = {
+        token,
+        pairedChatId: null,
+        readiness: "not-ready",
+        attachedAt: Date.now(),
+        pairReapTimer: null,
+      };
+      log(`[pair=${pair.pairId}] Proxy TUI slot allocated (token=${token.slice(0, 8)}…)`);
+      // Spec v2.2 §5.1: PAIR_RACE_MS=0 — Claude-first stays isolated. Do NOT
+      // retroactively pair an already-attached isolated Claude. Only chats that
+      // attach AFTER this point (in attachClaude) can claim the slot.
+    }
+    broadcastStatus();
+  });
+
+  on("tuiDisconnected", (connId: number) => {
+    pair.tuiConnectionState.handleTuiDisconnected(connId);
+    log(`[pair=${pair.pairId}] Codex TUI disconnected (conn #${connId})`);
+    // Spec v2.2 §5: TUI disconnect tears down the proxy slot. Paired Claude (if
+    // any) transitions to isolated mode with a system notice. No prior context
+    // is replayed.
+    if (pair.proxyTuiSlot) {
+      const wasPairedChat = pair.proxyTuiSlot.pairedChatId;
+      if (pair.proxyTuiSlot.pairReapTimer) clearTimeout(pair.proxyTuiSlot.pairReapTimer);
+      pair.proxyTuiSlot = null;
+      pair.codex.setPairedChat(null);
+      if (wasPairedChat) {
+        const state = chats.get(wasPairedChat);
+        if (state) {
+          log(`[pair=${pair.pairId}] Transitioning paired chat ${wasPairedChat} to isolated (TUI disconnect)`);
+          transitionToIsolated(state, "Shared Codex TUI thread is gone");
+        }
+      }
+    }
+    broadcastStatus();
+    scheduleIdleShutdown();
+  });
+
+  // ── Spec v2.2 §4.3 — shared transport outbound routing ────────
+  //
+  // When a chat is paired via proxyTuiSlot, CodexAdapter is the transport. All
+  // shared-thread events route to the paired chat only.
+
+  on("agentMessage", (msg: BridgeMessage) => {
+    const paired = getPairedChatState();
+    if (!paired) return;
+    log(`[${paired.chatId}] CodexAdapter → paired Claude (agentMessage, ${msg.content.length} chars)`);
+    paired.pairedTurnSawAgentMessage = true;
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, msg);
+  });
+
+  on("userMessage", (payload: { content: string; id?: string; turnId?: string }) => {
+    const paired = getPairedChatState();
+    if (!paired) return;
+    if (!payload.content) return;
+    log(`[${paired.chatId}] CodexAdapter → paired Claude (userMessage from TUI, ${payload.content.length} chars)`);
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, {
+      id: payload.id ?? `tui_user_${Date.now()}`,
+      source: "codex",
+      content: `[IMPORTANT] Human typed in the paired Codex TUI:\n${payload.content}`,
+      timestamp: Date.now(),
+    });
+  });
+
+  on("turnStarted", () => {
+    const paired = getPairedChatState();
+    if (!paired) return;
+    // Spec v2.2 §4.3: emit as diagnostic, MUST NOT satisfy requireReply.
+    // Reset per-turn agentMessage tracker so turn/completed can detect the
+    // "no-output failure" mode.
+    paired.pairedTurnSawAgentMessage = false;
+    emitToChat(paired, systemMessage("system_codex_turn_started", "[system] Codex turn started"));
+  });
+
+  on("turnCompleted", () => {
+    const paired = getPairedChatState();
+    if (!paired) return;
+    // Bug fix (2026-05-16): only surface "no-output failure" when Claude was
+    // actually waiting for a reply (replyRequired=true). User-typed TUI turns
+    // can legitimately complete without an agentMessage (e.g. silent ack) —
+    // emitting failure wording there confused paired Claude.
+    if (!paired.pairedTurnSawAgentMessage && paired.replyRequired) {
+      log(`[${paired.chatId}] Codex turn completed with no agentMessage while replyRequired — surfacing as failure signal`);
+      paired.replyReceivedDuringTurn = true;
+      emitToChat(paired, systemMessage("system_codex_turn_completed_no_output",
+        "[system] Codex turn completed without any agentMessage — likely a failure or empty response."));
+    } else {
+      emitToChat(paired, systemMessage("system_codex_turn_completed", "[system] Codex turn completed"));
+    }
+    paired.replyRequired = false;
+    paired.replyReceivedDuringTurn = false;
+  });
+
+  on("errorItem", (payload: { code?: number; message?: string }) => {
+    const paired = getPairedChatState();
+    if (!paired) return;
+    paired.replyReceivedDuringTurn = true;
+    emitToChat(paired, systemMessage("system_codex_error",
+      `[error] ${payload.message ?? "(no message)"}${payload.code !== undefined ? ` (code ${payload.code})` : ""}`));
+    paired.pairedTurnSawAgentMessage = true;
+    paired.replyRequired = false;
+    paired.replyReceivedDuringTurn = false;
+  });
+
+  // Spec v2.2 §8 E8: app-server reconnect restore flips paired readiness
+  // back to not-ready, surfacing "restoring shared Codex TUI session" to
+  // paired Claude until restore completes.
+  on("sessionRestoreStart", () => {
+    if (!pair.proxyTuiSlot) return;
+    log(`[pair=${pair.pairId}] Shared Codex session restore started — flipping paired readiness to not-ready`);
+    pair.proxyTuiSlot.readiness = "not-ready";
+    const paired = getPairedChatState();
+    if (paired) paired.ready = false;
+  });
+
+  on("sessionRestoreEnd", (payload: { ok?: boolean; threadId?: string } = {}) => {
+    if (!pair.proxyTuiSlot) return;
+    if (payload.ok === false) {
+      log(`[pair=${pair.pairId}] Shared Codex session restore FAILED — keeping readiness=not-ready, awaiting TUI tear-down`);
+      return;
+    }
+    log(`[pair=${pair.pairId}] Shared Codex session restore succeeded — flipping readiness back to ready`);
+    pair.proxyTuiSlot.readiness = "ready";
+    const paired = getPairedChatState();
+    if (paired) {
+      paired.ready = true;
+      emitToChat(paired, systemMessage("system_pair_restored",
+        "✅ Shared Codex TUI session restored. Replies can flow again."));
+    }
+  });
+
+  on("threadClosed", () => {
+    const paired = getPairedChatState();
+    log(`[pair=${pair.pairId}] Codex emitted thread/closed`);
+    if (pair.proxyTuiSlot) {
+      const wasPairedChat = pair.proxyTuiSlot.pairedChatId;
+      pair.proxyTuiSlot = null;
+      pair.codex.setPairedChat(null);
+      if (wasPairedChat && paired) {
+        log(`[pair=${pair.pairId}] Transitioning paired chat ${wasPairedChat} to isolated (thread/closed)`);
+        transitionToIsolated(paired, "Shared Codex thread closed");
+      }
+    }
+  });
+
+  on("error", (err: Error) => {
+    log(`[pair=${pair.pairId}] Codex error: ${err.message}`);
+  });
+
+  on("exit", (code: number | null) => {
+    log(`[pair=${pair.pairId}] Codex app-server process exited (code ${code})`);
+    codexBootstrapped = false;
+    pair.tuiConnectionState.handleCodexExit();
+    broadcastToAllClaudes(
+      systemMessage(
+        "system_codex_exit",
+        `⚠️ Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`,
+      ),
+    );
+    for (const state of chats.values()) {
+      try { state.thread.close(); } catch {}
+      state.ready = false;
+    }
+    broadcastStatus();
+  });
+}
+
+/** STM v2.3 §D9 P2: targeted off() — symmetric counterpart to attachPairHandlers. */
+function detachPairHandlers(pair: PairState): void {
+  for (const { eventName, handler } of pair.handlerRefs) {
+    pair.codex.off(eventName, handler);
   }
-});
+  pair.handlerRefs = [];
+}
+
+// Register the default pair's listeners now. In P2 this happens at module
+// load (matching v2.2 behavior — daemon starts listening before bootCodex
+// fires). P3 moves this call inside `ensurePair("default")` and gates it
+// on lazy creation.
+attachPairHandlers(defaultPairState);
 
 function getPairedChatState(): ChatState | null {
   if (!proxyTuiSlot?.pairedChatId) return null;
@@ -529,27 +589,6 @@ function transitionToIsolated(state: ChatState, reason: string): void {
   wireClaudeThreadEvents(state);
   bootstrapIsolatedThread(state);
 }
-
-codex.on("error", (err: Error) => {
-  log(`Codex error: ${err.message}`);
-});
-
-codex.on("exit", (code: number | null) => {
-  log(`Codex app-server process exited (code ${code})`);
-  codexBootstrapped = false;
-  tuiConnectionState.handleCodexExit();
-  broadcastToAllClaudes(
-    systemMessage(
-      "system_codex_exit",
-      `⚠️ Codex app-server exited (code ${code ?? "unknown"}). All ClaudeThread sessions terminated.`,
-    ),
-  );
-  for (const state of chats.values()) {
-    try { state.thread.close(); } catch {}
-    state.ready = false;
-  }
-  broadcastStatus();
-});
 
 // ── Control server / Claude WS handling ─────────────────────────
 
@@ -1144,6 +1183,58 @@ function writeStatusFile() {
 
 function removeStatusFile() { daemonLifecycle.removeStatusFile(); }
 
+/**
+ * STM v2.3 §6.2 P2: bring a pair live — start its Codex app-server.
+ *
+ * In P2 the only legal `pairId` is `"default"` and the PairState is
+ * pre-constructed at module load (handlers attached). This function just
+ * runs the codex.start() flow and flips `isLive`. Calling it on an
+ * already-live pair is idempotent.
+ *
+ * P3 generalizes this to:
+ *   - validate pairId per D1
+ *   - check `ensurePairInFlight` dedup mutex
+ *   - look up / allocate ports via registry
+ *   - construct CodexAdapter on demand for non-default pairs
+ *   - attachPairHandlers for the new PairState
+ *   - await codex.start() and flip isLive
+ *   - return URLs to caller
+ */
+async function ensurePair(pairId: string): Promise<PairState> {
+  if (pairId !== "default") {
+    throw new Error(`ensurePair: pairId="${pairId}" not yet supported in P2 (default only)`);
+  }
+  const pair = pairs.get(pairId);
+  if (!pair) {
+    throw new Error(`ensurePair: pair "${pairId}" missing from registry (P2 invariant violated)`);
+  }
+  if (pair.isLive) return pair;
+  log(`[pair=${pair.pairId}] ensurePair: starting codex app-server (appPort=${pair.codex.appServerUrl}, proxyPort=${pair.codex.proxyUrl})`);
+  await pair.codex.start();
+  pair.isLive = true;
+  return pair;
+}
+
+/**
+ * STM v2.3 §6.3 P2: tear a pair down — stop codex, detach handlers.
+ *
+ * In P2 the default pair is the only entry; destroying it puts the daemon
+ * into an effectively-shutdown state (no Codex to talk to). Real callers
+ * arrive in P3 with the `destroy_pair` control protocol; P2 just defines
+ * the symmetric counterpart of `ensurePair` so the lifecycle is closed.
+ */
+async function destroyPair(pairId: string): Promise<void> {
+  const pair = pairs.get(pairId);
+  if (!pair) return;
+  log(`[pair=${pair.pairId}] destroyPair: stopping codex + detaching handlers`);
+  detachPairHandlers(pair);
+  try { pair.codex.stop(); } catch (err: any) {
+    log(`[pair=${pair.pairId}] destroyPair: codex.stop() threw — ${err?.message ?? err}`);
+  }
+  pair.isLive = false;
+  // P3+ will also remove from the pairs Map for non-default pairs.
+}
+
 async function bootCodex() {
   log("Starting AgentBridge daemon (multi-Claude variant)...");
   log(`Codex app-server: ${codex.appServerUrl}`);
@@ -1151,7 +1242,7 @@ async function bootCodex() {
   log(`Control server: ws://127.0.0.1:${CONTROL_PORT}/ws`);
 
   try {
-    await codex.start();
+    await ensurePair("default");
     codexBootstrapped = true;
     writeStatusFile();
     broadcastStatus();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1499,11 +1499,22 @@ function handleClaudeToCodex(
     // Spec v2.2 §5 + §8 E8: paired-but-not-ready returns a transient error so
     // paired Claude can retry once the shared thread is provisioned or
     // session-restored. Distinguish first-time provisioning from restore.
+    //
+    // Issue #83 risk #1 (M06c probe found 2026-05-17): the paired branch
+    // previously consulted module-level `codex.isSessionRestoreInProgress`
+    // and `proxyTuiSlot` — both default-pair globals. For a chat homed
+    // on a non-default pair, this lied: default's proxyTuiSlot=null
+    // would surface "Shared Codex TUI is no longer connected" even
+    // when the chat's home pair (e.g. "work") has a TUI connected but
+    // not yet thread-started. Route through `pairs.get(state.homePairId)`.
     let errorMsg: string;
     if (state.paired) {
-      if (codex.isSessionRestoreInProgress) {
+      const homePair = state.homePairId ? pairs.get(state.homePairId) : undefined;
+      const homeCodex = homePair?.codex;
+      const homeSlot = homePair?.proxyTuiSlot;
+      if (homeCodex?.isSessionRestoreInProgress) {
         errorMsg = "Restoring shared Codex TUI session, retry shortly.";
-      } else if (proxyTuiSlot) {
+      } else if (homeSlot) {
         errorMsg = "Shared Codex TUI thread is still provisioning. Retry shortly.";
       } else {
         errorMsg = "Shared Codex TUI is no longer connected. Wait for transition to isolated mode.";

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -236,7 +236,11 @@ class CliE2EHarness {
     );
   }
 
-  readShimCalls(command: "claude" | "codex"): Array<{ args: string[]; cwd: string }> {
+  readShimCalls(command: "claude" | "codex"): Array<{
+    args: string[];
+    cwd: string;
+    env?: Record<string, string | null>;
+  }> {
     const logPath = join(this.shimLogDir, `${command}.jsonl`);
     return readJsonLines(logPath);
   }
@@ -415,7 +419,7 @@ describe("E2E: CLI surface", () => {
     });
   });
 
-  test("agentbridge codex ensures daemon is running and injects remote args", async () => {
+  test("agentbridge codex ensures daemon is running and injects direct remote args", async () => {
     await withHarness(async (harness) => {
       const result = await harness.runCli(["codex", "--model", "o3"]);
 
@@ -425,6 +429,7 @@ describe("E2E: CLI surface", () => {
       expect(harness.readLaunches()).toHaveLength(1);
       expect(harness.readPid()).not.toBeNull();
       expect(harness.readStatus()?.proxyUrl).toBe(`ws://127.0.0.1:${harness.proxyPort}`);
+      expect(harness.readStatus()?.appServerUrl).toBe(`ws://127.0.0.1:${harness.appPort}`);
       expect(harness.readTuiPid()).toBeNull();
 
       const invocations = harness
@@ -435,10 +440,36 @@ describe("E2E: CLI surface", () => {
         "--enable",
         "tui_app_server",
         "--remote",
-        `ws://127.0.0.1:${harness.proxyPort}`,
+        `ws://127.0.0.1:${harness.appPort}`,
         "--model",
         "o3",
       ]);
+    });
+  }, 20000);
+
+  test("agentbridge codex --via-proxy uses bearer auth token instead of query URL", async () => {
+    await withHarness(async (harness) => {
+      const result = await harness.runCli(["codex", "--via-proxy", "--model", "o3"]);
+
+      expect(result.code).toBe(0);
+      await harness.waitForHealth();
+
+      const invocations = harness
+        .readShimCalls("codex")
+        .filter((entry) => entry.args[0] !== "--version");
+      expect(invocations).toHaveLength(1);
+      expect(invocations[0]?.args).toEqual([
+        "--enable",
+        "tui_app_server",
+        "--remote",
+        `ws://127.0.0.1:${harness.proxyPort}`,
+        "--remote-auth-token-env",
+        "AGENTBRIDGE_PROXY_TOKEN",
+        "--model",
+        "o3",
+      ]);
+      expect(invocations[0]?.args.join(" ")).not.toContain("abg_token=");
+      expect(invocations[0]?.env?.AGENTBRIDGE_PROXY_TOKEN).toMatch(/^[0-9a-f]{16}$/);
     });
   }, 20000);
 
@@ -447,6 +478,10 @@ describe("E2E: CLI surface", () => {
       const remoteConflict = await harness.runCli(["codex", "--remote", "ws://127.0.0.1:7777"]);
       expect(remoteConflict.code).toBe(1);
       expect(remoteConflict.stderr).toContain("\"--remote\" is automatically set by agentbridge codex");
+
+      const remoteAuthConflict = await harness.runCli(["codex", "--remote-auth-token-env", "TOKEN"]);
+      expect(remoteAuthConflict.code).toBe(1);
+      expect(remoteAuthConflict.stderr).toContain("\"--remote-auth-token-env\" is automatically set by agentbridge codex");
 
       const enableConflict = await harness.runCli(["codex", "--enable", "tui_app_server"]);
       expect(enableConflict.code).toBe(1);
@@ -457,7 +492,7 @@ describe("E2E: CLI surface", () => {
     });
   });
 
-  test("agentbridge codex reuses healthy daemon and prefers status.json proxyUrl", async () => {
+  test("agentbridge codex reuses healthy daemon and prefers status.json appServerUrl", async () => {
     await withHarness({ configProxyPort: 49991 }, async (harness) => {
       const daemonProc = await harness.startManagedFakeDaemon();
       const pidBefore = harness.readPid();
@@ -478,7 +513,7 @@ describe("E2E: CLI surface", () => {
         "--enable",
         "tui_app_server",
         "--remote",
-        `ws://127.0.0.1:${harness.proxyPort}`,
+        `ws://127.0.0.1:${harness.appPort}`,
         "--profile",
         "default",
       ]);
@@ -505,7 +540,7 @@ describe("E2E: CLI surface", () => {
       for (const invocation of invocations) {
         expect(invocation.args[0]).toBe("--enable");
         expect(invocation.args[2]).toBe("--remote");
-        expect(invocation.args[3]).toBe(`ws://127.0.0.1:${harness.proxyPort}`);
+        expect(invocation.args[3]).toBe(`ws://127.0.0.1:${harness.appPort}`);
       }
     });
   }, 30000);
@@ -595,7 +630,7 @@ describe("E2E: CLI surface", () => {
       const codexRun = harness
         .readShimCalls("codex")
         .find((entry) => entry.args[0] === "--enable");
-      expect(codexRun?.args[3]).toBe(`ws://127.0.0.1:${harness.proxyPort}`);
+      expect(codexRun?.args[3]).toBe(`ws://127.0.0.1:${harness.appPort}`);
     });
   }, 30000);
 });
@@ -789,7 +824,13 @@ mkdirSync(dirname(logPath), { recursive: true });
 const args = process.argv.slice(2);
 appendFileSync(
   logPath,
-  JSON.stringify({ args, cwd: process.cwd() }) + "\\n",
+  JSON.stringify({
+    args,
+    cwd: process.cwd(),
+    env: {
+      AGENTBRIDGE_PROXY_TOKEN: process.env.AGENTBRIDGE_PROXY_TOKEN ?? null,
+    },
+  }) + "\\n",
   "utf-8",
 );
 
@@ -910,6 +951,18 @@ const server = Bun.serve({
   },
 });
 
+const appServer = Bun.serve({
+  port: appPort,
+  hostname: "127.0.0.1",
+  fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname === "/healthz" || url.pathname === "/readyz") {
+      return Response.json({ ok: true, appServerUrl });
+    }
+    return new Response("fake codex app-server");
+  },
+});
+
 const proxyServer = Bun.serve({
   port: proxyPort,
   hostname: "127.0.0.1",
@@ -925,6 +978,7 @@ const proxyServer = Bun.serve({
 function shutdown() {
   cleanupFiles();
   server.stop();
+  appServer.stop();
   proxyServer.stop();
   process.exit(0);
 }

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -696,6 +696,27 @@ describe("E2E: CLI surface", () => {
       expect(errOutput).toMatch(/--pair value .*invalid|Allowed: lowercase/);
     });
   }, 15000);
+
+  // Codex batch review must-fix (msg ..._184): --sandbox is captured at
+  // daemon spawn time. If the daemon is already running when the user
+  // passes --sandbox, the flag is silently dropped without this warning.
+  test("agentbridge codex --sandbox warns when daemon is already running", async () => {
+    await withHarness(async (harness) => {
+      // Spin up daemon first via a no-sandbox codex invocation.
+      const first = await harness.runCli(["codex", "--model", "o3"]);
+      expect(first.code).toBe(0);
+      await harness.waitForHealth();
+
+      // Second invocation passes --sandbox — daemon is already running,
+      // so the env-var path is a no-op. CLI must surface a warning.
+      const second = await harness.runCli(["codex", "--sandbox", "workspace-write", "--model", "o3"]);
+      // Command should still succeed (warning, not error).
+      expect(second.code).toBe(0);
+      const errOutput = `${second.stdout}${second.stderr}`;
+      expect(errOutput).toMatch(/--sandbox.*ignored.*daemon is already running/);
+      expect(errOutput).toMatch(/abg kill && abg codex --sandbox=workspace-write/);
+    });
+  }, 30000);
 });
 
 async function withHarness(

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -633,6 +633,69 @@ describe("E2E: CLI surface", () => {
       expect(codexRun?.args[3]).toBe(`ws://127.0.0.1:${harness.appPort}`);
     });
   }, 30000);
+
+  // ── Sprint #5 (2026-05-17 codex_msg_..._177): CLI e2e for --pair / pairs ──
+  //
+  // Unit tests already cover pair-registry logic, control-protocol shapes,
+  // and CLI flag parsing in isolation. These e2e tests verify that the
+  // user-facing entry points (`abg pairs ls`, `abg pairs rm`, `abg codex
+  // --pair NAME`) actually round-trip with a daemon and surface the right
+  // exit codes + error messages. Fake daemon (above) handles the pair WS
+  // protocol with a minimal in-memory pairs Map.
+
+  test("agentbridge pairs ls lists the default pair after daemon spins up", async () => {
+    await withHarness(async (harness) => {
+      // Spin up daemon via `codex` (creates it as a side-effect of ensureRunning).
+      const codexResult = await harness.runCli(["codex", "--model", "o3"]);
+      expect(codexResult.code).toBe(0);
+      await harness.waitForHealth();
+
+      const lsResult = await harness.runCli(["pairs", "ls"]);
+      expect(lsResult.code).toBe(0);
+      // Default pair should be in the listing. Output uses table format
+      // — assert on the pairId text without depending on column layout.
+      expect(lsResult.stdout).toContain("default");
+    });
+  }, 30000);
+
+  test("agentbridge pairs rm rejects 'default' (PAIR_PROTECTED) with non-zero exit", async () => {
+    await withHarness(async (harness) => {
+      const codexResult = await harness.runCli(["codex", "--model", "o3"]);
+      expect(codexResult.code).toBe(0);
+      await harness.waitForHealth();
+
+      const rmResult = await harness.runCli(["pairs", "rm", "default", "--force"]);
+      expect(rmResult.code).not.toBe(0);
+      // CLI surfaces the daemon's pair_error to the user — assert the
+      // error code or human message is shown.
+      const errOutput = `${rmResult.stdout}${rmResult.stderr}`;
+      expect(errOutput).toMatch(/PAIR_PROTECTED|cannot be destroyed/);
+    });
+  }, 30000);
+
+  test("agentbridge pairs rm rejects unknown pair (PAIR_NOT_FOUND)", async () => {
+    await withHarness(async (harness) => {
+      const codexResult = await harness.runCli(["codex", "--model", "o3"]);
+      expect(codexResult.code).toBe(0);
+      await harness.waitForHealth();
+
+      const rmResult = await harness.runCli(["pairs", "rm", "nonexistent-pair", "--force"]);
+      expect(rmResult.code).not.toBe(0);
+      const errOutput = `${rmResult.stdout}${rmResult.stderr}`;
+      expect(errOutput).toMatch(/PAIR_NOT_FOUND|not found/);
+    });
+  }, 30000);
+
+  test("agentbridge codex --pair rejects invalid pair name locally (no daemon round-trip)", async () => {
+    await withHarness(async (harness) => {
+      // No daemon needed — local validation should kick in immediately.
+      // Invalid name violates D1: uppercase letters not allowed.
+      const result = await harness.runCli(["codex", "--pair", "BadName", "--via-proxy"]);
+      expect(result.code).not.toBe(0);
+      const errOutput = `${result.stdout}${result.stderr}`;
+      expect(errOutput).toMatch(/--pair value .*invalid|Allowed: lowercase/);
+    });
+  }, 15000);
 });
 
 async function withHarness(
@@ -890,6 +953,11 @@ if (delayMs > 0) {
 
 writeFileSync(pidFile, \`\${process.pid}\\n\`, "utf-8");
 
+// STM v2.3 pair state — in-memory only. Default pre-populated with the
+// harness-allocated ports. ensure_pair adds entries; destroy_pair removes.
+const pairs = new Map();
+pairs.set("default", { appPort, proxyPort, isLive: true });
+
 function currentStatus() {
   return {
     bridgeReady: false,
@@ -946,6 +1014,80 @@ const server = Bun.serve({
 
       if (message.type === "claude_connect" || message.type === "status") {
         ws.send(JSON.stringify({ type: "status", status: currentStatus() }));
+        return;
+      }
+
+      // STM v2.3 pair protocol — minimal fake-daemon implementation so
+      // CLI e2e tests can exercise the \`abg pairs ls/rm\` and
+      // \`abg codex --pair\` round-trips. Real daemon logic (registry
+      // persistence, port allocation strategy, etc.) is covered by unit
+      // tests; here we just need to respond with the protocol-correct
+      // shapes the CLI expects.
+      if (message.type === "list_pairs") {
+        const entries = Array.from(pairs.entries()).map(([pairId, p]) => ({
+          pairId,
+          isLive: p.isLive,
+          appServerUrl: \`ws://127.0.0.1:\${p.appPort}\`,
+          proxyUrl: \`ws://127.0.0.1:\${p.proxyPort}\`,
+          tuiConnected: false,
+          proxyTuiConnected: false,
+          pairedChatId: null,
+          threadId: null,
+          attachedClaudes: [],
+        }));
+        ws.send(JSON.stringify({ type: "pair_list", requestId: message.requestId, pairs: entries }));
+        return;
+      }
+
+      if (message.type === "ensure_pair") {
+        let entry = pairs.get(message.pairId);
+        if (!entry) {
+          // Allocate in 50000+ band so we never collide with real codex
+          // or the harness-reserved ports.
+          const newAppPort = 50000 + pairs.size * 2;
+          const newProxyPort = newAppPort + 1;
+          entry = { appPort: newAppPort, proxyPort: newProxyPort, isLive: true };
+          pairs.set(message.pairId, entry);
+        }
+        ws.send(JSON.stringify({
+          type: "pair_ensured",
+          requestId: message.requestId,
+          pairId: message.pairId,
+          appServerUrl: \`ws://127.0.0.1:\${entry.appPort}\`,
+          proxyUrl: \`ws://127.0.0.1:\${entry.proxyPort}\`,
+        }));
+        return;
+      }
+
+      if (message.type === "destroy_pair") {
+        if (message.pairId === "default") {
+          ws.send(JSON.stringify({
+            type: "pair_error",
+            requestId: message.requestId,
+            pairId: message.pairId,
+            code: "PAIR_PROTECTED",
+            message: "default pair cannot be destroyed",
+          }));
+          return;
+        }
+        if (!pairs.has(message.pairId)) {
+          ws.send(JSON.stringify({
+            type: "pair_error",
+            requestId: message.requestId,
+            pairId: message.pairId,
+            code: "PAIR_NOT_FOUND",
+            message: \`pair "\${message.pairId}" not found\`,
+          }));
+          return;
+        }
+        pairs.delete(message.pairId);
+        ws.send(JSON.stringify({
+          type: "pair_destroyed",
+          requestId: message.requestId,
+          pairId: message.pairId,
+          forgotten: Boolean(message.forget),
+        }));
+        return;
       }
     },
   },

--- a/src/log-writer.ts
+++ b/src/log-writer.ts
@@ -1,0 +1,88 @@
+/**
+ * Async file logger — shared WriteStream pool keyed by file path.
+ *
+ * Replaces `appendFileSync` in the hot path. `appendFileSync` was
+ * synchronously blocking the event loop on every log line; with a
+ * busy proxy producing dozens-to-hundreds of lines per Codex response,
+ * that materially slowed end-to-end latency.
+ *
+ * Design:
+ * - One WriteStream per file (process-wide). Multiple call sites
+ *   sharing the same log file write through the same stream, so
+ *   ordering matches their call order.
+ * - `write()` is fire-and-forget. WriteStream's internal buffer
+ *   absorbs bursts; drains async to disk. Backpressure (returns
+ *   false) is accepted — we don't pause callers, just keep
+ *   buffering. Worst case: memory grows briefly until disk catches up.
+ * - On `error` we emit to stderr and keep going. A broken log file
+ *   never crashes the process — that's how the previous synchronous
+ *   `try { appendFileSync(...) } catch {}` pattern behaved too.
+ * - `close()` is provided for graceful shutdown — daemon SIGTERM
+ *   handler calls it to flush pending lines before exit.
+ *
+ * Performance note: this is a P0 optimization (2026-05-17). Combined
+ * with P1 (proxy frame logs gated behind AGENTBRIDGE_DEBUG_PROXY),
+ * the daemon's per-message log overhead drops from O(disk-IO sync)
+ * to O(buffer-write) on the hot path.
+ */
+
+import { createWriteStream, mkdirSync, existsSync, type WriteStream } from "node:fs";
+import { dirname } from "node:path";
+
+export interface AsyncFileLogger {
+  write(line: string): void;
+  /** Flush + close. Resolves when the underlying stream has finished. */
+  close(): Promise<void>;
+}
+
+const writers = new Map<string, WriteStream>();
+
+function getStream(filePath: string): WriteStream {
+  const existing = writers.get(filePath);
+  if (existing && !existing.destroyed) return existing;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    try { mkdirSync(dir, { recursive: true }); } catch { /* race / EACCES — let createWriteStream surface it */ }
+  }
+  const stream = createWriteStream(filePath, { flags: "a" });
+  stream.on("error", (err) => {
+    process.stderr.write(`[log-writer] write error on ${filePath}: ${err.message}\n`);
+  });
+  writers.set(filePath, stream);
+  return stream;
+}
+
+export function getAsyncFileLogger(filePath: string): AsyncFileLogger {
+  return {
+    write(line: string): void {
+      const stream = getStream(filePath);
+      try {
+        stream.write(line);
+      } catch (err: any) {
+        // Defensive: if the stream is somehow in a bad state, fall back
+        // to stderr without crashing.
+        process.stderr.write(`[log-writer] sync write failed on ${filePath}: ${err?.message ?? err}\n`);
+      }
+    },
+    close(): Promise<void> {
+      return new Promise<void>((resolve) => {
+        const stream = writers.get(filePath);
+        if (!stream || stream.destroyed) { resolve(); return; }
+        writers.delete(filePath);
+        stream.end(() => resolve());
+      });
+    },
+  };
+}
+
+/** Close all open file loggers — used by SIGTERM handlers for clean flush. */
+export async function closeAllAsyncFileLoggers(): Promise<void> {
+  const all = [...writers.entries()];
+  writers.clear();
+  await Promise.all(all.map(([_path, stream]) =>
+    new Promise<void>((resolve) => {
+      if (stream.destroyed) { resolve(); return; }
+      stream.end(() => resolve());
+    }),
+  ));
+}

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -1,0 +1,322 @@
+/**
+ * STM v2.3 §D2 P3: pair → port-assignment registry.
+ *
+ * Single source of truth for which pair name owns which (appPort, proxyPort)
+ * tuple. Lives at `<stateDir>/pairs/registry.json` as an atomic-rename
+ * JSON file. Not part of the project-local `.agentbridge/config.json` —
+ * port allocation is a machine-global concern, not a per-project one.
+ *
+ * Allocation strategy:
+ *   - `default` always maps to `(4500, 4501)` (the v2.2 values).
+ *   - Named pairs are assigned the next free stride from
+ *     `(STRIDE_BASE + STRIDE_STEP * n, STRIDE_BASE + STRIDE_STEP * n + 1)`
+ *     where `n >= 1` and the ports aren't already claimed by another entry.
+ *   - Up to `AGENTBRIDGE_MAX_PAIRS` live pairs and
+ *     `AGENTBRIDGE_PAIR_PORT_MAX` stride scans before MAX_PAIRS /
+ *     ALLOCATION_FAILED.
+ *
+ * Concurrency:
+ *   - Atomic write (temp file + `rename()`) prevents partial writes from
+ *     corrupting the registry across crashes.
+ *   - Daemon serializes registry mutations through a daemon-wide promise
+ *     chain mutex (lives in daemon.ts, not here — this module is pure).
+ *
+ * Validation:
+ *   - Pair names must match D1's regex `^[a-z0-9][a-z0-9_-]{0,31}$`.
+ *     Reserved values like `.` / `..` and any path-traversal char are
+ *     rejected. `default` is permitted (D1 v0.3 clarification).
+ *   - Invalid entries on load are dropped with a logged warning so a
+ *     corrupted registry never blocks the daemon from booting.
+ */
+
+import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync, unlinkSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+/** Default pair's port tuple. Fixed by v2.2 compatibility. */
+export const DEFAULT_PAIR_PORTS = { appPort: 4500, proxyPort: 4501 } as const;
+
+/** Stride start (first named pair gets STRIDE_BASE). Default 4510. */
+const STRIDE_BASE = 4510;
+/** Distance between consecutive pair allocations. */
+const STRIDE_STEP_DEFAULT = 10;
+/** Number of strides scanned before giving up with `ALLOCATION_FAILED`. */
+const STRIDE_MAX_DEFAULT = 20;
+/** Maximum live pairs the daemon will accept. */
+const MAX_PAIRS_DEFAULT = 8;
+
+// ── Pair name validation (D1) ──────────────────────────────────────────
+
+const PAIR_NAME_REGEX = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+/**
+ * D1 validation: lowercase alphanumeric + underscore + hyphen, 1-32 chars,
+ * first char must be alphanumeric. `default` is permitted (and is the
+ * reserved name with fixed ports). Anything that could escape a
+ * filesystem path is rejected (D5 uses the pair name as a directory).
+ */
+export function isValidPairName(name: string): boolean {
+  if (typeof name !== "string") return false;
+  if (!PAIR_NAME_REGEX.test(name)) return false;
+  // Belt-and-suspenders: the regex already excludes these but check
+  // explicitly so the intent is recorded.
+  if (name === "." || name === "..") return false;
+  return true;
+}
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface PairRegistryEntry {
+  pairId: string;
+  appPort: number;
+  proxyPort: number;
+  /** ms-since-epoch when this entry was first allocated. */
+  allocatedAt: number;
+}
+
+export interface PairRegistrySnapshot {
+  version: 1;
+  entries: PairRegistryEntry[];
+}
+
+export type AllocateError =
+  | { code: "INVALID_PAIR_NAME"; message: string }
+  | { code: "MAX_PAIRS"; message: string }
+  | { code: "ALLOCATION_FAILED"; message: string };
+
+export type AllocateResult =
+  | { ok: true; entry: PairRegistryEntry }
+  | { ok: false; error: AllocateError };
+
+// ── Registry class ─────────────────────────────────────────────────────
+
+export interface PairRegistryOptions {
+  /** Path to the registry JSON file. Parent dir is created if missing. */
+  filePath: string;
+  /** Logger (defaults to no-op). */
+  log?: (msg: string) => void;
+  /** Override stride step (default 10). */
+  strideStep?: number;
+  /** Override stride scan max (default 20). */
+  strideMax?: number;
+  /** Override max live pairs (default 8). */
+  maxPairs?: number;
+}
+
+export class PairRegistry {
+  private entries = new Map<string, PairRegistryEntry>();
+  private readonly filePath: string;
+  private readonly log: (msg: string) => void;
+  private readonly strideStep: number;
+  private readonly strideMax: number;
+  private readonly maxPairs: number;
+
+  constructor(opts: PairRegistryOptions) {
+    this.filePath = opts.filePath;
+    this.log = opts.log ?? (() => {});
+    this.strideStep = opts.strideStep ?? STRIDE_STEP_DEFAULT;
+    this.strideMax = opts.strideMax ?? STRIDE_MAX_DEFAULT;
+    this.maxPairs = opts.maxPairs ?? MAX_PAIRS_DEFAULT;
+  }
+
+  /** Load registry from disk. Missing file or invalid contents → empty registry. */
+  load(): void {
+    this.entries.clear();
+    if (!existsSync(this.filePath)) {
+      this.log(`[pair-registry] no registry file at ${this.filePath} — starting empty`);
+      return;
+    }
+    let raw: string;
+    try {
+      raw = readFileSync(this.filePath, "utf8");
+    } catch (err: any) {
+      this.log(`[pair-registry] failed to read ${this.filePath}: ${err?.message ?? err} — starting empty`);
+      return;
+    }
+    let parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err: any) {
+      this.log(`[pair-registry] invalid JSON in ${this.filePath}: ${err?.message ?? err} — starting empty`);
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+      this.log(`[pair-registry] unexpected registry shape (missing version/entries) — starting empty`);
+      return;
+    }
+    for (const candidate of parsed.entries) {
+      if (this.isValidEntry(candidate)) {
+        this.entries.set(candidate.pairId, candidate);
+      } else {
+        this.log(`[pair-registry] dropping invalid entry: ${JSON.stringify(candidate)}`);
+      }
+    }
+    this.log(`[pair-registry] loaded ${this.entries.size} entries from ${this.filePath}`);
+  }
+
+  private isValidEntry(e: any): e is PairRegistryEntry {
+    return (
+      e !== null &&
+      typeof e === "object" &&
+      typeof e.pairId === "string" &&
+      isValidPairName(e.pairId) &&
+      typeof e.appPort === "number" &&
+      typeof e.proxyPort === "number" &&
+      Number.isInteger(e.appPort) &&
+      Number.isInteger(e.proxyPort) &&
+      e.appPort > 0 &&
+      e.proxyPort > 0 &&
+      e.appPort < 65536 &&
+      e.proxyPort < 65536 &&
+      typeof e.allocatedAt === "number"
+    );
+  }
+
+  /** Atomic save: write to temp, then rename over the target. */
+  save(): void {
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const tmp = `${this.filePath}.tmp.${randomBytes(6).toString("hex")}`;
+    const snapshot: PairRegistrySnapshot = {
+      version: 1,
+      entries: [...this.entries.values()],
+    };
+    try {
+      writeFileSync(tmp, JSON.stringify(snapshot, null, 2), "utf8");
+      renameSync(tmp, this.filePath);
+    } catch (err: any) {
+      // Cleanup the temp on failure — leave the existing registry alone.
+      try { if (existsSync(tmp)) unlinkSync(tmp); } catch {}
+      throw new Error(`[pair-registry] save failed: ${err?.message ?? err}`);
+    }
+  }
+
+  /** Get the registered entry for a pair name, or null. */
+  get(pairId: string): PairRegistryEntry | null {
+    return this.entries.get(pairId) ?? null;
+  }
+
+  /** Return all registered entries in insertion order. */
+  list(): PairRegistryEntry[] {
+    return [...this.entries.values()];
+  }
+
+  has(pairId: string): boolean {
+    return this.entries.has(pairId);
+  }
+
+  /**
+   * Allocate (or return existing) ports for `pairId`. Always uses the fixed
+   * (4500, 4501) tuple for `"default"`; for other names, scans stride
+   * positions to find the first free one.
+   *
+   * Caller must hold the daemon's registry-write mutex before invoking
+   * allocate() + save() so concurrent allocations don't race.
+   */
+  allocate(pairId: string): AllocateResult {
+    if (!isValidPairName(pairId)) {
+      return {
+        ok: false,
+        error: {
+          code: "INVALID_PAIR_NAME",
+          message: `pair name "${pairId}" fails validation (regex ${PAIR_NAME_REGEX.source})`,
+        },
+      };
+    }
+
+    const existing = this.entries.get(pairId);
+    if (existing) return { ok: true, entry: existing };
+
+    if (this.entries.size >= this.maxPairs) {
+      return {
+        ok: false,
+        error: {
+          code: "MAX_PAIRS",
+          message: `pair registry is at the ${this.maxPairs}-entry limit; destroy an unused pair (--forget) before allocating a new one`,
+        },
+      };
+    }
+
+    let appPort: number;
+    let proxyPort: number;
+
+    if (pairId === "default") {
+      appPort = DEFAULT_PAIR_PORTS.appPort;
+      proxyPort = DEFAULT_PAIR_PORTS.proxyPort;
+      // If something else already holds these in the registry under a
+      // different name (would be invalid), reject the allocation rather
+      // than overwrite.
+      for (const other of this.entries.values()) {
+        if (other.appPort === appPort || other.proxyPort === proxyPort) {
+          return {
+            ok: false,
+            error: {
+              code: "ALLOCATION_FAILED",
+              message: `default pair's reserved ports (${appPort}, ${proxyPort}) collide with registry entry "${other.pairId}"`,
+            },
+          };
+        }
+      }
+    } else {
+      const usedPorts = new Set<number>();
+      for (const e of this.entries.values()) {
+        usedPorts.add(e.appPort);
+        usedPorts.add(e.proxyPort);
+      }
+      // Also reserve the default tuple even if it's not currently in the
+      // registry, so a future ensurePair("default") won't collide.
+      usedPorts.add(DEFAULT_PAIR_PORTS.appPort);
+      usedPorts.add(DEFAULT_PAIR_PORTS.proxyPort);
+
+      let found = false;
+      appPort = 0;
+      proxyPort = 0;
+      for (let i = 1; i <= this.strideMax; i++) {
+        const candidateApp = STRIDE_BASE + this.strideStep * (i - 1);
+        const candidateProxy = candidateApp + 1;
+        if (!usedPorts.has(candidateApp) && !usedPorts.has(candidateProxy)) {
+          appPort = candidateApp;
+          proxyPort = candidateProxy;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        return {
+          ok: false,
+          error: {
+            code: "ALLOCATION_FAILED",
+            message: `no free stride within ${this.strideMax} positions starting at ${STRIDE_BASE} (step ${this.strideStep})`,
+          },
+        };
+      }
+    }
+
+    const entry: PairRegistryEntry = {
+      pairId,
+      appPort,
+      proxyPort,
+      allocatedAt: Date.now(),
+    };
+    this.entries.set(pairId, entry);
+    this.log(`[pair-registry] allocated pair="${pairId}" appPort=${appPort} proxyPort=${proxyPort}`);
+    return { ok: true, entry };
+  }
+
+  /**
+   * Remove an entry. Returns true if something was removed. Caller is
+   * responsible for calling save() and holding the registry mutex.
+   */
+  remove(pairId: string): boolean {
+    if (!this.entries.has(pairId)) return false;
+    this.entries.delete(pairId);
+    this.log(`[pair-registry] removed pair="${pairId}"`);
+    return true;
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -78,4 +78,37 @@ export class StateDirResolver {
   get killedFile(): string {
     return join(this.stateDir, "killed");
   }
+
+  // ── STM v2.3 §D5 P3d — per-pair file paths ────────────────────────────
+  //
+  // The pair registry already lives under `pairs/` (see PairRegistry).
+  // P3d adds the per-pair subdirectories and file accessors so a future
+  // commit (and P4's CLI `--pair` flag) can populate them. Until that
+  // commit lands, the root-level `tuiPidFile` and `codexWrapperLogFile`
+  // accessors are retained as the canonical paths so v2.2 behavior is
+  // preserved end-to-end. Both v2.2 and v2.3 readers will coexist during
+  // the transition (the kill walker reads both).
+
+  /** Subdirectory for a specific pair's runtime state. */
+  pairDir(pairId: string): string {
+    return join(this.stateDir, "pairs", pairId);
+  }
+
+  /** Per-pair Codex app-server / TUI pid file. */
+  pairCodexPidFile(pairId: string): string {
+    return join(this.pairDir(pairId), "codex.pid");
+  }
+
+  /** Per-pair codex-wrapper log (matches the format of root codexWrapperLogFile). */
+  pairCodexWrapperLogFile(pairId: string): string {
+    return join(this.pairDir(pairId), "codex-wrapper.log");
+  }
+
+  /** Ensure a pair's subdirectory exists; safe to call repeatedly. */
+  ensurePairDir(pairId: string): void {
+    const dir = this.pairDir(pairId);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
 }

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
 import { createServer, Socket, type Server } from "node:net";
-import { CodexAdapter } from "../codex-adapter";
+import { CodexAdapter, buildCodexAppServerArgs } from "../codex-adapter";
 
 function createAdapter() {
   return new CodexAdapter({ appPort: 4510, proxyPort: 4511 }) as any;
@@ -1776,5 +1776,44 @@ describe("CodexAdapter echo dedup (spec v2.2 §4.5)", () => {
     expect(events.length).toBe(1);
     // Expired entry should have been cleaned up by isEchoOfInjection
     expect(adapter.injectedTurnIds.has("turn_old")).toBe(false);
+  });
+});
+
+// ── Sprint #3 (2026-05-17 codex_msg_..._177): sandbox flag propagation ──
+//
+// Codex sandbox is decided server-side (the app-server spawned by daemon),
+// not by the TUI in --remote mode. Before this, `abg codex --sandbox
+// workspace-write` set the flag on the TUI process which had no effect on
+// the daemon-owned app-server, leaving Codex effectively read-only and
+// breaking `apply_patch`. Helper now propagates sandbox into the app-server
+// spawn argv.
+
+describe("buildCodexAppServerArgs (sandbox propagation)", () => {
+  test("returns base args when no sandbox", () => {
+    expect(buildCodexAppServerArgs("ws://127.0.0.1:4500")).toEqual(
+      ["app-server", "--listen", "ws://127.0.0.1:4500"],
+    );
+    expect(buildCodexAppServerArgs("ws://127.0.0.1:4500", undefined)).toEqual(
+      ["app-server", "--listen", "ws://127.0.0.1:4500"],
+    );
+  });
+
+  test("appends --sandbox MODE when sandbox provided", () => {
+    expect(buildCodexAppServerArgs("ws://127.0.0.1:4500", "workspace-write")).toEqual(
+      ["app-server", "--listen", "ws://127.0.0.1:4500", "--sandbox", "workspace-write"],
+    );
+    expect(buildCodexAppServerArgs("ws://127.0.0.1:4510", "read-only")).toEqual(
+      ["app-server", "--listen", "ws://127.0.0.1:4510", "--sandbox", "read-only"],
+    );
+    // Pass-through any string — codex itself validates the value, the
+    // helper does not gate on a hardcoded list (which would go stale if
+    // codex adds modes).
+    expect(buildCodexAppServerArgs("ws://127.0.0.1:4500", "danger-full-access")).toContain("danger-full-access");
+  });
+
+  test("empty string is treated as 'no sandbox' (no flag appended)", () => {
+    expect(buildCodexAppServerArgs("ws://127.0.0.1:4500", "")).toEqual(
+      ["app-server", "--listen", "ws://127.0.0.1:4500"],
+    );
   });
 });

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -1608,3 +1608,173 @@ describe("CodexAdapter thread/closed diagnostic sniffer", () => {
     expect(diag.length).toBe(0);
   });
 });
+
+// ── Spec v2.2 §4.1 — paired-chat state ──────────────────────────
+
+describe("CodexAdapter paired-chat state (spec v2.2 §4.1)", () => {
+  test("setPairedChat / isPaired / currentPairedChatId roundtrip", () => {
+    const adapter = createAdapter();
+    expect(adapter.isPaired("chat_abc")).toBe(false);
+    expect(adapter.currentPairedChatId).toBe(null);
+
+    adapter.setPairedChat("chat_abc");
+    expect(adapter.isPaired("chat_abc")).toBe(true);
+    expect(adapter.isPaired("chat_xyz")).toBe(false);
+    expect(adapter.currentPairedChatId).toBe("chat_abc");
+
+    adapter.setPairedChat(null);
+    expect(adapter.isPaired("chat_abc")).toBe(false);
+    expect(adapter.currentPairedChatId).toBe(null);
+  });
+});
+
+// ── Spec v2.2 §4.3 — outbound event emissions ───────────────────
+
+describe("CodexAdapter outbound events for shared transport (spec v2.2 §4.3)", () => {
+  test("emits userMessage when item/completed has type userMessage and content", () => {
+    const adapter = createAdapter();
+    const events: Array<{ event: string; payload: any }> = [];
+    adapter.on("userMessage", (p: any) => events.push({ event: "userMessage", payload: p }));
+    adapter.on("agentMessage", (p: any) => events.push({ event: "agentMessage", payload: p }));
+
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u1", type: "userMessage", content: [{ type: "text", text: "hello from tui" }] },
+        turnId: "t1",
+      },
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].event).toBe("userMessage");
+    expect(events[0].payload.content).toBe("hello from tui");
+    expect(events[0].payload.source).toBe("codex");
+    expect(events[0].payload.turnId).toBe("t1");
+  });
+
+  test("emits errorItem on top-level error notification", () => {
+    const adapter = createAdapter();
+    const events: Array<{ code?: number; message?: string; data?: unknown }> = [];
+    adapter.on("errorItem", (p: any) => events.push(p));
+
+    adapter.handleServerNotification({
+      method: "error",
+      params: { error: { code: -32601, message: "Method not found" } },
+    });
+
+    expect(events).toEqual([{ code: -32601, message: "Method not found", data: undefined }]);
+  });
+
+  test("emits threadClosed on top-level thread/closed notification", () => {
+    const adapter = createAdapter();
+    const events: Array<{ threadId?: string }> = [];
+    adapter.on("threadClosed", (p: any) => events.push(p));
+
+    adapter.handleServerNotification({
+      method: "thread/closed",
+      params: { threadId: "th-99" },
+    });
+
+    expect(events).toEqual([{ threadId: "th-99" }]);
+  });
+
+  test("does NOT forward toolCall / shellCommand / approval items (whitelist exclusion §4.4)", () => {
+    const adapter = createAdapter();
+    const events: string[] = [];
+    adapter.on("agentMessage", () => events.push("agentMessage"));
+    adapter.on("userMessage", () => events.push("userMessage"));
+
+    for (const itemType of ["toolCall", "shellCommand", "fileChange", "reasoning"]) {
+      adapter.handleServerNotification({
+        method: "item/completed",
+        params: { item: { id: `i_${itemType}`, type: itemType, content: [{ type: "text", text: "x" }] } },
+      });
+    }
+
+    expect(events).toEqual([]);
+  });
+});
+
+// ── Spec v2.2 §4.5 — echo dedup ─────────────────────────────────
+
+describe("CodexAdapter echo dedup (spec v2.2 §4.5)", () => {
+  test("turnId match suppresses userMessage echo of injected text", () => {
+    const adapter = createAdapter();
+    const events: any[] = [];
+    adapter.on("userMessage", (p: any) => events.push(p));
+
+    // Simulate that an injection's turn/start response gave us this turnId.
+    adapter.recordInjectedTurnId("turn_inj_1", undefined);
+
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u1", type: "userMessage", content: [{ type: "text", text: "echo me" }] },
+        turnId: "turn_inj_1",
+      },
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  test("content-hash match suppresses echo when turnId not yet known (race window)", () => {
+    const adapter = createAdapter();
+    const events: any[] = [];
+    adapter.on("userMessage", (p: any) => events.push(p));
+
+    // Simulate that injectMessage was called (which would populate this map)
+    // but the turn/start response has not yet landed.
+    const hash = adapter.hashInjectionContent("race-window text");
+    adapter.pendingInjectionHashes.set(hash, Date.now() + 5_000);
+
+    // Notification arrives WITHOUT turnId (rare but possible in races).
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u2", type: "userMessage", content: [{ type: "text", text: "race-window text" }] },
+      },
+    });
+
+    expect(events).toEqual([]);
+    // Hash is one-shot consumed.
+    expect(adapter.pendingInjectionHashes.has(hash)).toBe(false);
+  });
+
+  test("legitimate user-typed message with no prior injection IS forwarded", () => {
+    const adapter = createAdapter();
+    const events: any[] = [];
+    adapter.on("userMessage", (p: any) => events.push(p));
+
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u3", type: "userMessage", content: [{ type: "text", text: "fresh user input" }] },
+        turnId: "turn_99",
+      },
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].content).toBe("fresh user input");
+  });
+
+  test("expired turnId entry does not suppress (TTL respected)", () => {
+    const adapter = createAdapter();
+    const events: any[] = [];
+    adapter.on("userMessage", (p: any) => events.push(p));
+
+    // Manually set expired entry
+    adapter.injectedTurnIds.set("turn_old", Date.now() - 1000);
+
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: {
+        item: { id: "u4", type: "userMessage", content: [{ type: "text", text: "after ttl" }] },
+        turnId: "turn_old",
+      },
+    });
+
+    expect(events.length).toBe(1);
+    // Expired entry should have been cleaned up by isEchoOfInjection
+    expect(adapter.injectedTurnIds.has("turn_old")).toBe(false);
+  });
+});

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -4,7 +4,7 @@ import { createServer, Socket, type Server } from "node:net";
 import { CodexAdapter } from "../codex-adapter";
 
 function createAdapter() {
-  return new CodexAdapter(4510, 4511) as any;
+  return new CodexAdapter({ appPort: 4510, proxyPort: 4511 }) as any;
 }
 
 describe("CodexAdapter app-server response handling", () => {

--- a/src/unit-test/daemon-client.test.ts
+++ b/src/unit-test/daemon-client.test.ts
@@ -394,6 +394,31 @@ describe("DaemonClient", () => {
     expect(elapsed).toBeLessThan(2000);
   });
 
+  test("P5e DAEMON_SHUTTING_DOWN: pending attachClaude resolves with ok=false when daemon disconnects", async () => {
+    // Don't reply to claude_connect — leave it pending. Then close the
+    // server side. attachClaude should resolve with ok=false carrying
+    // the DAEMON_SHUTTING_DOWN sentinel rather than timing out to ok.
+    onServerMessage = () => { /* swallow */ };
+    await client.connect();
+
+    const attachPromise = client.attachClaude(10_000); // generous timeout
+
+    // Give the request a tick to land on the server.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Daemon side closes — simulates SIGTERM mid-handshake.
+    for (const ws of serverSockets) {
+      ws.close();
+    }
+
+    const result = await attachPromise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("DAEMON_SHUTTING_DOWN");
+      expect(result.message).toContain("interrupted");
+    }
+  });
+
   test("P4 attachClaude: ignores claude_connect_result with mismatched requestId", async () => {
     // Daemon sends a response with WRONG requestId (e.g. crossed wires).
     // attachClaude should treat this as no response and timeout-to-ok.

--- a/src/unit-test/daemon-client.test.ts
+++ b/src/unit-test/daemon-client.test.ts
@@ -281,9 +281,136 @@ describe("DaemonClient", () => {
     });
 
     await client.connect();
-    client.attachClaude();
+    void client.attachClaude(1000);  // fire-and-forget; will timeout-to-ok
 
     const msg = await received;
     expect(msg.type).toBe("claude_connect");
+  });
+
+  // ── STM v2.3 §D4 / §D6 P4-cleanup HIGH#2 regression tests ─────────────
+
+  test("P4 attachClaude: sends requestId so daemon responses can correlate", async () => {
+    const received = new Promise<any>((resolve) => {
+      onServerMessage = (_ws: any, raw: any) => {
+        resolve(JSON.parse(typeof raw === "string" ? raw : raw.toString()));
+      };
+    });
+    await client.connect();
+    void client.attachClaude(1000);
+    const msg = await received;
+    expect(msg.type).toBe("claude_connect");
+    expect(typeof msg.requestId).toBe("string");
+    expect(msg.requestId.length).toBeGreaterThan(0);
+  });
+
+  test("P4 attachClaude: forwards pairId from constructor", async () => {
+    await client.disconnect();
+    const pairedClient = new DaemonClient(
+      `ws://127.0.0.1:${serverPort}/ws`,
+      { chatId: "chat-abc", pairId: "work" },
+    );
+    const received = new Promise<any>((resolve) => {
+      onServerMessage = (_ws: any, raw: any) => {
+        resolve(JSON.parse(typeof raw === "string" ? raw : raw.toString()));
+      };
+    });
+    await pairedClient.connect();
+    void pairedClient.attachClaude(1000);
+    const msg = await received;
+    expect(msg.pairId).toBe("work");
+    expect(msg.chatId).toBe("chat-abc");
+    await pairedClient.disconnect();
+  });
+
+  test("P4 attachClaude: resolves ok=true when daemon emits matching claude_connect_result", async () => {
+    let capturedRequestId: string | undefined;
+    onServerMessage = (ws: any, raw: any) => {
+      const incoming = JSON.parse(typeof raw === "string" ? raw : raw.toString());
+      if (incoming.type === "claude_connect") {
+        capturedRequestId = incoming.requestId;
+        // Daemon side replies with typed result.
+        ws.send(JSON.stringify({
+          type: "claude_connect_result",
+          requestId: capturedRequestId,
+          ok: true,
+          chatId: incoming.chatId ?? "test-chat",
+          homePairId: "default",
+          paired: false,
+        }));
+      }
+    };
+    await client.connect();
+    const result = await client.attachClaude(5000);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.homePairId).toBe("default");
+      expect(result.paired).toBe(false);
+    }
+  });
+
+  test("P4 attachClaude: resolves ok=false when daemon emits PAIR_NOT_FOUND", async () => {
+    await client.disconnect();
+    const pairedClient = new DaemonClient(
+      `ws://127.0.0.1:${serverPort}/ws`,
+      { chatId: "chat-ghost", pairId: "ghost-pair" },
+    );
+    onServerMessage = (ws: any, raw: any) => {
+      const incoming = JSON.parse(typeof raw === "string" ? raw : raw.toString());
+      if (incoming.type === "claude_connect") {
+        ws.send(JSON.stringify({
+          type: "claude_connect_result",
+          requestId: incoming.requestId,
+          ok: false,
+          error: "PAIR_NOT_FOUND",
+          message: `pair "${incoming.pairId}" is not live`,
+        }));
+      }
+    };
+    await pairedClient.connect();
+    const result = await pairedClient.attachClaude(5000);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("PAIR_NOT_FOUND");
+      expect(result.message).toContain("ghost-pair");
+    }
+    await pairedClient.disconnect();
+  });
+
+  test("P4 attachClaude: timeout-to-ok lets v2.2 daemon (no typed response) keep working", async () => {
+    // Server doesn't send any response — should fall through to ok=true
+    // after the short timeout (backwards-compat).
+    onServerMessage = () => { /* swallow */ };
+    await client.connect();
+    const start = Date.now();
+    const result = await client.attachClaude(300);
+    const elapsed = Date.now() - start;
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.homePairId).toBeNull();
+      expect(result.paired).toBe(false);
+    }
+    // Timed out close to the configured budget (give some slack for CI).
+    expect(elapsed).toBeGreaterThanOrEqual(290);
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  test("P4 attachClaude: ignores claude_connect_result with mismatched requestId", async () => {
+    // Daemon sends a response with WRONG requestId (e.g. crossed wires).
+    // attachClaude should treat this as no response and timeout-to-ok.
+    onServerMessage = (ws: any, raw: any) => {
+      const incoming = JSON.parse(typeof raw === "string" ? raw : raw.toString());
+      if (incoming.type === "claude_connect") {
+        ws.send(JSON.stringify({
+          type: "claude_connect_result",
+          requestId: "WRONG-ID",
+          ok: false,
+          error: "PAIR_NOT_FOUND",
+          message: "should be ignored",
+        }));
+      }
+    };
+    await client.connect();
+    const result = await client.attachClaude(300);
+    expect(result.ok).toBe(true); // timeout-to-ok, did NOT pick up the WRONG-ID response
   });
 });

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -756,35 +756,94 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
   // the "Reconnect to retry" instruction in `system_thread_failed`
   // was a lie. Reaping forces the next attach to construct a fresh
   // ChatState.
-  test("attachClaude bootstrap-failure reaps chat (so reconnect can retry)", async () => {
+  //
+  // Test hardening (Codex cross-review 2026-05-17 codex_msg_..._164):
+  // assert (a) system_thread_failed is emitted BEFORE close (so the
+  // user-facing recovery message lands while the WS is still up),
+  // (b) close uses code 1011 + the chat-reap reason — the contract
+  // reapChatState commits to, and (c) re-attaching the same chatId
+  // after the reap actually goes down the new-chat path with a fresh
+  // bootstrap (proving the resume-skipped-bootstrap pathological
+  // case can no longer happen).
+  test("attachClaude bootstrap-failure reaps chat + reconnect bootstraps fresh", async () => {
     const defaultPair = __testing.pairs.get("default")!;
     defaultPair.isLive = true;
     __testing.setProxyTuiSlot(null);
 
     const { ClaudeThread } = await import("../claude-thread");
     const originalBootstrap = (ClaudeThread.prototype as any).bootstrap;
-    (ClaudeThread.prototype as any).bootstrap = async () => {
-      throw new Error("app-server unreachable");
+    let bootstrapShouldFail = true;
+    (ClaudeThread.prototype as any).bootstrap = async function () {
+      if (bootstrapShouldFail) throw new Error("app-server unreachable");
+      return "stub-thread-id";
     };
+
+    function makeOrderedWs(clientId: number) {
+      const events: Array<
+        | { kind: "send"; payload: any }
+        | { kind: "close"; code?: number; reason?: string }
+      > = [];
+      const ws: any = {
+        // Positive send return — matches Bun's "delivered" contract so
+        // emitToChat actually goes through the WS (not buffered to state).
+        send: (payload: string) => { events.push({ kind: "send", payload: JSON.parse(payload) }); return 1; },
+        data: { clientId, attached: true, chatId: null },
+        readyState: 1,
+        close: (code?: number, reason?: string) => { events.push({ kind: "close", code, reason }); },
+      };
+      return { ws, events };
+    }
+
     try {
-      const { ws, sent } = makeAttachMockWs(9);
+      // ─── Phase 1: bootstrap fails → reap ──────────────────────────
+      const { ws, events } = makeOrderedWs(9);
       await (fns as any).attachClaude(ws, "chat-boot-fail", undefined, "req-boot-fail");
 
-      // claude_connect_result is sent BEFORE bootstrap awaits, so the
-      // attach itself reports ok=true (per spec §D6: ok means attached,
-      // not bootstrapped).
-      const result = findResult(sent);
-      expect(result?.ok).toBe(true);
+      // claude_connect_result is sent BEFORE bootstrap awaits, so attach
+      // reports ok=true (per spec §D6: ok means attached, not bootstrapped).
+      const result = events.find((e) => e.kind === "send" && e.payload.type === "claude_connect_result");
+      expect(result && (result as any).payload?.ok).toBe(true);
 
-      // system_thread_failed must have been emitted to the chat's buffer
-      // before reap (the user-facing recovery instruction).
-      const chat = __testing.chats.get("chat-boot-fail");
-      // After reap, the chat is gone — buffered messages were on the
-      // pre-reap ChatState. Capture them indirectly via the WS sends
-      // ... actually emitToChat for a chat without `ws.attached` buffers
-      // on the state, so we have to assert reap happened (entry removed)
-      // and trust the emit-then-reap ordering in the daemon code.
-      expect(chat).toBeUndefined();
+      // (a) system_thread_failed must precede the WS close.
+      const failIdx = events.findIndex((e) =>
+        e.kind === "send" &&
+        (e as any).payload.type === "codex_to_claude" &&
+        (e as any).payload.message?.id?.startsWith("system_thread_failed_"));
+      const closeIdx = events.findIndex((e) => e.kind === "close");
+      expect(failIdx).toBeGreaterThanOrEqual(0);
+      expect(closeIdx).toBeGreaterThanOrEqual(0);
+      expect(failIdx).toBeLessThan(closeIdx);
+
+      // (b) close uses 1011 + chat-reap reason — the contract.
+      const closeEvt = events[closeIdx] as { kind: "close"; code?: number; reason?: string };
+      expect(closeEvt.code).toBe(1011);
+      expect(closeEvt.reason ?? "").toMatch(/chat reaped: bootstrap failed/);
+
+      // Chat is gone from `chats` → next attach hits new-chat path.
+      expect(__testing.chats.get("chat-boot-fail")).toBeUndefined();
+
+      // ─── Phase 2: re-attach same chatId, bootstrap now succeeds ───
+      bootstrapShouldFail = false;
+      const { ws: ws2, events: events2 } = makeOrderedWs(10);
+      await (fns as any).attachClaude(ws2, "chat-boot-fail", undefined, "req-boot-fail-2");
+
+      const result2 = events2.find((e) => e.kind === "send" && e.payload.type === "claude_connect_result");
+      expect(result2 && (result2 as any).payload?.ok).toBe(true);
+
+      // (c) fresh ChatState exists and bootstrapped → ready=true.
+      // Proves the "resume branch skips bootstrap" pathological case
+      // can no longer happen: chats was empty, so the new attach went
+      // through createChatState + bootstrap fresh.
+      const freshChat = __testing.chats.get("chat-boot-fail");
+      expect(freshChat).toBeDefined();
+      expect(freshChat!.ready).toBe(true);
+
+      // system_thread_ready emitted (success path).
+      const readyEvt = events2.find((e) =>
+        e.kind === "send" &&
+        (e as any).payload.type === "codex_to_claude" &&
+        (e as any).payload.message?.id?.startsWith("system_thread_ready_"));
+      expect(readyEvt).toBeDefined();
     } finally {
       (ClaudeThread.prototype as any).bootstrap = originalBootstrap;
       __testing.chats.delete("chat-boot-fail");

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -1295,4 +1295,48 @@ describe("Issue #82 — ClaudeThread WS close lifecycle (2026-05-17)", () => {
     expect(() => chat.thread.emit("close")).not.toThrow();
     expect(chat.bufferedMessages.length).toBe(beforeBuffered);
   });
+
+  // Codex batch review must-fix (msg codex_msg_..._184): the
+  // `state.thread !== threadAtRegistration` guard exists because
+  // bootstrapIsolatedThread retry and transitionToIsolated both close
+  // the OLD ClaudeThread and assign `state.thread = new ClaudeThread(...)`.
+  // The OLD thread's pending "close" event fires after replacement; without
+  // the captured-reference guard, that close would falsely reap the live
+  // chat (chats still contains the same ChatState, just with a different
+  // .thread).
+  test("close on the OLD thread after replacement does NOT reap the live chat", async () => {
+    const { ClaudeThread } = await import("../claude-thread");
+    const chat = fns.createChatState("chat-issue-82-stale-thread");
+    chats.set(chat.chatId, chat);
+    (fns as any).wireClaudeThreadEvents(chat);
+
+    const oldThread = chat.thread;
+
+    // Simulate transitionToIsolated / bootstrapIsolatedThread retry:
+    // close the old thread and immediately replace `state.thread` with a
+    // freshly constructed ClaudeThread (handlers re-wired in production
+    // code; here we don't re-wire since we only want to assert the OLD
+    // handler doesn't fire reap).
+    chat.thread = new ClaudeThread({
+      appServerUrl: "ws://127.0.0.1:24500",
+      chatId: chat.chatId,
+      logFile: "/tmp/agentbridge-test-stale-thread.log",
+      cwd: "/tmp",
+    });
+
+    const beforeChatsCount = chats.size;
+    const beforeBuffered = chat.bufferedMessages.length;
+
+    // Old thread's close event fires LATE (after replacement). Guard
+    // catches `state.thread !== threadAtRegistration` → return.
+    expect(() => oldThread.emit("close")).not.toThrow();
+
+    // Chat is still in chats Map. NOT reaped.
+    expect(chats.has(chat.chatId)).toBe(true);
+    expect(chats.size).toBe(beforeChatsCount);
+    // No system_thread_failed buffered.
+    expect(chat.bufferedMessages.length).toBe(beforeBuffered);
+    // The new thread is still the live one.
+    expect(chat.thread).not.toBe(oldThread);
+  });
 });

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -747,6 +747,50 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     }
   });
 
+  // Bug regression D (2026-05-17): attachClaude bootstrap failure reaps
+  // the half-initialized chat. Before the fix, a bootstrap that threw
+  // (e.g. codex app-server unreachable during daemon restart) left
+  // `state.ready=false` permanently in `chats`. Subsequent reply attempts
+  // hit "thread still provisioning", and a bridge reconnect with the
+  // same chatId took the resume branch and skipped re-bootstrap, so
+  // the "Reconnect to retry" instruction in `system_thread_failed`
+  // was a lie. Reaping forces the next attach to construct a fresh
+  // ChatState.
+  test("attachClaude bootstrap-failure reaps chat (so reconnect can retry)", async () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    defaultPair.isLive = true;
+    __testing.setProxyTuiSlot(null);
+
+    const { ClaudeThread } = await import("../claude-thread");
+    const originalBootstrap = (ClaudeThread.prototype as any).bootstrap;
+    (ClaudeThread.prototype as any).bootstrap = async () => {
+      throw new Error("app-server unreachable");
+    };
+    try {
+      const { ws, sent } = makeAttachMockWs(9);
+      await (fns as any).attachClaude(ws, "chat-boot-fail", undefined, "req-boot-fail");
+
+      // claude_connect_result is sent BEFORE bootstrap awaits, so the
+      // attach itself reports ok=true (per spec §D6: ok means attached,
+      // not bootstrapped).
+      const result = findResult(sent);
+      expect(result?.ok).toBe(true);
+
+      // system_thread_failed must have been emitted to the chat's buffer
+      // before reap (the user-facing recovery instruction).
+      const chat = __testing.chats.get("chat-boot-fail");
+      // After reap, the chat is gone — buffered messages were on the
+      // pre-reap ChatState. Capture them indirectly via the WS sends
+      // ... actually emitToChat for a chat without `ws.attached` buffers
+      // on the state, so we have to assert reap happened (entry removed)
+      // and trust the emit-then-reap ordering in the daemon code.
+      expect(chat).toBeUndefined();
+    } finally {
+      (ClaudeThread.prototype as any).bootstrap = originalBootstrap;
+      __testing.chats.delete("chat-boot-fail");
+    }
+  });
+
   test("P3-cleanup claude_connect: ok=true with paired claim on explicit live+unpaired pair", async () => {
     const defaultPair = __testing.pairs.get("default")!;
     defaultPair.isLive = true;

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -587,6 +587,94 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     expect(sent[0].code).toBe("PAIR_BUSY_NOT_FORCED");
   });
 
+  // ── P3-cleanup claude_connect_result (Codex P3 close re-pass HIGH#1) ───
+
+  function makeAttachMockWs(clientId = 7) {
+    const sent: any[] = [];
+    const ws: any = {
+      send: (payload: string) => { sent.push(JSON.parse(payload)); return 0; },
+      data: { clientId, attached: false, chatId: null },
+      readyState: 1,
+      close: () => {},
+    };
+    return { sent, ws };
+  }
+
+  function findResult(sent: any[]) {
+    return sent.find((m) => m.type === "claude_connect_result");
+  }
+
+  test("P3-cleanup claude_connect: INVALID_PAIR_NAME for bad explicit pairId", async () => {
+    const { ws, sent } = makeAttachMockWs();
+    await (fns as any).attachClaude(ws, "chat-cc-1", "BAD CASE", "req-cc-1");
+    const result = findResult(sent);
+    expect(result?.ok).toBe(false);
+    expect(result?.error).toBe("INVALID_PAIR_NAME");
+    expect(result?.requestId).toBe("req-cc-1");
+  });
+
+  test("P3-cleanup claude_connect: PAIR_NOT_FOUND when explicit pair is not live", async () => {
+    const { ws, sent } = makeAttachMockWs();
+    await (fns as any).attachClaude(ws, "chat-cc-2", "ghost-pair", "req-cc-2");
+    const result = findResult(sent);
+    expect(result?.ok).toBe(false);
+    expect(result?.error).toBe("PAIR_NOT_FOUND");
+  });
+
+  test("P3-cleanup claude_connect: PAIR_NOT_FOUND when explicit pair is live but has no proxy TUI slot (Codex re-pass strict semantics)", async () => {
+    // Force-set default's slot to null then explicit-attach to it.
+    const defaultPair = __testing.pairs.get("default")!;
+    defaultPair.isLive = true;
+    // Clear the slot if anything is attached.
+    __testing.setProxyTuiSlot(null);
+    expect(defaultPair.proxyTuiSlot).toBeNull();
+
+    const { ws, sent } = makeAttachMockWs();
+    await (fns as any).attachClaude(ws, "chat-cc-3", "default", "req-cc-3");
+    const result = findResult(sent);
+    expect(result?.ok).toBe(false);
+    expect(result?.error).toBe("PAIR_NOT_FOUND");
+    expect(result?.message).toMatch(/no proxy TUI/i);
+  });
+
+  test("P3-cleanup claude_connect: PAIR_BUSY when explicit pair already has a different paired chat", async () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    defaultPair.isLive = true;
+    __testing.setProxyTuiSlot({
+      token: "t",
+      pairedChatId: "another-chat",
+      readiness: "ready",
+      attachedAt: Date.now(),
+      pairReapTimer: null,
+    });
+
+    const { ws, sent } = makeAttachMockWs();
+    await (fns as any).attachClaude(ws, "chat-cc-4", "default", "req-cc-4");
+    const result = findResult(sent);
+    expect(result?.ok).toBe(false);
+    expect(result?.error).toBe("PAIR_BUSY");
+  });
+
+  test("P3-cleanup claude_connect: ok=true with paired claim on explicit live+unpaired pair", async () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    defaultPair.isLive = true;
+    __testing.setProxyTuiSlot({
+      token: "t",
+      pairedChatId: null,
+      readiness: "ready",
+      attachedAt: Date.now(),
+      pairReapTimer: null,
+    });
+
+    const { ws, sent } = makeAttachMockWs();
+    await (fns as any).attachClaude(ws, "chat-cc-5", "default", "req-cc-5");
+    const result = findResult(sent);
+    expect(result?.ok).toBe(true);
+    expect(result?.chatId).toBe("chat-cc-5");
+    expect(result?.homePairId).toBe("default");
+    expect(result?.paired).toBe(true);
+  });
+
   // ── P3-cleanup (Codex P3-series review codex_msg_5753c73beafc_107) ─────
 
   test("P3-cleanup HIGH#2: same-pair concurrent ensurePair calls dedupe via ensurePairInFlight", async () => {

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -872,6 +872,44 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     }
   });
 
+  test("P5c PAIR_PORTS_BUSY: parses port + PID from CodexAdapter.checkPorts error message", async () => {
+    const { CodexAdapter } = await import("../codex-adapter");
+    const originalStart = (CodexAdapter.prototype as any).start;
+    (CodexAdapter.prototype as any).start = async function () {
+      // Canonical checkPorts error format (matches src/codex-adapter.ts:1832).
+      throw new Error("Port 4520 is already in use by non-Codex process(es): PID(s) 12345. Please stop the process or set a different port.");
+    };
+    if (__testing.pairRegistry.has("pid-pair")) {
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("pid-pair");
+        __testing.pairRegistry.save();
+      });
+    }
+    try {
+      const { ws, sent } = makeMockWs();
+      await fns.handleEnsurePair(ws, {
+        type: "ensure_pair",
+        requestId: "req-pid",
+        pairId: "pid-pair",
+      });
+      expect(sent[0].type).toBe("pair_error");
+      expect(sent[0].code).toBe("PAIR_PORTS_BUSY");
+      expect(sent[0].details?.conflictPort).toBe(4520);
+      expect(sent[0].details?.conflictPid).toBe(12345);
+    } finally {
+      (CodexAdapter.prototype as any).start = originalStart;
+      const pair = __testing.pairs.get("pid-pair");
+      if (pair) {
+        try { fns.detachPairHandlers(pair); } catch {}
+        __testing.pairs.delete("pid-pair");
+      }
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("pid-pair");
+        __testing.pairRegistry.save();
+      });
+    }
+  });
+
   test("P3-cleanup MEDIUM: codex.start EADDRINUSE maps to PAIR_PORTS_BUSY with details", async () => {
     const { CodexAdapter } = await import("../codex-adapter");
     const originalStart = (CodexAdapter.prototype as any).start;

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -419,6 +419,179 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     await expect(fns.ensurePair("work")).rejects.toThrow(/not yet supported in P2/);
   });
 
+  // ── STM v2.3 §D6 P3b — control-protocol handlers ────────────────────
+
+  function makeMockWs(): {
+    sent: any[];
+    ws: any;
+  } {
+    const sent: any[] = [];
+    return {
+      sent,
+      ws: {
+        send: (payload: string) => { sent.push(JSON.parse(payload)); return 0; },
+        data: { clientId: 1, attached: false, chatId: null },
+        readyState: 1,
+        close: () => {},
+      },
+    };
+  }
+
+  test("P3b ensure_pair: pair_error INVALID_PAIR_NAME for bad name", async () => {
+    const { ws, sent } = makeMockWs();
+    await fns.handleEnsurePair(ws, {
+      type: "ensure_pair",
+      requestId: "req-1",
+      pairId: "BAD CASE",
+    });
+    expect(sent.length).toBe(1);
+    expect(sent[0].type).toBe("pair_error");
+    expect(sent[0].code).toBe("INVALID_PAIR_NAME");
+    expect(sent[0].requestId).toBe("req-1");
+  });
+
+  test("P3b ensure_pair: pair_ensured for 'default' (idempotent across registry)", async () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    const originalStart = defaultPair.codex.start.bind(defaultPair.codex);
+    (defaultPair.codex as any).start = async () => {};
+    try {
+      // Pre-condition: default registered, not live.
+      expect(__testing.pairRegistry.has("default")).toBe(true);
+      defaultPair.isLive = false;
+
+      const { ws, sent } = makeMockWs();
+      await fns.handleEnsurePair(ws, {
+        type: "ensure_pair",
+        requestId: "req-2",
+        pairId: "default",
+      });
+      expect(sent.length).toBe(1);
+      expect(sent[0].type).toBe("pair_ensured");
+      expect(sent[0].pairId).toBe("default");
+      expect(sent[0].isLive).toBe(true);
+      expect(typeof sent[0].appServerUrl).toBe("string");
+      expect(typeof sent[0].proxyUrl).toBe("string");
+      expect(defaultPair.isLive).toBe(true);
+    } finally {
+      (defaultPair.codex as any).start = originalStart;
+    }
+  });
+
+  test("P3b ensure_pair: non-default name allocates registry entry but returns ALLOCATION_FAILED (P3c-bound)", async () => {
+    // Make sure "scratch-pair" isn't already in registry.
+    if (__testing.pairRegistry.has("scratch-pair")) {
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("scratch-pair");
+        __testing.pairRegistry.save();
+      });
+    }
+
+    const { ws, sent } = makeMockWs();
+    await fns.handleEnsurePair(ws, {
+      type: "ensure_pair",
+      requestId: "req-3",
+      pairId: "scratch-pair",
+    });
+
+    expect(sent.length).toBe(1);
+    expect(sent[0].type).toBe("pair_error");
+    expect(sent[0].code).toBe("ALLOCATION_FAILED");
+    expect(sent[0].message).toContain("non-default pair activation is not implemented in P3b");
+
+    // The registry entry IS allocated and persisted.
+    const entry = __testing.pairRegistry.get("scratch-pair");
+    expect(entry).not.toBeNull();
+    expect(entry?.appPort).toBeGreaterThanOrEqual(4510);
+
+    // Cleanup so subsequent tests don't see stride exhaustion.
+    await __testing.runUnderRegistryMutex(async () => {
+      __testing.pairRegistry.remove("scratch-pair");
+      __testing.pairRegistry.save();
+    });
+  });
+
+  test("P3b destroy_pair: PAIR_NOT_FOUND when pair is neither live nor registered", async () => {
+    const { ws, sent } = makeMockWs();
+    await fns.handleDestroyPair(ws, {
+      type: "destroy_pair",
+      requestId: "req-4",
+      pairId: "never-existed",
+    });
+    expect(sent[0].type).toBe("pair_error");
+    expect(sent[0].code).toBe("PAIR_NOT_FOUND");
+  });
+
+  test("P3b destroy_pair: forget removes registry-only entry, returns wasLive=false", async () => {
+    await __testing.runUnderRegistryMutex(async () => {
+      const result = __testing.pairRegistry.allocate("scratch-2");
+      if (result.ok) __testing.pairRegistry.save();
+    });
+    expect(__testing.pairRegistry.has("scratch-2")).toBe(true);
+
+    const { ws, sent } = makeMockWs();
+    await fns.handleDestroyPair(ws, {
+      type: "destroy_pair",
+      requestId: "req-5",
+      pairId: "scratch-2",
+      forget: true,
+    });
+    expect(sent[0].type).toBe("pair_destroyed");
+    expect(sent[0].wasLive).toBe(false);
+    expect(sent[0].registryEntryRemoved).toBe(true);
+    expect(__testing.pairRegistry.has("scratch-2")).toBe(false);
+  });
+
+  test("P3b destroy_pair: PAIR_BUSY_NOT_FORCED when pair has paired chat and no force", async () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    // Seed a fake paired-chat slot for the default pair.
+    __testing.setProxyTuiSlot({
+      token: "t",
+      pairedChatId: "some-chat",
+      readiness: "ready",
+      attachedAt: Date.now(),
+      pairReapTimer: null,
+    });
+    defaultPair.isLive = true;
+
+    const { ws, sent } = makeMockWs();
+    await fns.handleDestroyPair(ws, {
+      type: "destroy_pair",
+      requestId: "req-6",
+      pairId: "default",
+      forget: false,
+      force: false,
+    });
+    expect(sent[0].type).toBe("pair_error");
+    expect(sent[0].code).toBe("PAIR_BUSY_NOT_FORCED");
+  });
+
+  test("P3b list_pairs: returns live + registry-only entries", async () => {
+    // Allocate a registry-only "scratch-list" entry.
+    await __testing.runUnderRegistryMutex(async () => {
+      const result = __testing.pairRegistry.allocate("scratch-list");
+      if (result.ok) __testing.pairRegistry.save();
+    });
+
+    const { ws, sent } = makeMockWs();
+    fns.handleListPairs(ws, { type: "list_pairs", requestId: "req-7" });
+    expect(sent[0].type).toBe("pair_list");
+    const pairsList = sent[0].pairs as any[];
+
+    const defaultEntry = pairsList.find((p) => p.pairId === "default");
+    expect(defaultEntry).toBeDefined();
+
+    const scratchEntry = pairsList.find((p) => p.pairId === "scratch-list");
+    expect(scratchEntry).toBeDefined();
+    expect(scratchEntry.isLive).toBe(false);
+    expect(scratchEntry.appServerUrl).toMatch(/ws:\/\/127\.0\.0\.1:/);
+
+    // Cleanup.
+    await __testing.runUnderRegistryMutex(async () => {
+      __testing.pairRegistry.remove("scratch-list");
+      __testing.pairRegistry.save();
+    });
+  });
+
   test("Bug B: transitionToIsolated exercises the retry loop and emits a definitive 'failed' message when all attempts fail", async () => {
     __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
 

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -1324,6 +1324,11 @@ describe("Issue #82 — ClaudeThread WS close lifecycle (2026-05-17)", () => {
       cwd: "/tmp",
     });
 
+    // Per Codex batch re-pass msg ..._188: simulate the replacement
+    // having successfully bootstrapped so ready=true is the LIVE state.
+    // The stale OLD-thread close must NOT flip this back to false.
+    chat.ready = true;
+
     const beforeChatsCount = chats.size;
     const beforeBuffered = chat.bufferedMessages.length;
 
@@ -1338,5 +1343,10 @@ describe("Issue #82 — ClaudeThread WS close lifecycle (2026-05-17)", () => {
     expect(chat.bufferedMessages.length).toBe(beforeBuffered);
     // The new thread is still the live one.
     expect(chat.thread).not.toBe(oldThread);
+    // CRITICAL (Codex re-pass): ready must NOT have been flipped to false.
+    // Without the ordering fix, the stale handler ran `state.ready = false`
+    // before the guards — leaving the live thread effectively stuck in
+    // a soft "still provisioning" state even though no reap happened.
+    expect(chat.ready).toBe(true);
   });
 });

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -587,6 +587,152 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     expect(sent[0].code).toBe("PAIR_BUSY_NOT_FORCED");
   });
 
+  // ── P3-cleanup (Codex P3-series review codex_msg_5753c73beafc_107) ─────
+
+  test("P3-cleanup HIGH#2: same-pair concurrent ensurePair calls dedupe via ensurePairInFlight", async () => {
+    const { CodexAdapter } = await import("../codex-adapter");
+    const originalStart = (CodexAdapter.prototype as any).start;
+    let startCallCount = 0;
+    (CodexAdapter.prototype as any).start = async function () {
+      startCallCount++;
+      // Small delay to keep both racers in-flight at the same time.
+      await new Promise((r) => setTimeout(r, 20));
+    };
+    if (__testing.pairRegistry.has("dedup-pair")) {
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("dedup-pair");
+        __testing.pairRegistry.save();
+      });
+    }
+    try {
+      const [a, b] = await Promise.all([
+        fns.ensurePair("dedup-pair"),
+        fns.ensurePair("dedup-pair"),
+      ]);
+      // Both calls resolve to the exact same PairState instance —
+      // ensurePairInFlight dedup worked.
+      expect(a).toBe(b);
+      // codex.start called exactly once.
+      expect(startCallCount).toBe(1);
+    } finally {
+      (CodexAdapter.prototype as any).start = originalStart;
+      const pair = __testing.pairs.get("dedup-pair");
+      if (pair) {
+        try { fns.detachPairHandlers(pair); } catch {}
+        __testing.pairs.delete("dedup-pair");
+      }
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("dedup-pair");
+        __testing.pairRegistry.save();
+      });
+    }
+  });
+
+  test("P3-cleanup HIGH#3+4: destroy_pair on live non-default pair removes from pairs Map + clears slot", async () => {
+    const { CodexAdapter } = await import("../codex-adapter");
+    const originalStart = (CodexAdapter.prototype as any).start;
+    const originalStop = (CodexAdapter.prototype as any).stop;
+    (CodexAdapter.prototype as any).start = async () => {};
+    (CodexAdapter.prototype as any).stop = () => {};
+
+    try {
+      // Bring up a fresh non-default pair.
+      await fns.ensurePair("teardown-pair");
+      const pair = __testing.pairs.get("teardown-pair");
+      expect(pair).toBeDefined();
+      expect(pair?.isLive).toBe(true);
+      expect(pair?.handlerRefs.length).toBeGreaterThan(0);
+
+      // Seed a fake slot + paired chat so we can verify teardown handles them.
+      pair!.proxyTuiSlot = {
+        token: "t",
+        pairedChatId: "td-chat",
+        readiness: "ready",
+        attachedAt: Date.now(),
+        pairReapTimer: setTimeout(() => {}, 60_000),
+      };
+      const chat = fns.createChatState("td-chat");
+      chat.paired = true;
+      chat.homePairId = "teardown-pair";
+      __testing.chats.set("td-chat", chat);
+
+      const { ws, sent } = makeMockWs();
+      await fns.handleDestroyPair(ws, {
+        type: "destroy_pair",
+        requestId: "req-td",
+        pairId: "teardown-pair",
+        force: true,
+      });
+      expect(sent[0].type).toBe("pair_destroyed");
+      expect(sent[0].wasLive).toBe(true);
+
+      // Full teardown: removed from pairs Map, slot cleared, isLive=false,
+      // handlers detached.
+      expect(__testing.pairs.has("teardown-pair")).toBe(false);
+      expect(pair?.isLive).toBe(false);
+      expect(pair?.proxyTuiSlot).toBeNull();
+      expect(pair?.handlerRefs.length).toBe(0);
+
+      // The previously-paired chat was transitioned to isolated.
+      expect(chat.paired).toBe(false);
+      expect(chat.homePairId).toBe("default");
+    } finally {
+      (CodexAdapter.prototype as any).start = originalStart;
+      (CodexAdapter.prototype as any).stop = originalStop;
+      __testing.chats.delete("td-chat");
+      const pair = __testing.pairs.get("teardown-pair");
+      if (pair) {
+        try { fns.detachPairHandlers(pair); } catch {}
+        __testing.pairs.delete("teardown-pair");
+      }
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("teardown-pair");
+        __testing.pairRegistry.save();
+      });
+    }
+  });
+
+  test("P3-cleanup MEDIUM: codex.start EADDRINUSE maps to PAIR_PORTS_BUSY with details", async () => {
+    const { CodexAdapter } = await import("../codex-adapter");
+    const originalStart = (CodexAdapter.prototype as any).start;
+    (CodexAdapter.prototype as any).start = async function () {
+      const err: any = new Error("Failed to start app-server: EADDRINUSE :4520");
+      err.code = "EADDRINUSE";
+      throw err;
+    };
+    if (__testing.pairRegistry.has("busy-pair")) {
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("busy-pair");
+        __testing.pairRegistry.save();
+      });
+    }
+
+    try {
+      const { ws, sent } = makeMockWs();
+      await fns.handleEnsurePair(ws, {
+        type: "ensure_pair",
+        requestId: "req-busy",
+        pairId: "busy-pair",
+      });
+
+      expect(sent[0].type).toBe("pair_error");
+      expect(sent[0].code).toBe("PAIR_PORTS_BUSY");
+      expect(sent[0].message).toContain("busy-pair");
+    } finally {
+      (CodexAdapter.prototype as any).start = originalStart;
+      // PairState may have been partially constructed before start threw.
+      const pair = __testing.pairs.get("busy-pair");
+      if (pair) {
+        try { fns.detachPairHandlers(pair); } catch {}
+        __testing.pairs.delete("busy-pair");
+      }
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("busy-pair");
+        __testing.pairRegistry.save();
+      });
+    }
+  });
+
   test("P3b list_pairs: returns live + registry-only entries", async () => {
     // Allocate a registry-only "scratch-list" entry.
     await __testing.runUnderRegistryMutex(async () => {

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -415,8 +415,10 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     }
   });
 
-  test("P2 lifecycle: ensurePair rejects non-default pairId in P2", async () => {
-    await expect(fns.ensurePair("work")).rejects.toThrow(/not yet supported in P2/);
+  test("P3c lifecycle: ensurePair rejects INVALID_PAIR_NAME", async () => {
+    // P3c generalized ensurePair to accept any valid pairId. Invalid
+    // names (per D1) still throw a PairError.
+    await expect(fns.ensurePair("BAD CASE")).rejects.toThrow(/fails validation/);
   });
 
   // ── STM v2.3 §D6 P3b — control-protocol handlers ────────────────────
@@ -477,7 +479,7 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     }
   });
 
-  test("P3b ensure_pair: non-default name allocates registry entry but returns ALLOCATION_FAILED (P3c-bound)", async () => {
+  test("P3c ensure_pair: non-default name allocates a fresh PairState and goes live (with stubbed codex.start)", async () => {
     // Make sure "scratch-pair" isn't already in registry.
     if (__testing.pairRegistry.has("scratch-pair")) {
       await __testing.runUnderRegistryMutex(async () => {
@@ -486,28 +488,48 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
       });
     }
 
-    const { ws, sent } = makeMockWs();
-    await fns.handleEnsurePair(ws, {
-      type: "ensure_pair",
-      requestId: "req-3",
-      pairId: "scratch-pair",
-    });
+    // Stub CodexAdapter.prototype.start so the test doesn't actually
+    // spawn a real `codex app-server` process.
+    const { CodexAdapter } = await import("../codex-adapter");
+    const originalStart = (CodexAdapter.prototype as any).start;
+    (CodexAdapter.prototype as any).start = async function () {};
 
-    expect(sent.length).toBe(1);
-    expect(sent[0].type).toBe("pair_error");
-    expect(sent[0].code).toBe("ALLOCATION_FAILED");
-    expect(sent[0].message).toContain("non-default pair activation is not implemented in P3b");
+    try {
+      const { ws, sent } = makeMockWs();
+      await fns.handleEnsurePair(ws, {
+        type: "ensure_pair",
+        requestId: "req-3",
+        pairId: "scratch-pair",
+      });
 
-    // The registry entry IS allocated and persisted.
-    const entry = __testing.pairRegistry.get("scratch-pair");
-    expect(entry).not.toBeNull();
-    expect(entry?.appPort).toBeGreaterThanOrEqual(4510);
+      expect(sent.length).toBe(1);
+      expect(sent[0].type).toBe("pair_ensured");
+      expect(sent[0].pairId).toBe("scratch-pair");
+      expect(sent[0].isLive).toBe(true);
 
-    // Cleanup so subsequent tests don't see stride exhaustion.
-    await __testing.runUnderRegistryMutex(async () => {
-      __testing.pairRegistry.remove("scratch-pair");
-      __testing.pairRegistry.save();
-    });
+      // PairState now exists in the pairs Map.
+      const pair = __testing.pairs.get("scratch-pair");
+      expect(pair).toBeDefined();
+      expect(pair?.isLive).toBe(true);
+      expect(pair?.handlerRefs.length).toBeGreaterThan(0);
+
+      // Registry entry persisted.
+      const entry = __testing.pairRegistry.get("scratch-pair");
+      expect(entry).not.toBeNull();
+      expect(entry?.appPort).toBeGreaterThanOrEqual(4510);
+    } finally {
+      (CodexAdapter.prototype as any).start = originalStart;
+      // Tear down the test pair we created.
+      const pair = __testing.pairs.get("scratch-pair");
+      if (pair) {
+        try { fns.detachPairHandlers(pair); } catch {}
+        __testing.pairs.delete("scratch-pair");
+      }
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("scratch-pair");
+        __testing.pairRegistry.save();
+      });
+    }
   });
 
   test("P3b destroy_pair: PAIR_NOT_FOUND when pair is neither live nor registered", async () => {

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -1442,6 +1442,63 @@ describe("M01 regression — paired-inject routes to homePair's CodexAdapter (20
     }
   });
 
+  // Codex re-review of ebea1d3 (msg ..._197): the new home-pair-gone
+  // early return must roll back state.replyRequired when it was set
+  // by this same call. Without rollback, a requireReply reply racing
+  // with pair teardown leaves the chat stuck in stale reply-required
+  // state — mirrors the later `!injected` branch's rollback contract.
+  test("paired chat home-pair-gone with requireReply=true rolls back replyRequired", () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    const defaultCalls: string[] = [];
+    const defaultOriginalInject = defaultPair.codex.injectMessage.bind(defaultPair.codex);
+    (defaultPair.codex as any).injectMessage = (text: string) => {
+      defaultCalls.push(text);
+      return true;
+    };
+
+    const chat = fns.createChatState("chat-m01-gone-requirereply");
+    chat.paired = true;
+    chat.homePairId = "vanished";
+    chat.ready = true;
+    chat.replyRequired = false;
+    chats.set(chat.chatId, chat);
+
+    const sent: any[] = [];
+    const ws: any = {
+      send: (payload: string) => { sent.push(JSON.parse(payload)); return 1; },
+      data: { clientId: 101, attached: true, chatId: chat.chatId },
+      readyState: 1,
+      close: () => {},
+    };
+
+    try {
+      (fns as any).handleClaudeToCodex(ws, {
+        type: "claude_to_codex",
+        requestId: "req-m01-rollback",
+        chatId: chat.chatId,
+        message: {
+          id: "msg-m01-rollback",
+          source: "claude",
+          content: "racing reply",
+          timestamp: Date.now(),
+        },
+        requireReply: true,  // ← critical
+      });
+
+      expect(defaultCalls.length).toBe(0);
+      const result = sent.find((m) => m.type === "claude_to_codex_result");
+      expect(result?.success).toBe(false);
+      expect(result?.error ?? "").toMatch(/no longer live/);
+      // CRITICAL: replyRequired must have been rolled back. Without the
+      // fix, it would stay true because the requireReply path on line
+      // 1487 set it to true before reaching the home-pair-gone branch.
+      expect(chat.replyRequired).toBe(false);
+    } finally {
+      (defaultPair.codex as any).injectMessage = defaultOriginalInject;
+      chats.delete(chat.chatId);
+    }
+  });
+
   test("paired chat whose homePair is no longer live surfaces clean error (no injection)", () => {
     const defaultPair = __testing.pairs.get("default")!;
     const defaultCalls: string[] = [];

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -336,6 +336,89 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     expect(config.ISOLATED_BOOTSTRAP_RETRY_DELAY_MS).toBe(5);
   });
 
+  // ── STM v2.3 P2 lifecycle (Codex P2 review codex_msg_5753c73beafc_95) ──
+
+  test("P2 lifecycle: attachPairHandlers is idempotent (no duplicate handler refs)", () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    const baseline = defaultPair.handlerRefs.length;
+    expect(baseline).toBeGreaterThan(0); // module-load registration already ran
+
+    fns.attachPairHandlers(defaultPair);
+    expect(defaultPair.handlerRefs.length).toBe(baseline);
+  });
+
+  test("P2 lifecycle: detachPairHandlers uses targeted off(), preserves unrelated listeners", () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    const baseline = defaultPair.handlerRefs.length;
+
+    // Register an unrelated listener that detachPairHandlers must NOT remove.
+    const unrelatedHandler = () => {};
+    defaultPair.codex.on("ready", unrelatedHandler);
+    const readyBefore = defaultPair.codex.listenerCount("ready");
+
+    fns.detachPairHandlers(defaultPair);
+    expect(defaultPair.handlerRefs.length).toBe(0);
+
+    // The unrelated handler stays attached; only the daemon's own "ready"
+    // handler should have been removed (count drops by exactly 1).
+    expect(defaultPair.codex.listenerCount("ready")).toBe(readyBefore - 1);
+
+    // Cleanup + restore so subsequent tests see a normal default pair.
+    defaultPair.codex.off("ready", unrelatedHandler);
+    fns.attachPairHandlers(defaultPair);
+    expect(defaultPair.handlerRefs.length).toBe(baseline);
+  });
+
+  test("P2 lifecycle: destroyPair → ensurePair reattaches handlers (no event-deaf pair)", async () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    // Stub codex.start()/stop() so we don't spawn a real Codex app-server here.
+    const originalStart = defaultPair.codex.start.bind(defaultPair.codex);
+    const originalStop = defaultPair.codex.stop.bind(defaultPair.codex);
+    (defaultPair.codex as any).start = async () => {};
+    (defaultPair.codex as any).stop = () => {};
+
+    try {
+      defaultPair.isLive = true;
+      const baseline = defaultPair.handlerRefs.length;
+      expect(baseline).toBeGreaterThan(0);
+
+      await fns.destroyPair("default");
+      expect(defaultPair.isLive).toBe(false);
+      expect(defaultPair.handlerRefs.length).toBe(0);
+
+      await fns.ensurePair("default");
+      expect(defaultPair.isLive).toBe(true);
+      // Handlers reattached — pair is no longer event-deaf.
+      expect(defaultPair.handlerRefs.length).toBe(baseline);
+    } finally {
+      (defaultPair.codex as any).start = originalStart;
+      (defaultPair.codex as any).stop = originalStop;
+    }
+  });
+
+  test("P2 lifecycle: codex exit clears pair.isLive so a future ensurePair re-spawns (Codex P2 review finding HIGH#2)", async () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    const originalStart = defaultPair.codex.start.bind(defaultPair.codex);
+    (defaultPair.codex as any).start = async () => {};
+
+    try {
+      defaultPair.isLive = true;
+      // Simulate codex app-server crash.
+      defaultPair.codex.emit("exit", 137);
+      expect(defaultPair.isLive).toBe(false);
+
+      // ensurePair must now proceed past the early-return guard.
+      await fns.ensurePair("default");
+      expect(defaultPair.isLive).toBe(true);
+    } finally {
+      (defaultPair.codex as any).start = originalStart;
+    }
+  });
+
+  test("P2 lifecycle: ensurePair rejects non-default pairId in P2", async () => {
+    await expect(fns.ensurePair("work")).rejects.toThrow(/not yet supported in P2/);
+  });
+
   test("Bug B: transitionToIsolated exercises the retry loop and emits a definitive 'failed' message when all attempts fail", async () => {
     __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
 

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -655,6 +655,98 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     expect(result?.error).toBe("PAIR_BUSY");
   });
 
+  // ── P5a FIFO claim across pairs (spec §6.4) ──────────────────────────
+
+  test("P5a FIFO claim: Claude without explicit pairId claims first live unpaired pair (default if free)", async () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    defaultPair.isLive = true;
+    __testing.setProxyTuiSlot({
+      token: "t-default",
+      pairedChatId: null,
+      readiness: "ready",
+      attachedAt: Date.now(),
+      pairReapTimer: null,
+    });
+
+    const { ws, sent } = makeAttachMockWs(1);
+    await (fns as any).attachClaude(ws, "chat-fifo-1", undefined, "req-fifo-1");
+    const result = findResult(sent);
+    expect(result?.ok).toBe(true);
+    expect(result?.homePairId).toBe("default");
+    expect(result?.paired).toBe(true);
+
+    __testing.setProxyTuiSlot(null);
+    __testing.chats.delete("chat-fifo-1");
+  });
+
+  test("P5a FIFO claim: when default's slot is taken, second Claude claims next live unpaired pair", async () => {
+    const { CodexAdapter } = await import("../codex-adapter");
+    const originalStart = (CodexAdapter.prototype as any).start;
+    (CodexAdapter.prototype as any).start = async () => {};
+    try {
+      const defaultPair = __testing.pairs.get("default")!;
+      defaultPair.isLive = true;
+      __testing.setProxyTuiSlot({
+        token: "t-default",
+        pairedChatId: "existing-chat-on-default",
+        readiness: "ready",
+        attachedAt: Date.now(),
+        pairReapTimer: null,
+      });
+
+      await fns.ensurePair("fifo-work");
+      const workPair = __testing.pairs.get("fifo-work")!;
+      workPair.proxyTuiSlot = {
+        token: "t-work",
+        pairedChatId: null,
+        readiness: "ready",
+        attachedAt: Date.now(),
+        pairReapTimer: null,
+      };
+
+      const { ws, sent } = makeAttachMockWs(2);
+      await (fns as any).attachClaude(ws, "chat-fifo-2", undefined, "req-fifo-2");
+      const result = findResult(sent);
+      expect(result?.ok).toBe(true);
+      expect(result?.homePairId).toBe("fifo-work");
+      expect(result?.paired).toBe(true);
+    } finally {
+      (CodexAdapter.prototype as any).start = originalStart;
+      __testing.setProxyTuiSlot(null);
+      __testing.chats.delete("chat-fifo-2");
+      const pair = __testing.pairs.get("fifo-work");
+      if (pair) {
+        try { fns.detachPairHandlers(pair); } catch {}
+        __testing.pairs.delete("fifo-work");
+      }
+      await __testing.runUnderRegistryMutex(async () => {
+        __testing.pairRegistry.remove("fifo-work");
+        __testing.pairRegistry.save();
+      });
+    }
+  });
+
+  test("P5a FIFO claim: no live pair with slot → falls through to isolated bootstrap", async () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    defaultPair.isLive = true;
+    __testing.setProxyTuiSlot(null);
+
+    const { ClaudeThread } = await import("../claude-thread");
+    const originalBootstrap = (ClaudeThread.prototype as any).bootstrap;
+    (ClaudeThread.prototype as any).bootstrap = async () => "stub-thread-id";
+    try {
+      const { ws, sent } = makeAttachMockWs(3);
+      await (fns as any).attachClaude(ws, "chat-fifo-3", undefined, "req-fifo-3");
+      const result = findResult(sent);
+      expect(result?.ok).toBe(true);
+      expect(result?.paired).toBe(false);
+      expect(result?.homePairId).toBe("default");
+    } finally {
+      (ClaudeThread.prototype as any).bootstrap = originalBootstrap;
+      __testing.chats.delete("chat-fifo-3");
+    }
+  });
+
   test("P3-cleanup claude_connect: ok=true with paired claim on explicit live+unpaired pair", async () => {
     const defaultPair = __testing.pairs.get("default")!;
     defaultPair.isLive = true;

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -1169,3 +1169,52 @@ describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
     expect(chat.pairedTurnSawAgentMessage).toBe(true);
   });
 });
+
+// ── Bug regression E (2026-05-17 EPIPE infinite loop) ─────────────────
+
+describe("daemon log() EPIPE handling (Bug regression E 2026-05-17)", () => {
+  // Historical incident: daemon was launched as `bun daemon.js | head -40 &`
+  // — head closed its stdin after 40 lines, breaking the daemon's stdout/
+  // stderr pipe. Any subsequent log() call hit `process.stderr.write()`
+  // which threw EPIPE; the uncaughtException handler caught it and called
+  // log() again, which threw EPIPE again. Loop wrote 8.5 GB of log to disk
+  // before user noticed.
+  //
+  // Fix: sticky `stderrBroken` flag + try/catch around stderr.write. Once
+  // EPIPE seen, stop attempting stderr forever; file logger keeps recording.
+
+  test("log() does not throw when stderr.write throws EPIPE; subsequent calls skip stderr", () => {
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    let stderrCallCount = 0;
+    process.stderr.write = ((..._args: any[]) => {
+      stderrCallCount++;
+      const err: any = new Error("write EPIPE");
+      err.code = "EPIPE";
+      throw err;
+    }) as any;
+
+    try {
+      // First call: stderr.write throws EPIPE, log() catches it, sets
+      // sticky flag, file write still happens (no observable error).
+      expect(() => (fns as any).log("first call after pipe broke")).not.toThrow();
+      expect(stderrCallCount).toBe(1);
+
+      // 10 more calls: stderrBroken=true → log() skips stderr entirely.
+      // Count must NOT grow. This is the loop-prevention contract.
+      for (let i = 0; i < 10; i++) {
+        expect(() => (fns as any).log(`subsequent ${i}`)).not.toThrow();
+      }
+      expect(stderrCallCount).toBe(1);
+
+      // Simulate the historical loop trigger: an uncaughtException handler
+      // that calls log() with the err message. Before fix this re-entered
+      // stderr.write → re-threw → uncaughtException → log() → ∞. With fix,
+      // the handler runs and returns cleanly.
+      const fakeErr = new Error("simulated uncaught");
+      expect(() => (fns as any).log(`UNCAUGHT EXCEPTION: ${fakeErr.stack}`)).not.toThrow();
+      expect(stderrCallCount).toBe(1);
+    } finally {
+      process.stderr.write = originalWrite as any;
+    }
+  });
+});

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -1218,3 +1218,81 @@ describe("daemon log() EPIPE handling (Bug regression E 2026-05-17)", () => {
     }
   });
 });
+
+// ── Issue #82 (2026-05-17): ClaudeThread WS close lifecycle handling ──
+//
+// Before fix: state.thread.on("close") only flipped state.ready=false.
+// On app-server crash the chat stayed in `chats` forever; subsequent
+// reply attempts hit "thread still provisioning" with no recovery path.
+//
+// After fix: close triggers system_thread_failed + reapChatState, which
+// closes the bridge WS with 1011 and removes the chat. Bridge auto-
+// reconnect runs the new-chat path with fresh bootstrap. Guarded by
+// `shuttingDown` (don't reap during daemon SIGTERM) and a stale-state
+// check (don't recursively reap when reapChatState itself triggered the
+// close event).
+
+describe("Issue #82 — ClaudeThread WS close lifecycle (2026-05-17)", () => {
+  test("unexpected close reaps the chat and emits system_thread_failed", () => {
+    const chat = fns.createChatState("chat-issue-82-reap");
+    chat.ready = true;
+    chats.set(chat.chatId, chat);
+    (fns as any).wireClaudeThreadEvents(chat);
+
+    // Sanity: chat is in registry before close.
+    expect(chats.has(chat.chatId)).toBe(true);
+
+    // Simulate app-server crash via ClaudeThread emitting "close".
+    chat.thread.emit("close");
+
+    // Chat was reaped → removed from registry.
+    expect(chats.has(chat.chatId)).toBe(false);
+    // ready was flipped (handler runs the assignment before the guard
+    // check, so even guarded paths still mark stale).
+    expect(chat.ready).toBe(false);
+    // system_thread_failed was buffered onto the chat (no live WS in
+    // this unit test, so emitToChat buffers).
+    const fail = chat.bufferedMessages.find((m) => m.id.startsWith("system_thread_failed_"));
+    expect(fail).toBeDefined();
+    expect(fail?.content ?? "").toMatch(/Lost connection to Codex app-server/);
+  });
+
+  test("close during shuttingDown does NOT reap (avoid teardown cascade noise)", () => {
+    const chat = fns.createChatState("chat-issue-82-shutdown");
+    chats.set(chat.chatId, chat);
+    (fns as any).wireClaudeThreadEvents(chat);
+
+    (fns as any).setShuttingDownForTest(true);
+    try {
+      chat.thread.emit("close");
+      // Chat NOT reaped — still in registry. shuttingDown short-circuits
+      // before reapChatState runs.
+      expect(chats.has(chat.chatId)).toBe(true);
+      // No system_thread_failed buffered (the emit happens after the
+      // shuttingDown guard).
+      const fail = chat.bufferedMessages.find((m) => m.id.startsWith("system_thread_failed_"));
+      expect(fail).toBeUndefined();
+    } finally {
+      (fns as any).setShuttingDownForTest(false);
+      __testing.chats.delete(chat.chatId);
+    }
+  });
+
+  test("close after reapChatState already removed chat does NOT recurse", () => {
+    const chat = fns.createChatState("chat-issue-82-recurse");
+    chats.set(chat.chatId, chat);
+    (fns as any).wireClaudeThreadEvents(chat);
+
+    // Pre-remove from chats — simulates the path where reapChatState
+    // already ran (e.g. it called state.thread.close() which is about to
+    // emit close on the now-stale handler).
+    chats.delete(chat.chatId);
+
+    const beforeBuffered = chat.bufferedMessages.length;
+
+    // Emitting close on the stale handler: guard catches `chats.get
+    // !== state` and returns. No recursive reap, no extra system message.
+    expect(() => chat.thread.emit("close")).not.toThrow();
+    expect(chat.bufferedMessages.length).toBe(beforeBuffered);
+  });
+});

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -1350,3 +1350,145 @@ describe("Issue #82 — ClaudeThread WS close lifecycle (2026-05-17)", () => {
     expect(chat.ready).toBe(true);
   });
 });
+
+// ── M01 probe bug regression (2026-05-17 paired-inject routing) ──────
+//
+// M01 multi-pair probe caught: paired-inject path in handleClaudeToCodex
+// was calling the module-level `codex` (default pair's CodexAdapter)
+// instead of looking up the chat's home-pair adapter. For a Claude
+// paired with the "work" pair, this attempted injection into the
+// default pair's TUI/thread (which had no active TUI), surfacing
+// "Cannot inject: no active thread" + "Shared Codex TUI is busy"
+// — multi-pair was actually broken for non-default paired Claudes.
+//
+// Fix: handleClaudeToCodex now reads pairs.get(state.homePairId)?.codex
+// and injects through THAT adapter. Plus surfaces a clear error if
+// the home pair vanished mid-flight.
+
+describe("M01 regression — paired-inject routes to homePair's CodexAdapter (2026-05-17)", () => {
+  test("paired chat with homePairId='work' injects into work's adapter, not default's", () => {
+    // Set up a fake "work" pair with a stubbed CodexAdapter that
+    // records its injectMessage calls. Default pair's codex also
+    // recorded so we can assert it was NOT touched.
+    const defaultPair = __testing.pairs.get("default")!;
+    const defaultCalls: string[] = [];
+    const workCalls: string[] = [];
+
+    // Stub default pair's injectMessage.
+    const defaultOriginalInject = defaultPair.codex.injectMessage.bind(defaultPair.codex);
+    (defaultPair.codex as any).injectMessage = (text: string) => {
+      defaultCalls.push(text);
+      return true;
+    };
+
+    // Build a fake "work" pair with its own stubbed CodexAdapter.
+    const fakeWorkCodex = {
+      injectMessage: (text: string) => { workCalls.push(text); return true; },
+    } as any;
+    const fakeWorkPair = {
+      pairId: "work",
+      codex: fakeWorkCodex,
+      tuiConnectionState: defaultPair.tuiConnectionState,
+      proxyTuiSlot: null,
+      handlerRefs: [],
+      isLive: true,
+    } as any;
+    __testing.pairs.set("work", fakeWorkPair);
+
+    // Create a paired chat homed on "work".
+    const chat = fns.createChatState("chat-m01-routing");
+    chat.paired = true;
+    chat.homePairId = "work";
+    chat.ready = true;  // bypass the "still provisioning" guard
+    chats.set(chat.chatId, chat);
+
+    // Minimal WS mock for handleClaudeToCodex result responses.
+    const sent: any[] = [];
+    const ws: any = {
+      send: (payload: string) => { sent.push(JSON.parse(payload)); return 1; },
+      data: { clientId: 99, attached: true, chatId: chat.chatId },
+      readyState: 1,
+      close: () => {},
+    };
+
+    try {
+      (fns as any).handleClaudeToCodex(ws, {
+        type: "claude_to_codex",
+        requestId: "req-m01-routing",
+        chatId: chat.chatId,
+        message: {
+          id: "msg-m01-routing",
+          source: "claude",
+          content: "test payload",
+          timestamp: Date.now(),
+        },
+      });
+
+      // Work's stubbed injectMessage should have been called exactly
+      // once with the chat's content. Default's must NOT have been
+      // called — that was the bug.
+      expect(workCalls.length).toBe(1);
+      expect(workCalls[0]).toContain("test payload");
+      expect(defaultCalls.length).toBe(0);
+
+      // claude_to_codex_result success=true since stubbed injectMessage
+      // returned true.
+      const result = sent.find((m) => m.type === "claude_to_codex_result");
+      expect(result?.success).toBe(true);
+    } finally {
+      (defaultPair.codex as any).injectMessage = defaultOriginalInject;
+      __testing.pairs.delete("work");
+      chats.delete(chat.chatId);
+    }
+  });
+
+  test("paired chat whose homePair is no longer live surfaces clean error (no injection)", () => {
+    const defaultPair = __testing.pairs.get("default")!;
+    const defaultCalls: string[] = [];
+    const defaultOriginalInject = defaultPair.codex.injectMessage.bind(defaultPair.codex);
+    (defaultPair.codex as any).injectMessage = (text: string) => {
+      defaultCalls.push(text);
+      return true;
+    };
+
+    const chat = fns.createChatState("chat-m01-gone-pair");
+    chat.paired = true;
+    chat.homePairId = "deleted-pair"; // never registered
+    chat.ready = true;  // bypass the "still provisioning" guard
+    chats.set(chat.chatId, chat);
+
+    const sent: any[] = [];
+    const ws: any = {
+      send: (payload: string) => { sent.push(JSON.parse(payload)); return 1; },
+      data: { clientId: 100, attached: true, chatId: chat.chatId },
+      readyState: 1,
+      close: () => {},
+    };
+
+    try {
+      (fns as any).handleClaudeToCodex(ws, {
+        type: "claude_to_codex",
+        requestId: "req-m01-gone",
+        chatId: chat.chatId,
+        message: {
+          id: "msg-m01-gone",
+          source: "claude",
+          content: "should not reach any adapter",
+          timestamp: Date.now(),
+        },
+      });
+
+      // No adapter should have been called.
+      expect(defaultCalls.length).toBe(0);
+      // Clean error surfaced with home-pair-not-live message (NOT the
+      // generic "Shared Codex TUI is busy" — that would be a silent
+      // wrong-pair injection symptom).
+      const result = sent.find((m) => m.type === "claude_to_codex_result");
+      expect(result?.success).toBe(false);
+      expect(result?.error ?? "").toMatch(/Home pair "deleted-pair" is no longer live/);
+    } finally {
+      (defaultPair.codex as any).injectMessage = defaultOriginalInject;
+      chats.delete(chat.chatId);
+    }
+  });
+});

--- a/src/unit-test/daemon.test.ts
+++ b/src/unit-test/daemon.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Unit tests for the daemon pairing state machine (spec v2.2 §9 / §5).
+ *
+ * The daemon module's top-level boot is gated by `import.meta.main`, so
+ * importing it from here does NOT spin up sockets, the Codex app-server,
+ * or any background processes. We drive the state machine through the
+ * `__testing` harness, emit events directly on the singleton CodexAdapter,
+ * and inspect each chat's `bufferedMessages` to verify what was emitted.
+ *
+ * Coverage:
+ *   §9 Pairing FIFO
+ *   §9 Grace window (AGENTBRIDGE_PAIR_REAP_MS)
+ *   §9 Race-protection (PAIR_RACE_MS=0 — no retroactive pairing)
+ *   §9 Isolation transition on TUI disconnect / thread/closed
+ *   Bug regression A (2026-05-16): no-output failure gated on replyRequired
+ *   Bug regression B (2026-05-16): bootstrap failure surfaces final error
+ *   Bug regression C (2026-05-16): errorItem sets pairedTurnSawAgentMessage
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test, beforeEach, afterAll } from "bun:test";
+import type { BridgeMessage } from "../types";
+
+// Test-only env overrides MUST be set before the daemon module loads,
+// because daemon.ts captures several constants (PAIR_REAP_MS, the isolated-
+// bootstrap retry knobs, IDLE_SHUTDOWN_MS, ...) at the top of the file.
+// Static ESM `import` statements are hoisted above module body code, so we
+// use a dynamic `await import()` here to guarantee env precedence.
+const testStateDir = mkdtempSync(join(tmpdir(), "agentbridge-daemon-test-"));
+process.env.AGENTBRIDGE_STATE_DIR = testStateDir;
+process.env.AGENTBRIDGE_PAIR_REAP_MS = "100";
+// MAX_ATTEMPTS=2 + RETRY_DELAY=5ms gives the retry test a real loop to
+// exercise (attempt 1 fails → emit retry → attempt 2 fails → emit final
+// failure + reap), and stays under 100ms total.
+process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_MAX_ATTEMPTS = "2";
+process.env.AGENTBRIDGE_ISOLATED_BOOTSTRAP_RETRY_DELAY_MS = "5";
+process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS = "60000";
+// Point the daemon at a deliberately unbound port so any ClaudeThread
+// bootstrap attempt in tests (e.g. via transitionToIsolated) fails fast
+// instead of accidentally connecting to a real Codex app-server that
+// happens to be running on the developer's machine.
+process.env.CODEX_WS_PORT = "24500";
+process.env.CODEX_PROXY_PORT = "24501";
+
+const daemonModule = await import("../daemon");
+const { __testing } = daemonModule;
+const { fns, codex, chats, config } = __testing;
+
+function makeSlot(opts: { pairedChatId?: string | null; readiness?: "not-ready" | "ready" } = {}) {
+  return {
+    token: "test-token-" + Math.random().toString(36).slice(2, 8),
+    pairedChatId: opts.pairedChatId ?? null,
+    readiness: opts.readiness ?? "ready" as const,
+    attachedAt: Date.now(),
+    pairReapTimer: null as ReturnType<typeof setTimeout> | null,
+  };
+}
+
+function attachFakeWs(chat: ReturnType<typeof fns.createChatState>) {
+  // Minimal WS shape sufficient for detachClaudeWs's guard / clientId log.
+  chat.ws = {
+    data: { clientId: 999, attached: true, chatId: chat.chatId },
+    readyState: 1, // OPEN
+    send: () => 0,
+    close: () => {},
+  } as any;
+}
+
+function findMessage(messages: BridgeMessage[], idPrefix: string): BridgeMessage | undefined {
+  return messages.find((m) => m.id.startsWith(idPrefix));
+}
+
+function findMessageContaining(messages: BridgeMessage[], needle: string): BridgeMessage | undefined {
+  return messages.find((m) => m.content.includes(needle));
+}
+
+beforeEach(() => {
+  __testing.reset();
+});
+
+afterAll(() => {
+  __testing.reset();
+  rmSync(testStateDir, { recursive: true, force: true });
+});
+
+// ── §9 Pairing FIFO ─────────────────────────────────────────────
+
+describe("daemon pairing FIFO (spec v2.2 §5)", () => {
+  test("first attached Claude claims the slot, second stays isolated", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat1 = fns.createChatState("chat_one");
+    chats.set("chat_one", chat1);
+    fns.pairChat(chat1);
+
+    expect(chat1.paired).toBe(true);
+    expect(chat1.ready).toBe(true);
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBe("chat_one");
+
+    const chat2 = fns.createChatState("chat_two");
+    chats.set("chat_two", chat2);
+    fns.pairChat(chat2);
+
+    // Second pair attempt is rejected by the guard inside pairChat — slot
+    // stays with chat_one and chat_two never flips `paired`.
+    expect(chat2.paired).toBe(false);
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBe("chat_one");
+  });
+
+  test("pairChat is a no-op when proxyTuiSlot is null", () => {
+    const chat = fns.createChatState("chat_solo");
+    chats.set("chat_solo", chat);
+    fns.pairChat(chat);
+
+    expect(chat.paired).toBe(false);
+    expect(__testing.proxyTuiSlot).toBeNull();
+  });
+
+  test("pairing flips ready according to slot readiness (provisioning case)", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "not-ready" }));
+
+    const chat = fns.createChatState("chat_prov");
+    chats.set("chat_prov", chat);
+    fns.pairChat(chat);
+
+    expect(chat.paired).toBe(true);
+    expect(chat.ready).toBe(false); // waits for codex.on("ready") to flip it
+
+    const provisioningMsg = findMessage(chat.bufferedMessages, "system_paired_provisioning");
+    expect(provisioningMsg).toBeDefined();
+  });
+});
+
+// ── §9 Grace window ─────────────────────────────────────────────
+
+describe("daemon paired-Claude grace window (spec v2.2 §5)", () => {
+  test("pairReapTimer expires after PAIR_REAP_MS and clears the slot", async () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_g");
+    chats.set("chat_g", chat);
+    attachFakeWs(chat);
+    fns.pairChat(chat);
+
+    fns.detachClaudeWs(chat, "test detach");
+
+    expect(__testing.proxyTuiSlot?.pairReapTimer).not.toBeNull();
+
+    // Wait past the grace window — PAIR_REAP_MS is 100ms in test env.
+    await new Promise((r) => setTimeout(r, config.PAIR_REAP_MS + 80));
+
+    // Slot's pairedChatId cleared; orphaned chat state fully reaped.
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBeNull();
+    expect(chats.has("chat_g")).toBe(false);
+  });
+
+  test("reconnecting within grace cancels the reaper and preserves pair", async () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_grace_keep");
+    chats.set("chat_grace_keep", chat);
+    attachFakeWs(chat);
+    fns.pairChat(chat);
+
+    fns.detachClaudeWs(chat, "test detach");
+
+    // Reattach a WS before the grace expires (simulates same chatId
+    // reconnecting). The reaper's body checks `currentState.ws` and bails.
+    await new Promise((r) => setTimeout(r, 30));
+    attachFakeWs(chat);
+
+    // Wait past where the original reaper would have fired.
+    await new Promise((r) => setTimeout(r, config.PAIR_REAP_MS + 80));
+
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBe("chat_grace_keep");
+    expect(chats.has("chat_grace_keep")).toBe(true);
+  });
+});
+
+// ── §9 Race protection (PAIR_RACE_MS=0) ─────────────────────────
+
+describe("daemon race protection (spec v2.2 §5.1, PAIR_RACE_MS=0)", () => {
+  test("Claude-first stays isolated when TUI connects later (no retroactive pairing)", () => {
+    // Existing isolated chat — already provisioned before any TUI shows up.
+    const chat = fns.createChatState("chat_preexisting");
+    chat.ready = true; // pretend its own ClaudeThread bootstrap already finished
+    chats.set("chat_preexisting", chat);
+
+    expect(chat.paired).toBe(false);
+    expect(__testing.proxyTuiSlot).toBeNull();
+
+    // TUI connects, carrying a token (this is what makes it a proxy TUI).
+    codex.emit("tuiConnected", 1, "race-token-abc");
+
+    // Slot is allocated — but the existing chat is NOT retroactively paired.
+    expect(__testing.proxyTuiSlot).not.toBeNull();
+    expect(__testing.proxyTuiSlot?.pairedChatId).toBeNull();
+    expect(chat.paired).toBe(false);
+  });
+
+  test("tuiConnected with empty token does NOT allocate a proxy slot (legacy TUI)", () => {
+    expect(__testing.proxyTuiSlot).toBeNull();
+    codex.emit("tuiConnected", 1, "");
+    expect(__testing.proxyTuiSlot).toBeNull();
+  });
+});
+
+// ── §9 Isolation transition ─────────────────────────────────────
+
+describe("daemon isolation transition (spec v2.2 §5)", () => {
+  test("TUI disconnect tears down the slot and transitions paired chat to isolated", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_iso_tui");
+    chats.set("chat_iso_tui", chat);
+    fns.pairChat(chat);
+    expect(chat.paired).toBe(true);
+
+    // Capture bufferedMessages length BEFORE the transition so we can find
+    // the new system_pair_torn_down message specifically.
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("tuiDisconnected", 1);
+
+    expect(chat.paired).toBe(false);
+    expect(__testing.proxyTuiSlot).toBeNull();
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    const tornDown = findMessage(newMessages, "system_pair_torn_down");
+    expect(tornDown).toBeDefined();
+    expect(tornDown!.content).toContain("Shared Codex TUI thread is gone");
+  });
+
+  test("thread/closed notification triggers same isolation transition", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_iso_tc");
+    chats.set("chat_iso_tc", chat);
+    fns.pairChat(chat);
+    expect(chat.paired).toBe(true);
+
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("threadClosed", { threadId: "tid-xyz" });
+
+    expect(chat.paired).toBe(false);
+    expect(__testing.proxyTuiSlot).toBeNull();
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    const tornDown = findMessage(newMessages, "system_pair_torn_down");
+    expect(tornDown).toBeDefined();
+    expect(tornDown!.content).toContain("Shared Codex thread closed");
+  });
+});
+
+// ── Bug regressions ─────────────────────────────────────────────
+
+describe("daemon bug regressions (2026-05-16 STM v2.2 review)", () => {
+  test("Bug A: turn/completed with no agentMessage does NOT emit no-output failure when replyRequired=false", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_a");
+    chats.set("chat_bug_a", chat);
+    fns.pairChat(chat);
+
+    // User typed in TUI scenario — replyRequired stayed false, no agentMessage.
+    chat.replyRequired = false;
+    chat.pairedTurnSawAgentMessage = false;
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("turnCompleted");
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    expect(findMessage(newMessages, "system_codex_turn_completed_no_output")).toBeUndefined();
+    expect(findMessage(newMessages, "system_codex_turn_completed")).toBeDefined();
+  });
+
+  test("Bug A: no-output failure IS emitted when replyRequired=true (Claude waiting for reply)", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_a_pos");
+    chats.set("chat_bug_a_pos", chat);
+    fns.pairChat(chat);
+
+    chat.replyRequired = true;
+    chat.pairedTurnSawAgentMessage = false;
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("turnCompleted");
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    const failure = findMessage(newMessages, "system_codex_turn_completed_no_output");
+    expect(failure).toBeDefined();
+    // Cleanup flags are reset at end of handler.
+    expect(chat.replyRequired).toBe(false);
+    expect(chat.replyReceivedDuringTurn).toBe(false);
+  });
+
+  test("Bug C: errorItem sets pairedTurnSawAgentMessage so subsequent turn/completed does NOT fire spurious failure", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_c");
+    chats.set("chat_bug_c", chat);
+    fns.pairChat(chat);
+
+    // Simulate: Claude was waiting for reply, error arrives, then turn ends.
+    chat.replyRequired = true;
+    chat.pairedTurnSawAgentMessage = false;
+    const beforeCount = chat.bufferedMessages.length;
+
+    codex.emit("errorItem", { code: -32601, message: "Method not found" });
+
+    expect(chat.pairedTurnSawAgentMessage).toBe(true);
+    expect(chat.replyRequired).toBe(false);
+
+    const afterErrorCount = chat.bufferedMessages.length;
+    const errMsg = findMessageContaining(
+      chat.bufferedMessages.slice(beforeCount),
+      "Method not found",
+    );
+    expect(errMsg).toBeDefined();
+
+    // Now turn/completed fires after the error. Should NOT emit a second
+    // failure system message — Claude already heard the error.
+    codex.emit("turnCompleted");
+    const newMessages = chat.bufferedMessages.slice(afterErrorCount);
+    expect(findMessage(newMessages, "system_codex_turn_completed_no_output")).toBeUndefined();
+    expect(findMessage(newMessages, "system_codex_turn_completed")).toBeDefined();
+  });
+
+  test("Bug B: bootstrap retry config is wired in via env", () => {
+    // Smoke test for the retry plumbing — verify env-driven knobs landed.
+    expect(config.ISOLATED_BOOTSTRAP_MAX_ATTEMPTS).toBe(2);
+    expect(config.ISOLATED_BOOTSTRAP_RETRY_DELAY_MS).toBe(5);
+  });
+
+  test("Bug B: transitionToIsolated exercises the retry loop and emits a definitive 'failed' message when all attempts fail", async () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_b");
+    chats.set("chat_bug_b", chat);
+    fns.pairChat(chat);
+
+    const beforeCount = chat.bufferedMessages.length;
+
+    // Trigger transition. The ClaudeThread it constructs will try to
+    // bootstrap against ws://127.0.0.1:24500 (unbound), so each bootstrap
+    // attempt rejects. With MAX_ATTEMPTS=2 + RETRY_DELAY=5ms we should see
+    // attempt 1 → emit retry → attempt 2 → emit final failure + reap.
+    fns.transitionToIsolated(chat, "test reason");
+
+    await new Promise((r) => setTimeout(r, 400));
+
+    const newMessages = chat.bufferedMessages.slice(beforeCount);
+    const retryMsg = findMessage(newMessages, "system_isolated_retry");
+    expect(retryMsg).toBeDefined();
+    expect(retryMsg!.content).toContain("(attempt 1/2)");
+
+    const failed = findMessage(newMessages, "system_isolated_failed");
+    expect(failed).toBeDefined();
+    expect(failed!.content).toContain("after 2 attempts");
+    expect(failed!.content).toContain("reconnect Claude");
+  });
+
+  test("Bug B (Codex review): final failure REAPS the chat so subsequent attach gets a fresh bootstrap", async () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bug_b_reap");
+    chats.set("chat_bug_b_reap", chat);
+    fns.pairChat(chat);
+
+    expect(chats.has("chat_bug_b_reap")).toBe(true);
+
+    fns.transitionToIsolated(chat, "test reason");
+
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Without this Codex-review fix, the chat stays in the map and the
+    // "reconnect Claude" guidance is a lie because attachClaude takes the
+    // resume branch and never re-bootstraps.
+    expect(chats.has("chat_bug_b_reap")).toBe(false);
+  });
+
+  test("Codex review #2: transitionToIsolated clears stale paired-turn flags so they don't bleed into isolated thread", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_bleed");
+    chats.set("chat_bleed", chat);
+    fns.pairChat(chat);
+
+    // Mid-turn state when TUI disconnects.
+    chat.replyRequired = true;
+    chat.replyReceivedDuringTurn = true;
+    chat.pairedTurnSawAgentMessage = true;
+
+    fns.transitionToIsolated(chat, "test reason");
+
+    // After transition the flags are reset so the fresh isolated thread
+    // does not inherit a stale "Claude is waiting for a reply" state.
+    expect(chat.replyRequired).toBe(false);
+    expect(chat.replyReceivedDuringTurn).toBe(false);
+    expect(chat.pairedTurnSawAgentMessage).toBe(false);
+  });
+
+  test("Codex review #3: errorItem clears replyReceivedDuringTurn (symmetric with turnCompleted)", () => {
+    __testing.setProxyTuiSlot(makeSlot({ readiness: "ready" }));
+
+    const chat = fns.createChatState("chat_err_sym");
+    chats.set("chat_err_sym", chat);
+    fns.pairChat(chat);
+
+    chat.replyRequired = true;
+    chat.replyReceivedDuringTurn = false;
+
+    codex.emit("errorItem", { code: -32000, message: "test error" });
+
+    // turnCompleted-style cleanup: both flags reset, plus
+    // pairedTurnSawAgentMessage tracked so a follow-on turnCompleted
+    // does not fire spurious no-output failure.
+    expect(chat.replyRequired).toBe(false);
+    expect(chat.replyReceivedDuringTurn).toBe(false);
+    expect(chat.pairedTurnSawAgentMessage).toBe(true);
+  });
+});

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for `PairRegistry` (STM v2.3 §D2 P3).
+ *
+ * Covers: D1 pair-name validation, atomic save (temp+rename), allocation
+ * for default + named pairs, MAX_PAIRS + ALLOCATION_FAILED edge cases,
+ * registry round-trip across load(), invalid-entry filtering.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PairRegistry, isValidPairName, DEFAULT_PAIR_PORTS } from "../pair-registry";
+
+describe("isValidPairName (spec v2.3 D1)", () => {
+  test("accepts lowercase alphanumeric + underscore + hyphen", () => {
+    for (const name of ["default", "work", "side", "a", "abc-123", "x_y_z", "1pair", "p9_3-a"]) {
+      expect(isValidPairName(name)).toBe(true);
+    }
+  });
+
+  test("rejects names that violate the D1 contract", () => {
+    const bad = [
+      "",            // empty
+      "_starts-underscore",  // first char must be alphanumeric
+      "-starts-hyphen",
+      "UPPER",       // uppercase
+      "MixedCase",
+      "has space",
+      "has/slash",
+      "has\\back",
+      ".",
+      "..",
+      "..hidden",
+      "has.dot",
+      "a".repeat(33), // 33 chars — over the 32-char cap
+    ];
+    for (const name of bad) {
+      expect(isValidPairName(name)).toBe(false);
+    }
+  });
+
+  test("rejects non-string inputs", () => {
+    expect(isValidPairName(undefined as any)).toBe(false);
+    expect(isValidPairName(null as any)).toBe(false);
+    expect(isValidPairName(123 as any)).toBe(false);
+  });
+});
+
+describe("PairRegistry", () => {
+  let tempDir: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "agentbridge-pair-registry-test-"));
+    logs = [];
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function makeRegistry(overrides: { strideStep?: number; strideMax?: number; maxPairs?: number } = {}) {
+    return new PairRegistry({
+      filePath: join(tempDir, "pairs", "registry.json"),
+      log: (msg) => logs.push(msg),
+      ...overrides,
+    });
+  }
+
+  test("starts empty when no file exists", () => {
+    const reg = makeRegistry();
+    reg.load();
+    expect(reg.size()).toBe(0);
+    expect(reg.get("anything")).toBeNull();
+  });
+
+  test("default pair allocates to (4500, 4501)", () => {
+    const reg = makeRegistry();
+    const result = reg.allocate("default");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.entry.pairId).toBe("default");
+      expect(result.entry.appPort).toBe(DEFAULT_PAIR_PORTS.appPort);
+      expect(result.entry.proxyPort).toBe(DEFAULT_PAIR_PORTS.proxyPort);
+    }
+  });
+
+  test("named pairs allocate from the stride table", () => {
+    const reg = makeRegistry();
+    reg.allocate("default"); // 4500/4501
+
+    const r1 = reg.allocate("work");
+    expect(r1.ok).toBe(true);
+    if (r1.ok) {
+      expect(r1.entry.appPort).toBe(4510);
+      expect(r1.entry.proxyPort).toBe(4511);
+    }
+
+    const r2 = reg.allocate("side");
+    expect(r2.ok).toBe(true);
+    if (r2.ok) {
+      expect(r2.entry.appPort).toBe(4520);
+      expect(r2.entry.proxyPort).toBe(4521);
+    }
+  });
+
+  test("allocate returns existing entry on duplicate (idempotent)", () => {
+    const reg = makeRegistry();
+    const first = reg.allocate("work");
+    expect(first.ok).toBe(true);
+    const second = reg.allocate("work");
+    expect(second.ok).toBe(true);
+    if (first.ok && second.ok) {
+      expect(second.entry).toEqual(first.entry);
+    }
+  });
+
+  test("INVALID_PAIR_NAME for bad names", () => {
+    const reg = makeRegistry();
+    const result = reg.allocate("Has Space");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_PAIR_NAME");
+    }
+  });
+
+  test("MAX_PAIRS fires when registry is at the limit", () => {
+    const reg = makeRegistry({ maxPairs: 2 });
+    expect(reg.allocate("default").ok).toBe(true);
+    expect(reg.allocate("work").ok).toBe(true);
+    const third = reg.allocate("side");
+    expect(third.ok).toBe(false);
+    if (!third.ok) {
+      expect(third.error.code).toBe("MAX_PAIRS");
+    }
+  });
+
+  test("ALLOCATION_FAILED when stride range is exhausted", () => {
+    const reg = makeRegistry({ strideMax: 1 });
+    // 1 stride slot available; default doesn't consume it (fixed at 4500/4501).
+    expect(reg.allocate("default").ok).toBe(true);
+    expect(reg.allocate("work").ok).toBe(true);  // consumes 4510/4511
+    const second = reg.allocate("side");
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.error.code).toBe("ALLOCATION_FAILED");
+    }
+  });
+
+  test("save() creates the file atomically (temp file is gone afterwards)", () => {
+    const reg = makeRegistry();
+    reg.allocate("default");
+    reg.allocate("work");
+    reg.save();
+
+    expect(existsSync(join(tempDir, "pairs", "registry.json"))).toBe(true);
+    // No leftover temp files in the pairs/ dir.
+    const leftoverTmps = readdirSync(join(tempDir, "pairs"))
+      .filter((f) => f.includes(".tmp."));
+    expect(leftoverTmps).toEqual([]);
+  });
+
+  test("load() round-trips a saved registry", () => {
+    const reg1 = makeRegistry();
+    reg1.allocate("default");
+    const work = reg1.allocate("work");
+    reg1.save();
+
+    const reg2 = makeRegistry();
+    reg2.load();
+    expect(reg2.size()).toBe(2);
+    expect(reg2.get("default")?.appPort).toBe(DEFAULT_PAIR_PORTS.appPort);
+    if (work.ok) {
+      expect(reg2.get("work")?.appPort).toBe(work.entry.appPort);
+    }
+  });
+
+  test("load() filters invalid entries with a warning, keeps valid ones", () => {
+    const filePath = join(tempDir, "pairs", "registry.json");
+    const dir = join(tempDir, "pairs");
+    require("node:fs").mkdirSync(dir, { recursive: true });
+    writeFileSync(filePath, JSON.stringify({
+      version: 1,
+      entries: [
+        { pairId: "default", appPort: 4500, proxyPort: 4501, allocatedAt: 1 },
+        { pairId: "BAD CASE", appPort: 4510, proxyPort: 4511, allocatedAt: 1 },  // invalid name
+        { pairId: "work", appPort: "not-a-port", proxyPort: 4521, allocatedAt: 1 },  // invalid port
+        { pairId: "side", appPort: 4520, proxyPort: 4521, allocatedAt: 1 },
+      ],
+    }), "utf8");
+
+    const reg = makeRegistry();
+    reg.load();
+    expect(reg.size()).toBe(2);
+    expect(reg.get("default")).not.toBeNull();
+    expect(reg.get("side")).not.toBeNull();
+    expect(reg.get("BAD CASE")).toBeNull();
+    expect(reg.get("work")).toBeNull();
+    // Verify drop messages went to log.
+    expect(logs.filter((l) => l.includes("dropping invalid entry")).length).toBe(2);
+  });
+
+  test("load() handles malformed JSON gracefully", () => {
+    const filePath = join(tempDir, "pairs", "registry.json");
+    const dir = join(tempDir, "pairs");
+    require("node:fs").mkdirSync(dir, { recursive: true });
+    writeFileSync(filePath, "{not valid json", "utf8");
+
+    const reg = makeRegistry();
+    reg.load();
+    expect(reg.size()).toBe(0);
+    expect(logs.some((l) => l.includes("invalid JSON"))).toBe(true);
+  });
+
+  test("load() handles missing version field", () => {
+    const filePath = join(tempDir, "pairs", "registry.json");
+    const dir = join(tempDir, "pairs");
+    require("node:fs").mkdirSync(dir, { recursive: true });
+    writeFileSync(filePath, JSON.stringify({ entries: [] }), "utf8");
+
+    const reg = makeRegistry();
+    reg.load();
+    expect(reg.size()).toBe(0);
+    expect(logs.some((l) => l.includes("unexpected registry shape"))).toBe(true);
+  });
+
+  test("remove() takes an entry out of the registry", () => {
+    const reg = makeRegistry();
+    reg.allocate("work");
+    expect(reg.has("work")).toBe(true);
+    expect(reg.remove("work")).toBe(true);
+    expect(reg.has("work")).toBe(false);
+    expect(reg.remove("work")).toBe(false); // idempotent
+  });
+
+  test("allocation reuses ports freed by remove()", () => {
+    const reg = makeRegistry();
+    const first = reg.allocate("work");
+    expect(first.ok).toBe(true);
+    reg.remove("work");
+    const second = reg.allocate("work");
+    expect(second.ok).toBe(true);
+    if (first.ok && second.ok) {
+      // Same name re-allocated → same ports.
+      expect(second.entry.appPort).toBe(first.entry.appPort);
+    }
+  });
+
+  test("named-pair stride skips the default-pair ports even when default is absent", () => {
+    const reg = makeRegistry();
+    // No default allocated yet. First named pair must still avoid 4500/4501.
+    const r = reg.allocate("solo");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.entry.appPort).toBe(4510);
+      expect(r.entry.proxyPort).toBe(4511);
+    }
+  });
+
+  test("list() returns entries in insertion order", () => {
+    const reg = makeRegistry();
+    reg.allocate("default");
+    reg.allocate("work");
+    reg.allocate("side");
+    const list = reg.list();
+    expect(list.map((e) => e.pairId)).toEqual(["default", "work", "side"]);
+  });
+});

--- a/src/unit-test/state-dir.test.ts
+++ b/src/unit-test/state-dir.test.ts
@@ -53,4 +53,36 @@ describe("StateDirResolver", () => {
     const resolver = new StateDirResolver();
     expect(resolver.dir.length).toBeGreaterThan(0);
   });
+
+  // ── STM v2.3 §D5 P3d — per-pair file path methods ─────────────────────
+
+  test("pairDir returns <stateDir>/pairs/<pairId>", () => {
+    const resolver = new StateDirResolver(tempDir);
+    expect(resolver.pairDir("default")).toBe(join(tempDir, "pairs", "default"));
+    expect(resolver.pairDir("work")).toBe(join(tempDir, "pairs", "work"));
+  });
+
+  test("pairCodexPidFile returns <stateDir>/pairs/<pairId>/codex.pid", () => {
+    const resolver = new StateDirResolver(tempDir);
+    expect(resolver.pairCodexPidFile("default")).toBe(join(tempDir, "pairs", "default", "codex.pid"));
+    expect(resolver.pairCodexPidFile("work")).toBe(join(tempDir, "pairs", "work", "codex.pid"));
+  });
+
+  test("pairCodexWrapperLogFile returns <stateDir>/pairs/<pairId>/codex-wrapper.log", () => {
+    const resolver = new StateDirResolver(tempDir);
+    expect(resolver.pairCodexWrapperLogFile("default")).toBe(
+      join(tempDir, "pairs", "default", "codex-wrapper.log"),
+    );
+  });
+
+  test("ensurePairDir creates the per-pair subdir, idempotent", () => {
+    const resolver = new StateDirResolver(tempDir);
+    resolver.ensure();
+    resolver.ensurePairDir("default");
+    resolver.ensurePairDir("default"); // idempotent
+
+    const { writeFileSync, existsSync } = require("node:fs");
+    writeFileSync(join(resolver.pairDir("default"), "marker"), "ok");
+    expect(existsSync(join(resolver.pairDir("default"), "marker"))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

STM v2.3 vertical upgrade: multi-pair support for parallel `abg codex --pair NAME --via-proxy` instances, end-to-end (spec → P1 plumbing → P2 handlers → P3 control protocol → P4 CLI → P5 UX/probes), plus perf P0+P1 and the chatId-drift bootstrap-reap hotfix that triggered at runtime during validation.

**This PR supersedes #80 in scope** — #80's `feat/multi-claude-routing` covers commits `8dc2cb8`/`6a81e38`/etc. which are also at the base of `feat/v2.3`. Recommend closing #80 once this lands (or rebasing #80 onto whatever's left after v2.3 merges).

STM v2.3 多 pair 垂直升级：支持 `abg codex --pair NAME --via-proxy` 并行多实例的完整链路（spec → P1 底层 → P2 handlers → P3 控制协议 → P4 CLI → P5 UX/probes），加上 perf P0+P1 优化、以及验证期实测命中的 chatId-drift bootstrap-reap 热修复。

## 高层改动 / High-level changes

- **STM v2.2** (`f84346e`, `54e806e`)：paired-TUI shared-thread mode 落地
- **STM v2.3 spec** (`b341186`, `6eb2f22`, `93c42dc`)：v0.4 spec + Codex review fixes
- **P1 plumbing** (`826bbd5`, `7b8fdf3`)：`PairState` + `pairs Map`，`CodexAdapter` options ctor
- **P2 handlers** (`95b1e4b`, `32588f4`)：pair-aware event handlers + `ensurePair`/`destroyPair` 内部 API
- **P3 control protocol** (`dba86b9`, `2c00246`, `6faf4b1`, `6461642`, `b9c8fce`, `cd5a58e`, `82da955`)：control protocol shape + pair registry + write mutex + helpers pair-aware + per-pair state-dir
- **P4 CLI** (`5ec62f8`, `9b0d328`, `427fe43`, `7478431`, `aa2b71f`, `a99665e`, `638ce19`)：`abg codex --pair`/`abg claude --pair`/`abg pairs ls`/`abg pairs rm` + per-pair pid/log + kill walker
- **P5 UX & probes** (`3d27f3e`, `5d45b97`, `51375bc`)：FIFO pair claim, `[pair: NAME]` UX prefix, `PAIR_PORTS_BUSY.conflictPid`, multi-pair probe specs
- **Perf** (`83b8e03`)：P0 async file logger (替换 `appendFileSync`) + P1 proxy frame log gate (`AGENTBRIDGE_DEBUG_PROXY=1`)
- **Bootstrap-reap fix** (`18f60d8`, `f1a7338`)：daemon 重启 race 下 ClaudeThread bootstrap 失败时 reap 半初始化 chat，让 bridge 重连能 fresh bootstrap

## 数据 / Stats
- 32 commits, +11,186 / -848 lines, 49 files
- 301 tests pass (was 219)
- typecheck clean
- bilingual commits (中文 + English)
- multi-pair probe specs (M01-M12) frozen at `probes/multi-pair/README.md`

## Cross-review

每个 phase 由 Codex 独立审阅；总共 ~17 轮 cross-review GO，所有 HIGH/MEDIUM 回归到位。最后两个 commit (`18f60d8` / `f1a7338`) 实测命中并修复了 daemon-restart 下的 startup-race，Codex 审阅 GO + 提出 test hardening 全部应用。

Cross-reviewed by Codex through each phase boundary (~17 review rounds, all HIGH/MEDIUM addressed). Final bootstrap-reap fix triggered at runtime during validation; Codex reviewed and signed off with test-hardening recommendations now applied.

## Adjacent risk follow-up
- `app-server exit closes ClaudeThread sessions and sets ready=false without rebootstrap/reap` — separate ticket (see linked issue).

## Test plan
- [ ] Reviewer runs `bun run check` (typecheck + 301 tests + plugin sync)
- [ ] `bun run build:plugin` produces clean `plugins/agentbridge/server/*.js`
- [ ] Manual: `abg codex --via-proxy` (terminal 1) + `abg codex --pair work --via-proxy` (terminal 2) + `abg claude --pair work` (terminal 3) — second TUI's chat routes to "work" pair, isolated from default
- [ ] Manual: `abg pairs ls` shows both pairs with `LIVE ●`
- [ ] Manual: kill one pair's codex (`kill -9 <pid from codex.pid>`) — other pair survives, `abg pairs ls` shows `LIVE ○` for killed one
- [ ] Run M01-M12 probes from `probes/multi-pair/README.md` (specs frozen; harness pending separately)

**Merge mode**: squash merge per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)