### PR TITLE
test: fix port precheck LISTEN filter test 100% timing out on Linux CI / 修复 port precheck 测试在 Linux CI 上 100% 超时

### DIFF
--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { createServer, Socket, type Server } from "node:net";
+import { createServer, Socket, type AddressInfo, type Server } from "node:net";
 import { CodexAdapter } from "../codex-adapter";
 
 function createAdapter() {
@@ -1081,13 +1081,14 @@ describe("CodexAdapter port precheck — LISTEN-only filter", () => {
   });
 
   test("LISTEN filter ignores stale outbound FDs after listener dies", async () => {
-    const port = 40000 + Math.floor(Math.random() * 10000);
-
+    // Use port 0 so the OS picks a guaranteed-free port — random 40000-50000
+    // can collide on shared CI runners, causing s.listen() to error.
     const server: Server = await new Promise((resolve, reject) => {
       const s = createServer();
       s.once("error", reject);
-      s.listen(port, "127.0.0.1", () => resolve(s));
+      s.listen(0, "127.0.0.1", () => resolve(s));
     });
+    const port = (server.address() as AddressInfo).port;
 
     const client: Socket = await new Promise((resolve, reject) => {
       const c = new Socket();
@@ -1100,8 +1101,16 @@ describe("CodexAdapter port precheck — LISTEN-only filter", () => {
       const withListener = runLsof(CodexAdapter.buildPortListenLsofCommand(port).slice(5));
       expect(withListener).toContain(String(process.pid));
 
-      // Close the listener; the established outbound client FD lingers in this process.
-      await new Promise<void>((r) => server.close(() => r()));
+      // Stop accepting new connections. We intentionally do NOT await the
+      // close callback — that callback only fires when ALL existing
+      // connections drain, but the whole point of this test is to keep the
+      // client connection open so a stale outbound FD lingers. The listener
+      // itself is released synchronously; setImmediate yields once so the
+      // close syscall lands before we run lsof. (Previously we awaited the
+      // callback, which hung forever on Bun/Linux and passed only by event-
+      // loop accident on Bun/macOS.)
+      server.close();
+      await new Promise((r) => setImmediate(r));
 
       // OLD impl `lsof -ti :PORT` (no LISTEN filter) would still find this process
       // via the lingering outbound FD — the false positive that broke `abg claude`.


### PR DESCRIPTION
## Summary

A test in `src/unit-test/codex-adapter.test.ts` (`CodexAdapter port precheck — LISTEN-only filter > LISTEN filter ignores stale outbound FDs after listener dies`) is currently **deterministically failing** on Bun/Linux CI but passing on Bun/macOS locally. This blocks #72 and #73 CI even though neither PR touches this code.

master HEAD's most recent CI run (commit `4801942`, 2026-05-14) also failed at the same test — so this is not introduced by either in-flight PR.

## Root cause

```ts
await new Promise<void>((r) => server.close(() => r()));
```

`net.Server.close(cb)` only invokes the callback **after all existing connections drain**. The test intentionally keeps the `client` connection open to simulate a stale outbound FD lingering after the listener dies. On Linux Bun, that callback never fires → the test hits its 5 s timeout. On macOS Bun, an event-loop quirk fires the callback anyway, so the test passes by accident.

## Fix (test-only, no production code changed)

- Use `port 0` + `server.address().port` instead of `40000 + random(10000)` so the OS picks a guaranteed-free port (eliminates collision risk on shared runners).
- Replace `await new Promise(r => server.close(() => r()))` with `server.close(); await new Promise(r => setImmediate(r))`. `server.close()` synchronously stops accepting new connections; `setImmediate` yields one event-loop tick so the close syscall lands before `lsof` runs. We deliberately do NOT wait for the connection-drain callback because the test intentionally keeps the client connected.

## Test plan

- [x] `bun run typecheck` — clean
- [x] 20 consecutive local runs of just this test — 20/20 pass
- [x] `bun test src` full suite — 219/219 pass
- [ ] CI green
- [ ] After merge: re-run CI on #72 and #73 (with this fix cherry-picked or merged in)