### PR TITLE
feat: 单机多对 Claude+Codex 并行 (Route A, shared-nothing) / single-machine multi-pair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,9 @@ jobs:
 
       - name: Run full check
         run: bun run check
+
+      - name: Release smoke (built CLI artifacts)
+        run: bun run smoke:built
+
+      - name: Release smoke (npm pack completeness)
+        run: bun run smoke:pack

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Build
         run: bun run prepublishOnly
 
+      - name: Release smoke (built CLI artifacts) — blocks publish if the package can't start a daemon
+        # --skip-build: reuse the exact dist/ from the Build step above (the bytes
+        # that will be published) instead of rebuilding.
+        run: bun scripts/smoke-built-cli.mjs --skip-build
+
+      - name: Release smoke (npm pack completeness) — blocks publish if a shipped artifact is missing
+        run: bun run smoke:pack
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ agentbridge-context.md
 V1_PROGRESS.md
 # Added by code-review-graph
 .code-review-graph/
+
+# Runtime E2E artifacts and python cache
+artifacts/
+__pycache__/

--- a/docs/multi-pair-guide.html
+++ b/docs/multi-pair-guide.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AgentBridge · 单机多对 Claude+Codex / Single-Machine Multi-Pair</title>
+<style>
+  :root {
+    color-scheme: dark light;
+    --bg:        #0d1117;
+    --bg-elev:   #161b22;
+    --bg-elev-2: #1c2230;
+    --border:    #2a313c;
+    --border-2:  #353d4a;
+    --fg:        #e6edf3;
+    --fg-muted:  #9aa7b5;
+    --fg-dim:    #6e7b8a;
+    --accent:    #58a6ff;
+    --accent-2:  #7ee787;
+    --accent-3:  #d2a8ff;
+    --warn-bg:   #2b2113;
+    --warn-bd:   #6b4f1d;
+    --warn-fg:   #f0c674;
+    --key-bg:    #0f2a1c;
+    --key-bd:    #1f6f43;
+    --key-fg:    #7ee787;
+    --code-bg:   #0a0e14;
+    --radius:    12px;
+    --mono: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg:#f6f8fa; --bg-elev:#ffffff; --bg-elev-2:#f0f3f6; --border:#d0d7de; --border-2:#c0c8d0;
+      --fg:#1f2328; --fg-muted:#57606a; --fg-dim:#8c959f; --accent:#0969da; --accent-2:#1a7f37;
+      --accent-3:#8250df; --warn-bg:#fff8e6; --warn-bd:#e6c259; --warn-fg:#7a5b00;
+      --key-bg:#eafbf0; --key-bd:#56c781; --key-fg:#1a7f37; --code-bg:#0d1117;
+    }
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: var(--sans); line-height: 1.7; font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { font-family: var(--mono); font-size: 0.88em; }
+
+  /* ---- Header ---- */
+  header.hero {
+    background: linear-gradient(135deg, #0d1117 0%, #15233a 55%, #1a2f24 100%);
+    border-bottom: 1px solid var(--border);
+    padding: 56px 24px 44px;
+  }
+  @media (prefers-color-scheme: light) {
+    header.hero { background: linear-gradient(135deg,#ffffff 0%,#eaf2ff 55%,#eafbf0 100%); }
+  }
+  .hero-inner { max-width: 960px; margin: 0 auto; }
+  .badge {
+    display: inline-block; font-family: var(--mono); font-size: 12px; letter-spacing: .5px;
+    color: var(--accent-2); background: var(--key-bg); border: 1px solid var(--key-bd);
+    padding: 4px 12px; border-radius: 999px; margin-bottom: 18px;
+  }
+  h1 { margin: 0 0 8px; font-size: 2.2rem; line-height: 1.2; letter-spacing: -0.5px; }
+  h1 .en { display: block; font-size: 1.15rem; font-weight: 500; color: var(--fg-muted); margin-top: 6px; }
+  .approach {
+    margin-top: 18px; font-size: 1.02rem; color: var(--fg-muted);
+    border-left: 3px solid var(--accent-3); padding: 4px 0 4px 16px;
+  }
+  .approach strong { color: var(--accent-3); }
+
+  /* ---- Layout ---- */
+  main { max-width: 960px; margin: 0 auto; padding: 0 24px 80px; }
+
+  /* ---- TOC nav ---- */
+  nav.toc {
+    position: sticky; top: 0; z-index: 5;
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border);
+    margin: 0 -24px 36px; padding: 12px 24px;
+    display: flex; flex-wrap: wrap; gap: 6px 4px;
+  }
+  nav.toc a {
+    font-size: 13px; color: var(--fg-muted); padding: 4px 10px; border-radius: 6px;
+    border: 1px solid transparent; white-space: nowrap;
+  }
+  nav.toc a:hover { color: var(--fg); background: var(--bg-elev); border-color: var(--border); text-decoration: none; }
+
+  section { margin: 48px 0; scroll-margin-top: 64px; }
+  h2 {
+    font-size: 1.5rem; margin: 0 0 6px; padding-bottom: 10px;
+    border-bottom: 1px solid var(--border); display: flex; align-items: baseline; gap: 12px;
+  }
+  h2 .num {
+    font-family: var(--mono); font-size: 0.85rem; color: var(--accent);
+    border: 1px solid var(--border-2); border-radius: 6px; padding: 1px 8px;
+  }
+  h2 .en { font-size: 0.95rem; font-weight: 500; color: var(--fg-dim); }
+  h3 { font-size: 1.12rem; margin: 28px 0 8px; color: var(--fg); }
+  h3 .en { font-weight: 500; color: var(--fg-dim); font-size: .92rem; }
+  p { margin: 10px 0; }
+  .lead { color: var(--fg-muted); }
+  ul, ol { padding-left: 22px; }
+  li { margin: 6px 0; }
+
+  /* ---- Code blocks ---- */
+  pre {
+    background: var(--code-bg); color: #e6edf3; border: 1px solid var(--border-2);
+    border-radius: var(--radius); padding: 16px 18px; overflow-x: auto;
+    font-family: var(--mono); font-size: 13.5px; line-height: 1.65; margin: 14px 0;
+    position: relative;
+  }
+  pre.diagram { font-size: 13px; line-height: 1.55; color: #cdd9e5; }
+  pre .cmd { color: #7ee787; }      /* command */
+  pre .flag { color: #79c0ff; }     /* flags / args */
+  pre .cmt { color: #768390; font-style: italic; } /* comments */
+  pre .dim { color: #8b98a5; }
+  .codecap {
+    font-family: var(--mono); font-size: 11px; color: var(--fg-dim);
+    text-transform: uppercase; letter-spacing: 1px; margin: 18px 0 -6px;
+  }
+  p code, li code, td code {
+    background: var(--bg-elev-2); border: 1px solid var(--border);
+    padding: 1px 6px; border-radius: 5px; color: var(--accent);
+  }
+
+  /* ---- Tables ---- */
+  table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 14.5px; }
+  th, td { padding: 10px 14px; text-align: left; border: 1px solid var(--border); }
+  th { background: var(--bg-elev-2); font-weight: 600; color: var(--fg); }
+  tbody tr:nth-child(odd) { background: var(--bg-elev); }
+  td code { font-size: 0.9em; }
+  .port-table td:first-child, .port-table th:first-child { text-align: center; font-weight: 600; }
+  .slot0 td { color: var(--accent-2); }
+  .pending { color: var(--warn-fg); font-family: var(--mono); font-size: 0.85em; }
+
+  /* ---- Callouts ---- */
+  .callout {
+    border-radius: var(--radius); padding: 16px 20px; margin: 20px 0;
+    border: 1px solid var(--border-2); background: var(--bg-elev);
+  }
+  .callout .title {
+    font-weight: 700; display: flex; align-items: center; gap: 8px; margin-bottom: 6px;
+  }
+  .callout.key { background: var(--key-bg); border-color: var(--key-bd); }
+  .callout.key .title { color: var(--key-fg); }
+  .callout.warn { background: var(--warn-bg); border-color: var(--warn-bd); }
+  .callout.warn .title { color: var(--warn-fg); }
+  .callout p { margin: 6px 0; }
+  .callout p:first-of-type { margin-top: 0; }
+
+  .en-line { color: var(--fg-dim); font-size: 0.93em; }
+
+  /* ---- Footer ---- */
+  footer {
+    max-width: 960px; margin: 0 auto; padding: 28px 24px 48px;
+    border-top: 1px solid var(--border); color: var(--fg-dim); font-size: 13px;
+  }
+  footer code { color: var(--fg-muted); }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="hero-inner">
+    <span class="badge">AgentBridge · feat/multi-pair</span>
+    <h1>
+      单机多对 Claude + Codex
+      <span class="en">Single-Machine Multi-Pair Collaboration</span>
+    </h1>
+    <div class="approach">
+      <strong>Approach A — Shared-Nothing Multi-Instance</strong><br>
+      每一对 Claude↔Codex 都是完全隔离的实例：独立 daemon + 独立端口三元组 + 独立状态目录。<br>
+      <span class="en-line">Each Claude↔Codex pair is a fully isolated instance: its own daemon, its own port triple, and its own state directory.</span>
+    </div>
+  </div>
+</header>
+
+<main>
+  <nav class="toc" aria-label="Table of contents">
+    <a href="#built">1 · 背景与方案</a>
+    <a href="#arch">2 · 架构</a>
+    <a href="#ports">3 · Slot → Port</a>
+    <a href="#usage">4 · 用法 Usage</a>
+    <a href="#how">5 · 底层原理</a>
+    <a href="#concurrency">6 · 并发安全</a>
+    <a href="#migration">7 · 升级迁移</a>
+    <a href="#verify">8 · 验证状态</a>
+  </nav>
+
+  <!-- ===================== 1 ===================== -->
+  <section id="built">
+    <h2><span class="num">01</span> 背景与方案 <span class="en">What Was Built</span></h2>
+
+    <h3>问题 <span class="en">/ Problem</span></h3>
+    <p>AgentBridge 此前每台机器只能运行 <strong>一对</strong> Claude↔Codex：单个 daemon，固定端口 <code>4500 / 4501 / 4502</code>。想同时跑两份协作（比如一份写功能、一份做 review）就会端口冲突、状态互相覆盖。</p>
+    <p class="en-line">Previously AgentBridge ran only <strong>one</strong> Claude↔Codex pair per machine: a single daemon on fixed ports <code>4500 / 4501 / 4502</code>. Running two collaborations at once caused port collisions and state clobbering.</p>
+
+    <h3>方案 <span class="en">/ Solution</span></h3>
+    <p>每一对 = <strong>一个隔离的 daemon + 它自己的端口三元组 + 它自己的状态目录</strong>。</p>
+    <ul>
+      <li><strong>无需改动 daemon 内部逻辑</strong> —— 所有多对（multi-pair）逻辑都落在一个全新的「解析层（resolution layer）」+ CLI 里。<br>
+      <span class="en-line">No daemon-internal changes — all multi-pair logic lives in a new resolution layer + CLI.</span></li>
+      <li>对比已废弃的 <strong>PR #81「单 daemon 多 router」（route B）</strong>：路线 B 让多对共享一个 daemon，导致生命周期状态泄漏（kill/restart 一对会污染另一对）。本方案的 shared-nothing 隔离从根上避免了这类 bug。<br>
+      <span class="en-line">Contrast with the abandoned PR #81 "single daemon multi-router" (route B), which leaked lifecycle state. Shared-nothing isolation eliminates that class of bug.</span></li>
+    </ul>
+
+    <div class="callout key">
+      <div class="title">🔑 关键洞察（运行时已验证） / Key Insight (runtime-verified)</div>
+      <p><strong>Claude Code 会把继承到的环境变量原样传给它的 plugin MCP server。</strong> 因此选择「跑哪一对」纯粹靠在启动前设置环境变量即可完成 —— <strong><code>.mcp.json</code> 完全不用改</strong>。</p>
+      <p class="en-line">Claude Code passes inherited environment variables straight through to its plugin MCP server. A pair is therefore selected purely by setting env vars before launch — <code>.mcp.json</code> is unchanged.</p>
+    </div>
+  </section>
+
+  <!-- ===================== 2 ===================== -->
+  <section id="arch">
+    <h2><span class="num">02</span> 架构 <span class="en">Architecture</span></h2>
+    <p class="lead">两对并排运行，互不干扰 / Two pairs side by side, fully isolated:</p>
+
+    <pre class="diagram">  <span class="cmd">abg claude</span> <span class="flag">--pair work</span>            <span class="cmd">abg claude</span> <span class="flag">--pair review</span>
+  <span class="cmt">(env: ports + statedir = work)</span>    <span class="cmt">(env: ports + statedir = review)</span>
+           │                                  │
+           ▼                                  ▼
+  daemon(<span class="flag">work</span>)  <span class="dim">4500/01/02</span>          daemon(<span class="flag">review</span>)  <span class="dim">4510/11/12</span>
+           │                                  │
+           ▼                                  ▼
+  <span class="cmd">codex</span> <span class="flag">--pair work</span>                 <span class="cmd">codex</span> <span class="flag">--pair review</span>
+    <span class="flag">--remote :4501</span>                    <span class="flag">--remote :4511</span></pre>
+
+    <p>每一对都完全隔离，各自拥有独立的 <code>daemon.pid</code> / <code>status.json</code> / 日志 / <code>killed</code> sentinel，统一放在 <code>&lt;stateDir&gt;/pairs/&lt;pairId&gt;/</code> 下。</p>
+    <p class="en-line">Each pair is fully isolated, with its own <code>daemon.pid</code> / <code>status.json</code> / logs / <code>killed</code> sentinel under <code>&lt;stateDir&gt;/pairs/&lt;pairId&gt;/</code>.</p>
+  </section>
+
+  <!-- ===================== 3 ===================== -->
+  <section id="ports">
+    <h2><span class="num">03</span> Slot → Port 映射 <span class="en">Slot → Port Table</span></h2>
+    <p class="lead">每一对占据一个 <strong>slot</strong>，slot 决定端口三元组。规律：第 N 个 slot 在经典基址上 <code>+ N*10</code>。<br>
+    <span class="en-line">Each pair occupies a <strong>slot</strong>, which determines its port triple. Rule: slot N is offset <code>+ N*10</code> from the classic base.</span></p>
+
+    <table class="port-table">
+      <thead>
+        <tr>
+          <th>slot</th>
+          <th>appPort<br><code>CODEX_WS_PORT</code></th>
+          <th>proxyPort<br><code>CODEX_PROXY_PORT</code></th>
+          <th>controlPort<br><code>AGENTBRIDGE_CONTROL_PORT</code></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="slot0"><td>0 <span style="font-weight:400">(第一对 / first pair)</span></td><td><code>4500</code></td><td><code>4501</code></td><td><code>4502</code></td></tr>
+        <tr><td>1</td><td><code>4510</code></td><td><code>4511</code></td><td><code>4512</code></td></tr>
+        <tr><td>2</td><td><code>4520</code></td><td><code>4521</code></td><td><code>4522</code></td></tr>
+        <tr><td>N</td><td><code>4500 + N*10</code></td><td><code>+1</code></td><td><code>+2</code></td></tr>
+      </tbody>
+    </table>
+
+    <div class="callout">
+      <div class="title">📌 注意 / Note</div>
+      <p>slot 0 = 经典端口（the classic ports）。所以 <strong>单对用户 100% 不受影响</strong> —— 行为与升级前完全一致。</p>
+      <p class="en-line">slot 0 = the classic ports, so a single-pair user is 100% unchanged.</p>
+    </div>
+  </section>
+
+  <!-- ===================== 4 ===================== -->
+  <section id="usage">
+    <h2><span class="num">04</span> 用法 <span class="en">Usage</span></h2>
+    <p class="lead">这是最重要的一节。下面所有命令都可以直接复制粘贴。<br>
+    <span class="en-line">This is the most important section. Every command below is copy-pasteable.</span></p>
+
+    <h3>启动一个命名对 <span class="en">/ Start a named pair</span></h3>
+    <p>终端 1 启动 Claude 侧，终端 2 启动 Codex 侧（两者用同一个 <code>--pair</code> 名字配对）：</p>
+    <div class="codecap">Terminal 1 &amp; Terminal 2</div>
+    <pre><span class="cmt"># Terminal 1</span>
+<span class="cmd">abg claude</span> <span class="flag">--pair work</span>
+
+<span class="cmt"># Terminal 2</span>
+<span class="cmd">abg codex</span> <span class="flag">--pair work</span></pre>
+
+    <h3>第二个对（自动分配下一个 slot）<span class="en">/ A second pair, auto-assigned next slot</span></h3>
+    <pre><span class="cmt"># Terminal 3</span>
+<span class="cmd">abg claude</span> <span class="flag">--pair review</span>
+
+<span class="cmt"># Terminal 4</span>
+<span class="cmd">abg codex</span> <span class="flag">--pair review</span></pre>
+    <p><code>review</code> 这一对会自动拿到下一个空闲 slot（例如 slot 1 → 端口 <code>4510/11/12</code>），与 <code>work</code> 对完全隔离。</p>
+    <p class="en-line">The <code>review</code> pair automatically takes the next free slot (e.g. slot 1 → ports 4510/11/12), fully isolated from <code>work</code>.</p>
+
+    <h3>不带参数：按目录自动推导 <span class="en">/ No flag: pair derived from cwd</span></h3>
+    <pre><span class="cmd">abg claude</span></pre>
+    <p>不带 <code>--pair</code> 时，<strong>对的身份由当前目录自动推导</strong>（realpath + 短 hash）。在同一个项目目录里再次运行，会 <strong>重连到同一个对</strong>。</p>
+    <p class="en-line">Without <code>--pair</code>, the pair identity is auto-derived from the current directory (realpath + short hash). Running it again in the same project reconnects to the same pair.</p>
+
+    <h3>列出所有对 <span class="en">/ List all pairs</span></h3>
+    <pre><span class="cmd">abg pairs</span>           <span class="cmt"># pairId, slot, ports, cwd, running/stopped, pid</span>
+<span class="cmd">abg pairs</span> <span class="flag">--json</span>    <span class="cmt"># machine-readable output for scripting</span>
+<span class="cmd">abg pairs rm</span> <span class="flag">&lt;id&gt;</span>   <span class="cmt"># stop a pair and free its slot</span></pre>
+
+    <h3>停止 <span class="en">/ Kill</span></h3>
+    <pre><span class="cmt"># 停止所有对（以及任何遗留的旧版单对 daemon）</span>
+<span class="cmt"># Stop ALL pairs (and any legacy single-pair daemon)</span>
+<span class="cmd">abg kill</span>
+
+<span class="cmt"># 只停 "work" 这一对（保留它的注册表条目 / slot）</span>
+<span class="cmt"># Stop only the "work" pair (keeps its registry entry / slot)</span>
+<span class="cmd">abg kill</span> <span class="flag">--pair work</span></pre>
+
+    <h3>对身份规则 <span class="en">/ Pair identity rules</span></h3>
+    <ul>
+      <li><strong>显式 <code>--pair &lt;name&gt;</code> 优先</strong> / explicit <code>--pair &lt;name&gt;</code> wins。</li>
+      <li>否则由<strong>目录决定</strong> / otherwise the directory decides。</li>
+      <li><strong>命名对是全局的</strong> / named pairs are global —— 跨目录共享同一组端口。</li>
+      <li><strong>目录推导的对是按目录的</strong> / directory-derived pairs are per-directory —— 每个目录一个独立的对。</li>
+    </ul>
+  </section>
+
+  <!-- ===================== 5 ===================== -->
+  <section id="how">
+    <h2><span class="num">05</span> 底层原理 <span class="en">How It Works · env-injection seam</span></h2>
+    <p>每个 CLI 命令的最顶端都会先跑一个 <strong>「对解析器（pair resolver）」</strong>：</p>
+    <ol>
+      <li>在跨进程锁（cross-process lock）保护下，到注册表 <code>&lt;base&gt;/pairs/registry.json</code> 里 <strong>分配 / 查找</strong> 这个对的 slot。</li>
+      <li>然后设置这些环境变量：<code>AGENTBRIDGE_STATE_DIR</code>（该对的 state 目录）、<code>AGENTBRIDGE_CONTROL_PORT</code>、<code>CODEX_WS_PORT</code>、<code>CODEX_PROXY_PORT</code>，外加 <code>AGENTBRIDGE_BASE_DIR</code>（注册表 base —— 子进程 <code>abg pairs</code>/<code>kill</code> 据此解析正确的 registry）和 <code>AGENTBRIDGE_PAIR_ID</code>（对 id，用于诊断 / status.json）。</li>
+      <li>既有的 <code>claude</code> / <code>codex</code> / <code>kill</code> 代码，以及 daemon，因为<strong>本来就从环境变量读取这些值</strong>，所以无需任何改动就「自动工作」。</li>
+    </ol>
+    <p class="en-line">A "pair resolver" runs at the top of each CLI command: under a cross-process lock it allocates/looks up the pair's slot in <code>&lt;base&gt;/pairs/registry.json</code>, then sets <code>AGENTBRIDGE_STATE_DIR</code> (the pair dir), <code>AGENTBRIDGE_CONTROL_PORT</code>, <code>CODEX_WS_PORT</code>, <code>CODEX_PROXY_PORT</code>, plus <code>AGENTBRIDGE_BASE_DIR</code> (the registry base, so child <code>abg pairs</code>/<code>kill</code> resolve the real registry) and <code>AGENTBRIDGE_PAIR_ID</code>. The existing claude/codex/kill code and the daemon then just work, because they already read these from env.</p>
+    <div class="callout">
+      <div class="title">🧩 这就是整个特性的接缝 / The seam</div>
+      <p><strong>靠环境变量注入，而不是改动核心代码。</strong> <span class="en-line">Env-injection, not core-code surgery.</span></p>
+    </div>
+  </section>
+
+  <!-- ===================== 6 ===================== -->
+  <section id="concurrency">
+    <h2><span class="num">06</span> 并发安全 <span class="en">Concurrency Safety</span></h2>
+    <ul>
+      <li><strong>两个 <code>abg claude</code> 同时启动不会撞车。</strong> Slot 分配由一个 <strong>原子锁文件（atomic lock file，靠 <code>link(2)</code>：写临时文件再 link 到锁路径）</strong> 串行化，锁内含 owner pid + nonce。陈旧锁回收<strong>只针对已死的 owner</strong>（绝不抢活进程的锁，以免 lost update），且回收经一个独立 reclaim lock 串行化 + 重新确认 dead 后才删。陈旧判定靠<strong>进程存活性，不是 TTL</strong>。<br>
+      <span class="en-line">Two <code>abg claude</code> started at the same time can't collide: slot allocation is serialized by an atomic <code>link(2)</code> lock file (write temp → link onto the lock path) carrying owner pid + nonce. Stale reclaim targets only a DEAD owner (never steals a live lock — that would risk a lost update), is itself serialized through a dedicated reclaim lock, and re-confirms death before removing. Staleness is by process liveness, not TTL.</span></li>
+      <li><strong>端口会被探测。</strong> 如果某个外部进程占用了目标端口，你会得到清晰的 <code>PAIR_PORTS_BUSY</code> 错误，而不是悄悄连到错误的端口。<br>
+      <span class="en-line">Allocated ports are probed; if an external process squats a port, you get a clear <code>PAIR_PORTS_BUSY</code> error instead of a silent wrong-port connection.</span></li>
+    </ul>
+  </section>
+
+  <!-- ===================== 7 ===================== -->
+  <section id="migration">
+    <h2><span class="num">07</span> 升级迁移 <span class="en">Migration Note</span></h2>
+    <div class="callout warn">
+      <div class="title">⚠️ 升级后请执行一次 / Run once after upgrading</div>
+      <p>升级到多对版本后，如果还有一个 <strong>旧版（pre-multi-pair）daemon</strong> 在跑，请执行一次：</p>
+      <pre style="margin:10px 0;"><span class="cmd">abg kill</span></pre>
+      <p>新代码会 <strong>检测到这个 legacy-root daemon 并给出引导</strong>。</p>
+      <p class="en-line">After upgrading, if an old (pre-multi-pair) daemon is still running, run <code>abg kill</code> once — the new code detects the legacy-root daemon and guides you.</p>
+    </div>
+  </section>
+
+  <!-- ===================== 8 ===================== -->
+  <section id="verify">
+    <h2><span class="num">08</span> 验证状态 <span class="en">Verification</span></h2>
+    <p class="lead">全部通过。 / All green.</p>
+    <table>
+      <thead>
+        <tr><th>项 / Item</th><th>状态 / Status</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>单元测试（pair-registry / concurrency / resolver / command）<br><span class="en-line">Unit tests</span></td><td>✅ pass — 含 8 进程并发 + seeded-dead-lock 锁测试，20+ 次 stress 0 碰撞<br><span class="en-line">incl. an 8-process + seeded-dead-lock concurrency test, 0 collisions over 20+ stress runs</span></td></tr>
+        <tr><td>类型检查 + 全量测试 + 插件同步（<code>bun run check</code>）<br><span class="en-line">Type check + full suite + plugin sync</span></td><td>✅ 334 pass / 0 fail，typecheck clean，bundles in sync，version-aligned 0.1.6</td></tr>
+        <tr><td>真实双对运行时 E2E（Codex sandbox，仓库原脚本）<br><span class="en-line">Real two-pair runtime E2E</span></td><td>✅ pass — pair <code>a</code>=slot2 (4520/4521/4522, status pairId "a")、pair <code>b</code>=slot3 (4530/4531/4532, status pairId "b")；端口/state/日志隔离 ✓；<code>kill --pair a</code> 只停 a、b 仍 LISTEN ✓；<code>kill --all</code> 后 4520-4532 全清 ✓</td></tr>
+        <tr><td>交叉评审（Claude×2 全新 reviewer + Codex / 轮）<br><span class="en-line">Cross-review</span></td><td>✅ 8 轮迭代收敛到连续 2 轮 0 真实 issue（第 7、8 轮）+ post-gate packaging delta focused 复审 0 issue。修掉的真实 bug：跨进程锁竞争（3 次迭代）、<code>AGENTBRIDGE_STATE_DIR</code> 双重语义、空串 env、<code>kill --help</code> 误杀、pair-scoped 命令提示（含 SessionStart hook）</td></tr>
+      </tbody>
+    </table>
+  </section>
+</main>
+
+<footer>
+  AgentBridge · 单机多对 / Single-Machine Multi-Pair · <code>feat/multi-pair</code> ·
+  Approach A — Shared-Nothing Multi-Instance.
+  生成于 / generated 2026-05-30. 离线可用，双击打开即可 / works offline, just double-click.
+</footer>
+
+</body>
+</html>

--- a/docs/multi-pair.md
+++ b/docs/multi-pair.md
@@ -1,0 +1,247 @@
+# 单机多对 Claude+Codex / Single-Machine Multi-Pair
+
+> **Approach A — Shared-Nothing Multi-Instance**
+> 每一对 Claude↔Codex 都是完全隔离的实例：独立 daemon + 独立端口三元组 + 独立状态目录。
+> Each Claude↔Codex pair is a fully isolated instance: its own daemon, its own port triple, and its own state directory.
+
+---
+
+## 目录 / Table of Contents
+
+1. [背景与方案 / What Was Built](#背景与方案--what-was-built)
+2. [架构 / Architecture](#架构--architecture)
+3. [Slot → Port 映射 / Slot → Port Table](#slot--port-映射--slot--port-table)
+4. [用法 / Usage](#用法--usage)
+5. [底层原理 / How It Works](#底层原理--how-it-works)
+6. [并发安全 / Concurrency Safety](#并发安全--concurrency-safety)
+7. [升级迁移 / Migration Note](#升级迁移--migration-note)
+8. [验证状态 / Verification](#验证状态--verification)
+
+---
+
+## 背景与方案 / What Was Built
+
+### 问题 / Problem
+
+AgentBridge 此前每台机器只能运行 **一对** Claude↔Codex：单个 daemon，固定端口 `4500 / 4501 / 4502`。想同时跑两份协作（比如一份写功能、一份做 review）就会端口冲突、状态互相覆盖。
+
+Previously AgentBridge ran only **one** Claude↔Codex pair per machine: a single daemon on fixed ports `4500 / 4501 / 4502`. Running two collaborations at once (e.g. one for feature work, one for review) caused port collisions and state clobbering.
+
+### 方案 / Solution
+
+每一对 = **一个隔离的 daemon + 它自己的端口三元组 + 它自己的状态目录**。
+
+- **无需改动 daemon 内部逻辑** —— 所有多对（multi-pair）逻辑都落在一个全新的「解析层（resolution layer）」+ CLI 里。
+- 这与已废弃的 **PR #81「单 daemon 多 router」（路线 B）** 形成对比：路线 B 让多对共享一个 daemon，导致生命周期状态泄漏（一对的 kill/restart 会污染另一对）。本方案的 shared-nothing 隔离从根上避免了这个问题。
+
+Each pair = **one isolated daemon + its own port triple + its own state dir**.
+
+- **No daemon-internal changes** — all multi-pair logic lives in a new resolution layer + CLI.
+- This contrasts with the abandoned **PR #81 "single daemon multi-router" (route B)**, where pairs shared one daemon and lifecycle state leaked between them (killing/restarting one pair corrupted another). Shared-nothing isolation eliminates that class of bug.
+
+> ### 🔑 关键洞察（运行时已验证）/ Key Insight (runtime-verified)
+>
+> **Claude Code 会把继承到的环境变量原样传给它的 plugin MCP server。** 因此选择「跑哪一对」纯粹靠在启动前设置环境变量即可完成 —— **`.mcp.json` 完全不用改**。
+>
+> **Claude Code passes inherited environment variables straight through to its plugin MCP server.** A pair is therefore selected purely by setting env vars before launch — **`.mcp.json` is unchanged.**
+
+---
+
+## 架构 / Architecture
+
+两对并排运行，互不干扰 / Two pairs side by side, fully isolated:
+
+```
+   abg claude --pair work            abg claude --pair review
+   (env: ports + statedir = work)    (env: ports + statedir = review)
+            │                                  │
+            ▼                                  ▼
+   daemon(work)  4500/01/02          daemon(review)  4510/11/12
+            │                                  │
+            ▼                                  ▼
+   codex --pair work                 codex --pair review
+     --remote :4501                    --remote :4511
+```
+
+每一对都完全隔离，各自拥有独立的 `daemon.pid` / `status.json` / 日志 / `killed` sentinel，统一放在：
+
+Each pair is fully isolated, with its own `daemon.pid` / `status.json` / logs / `killed` sentinel under:
+
+```
+<stateDir>/pairs/<pairId>/
+```
+
+---
+
+## Slot → Port 映射 / Slot → Port Table
+
+每一对占据一个 **slot**，slot 决定它的端口三元组。规律：第 N 个 slot 在经典基址上 `+ N*10`。
+
+Each pair occupies a **slot**, and the slot determines its port triple. Rule: slot N is offset `+ N*10` from the classic base.
+
+| slot | appPort (`CODEX_WS_PORT`) | proxyPort (`CODEX_PROXY_PORT`) | controlPort (`AGENTBRIDGE_CONTROL_PORT`) |
+|:----:|:-------------------------:|:------------------------------:|:----------------------------------------:|
+| **0** (第一对 / first pair) | `4500` | `4501` | `4502` |
+| **1** | `4510` | `4511` | `4512` |
+| **2** | `4520` | `4521` | `4522` |
+| **N** | `4500 + N*10` | `+1` | `+2` |
+
+> **注意 / Note：** slot 0 = 经典端口（the classic ports）。所以**单对用户 100% 不受影响** —— 行为与升级前完全一致。
+> slot 0 = the classic ports, so a single-pair user is **100% unchanged**.
+
+---
+
+## 用法 / Usage
+
+> 这是最重要的一节。下面所有命令都可以直接复制粘贴。
+> This is the most important section. Every command below is copy-pasteable.
+
+### 启动一个命名对 / Start a named pair
+
+终端 1 启动 Claude 侧，终端 2 启动 Codex 侧（两者用同一个 `--pair` 名字配对）：
+
+Terminal 1 starts the Claude side, terminal 2 starts the Codex side (both use the same `--pair` name):
+
+```bash
+# Terminal 1
+abg claude --pair work
+
+# Terminal 2
+abg codex --pair work
+```
+
+### 第二个对（自动分配下一个 slot）/ A second pair (auto-assigned next slot)
+
+```bash
+# Terminal 3
+abg claude --pair review
+
+# Terminal 4
+abg codex --pair review
+```
+
+`review` 这一对会自动拿到下一个空闲 slot（例如 slot 1 → 端口 `4510/11/12`），与 `work` 对完全隔离。
+
+The `review` pair automatically takes the next free slot (e.g. slot 1 → ports `4510/11/12`), fully isolated from `work`.
+
+### 不带参数：按目录自动推导 / No flag: pair derived from the current directory
+
+```bash
+abg claude
+```
+
+不带 `--pair` 时，**对的身份由当前目录自动推导**（realpath + 短 hash）。在同一个项目目录里再次运行，会**重连到同一个对**。
+
+Without `--pair`, the pair identity is **auto-derived from the current directory** (realpath + short hash). Running it again in the same project **reconnects to the same pair**.
+
+### 列出所有对 / List all pairs
+
+```bash
+abg pairs
+```
+
+输出每个对的 `pairId`、slot、端口、cwd、运行/停止状态、pid。脚本场景用 JSON：
+
+Shows each pair's `pairId`, slot, ports, cwd, running/stopped state, and pid. For scripting:
+
+```bash
+abg pairs --json
+```
+
+停止某个对并释放它的 slot：
+
+Stop a pair and free its slot:
+
+```bash
+abg pairs rm <id>
+```
+
+### 停止 / Kill
+
+```bash
+# 停止所有对（以及任何遗留的旧版单对 daemon）
+# Stop ALL pairs (and any legacy single-pair daemon)
+abg kill
+
+# 只停 "work" 这一对（保留它的注册表条目 / slot）
+# Stop only the "work" pair (keeps its registry entry / slot)
+abg kill --pair work
+```
+
+### 对身份规则 / Pair identity rules
+
+- **显式 `--pair <name>` 优先 / explicit `--pair <name>` wins。**
+- 否则由**目录决定 / otherwise the directory decides。**
+- **命名对是全局的 / named pairs are global** —— 跨目录共享同一组端口。
+- **目录推导的对是按目录的 / directory-derived pairs are per-directory** —— 每个目录一个独立的对。
+
+---
+
+## 底层原理 / How It Works (env-injection seam)
+
+每个 CLI 命令的最顶端都会先跑一个 **「对解析器（pair resolver）」**：
+
+1. 在跨进程锁（cross-process lock）保护下，到注册表 `<base>/pairs/registry.json` 里**分配 / 查找**这个对的 slot。
+2. 然后设置这些环境变量：
+   - `AGENTBRIDGE_STATE_DIR`（该对的 state 目录 `<base>/pairs/<id>`）
+   - `AGENTBRIDGE_CONTROL_PORT`
+   - `CODEX_WS_PORT`
+   - `CODEX_PROXY_PORT`
+   - `AGENTBRIDGE_BASE_DIR`（注册表 base —— 子进程 `abg pairs`/`kill` 据此解析正确的 registry，而不会误把 per-pair 目录当 base）
+   - `AGENTBRIDGE_PAIR_ID`（对的 id，用于诊断 / 写入 status.json）
+3. 既有的 `claude` / `codex` / `kill` 代码，以及 daemon，因为**本来就从环境变量读取这些值**，所以无需任何改动就「自动工作」。
+
+A **"pair resolver"** runs at the top of each CLI command:
+
+1. Under a cross-process lock, it **allocates / looks up** the pair's slot in the registry `<base>/pairs/registry.json`.
+2. It then sets these env vars: `AGENTBRIDGE_STATE_DIR` (the pair dir `<base>/pairs/<id>`), `AGENTBRIDGE_CONTROL_PORT`, `CODEX_WS_PORT`, `CODEX_PROXY_PORT`, plus `AGENTBRIDGE_BASE_DIR` (the registry base, so child `abg pairs`/`kill` resolve the real registry rather than the per-pair dir) and `AGENTBRIDGE_PAIR_ID` (the pair id, for diagnostics / status.json).
+3. The existing claude / codex / kill code and the daemon **just work**, because they already read these from env.
+
+这就是整个特性的接缝（seam）：**靠环境变量注入，而不是改动核心代码。**
+
+This is the entire seam of the feature: **env-injection, not core-code surgery.**
+
+---
+
+## 并发安全 / Concurrency Safety
+
+- **两个 `abg claude` 同时启动不会撞车 / Two `abg claude` started at the same time can't collide。** Slot 分配由一个**原子锁文件（atomic lock file，靠 `link(2)`：先写临时文件,再 `link` 到锁路径,EEXIST 即已持有)**串行化,锁内含 owner pid + nonce。陈旧锁回收**只针对已死的 owner**(绝不抢占活进程的锁,以免恢复后写回旧 registry 造成 lost update);回收本身还经一个独立的 serialized reclaim lock + 重新确认 owner 已死后才删,杜绝并发 evict 活锁。Stale recovery is by **process liveness, not TTL**.
+- **端口会被探测 / allocated ports are probed。** 如果某个外部进程占用了目标端口，你会得到一个清晰的 **`PAIR_PORTS_BUSY`** 错误，而不是悄悄连到错误的端口（silent wrong-port connection）。
+
+---
+
+## 升级迁移 / Migration Note
+
+> ### ⚠️ 升级后请执行一次 / Run once after upgrading
+>
+> 升级到多对版本后，如果还有一个**旧版（pre-multi-pair）daemon** 在跑，请执行一次：
+>
+> After upgrading, if an old (pre-multi-pair) daemon is still running, run once:
+>
+> ```bash
+> abg kill
+> ```
+>
+> 新代码会**检测到这个 legacy-root daemon 并给出引导**。
+> The new code detects the legacy-root daemon and guides you.
+
+---
+
+## 验证状态 / Verification
+
+全部通过。 / All green.
+
+| 项 / Item | 状态 / Status |
+|---|---|
+| 单元测试（pair-registry / concurrency / resolver / command）/ Unit tests | ✅ pass — 含 8 进程并发 + seeded-dead-lock 锁测试，20+ 次 stress 0 碰撞 |
+| 类型检查 + 全量测试 + 插件同步（`bun run check`）/ Type check + full suite + plugin sync | ✅ 334 pass / 0 fail，typecheck clean，bundles in sync，version-aligned 0.1.6 |
+| 真实双对运行时 E2E（Codex sandbox，仓库原脚本无 workaround）/ Real two-pair runtime E2E | ✅ pass — pair `a`=slot2 (4520/4521/4522, pairId "a")、pair `b`=slot3 (4530/4531/4532, pairId "b")；端口/state/日志隔离；`kill --pair a` 只停 a，b 仍 LISTEN；`kill --all` 后 4520-4532 全清 |
+| 交叉评审（Claude×2 全新 reviewer + Codex / 轮）/ Cross-review | ✅ 8 轮迭代收敛到连续 2 轮 0 真实 issue（第 7、8 轮）+ post-gate packaging delta focused 复审 0 issue |
+
+真实修掉的 bug（交叉评审捕获）/ Real bugs caught & fixed by cross-review:
+- 跨进程锁竞争（3 次迭代：发布窗口 → CAS → reclaim-lock 串行化 + dead-pid-only + nonce）
+- `AGENTBRIDGE_STATE_DIR` 双重语义（引入 `AGENTBRIDGE_BASE_DIR`）
+- 空字符串 env 被当有效路径
+- `kill --help` / 未知 flag 误落 kill-all
+- pair-scoped 命令提示（bridge / disabled-state / codex / kill / SessionStart health-check.sh）
+- packaging：`build:cli` 未产 `dist/daemon.js` + daemon entry 默认

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "start": "bun run src/bridge.ts",
     "build:cli": "mkdir -p dist && bun build src/cli.ts --outfile dist/cli.js --target bun && bun build src/daemon.ts --outfile dist/daemon.js --target bun && chmod +x dist/cli.js",
     "build:plugin": "mkdir -p plugins/agentbridge/server && bun build src/bridge.ts --outfile plugins/agentbridge/server/bridge-server.js --target bun && bun build src/daemon.ts --outfile plugins/agentbridge/server/daemon.js --target bun",
+    "smoke:built": "bun scripts/smoke-built-cli.mjs",
+    "smoke:pack": "bun scripts/smoke-pack.mjs",
     "verify:plugin-sync": "node scripts/verify-plugin-sync.cjs",
     "postinstall": "node scripts/postinstall.cjs",
     "prepublishOnly": "bun run build:cli && bun run build:plugin",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "start": "bun run src/bridge.ts",
-    "build:cli": "mkdir -p dist && bun build src/cli.ts --outfile dist/cli.js --target bun && chmod +x dist/cli.js",
+    "build:cli": "mkdir -p dist && bun build src/cli.ts --outfile dist/cli.js --target bun && bun build src/daemon.ts --outfile dist/daemon.js --target bun && chmod +x dist/cli.js",
     "build:plugin": "mkdir -p plugins/agentbridge/server && bun build src/bridge.ts --outfile plugins/agentbridge/server/bridge-server.js --target bun && bun build src/daemon.ts --outfile plugins/agentbridge/server/daemon.js --target bun",
     "verify:plugin-sync": "node scripts/verify-plugin-sync.cjs",
     "postinstall": "node scripts/postinstall.cjs",

--- a/plugins/agentbridge/scripts/health-check.sh
+++ b/plugins/agentbridge/scripts/health-check.sh
@@ -9,6 +9,16 @@ cooldown_seconds="${AGENTBRIDGE_HEALTH_HOOK_COOLDOWN_SECONDS:-120}"
 state_root="${AGENTBRIDGE_HOOK_STATE_DIR:-${TMPDIR:-/tmp}/agentbridge-hooks}"
 port="${AGENTBRIDGE_CONTROL_PORT:-4502}"
 
+# In multi-pair mode the resolver exports AGENTBRIDGE_PAIR_ID, inherited here via
+# the SessionStart hook env. Scope the suggested commands to that pair so the
+# user is not sent to a different (cwd-derived) pair. Guard the charset (the
+# resolver already restricts it) so nothing unsafe is interpolated into the JSON.
+pair_id="${AGENTBRIDGE_PAIR_ID:-}"
+pair_arg=""
+if printf '%s' "$pair_id" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+  pair_arg=" --pair ${pair_id}"
+fi
+
 if ! command -v curl >/dev/null 2>&1; then
   exit 0
 fi
@@ -41,11 +51,11 @@ if [ -n "$health_json" ]; then
 EOF
   else
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex"}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex${pair_arg}"}}
 EOF
   fi
 else
   cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude (this terminal) + agentbridge codex (another terminal). If you're already using agentbridge claude, the daemon may still be starting up."}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude${pair_arg} (this terminal) + agentbridge codex${pair_arg} (another terminal). If you're already using agentbridge claude${pair_arg}, the daemon may still be starting up."}}
 EOF
 fi

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13671,16 +13671,16 @@ import { homedir, platform } from "os";
 
 class StateDirResolver {
   stateDir;
+  static platformBaseDir() {
+    if (platform() === "darwin") {
+      return join(homedir(), "Library", "Application Support", "AgentBridge");
+    }
+    const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+    return join(xdgState, "agentbridge");
+  }
   constructor(envOverride) {
     const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
-    if (override) {
-      this.stateDir = override;
-    } else if (platform() === "darwin") {
-      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
-    } else {
-      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-      this.stateDir = join(xdgState, "agentbridge");
-    }
+    this.stateDir = override && override.length > 0 ? override : StateDirResolver.platformBaseDir();
   }
   ensure() {
     if (!existsSync(this.stateDir)) {
@@ -14187,7 +14187,8 @@ class DaemonClient extends EventEmitter2 {
 import { spawn, execFileSync } from "child_process";
 import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
-var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
+var DEFAULT_DAEMON_ENTRY = import.meta.url.endsWith(".ts") ? "./daemon.ts" : "./daemon.js";
+var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 
 class DaemonLifecycle {
@@ -14539,19 +14540,30 @@ class ConfigService {
   }
 }
 
+// src/pair-command.ts
+function pairScopedCommand(cmd) {
+  const pairId = process.env.AGENTBRIDGE_PAIR_ID;
+  if (!pairId)
+    return `agentbridge ${cmd}`;
+  const [sub, ...rest] = cmd.split(" ");
+  const tail = rest.length > 0 ? ` ${rest.join(" ")}` : "";
+  return `agentbridge ${sub} --pair ${pairId}${tail}`;
+}
+
 // src/bridge-disabled-state.ts
 function disabledReplyError(reason) {
+  const claudeCmd = pairScopedCommand("claude");
   switch (reason) {
     case "rejected":
-      return "AgentBridge rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset.";
+      return `AgentBridge rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run \`${pairScopedCommand("kill")}\` to reset.`;
     case "evicted":
-      return "AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude`.";
+      return `AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with \`${claudeCmd}\`.`;
     case "probe_in_progress":
-      return "AgentBridge rejected this session \u2014 a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with `agentbridge claude`.";
+      return `AgentBridge rejected this session \u2014 a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with \`${claudeCmd}\`.`;
     case "auto_recovery_exhausted":
-      return "AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`.";
+      return `AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${claudeCmd}\`.`;
     case "killed":
-      return "AgentBridge is disabled by `agentbridge kill`. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.";
+      return `AgentBridge is disabled by \`agentbridge kill\`. Restart Claude Code (\`${claudeCmd}\`), switch to a new conversation, or run \`/resume\` to reconnect.`;
   }
 }
 
@@ -14633,17 +14645,17 @@ daemonClient.on("rejected", async (code) => {
     case CLOSE_CODE_EVICTED_STALE:
       reason = "evicted";
       notificationId = "system_bridge_evicted";
-      notificationContent = "\u26A0\uFE0F AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge \u56E0\u6B64\u4F1A\u8BDD\u672A\u54CD\u5E94\u5B58\u6D3B\u63A2\u6D4B\u800C\u5C06\u5176\u9A71\u9010\u2014\u2014\u66F4\u65B0\u7684 Claude Code \u4F1A\u8BDD\u5DF2\u63A5\u7BA1\u3002\u5982\u9700\u91CD\u8FDE\uFF0C\u8BF7\u5173\u95ED\u6B64\u4F1A\u8BDD\u5E76\u8FD0\u884C `agentbridge claude` \u542F\u52A8\u65B0\u4F1A\u8BDD\u3002";
+      notificationContent = `\u26A0\uFE0F AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with \`${pairScopedCommand("claude")}\` if you want to reconnect. AgentBridge \u56E0\u6B64\u4F1A\u8BDD\u672A\u54CD\u5E94\u5B58\u6D3B\u63A2\u6D4B\u800C\u5C06\u5176\u9A71\u9010\u2014\u2014\u66F4\u65B0\u7684 Claude Code \u4F1A\u8BDD\u5DF2\u63A5\u7BA1\u3002\u5982\u9700\u91CD\u8FDE\uFF0C\u8BF7\u5173\u95ED\u6B64\u4F1A\u8BDD\u5E76\u8FD0\u884C \`${pairScopedCommand("claude")}\` \u542F\u52A8\u65B0\u4F1A\u8BDD\u3002`;
       break;
     case CLOSE_CODE_PROBE_IN_PROGRESS:
       reason = "probe_in_progress";
       notificationId = "system_bridge_probe_in_progress";
-      notificationContent = "\u26A0\uFE0F AgentBridge rejected this session \u2014 a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with `agentbridge claude`. AgentBridge \u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u6B63\u5728\u901A\u8FC7\u5B58\u6D3B\u63A2\u6D4B\u68C0\u67E5\u73B0\u6709 Claude \u4F1A\u8BDD\u662F\u5426\u4ECD\u7136\u5728\u7EBF\u3002\u8BF7\u7A0D\u540E\u7528 `agentbridge claude` \u91CD\u8BD5\u3002";
+      notificationContent = `\u26A0\uFE0F AgentBridge rejected this session \u2014 a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with \`${pairScopedCommand("claude")}\`. AgentBridge \u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u6B63\u5728\u901A\u8FC7\u5B58\u6D3B\u63A2\u6D4B\u68C0\u67E5\u73B0\u6709 Claude \u4F1A\u8BDD\u662F\u5426\u4ECD\u7136\u5728\u7EBF\u3002\u8BF7\u7A0D\u540E\u7528 \`${pairScopedCommand("claude")}\` \u91CD\u8BD5\u3002`;
       break;
     default:
       reason = "rejected";
       notificationId = "system_bridge_replaced";
-      notificationContent = "\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge \u5B88\u62A4\u8FDB\u7A0B\u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u53E6\u4E00\u4E2A Claude Code \u4F1A\u8BDD\u5DF2\u5728\u8FDE\u63A5\u4E2D\u3002\u8BF7\u5148\u5173\u95ED\u53E6\u4E00\u4E2A\u4F1A\u8BDD\uFF0C\u6216\u8FD0\u884C `agentbridge kill` \u91CD\u7F6E\u3002";
+      notificationContent = `\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run \`${pairScopedCommand("kill")}\` to reset. AgentBridge \u5B88\u62A4\u8FDB\u7A0B\u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u53E6\u4E00\u4E2A Claude Code \u4F1A\u8BDD\u5DF2\u5728\u8FDE\u63A5\u4E2D\u3002\u8BF7\u5148\u5173\u95ED\u53E6\u4E00\u4E2A\u4F1A\u8BDD\uFF0C\u6216\u8FD0\u884C \`${pairScopedCommand("kill")}\` \u91CD\u7F6E\u3002`;
       break;
   }
   log(`Daemon rejected this session (close code ${code}, reason=${reason})`);
@@ -14659,7 +14671,7 @@ daemonClient.on("rejected", async (code) => {
 claude.on("ready", async () => {
   log(`MCP server ready (delivery mode: ${claude.getDeliveryMode()}) \u2014 ensuring AgentBridge daemon...`);
   if (daemonLifecycle.wasKilled()) {
-    await enterDisabledState("Killed sentinel found \u2014 bridge staying idle", "\u26D4 AgentBridge was stopped by `agentbridge kill`. Bridge is staying idle. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.");
+    await enterDisabledState("Killed sentinel found \u2014 bridge staying idle", `\u26D4 AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`);
     return;
   }
   await connectToDaemon();
@@ -14675,7 +14687,7 @@ async function connectToDaemon(isReconnect = false) {
     daemonClient.attachClaude();
     daemonDisabledReason = null;
     if (!isReconnect) {
-      claude.pushNotification(systemMessage("system_bridge_ready", "\u2705 AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: agentbridge codex"));
+      claude.pushNotification(systemMessage("system_bridge_ready", `\u2705 AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: ${pairScopedCommand("codex")}`));
     }
   } catch (err) {
     log(`Failed to connect to daemon: ${err.message}`);
@@ -14698,7 +14710,7 @@ var reconnectTask = null;
 async function notifyIfDaemonKilled(logMessage) {
   if (!daemonLifecycle.wasKilled())
     return false;
-  await enterDisabledState(logMessage, "\u26D4 AgentBridge was stopped by `agentbridge kill`. Bridge is staying idle. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.");
+  await enterDisabledState(logMessage, `\u26D4 AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`);
   return true;
 }
 function reconnectToDaemon() {
@@ -14779,7 +14791,7 @@ async function pollDisabledRecovery() {
           daemonDisabledReason = "auto_recovery_exhausted";
           disabledRecoveryAttempts = 0;
           stopDisabledRecoveryPoller();
-          claude.pushNotification(systemMessage("system_bridge_auto_recovery_gave_up", "\u26A0\uFE0F AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`. AgentBridge \u81EA\u52A8\u6062\u590D\u5DF2\u653E\u5F03\u2014\u2014\u5B58\u6D3B\u63A2\u6D4B\u4E89\u7528\u7684\u91CD\u8BD5\u9884\u7B97\u5DF2\u7528\u5C3D\u3002\u8BF7\u4F7F\u7528 `agentbridge claude` \u624B\u52A8\u91CD\u8BD5\u3002"));
+          claude.pushNotification(systemMessage("system_bridge_auto_recovery_gave_up", `\u26A0\uFE0F AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${pairScopedCommand("claude")}\`. AgentBridge \u81EA\u52A8\u6062\u590D\u5DF2\u653E\u5F03\u2014\u2014\u5B58\u6D3B\u63A2\u6D4B\u4E89\u7528\u7684\u91CD\u8BD5\u9884\u7B97\u5DF2\u7528\u5C3D\u3002\u8BF7\u4F7F\u7528 \`${pairScopedCommand("claude")}\` \u624B\u52A8\u91CD\u8BD5\u3002`));
           return;
         }
         disabledRecoveryAttempts += 1;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -17,16 +17,16 @@ import { homedir, platform } from "os";
 
 class StateDirResolver {
   stateDir;
+  static platformBaseDir() {
+    if (platform() === "darwin") {
+      return join(homedir(), "Library", "Application Support", "AgentBridge");
+    }
+    const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+    return join(xdgState, "agentbridge");
+  }
   constructor(envOverride) {
     const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
-    if (override) {
-      this.stateDir = override;
-    } else if (platform() === "darwin") {
-      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
-    } else {
-      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-      this.stateDir = join(xdgState, "agentbridge");
-    }
+    this.stateDir = override && override.length > 0 ? override : StateDirResolver.platformBaseDir();
   }
   ensure() {
     if (!existsSync(this.stateDir)) {
@@ -1487,7 +1487,8 @@ class TuiConnectionState {
 import { spawn as spawn2, execFileSync } from "child_process";
 import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
-var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
+var DEFAULT_DAEMON_ENTRY = import.meta.url.endsWith(".ts") ? "./daemon.ts" : "./daemon.js";
+var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 
 class DaemonLifecycle {
@@ -2421,7 +2422,8 @@ function writeStatusFile() {
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
     controlPort: CONTROL_PORT,
-    pid: process.pid
+    pid: process.pid,
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null
   });
 }
 function removeStatusFile() {

--- a/scripts/runtime-dual-pair-e2e.py
+++ b/scripts/runtime-dual-pair-e2e.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+Manual runtime E2E harness for AgentBridge route-A multi-pair.
+
+This is intentionally outside `bun test src`: it launches real Claude Code and
+Codex TUIs and therefore depends on local auth, terminal behavior, and plugin
+setup. It is a repeatable operator harness for the final validation pass.
+
+Example:
+  python3 scripts/runtime-dual-pair-e2e.py --pairs a b --mode pull
+  python3 scripts/runtime-dual-pair-e2e.py --state-base /tmp/abg-e2e --reserve-slots 2
+
+Notes:
+  - Requires the multi-pair branch where `abg claude/codex/kill --pair` and
+    `abg pairs --json` exist.
+  - Uses Python's stdlib pty module; no npm dependency is required.
+  - If `--state-base` is supplied, the harness exports both AGENTBRIDGE_BASE_DIR
+    (registry base) and AGENTBRIDGE_STATE_DIR (legacy/base compatibility).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import selectors
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import pty
+
+
+BASE_PORT = 4500
+STRIDE = 10
+
+
+def now_stamp() -> str:
+    return time.strftime("%Y%m%d-%H%M%S")
+
+
+def strip_ansi(text: str) -> str:
+    # Small, sufficient ANSI stripper for transcript searches.
+    import re
+
+    return re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)", "", text)
+
+
+def run(
+    args: list[str],
+    env: dict[str, str] | None = None,
+    timeout: float = 10,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def command_exists(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def lsof_listen_pid(port: int) -> str | None:
+    if not command_exists("lsof"):
+        return None
+    proc = run(["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"], timeout=3)
+    out = proc.stdout.strip().splitlines()
+    return out[0].strip() if out else None
+
+
+def curl_ok(port: int, path: str = "/healthz") -> bool:
+    try:
+        proc = run(
+            ["curl", "-fsS", "--max-time", "1", f"http://127.0.0.1:{port}{path}"],
+            timeout=2,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+def ports_for_slot(slot: int) -> tuple[int, int, int]:
+    app = BASE_PORT + slot * STRIDE
+    return app, app + 1, app + 2
+
+
+@dataclass
+class PtyProcess:
+    name: str
+    argv: list[str]
+    env: dict[str, str]
+    log_path: Path
+    pid: int | None = None
+    fd: int | None = None
+    _buffer: str = ""
+
+    def start(self) -> None:
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.execvpe(self.argv[0], self.argv, self.env)
+        self.pid = pid
+        self.fd = fd
+        os.set_blocking(fd, False)
+
+    def pump(self, duration: float = 0.5) -> str:
+        if self.fd is None:
+            return ""
+        sel = selectors.DefaultSelector()
+        sel.register(self.fd, selectors.EVENT_READ)
+        deadline = time.time() + duration
+        chunks: list[str] = []
+        with self.log_path.open("ab") as out:
+            while time.time() < deadline:
+                timeout = max(0, min(0.1, deadline - time.time()))
+                events = sel.select(timeout)
+                if not events:
+                    continue
+                try:
+                    data = os.read(self.fd, 8192)
+                except BlockingIOError:
+                    continue
+                except OSError:
+                    break
+                if not data:
+                    break
+                out.write(data)
+                out.flush()
+                text = data.decode("utf-8", errors="replace")
+                chunks.append(text)
+                self._buffer += text
+        return "".join(chunks)
+
+    def send(self, text: str) -> None:
+        if self.fd is not None:
+            os.write(self.fd, text.encode("utf-8"))
+
+    def wait_for(self, patterns: Iterable[str], timeout: float = 30) -> bool:
+        wanted = list(patterns)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            self.pump(0.3)
+            clean = strip_ansi(self._buffer)
+            if any(p in clean for p in wanted):
+                return True
+        return False
+
+    def terminate(self) -> None:
+        if self.pid is None:
+            return
+        try:
+            self.send("/exit\r")
+            time.sleep(0.5)
+            self.pump(0.5)
+        except Exception:
+            pass
+        try:
+            os.kill(self.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        except Exception:
+            pass
+        deadline = time.time() + 3
+        while time.time() < deadline:
+            try:
+                pid, _ = os.waitpid(self.pid, os.WNOHANG)
+                if pid == self.pid:
+                    return
+            except ChildProcessError:
+                return
+            time.sleep(0.1)
+        try:
+            os.kill(self.pid, signal.SIGKILL)
+        except Exception:
+            pass
+
+
+def default_state_base() -> Path:
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "AgentBridge"
+    xdg = os.environ.get("XDG_STATE_HOME")
+    return Path(xdg) / "agentbridge" if xdg else Path.home() / ".local" / "state" / "agentbridge"
+
+
+def build_env(args: argparse.Namespace) -> dict[str, str]:
+    env = os.environ.copy()
+    env["AGENTBRIDGE_MODE"] = args.mode
+    if args.state_base:
+        base = str(Path(args.state_base).expanduser().resolve())
+        env["AGENTBRIDGE_BASE_DIR"] = base
+        env["AGENTBRIDGE_STATE_DIR"] = base
+    return env
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def seed_reserved_slots(state_base: Path, count: int) -> None:
+    if count <= 0:
+        return
+    registry_path = state_base / "pairs" / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    if registry_path.exists():
+        registry = read_json(registry_path)
+    else:
+        registry = {"version": 1, "pairs": []}
+    require(registry.get("version") == 1 and isinstance(registry.get("pairs"), list), "registry shape is invalid")
+
+    pairs = registry["pairs"]
+    used_slots = {entry.get("slot") for entry in pairs if isinstance(entry, dict)}
+    used_ids = {str(entry.get("pairId", "")).lower() for entry in pairs if isinstance(entry, dict)}
+    created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    for slot in range(count):
+        pair_id = f"_reserved-slot-{slot}"
+        if slot in used_slots:
+            continue
+        require(pair_id.lower() not in used_ids, f"reserved pair id already exists: {pair_id}")
+        pairs.append(
+            {
+                "pairId": pair_id,
+                "slot": slot,
+                "cwd": str(state_base),
+                "source": "flag",
+                "createdAt": created_at,
+            }
+        )
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+
+
+def assert_no_initial_port_conflicts(pairs: list[str], start_slot: int, allow_busy: bool) -> None:
+    busy: list[str] = []
+    for index, _pair in enumerate(pairs):
+        slot = start_slot + index
+        for port in ports_for_slot(slot):
+            pid = lsof_listen_pid(port)
+            if pid:
+                busy.append(f"{port} pid={pid}")
+    if busy and not allow_busy:
+        raise RuntimeError(
+            "Target ports are already busy; aborting before launch: " + ", ".join(busy)
+        )
+
+
+def dump_diagnostics(artifact: Path, state_base: Path, pairs: list[str], start_slot: int, env: dict[str, str], abg: str) -> None:
+    diag = artifact / "diagnostics.txt"
+    with diag.open("w", encoding="utf-8") as f:
+        f.write("== ports ==\n")
+        for index, pair in enumerate(pairs):
+            slot = start_slot + index
+            f.write(f"# pair {pair} slot {slot}\n")
+            for port in ports_for_slot(slot):
+                proc = run(["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN"], timeout=3)
+                f.write(proc.stdout or proc.stderr or f"(no listener on {port})\n")
+        f.write("\n== abg pairs --json ==\n")
+        proc = run([abg, "pairs", "--json"], env=env, timeout=10)
+        f.write(proc.stdout)
+        f.write(proc.stderr)
+        f.write("\n== state files ==\n")
+        for pair in pairs:
+            state = state_base / "pairs" / pair
+            f.write(f"\n# {state}\n")
+            for rel in ["status.json", "daemon.pid", "codex-tui.pid", "agentbridge.log", "codex-wrapper.log"]:
+                path = state / rel
+                f.write(f"--- {path} ---\n")
+                if path.exists():
+                    content = path.read_text(errors="replace")
+                    f.write(content[-20000:])
+                else:
+                    f.write("(missing)\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pairs", nargs=2, default=["a", "b"], metavar=("PAIR_A", "PAIR_B"))
+    parser.add_argument("--mode", choices=["pull", "push"], default="pull")
+    parser.add_argument("--abg", default="abg", help="agentbridge/abg command")
+    parser.add_argument("--artifact-dir", default=f"artifacts/runtime-dual-pair/{now_stamp()}")
+    parser.add_argument("--state-base", help="optional multi-pair registry base override")
+    parser.add_argument(
+        "--reserve-slots",
+        type=int,
+        default=0,
+        help="pre-seed registry placeholders for slots 0..N-1 so test pairs start at slot N",
+    )
+    parser.add_argument("--allow-busy-ports", action="store_true")
+    parser.add_argument("--skip-launch", action="store_true", help="only run state/port assertions")
+    parser.add_argument("--no-cleanup", action="store_true")
+    args = parser.parse_args()
+
+    artifact = Path(args.artifact_dir).resolve()
+    artifact.mkdir(parents=True, exist_ok=True)
+    env = build_env(args)
+    state_base = Path(args.state_base).expanduser().resolve() if args.state_base else default_state_base()
+    pairs = list(args.pairs)
+
+    require(command_exists(args.abg), f"{args.abg} not found")
+    require(command_exists("lsof"), "lsof not found")
+    require(command_exists("curl"), "curl not found")
+
+    processes: list[PtyProcess] = []
+    try:
+        require(args.reserve_slots >= 0, "--reserve-slots must be >= 0")
+        require(args.reserve_slots == 0 or args.state_base, "--reserve-slots requires an isolated --state-base")
+        if args.reserve_slots > 0:
+            seed_reserved_slots(state_base, args.reserve_slots)
+        assert_no_initial_port_conflicts(pairs, args.reserve_slots, args.allow_busy_ports)
+
+        if not args.skip_launch:
+            for pair in pairs:
+                claude = PtyProcess(
+                    name=f"claude-{pair}",
+                    argv=[args.abg, "claude", "--pair", pair],
+                    env=env,
+                    log_path=artifact / "pty" / f"claude-{pair}.log",
+                )
+                codex = PtyProcess(
+                    name=f"codex-{pair}",
+                    argv=[args.abg, "codex", "--pair", pair],
+                    env=env,
+                    log_path=artifact / "pty" / f"codex-{pair}.log",
+                )
+                print(f"starting {claude.name}: {' '.join(claude.argv)}")
+                claude.start()
+                processes.append(claude)
+                time.sleep(1)
+                claude.pump(1)
+                clean_prompt = strip_ansi(claude._buffer)
+                if "Enter" in clean_prompt and "confirm" in clean_prompt:
+                    claude.send("\r")
+                print(f"starting {codex.name}: {' '.join(codex.argv)}")
+                codex.start()
+                processes.append(codex)
+                time.sleep(2)
+                codex.pump(1)
+
+        # Let daemons and TUIs settle.
+        deadline = time.time() + 90
+        while time.time() < deadline:
+            for proc in processes:
+                proc.pump(0.05)
+            if all(curl_ok(ports_for_slot(args.reserve_slots + i)[2]) for i in range(len(pairs))):
+                break
+            time.sleep(0.5)
+
+        # Port/status assertions.
+        for index, pair in enumerate(pairs):
+            slot = args.reserve_slots + index
+            app, proxy, control = ports_for_slot(slot)
+            state = state_base / "pairs" / pair
+            status_path = state / "status.json"
+            require(status_path.exists(), f"missing status for {pair}: {status_path}")
+            status = read_json(status_path)
+            require(status.get("controlPort") == control, f"{pair} wrong controlPort: {status}")
+            require(status.get("appServerUrl") == f"ws://127.0.0.1:{app}", f"{pair} wrong appServerUrl: {status}")
+            require(status.get("proxyUrl") == f"ws://127.0.0.1:{proxy}", f"{pair} wrong proxyUrl: {status}")
+            require(curl_ok(control), f"{pair} control healthz failed on {control}")
+            require(lsof_listen_pid(control) is not None, f"{pair} no LISTEN on control {control}")
+            require(lsof_listen_pid(proxy) is not None, f"{pair} no LISTEN on proxy {proxy}")
+            require(lsof_listen_pid(app) is not None, f"{pair} no LISTEN on app {app}")
+
+            log = (state / "agentbridge.log").read_text(errors="replace")
+            require(f"Control server: ws://127.0.0.1:{control}/ws" in log, f"{pair} daemon log missing control port")
+            require(f"Codex app-server: ws://127.0.0.1:{app}" in log, f"{pair} daemon log missing app port")
+            require(f"Codex proxy: ws://127.0.0.1:{proxy}" in log, f"{pair} daemon log missing proxy port")
+            require(
+                f"Starting AgentBridge frontend (daemon ws ws://127.0.0.1:{control}/ws)" in log,
+                f"{pair} frontend log missing control port",
+            )
+
+        # Cross-negative checks.
+        state_a = state_base / "pairs" / pairs[0] / "agentbridge.log"
+        state_b = state_base / "pairs" / pairs[1] / "agentbridge.log"
+        if state_a.exists() and state_b.exists():
+            a_log = state_a.read_text(errors="replace")
+            b_log = state_b.read_text(errors="replace")
+            pair_a_control = ports_for_slot(args.reserve_slots)[2]
+            pair_b_control = ports_for_slot(args.reserve_slots + 1)[2]
+            require(f"ws://127.0.0.1:{pair_b_control}/ws" not in a_log, "pair a log mentions pair b control port")
+            require(f"ws://127.0.0.1:{pair_a_control}/ws" not in b_log, "pair b log mentions pair a control port")
+
+        print("PASS: dual-pair port/state/log assertions passed")
+        print(f"artifacts: {artifact}")
+        return 0
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        dump_diagnostics(artifact, state_base, pairs, args.reserve_slots, env, args.abg)
+        print(f"diagnostics: {artifact / 'diagnostics.txt'}", file=sys.stderr)
+        return 1
+    finally:
+        if not args.no_cleanup:
+            for pair in pairs:
+                run([args.abg, "kill", "--pair", pair], env=env, timeout=20)
+            for proc in reversed(processes):
+                proc.terminate()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke-built-cli.mjs
+++ b/scripts/smoke-built-cli.mjs
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, statSync, readFileSync } from "node:fs";
+import { chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import net from "node:net";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distCli = join(repoRoot, "dist", "cli.js");
+const distDaemon = join(repoRoot, "dist", "daemon.js");
+const skipBuild = process.argv.includes("--skip-build");
+const keepTmp = process.env.AGENTBRIDGE_SMOKE_KEEP_TMP === "1";
+const fakeCodexHealthStatus = Number.parseInt(process.env.AGENTBRIDGE_SMOKE_FAKE_CODEX_HEALTH_STATUS ?? "200", 10);
+
+const SMOKE_TIMEOUT_MS = 20_000;
+
+function log(message) {
+  process.stderr.write(`[smoke-built-cli] ${message}\n`);
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assert(condition, message) {
+  if (!condition) fail(message);
+}
+
+async function run(command, args, options = {}) {
+  const {
+    cwd = repoRoot,
+    env = process.env,
+    timeoutMs = SMOKE_TIMEOUT_MS,
+  } = options;
+
+  return await new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (child.exitCode === null) child.kill("SIGKILL");
+      }, 1000).unref();
+      reject(new Error(`${command} ${args.join(" ")} timed out after ${timeoutMs}ms\n${stderr}`));
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolvePromise({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+async function runChecked(command, args, options = {}) {
+  const result = await run(command, args, options);
+  if (result.code !== 0) {
+    fail(
+      `${command} ${args.join(" ")} failed with code ${result.code ?? `signal ${result.signal}`}\n` +
+        `--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+    );
+  }
+  return result;
+}
+
+function assertRunnableArtifact(path, label) {
+  assert(existsSync(path), `${label} is missing: ${path}`);
+  const mode = statSync(path).mode;
+  assert((mode & 0o111) !== 0, `${label} is not executable: ${path}`);
+}
+
+async function getFreePort() {
+  return await new Promise((resolvePort, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("failed to allocate a TCP port")));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolvePort(port));
+    });
+  });
+}
+
+async function assertPortFree(port, label) {
+  const deadline = Date.now() + 3000;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    const free = await new Promise((resolveProbe) => {
+      const server = net.createServer();
+      server.unref();
+      server.on("error", (err) => {
+        lastError = err;
+        resolveProbe(false);
+      });
+      server.listen(port, "127.0.0.1", () => {
+        server.close(() => resolveProbe(true));
+      });
+    });
+
+    if (free) return;
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 100));
+  }
+
+  throw new Error(`${label} port ${port} was not released: ${lastError?.message ?? "still busy"}`);
+}
+
+function readPidFile(path) {
+  try {
+    const raw = readFileSync(path, "utf-8").trim();
+    if (!raw) return null;
+    const pid = Number.parseInt(raw, 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function pidFromStatus(path) {
+  try {
+    const status = JSON.parse(readFileSync(path, "utf-8"));
+    return Number.isInteger(status.pid) && status.pid > 0 ? status.pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function waitForHttpOk(url, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response;
+      lastError = new Error(`${url} returned ${response.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 100));
+  }
+  throw lastError ?? new Error(`${url} did not become ready`);
+}
+
+async function waitForProcessExit(pid, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 100));
+  }
+  fail(`daemon pid ${pid} did not exit within ${timeoutMs}ms`);
+}
+
+function writeFakeCodex(binDir) {
+  const fakeCodexPath = join(binDir, "codex");
+  const fakeCodex = `#!${process.execPath}
+const args = process.argv.slice(2);
+
+if (args[0] === "app-server") {
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: codex app-server [OPTIONS]");
+    console.log("      --listen <URL>");
+    console.log("          Transport endpoint URL. Supported values: stdio://, unix://, unix://PATH, ws://IP:PORT, off");
+    process.exit(0);
+  }
+
+  const listenIndex = args.indexOf("--listen");
+  const listenUrl = listenIndex >= 0 ? args[listenIndex + 1] : "stdio://";
+  if (!listenUrl || !listenUrl.startsWith("ws://")) {
+    console.error("fake codex only supports app-server --listen ws://HOST:PORT");
+    process.exit(2);
+  }
+
+  const url = new URL(listenUrl);
+  const port = Number.parseInt(url.port, 10);
+  const hostname = url.hostname || "127.0.0.1";
+  const healthStatus = () => Number.parseInt(process.env.AGENTBRIDGE_SMOKE_FAKE_CODEX_HEALTH_STATUS || "200", 10);
+
+  if (typeof Bun !== "undefined" && typeof Bun.serve === "function") {
+    const server = Bun.serve({
+      port,
+      hostname,
+      fetch(req, server) {
+        const url = new URL(req.url);
+        if (url.pathname === "/healthz" || url.pathname === "/readyz") {
+          const status = healthStatus();
+          return Response.json({ ok: status >= 200 && status < 300 }, { status });
+        }
+        if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+          if (server.upgrade(req)) return undefined;
+          return new Response("websocket upgrade failed", { status: 400 });
+        }
+        return new Response("fake codex app-server\\n");
+      },
+      websocket: {
+        open() {},
+        message() {},
+        close() {},
+      },
+    });
+
+    console.error("fake codex app-server listening " + listenUrl);
+
+    function shutdown() {
+      server.stop(true);
+      process.exit(0);
+    }
+    process.on("SIGTERM", shutdown);
+    process.on("SIGINT", shutdown);
+    setInterval(() => {}, 1000);
+    return;
+  }
+
+  const http = require("node:http");
+  const crypto = require("node:crypto");
+
+  function websocketAccept(key) {
+    return crypto
+      .createHash("sha1")
+      .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+      .digest("base64");
+  }
+
+  const server = http.createServer((req, res) => {
+    if (req.url === "/healthz" || req.url === "/readyz") {
+      const status = healthStatus();
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: status >= 200 && status < 300 }) + "\\n");
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("fake codex app-server\\n");
+  });
+
+  server.on("upgrade", (req, socket) => {
+    const key = req.headers["sec-websocket-key"];
+    if (!key) {
+      socket.destroy();
+      return;
+    }
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\\r\\n" +
+        "Upgrade: websocket\\r\\n" +
+        "Connection: Upgrade\\r\\n" +
+        "Sec-WebSocket-Accept: " + websocketAccept(key) + "\\r\\n" +
+        "\\r\\n",
+    );
+    socket.on("data", () => {});
+    socket.on("error", () => {});
+  });
+
+  server.listen(port, hostname, () => {
+    console.error("fake codex app-server listening " + listenUrl);
+  });
+
+  function shutdown() {
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(0), 500).unref();
+  }
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+  setInterval(() => {}, 1000).unref();
+  return;
+}
+
+if (args.includes("--version")) {
+  console.log("fake-codex 0.0.0");
+  process.exit(0);
+}
+
+console.log("fake codex " + args.join(" "));
+process.exit(0);
+`;
+
+  writeFileSync(fakeCodexPath, fakeCodex, "utf-8");
+  return fakeCodexPath;
+}
+
+async function main() {
+  if (!skipBuild) {
+    log("building CLI artifacts");
+    await runChecked("bun", ["run", "build:cli"], { timeoutMs: 60_000 });
+  } else {
+    log("skipping build (--skip-build)");
+  }
+
+  assertRunnableArtifact(distCli, "dist/cli.js");
+  assertRunnableArtifact(distDaemon, "dist/daemon.js");
+
+  const tempRoot = mkdtempSync(join(tmpdir(), "agentbridge-built-smoke-"));
+  const stateDir = join(tempRoot, "state");
+  const binDir = join(tempRoot, "bin");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeCodexPath = writeFakeCodex(binDir);
+  await chmod(fakeCodexPath, 0o755);
+
+  const appPort = await getFreePort();
+  const proxyPort = await getFreePort();
+  const controlPort = await getFreePort();
+  let daemonPid = null;
+  const statusPath = join(stateDir, "status.json");
+
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    AGENTBRIDGE_STATE_DIR: stateDir,
+    AGENTBRIDGE_CONTROL_PORT: String(controlPort),
+    CODEX_WS_PORT: String(appPort),
+    CODEX_PROXY_PORT: String(proxyPort),
+    AGENTBRIDGE_SMOKE_FAKE_CODEX_HEALTH_STATUS: String(fakeCodexHealthStatus),
+  };
+
+  try {
+    log(`starting built CLI smoke on app:${appPort} proxy:${proxyPort} control:${controlPort}`);
+    const cliResult = await run(distCli, ["codex", "help"], {
+      env,
+      timeoutMs: SMOKE_TIMEOUT_MS,
+    });
+
+    if (cliResult.code !== 0) {
+      fail(
+        `built CLI smoke command failed with code ${cliResult.code ?? `signal ${cliResult.signal}`}\n` +
+          `--- stdout ---\n${cliResult.stdout}\n--- stderr ---\n${cliResult.stderr}`,
+      );
+    }
+
+    await waitForHttpOk(`http://127.0.0.1:${controlPort}/healthz`);
+    await waitForHttpOk(`http://127.0.0.1:${controlPort}/readyz`);
+
+    assert(existsSync(statusPath), `status.json was not written: ${statusPath}`);
+    const status = JSON.parse(readFileSync(statusPath, "utf-8"));
+    assert(Number.isInteger(status.pid) && status.pid > 0, "status.json missing numeric pid");
+    assert(status.controlPort === controlPort, `status.json controlPort mismatch: ${status.controlPort}`);
+    assert(status.proxyUrl === `ws://127.0.0.1:${proxyPort}`, `status.json proxyUrl mismatch: ${status.proxyUrl}`);
+    assert(status.appServerUrl === `ws://127.0.0.1:${appPort}`, `status.json appServerUrl mismatch: ${status.appServerUrl}`);
+
+    daemonPid = status.pid;
+    try {
+      process.kill(daemonPid, 0);
+    } catch {
+      fail(`daemon pid from status.json is not alive: ${daemonPid}`);
+    }
+
+    log(`daemon healthy pid=${daemonPid}`);
+  } finally {
+    const pidPath = join(stateDir, "daemon.pid");
+    daemonPid ??= pidFromStatus(statusPath);
+    daemonPid ??= readPidFile(pidPath);
+
+    let cleanupError = null;
+    if (daemonPid) {
+      try {
+        process.kill(daemonPid, "SIGTERM");
+        await waitForProcessExit(daemonPid);
+      } catch (err) {
+        log(`cleanup warning: ${err.message}`);
+        try { process.kill(daemonPid, "SIGKILL"); } catch {}
+      }
+    }
+
+    for (const [port, label] of [
+      [appPort, "app"],
+      [proxyPort, "proxy"],
+      [controlPort, "control"],
+    ]) {
+      try {
+        await assertPortFree(port, label);
+      } catch (err) {
+        cleanupError ??= new Error(
+          `${err.message}. This often means daemon bootstrap failed before status.json was written; ` +
+            `cleanup attempted pid from ${statusPath} and ${pidPath}.`,
+        );
+      }
+    }
+
+    if (keepTmp) {
+      log(`kept temp dir: ${tempRoot}`);
+    } else {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+
+    if (cleanupError) throw cleanupError;
+  }
+
+  log("PASS");
+}
+
+main().catch((err) => {
+  console.error(`[smoke-built-cli] FAIL: ${err.stack ?? err.message}`);
+  process.exit(1);
+});

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env bun
+
+// Packaged-artifact smoke test: verifies that `npm pack` would ship every file
+// the CLI + daemon + plugin need at runtime.
+//
+// Background: a recent release shipped a broken package because `build:cli` did
+// not emit `dist/daemon.js` and nothing verified the packed output. This script
+// is the packaging-completeness guard (sibling to scripts/smoke-built-cli.mjs).
+//
+// It is deterministic, fast, offline, and side-effect-free on the repo:
+//   1. builds dist/ + plugin bundles,
+//   2. asks `npm pack --dry-run --json` what would be packed (no publish, no
+//      install, no postinstall),
+//   3. asserts every required artifact (incl. dist/daemon.js and the bin
+//      targets) is present and that bin targets exist + are executable on disk.
+//
+// Manual regression check (confirm it catches the original bug class — a
+// build:cli that FAILS to emit dist/daemon.js): temporarily delete the
+// `bun build src/daemon.ts ...` step from the build:cli script, then run
+// `bun scripts/smoke-pack.mjs` — it must exit non-zero (MISSING: dist/daemon.js).
+// Restore build:cli afterward. (Deleting dist/daemon.js on disk does NOT
+// reproduce it — this script rebuilds dist/ before packing.)
+// `npm pack --dry-run` writes no tarball, so this script touches nothing on disk.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+function fail(message, details = []) {
+  console.error(`\nsmoke-pack FAILED: ${message}`);
+  for (const line of details) {
+    console.error(`  - ${line}`);
+  }
+  process.exit(1);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function build() {
+  console.log("smoke-pack: building dist/ + plugin bundles ...");
+  for (const script of ["build:cli", "build:plugin"]) {
+    execFileSync("bun", ["run", script], {
+      cwd: repoRoot,
+      stdio: "inherit",
+    });
+  }
+}
+
+function packedPaths() {
+  // `npm pack --dry-run --json` reports exactly what would ship, without
+  // publishing or creating a tarball on disk. Output is a JSON array whose
+  // single entry has a `files: [{ path }]` list.
+  const raw = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    fail(`could not parse \`npm pack --dry-run --json\` output: ${error.message}`);
+  }
+  const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!entry || !Array.isArray(entry.files)) {
+    fail("`npm pack --dry-run --json` did not return a files list");
+  }
+  return new Set(entry.files.map((f) => f.path));
+}
+
+function main() {
+  build();
+
+  const pkg = readJson(join(repoRoot, "package.json"));
+  const binTargets = [...new Set(Object.values(pkg.bin ?? {}))];
+  if (binTargets.length === 0) {
+    fail("package.json has no bin targets to verify");
+  }
+
+  // Required artifacts the published package must contain for CLI + daemon +
+  // plugin to work. Bin targets are unioned in so package.json drift is caught.
+  const required = new Set([
+    "dist/cli.js",
+    "dist/daemon.js", // ← the omission that shipped the original broken package
+    "plugins/agentbridge/server/bridge-server.js",
+    "plugins/agentbridge/server/daemon.js",
+    "package.json",
+    "README.md",
+    ...binTargets,
+  ]);
+
+  const packed = packedPaths();
+  const missing = [...required].filter((path) => !packed.has(path)).sort();
+  if (missing.length > 0) {
+    const present = [...packed].sort();
+    fail(
+      `${missing.length} required artifact(s) missing from the packed set`,
+      [
+        ...missing.map((path) => `MISSING: ${path}`),
+        `--- ${present.length} packed paths ---`,
+        ...present.map((path) => `present: ${path}`),
+      ],
+    );
+  }
+
+  // Bin targets must also exist on disk and be executable (chmod +x), since the
+  // packed `mode` only matters if the source file is actually executable.
+  const binProblems = [];
+  for (const target of binTargets) {
+    const absolute = join(repoRoot, target);
+    if (!existsSync(absolute)) {
+      binProblems.push(`bin target does not exist on disk: ${target}`);
+      continue;
+    }
+    const mode = statSync(absolute).mode;
+    const isExecutable = (mode & 0o111) !== 0;
+    if (!isExecutable) {
+      binProblems.push(`bin target is not executable (missing +x): ${target}`);
+    }
+  }
+  if (binProblems.length > 0) {
+    fail("bin target on-disk checks failed", binProblems);
+  }
+
+  console.log(
+    `\nsmoke-pack OK: ${packed.size} files packed, all ${required.size} required artifacts present; ` +
+      `bin targets [${binTargets.join(", ")}] exist + are executable.`,
+  );
+  process.exit(0);
+}
+
+// `npm pack --dry-run` writes no tarball, so the script touches nothing on disk
+// (and never the repo) — no temp dir to manage.
+main();

--- a/src/bridge-disabled-state.ts
+++ b/src/bridge-disabled-state.ts
@@ -5,17 +5,23 @@ export type BridgeDisabledReason =
   | "probe_in_progress"
   | "auto_recovery_exhausted";
 
+import { pairScopedCommand } from "./pair-command";
+
 export function disabledReplyError(reason: BridgeDisabledReason): string {
+  // These render in the bridge (MCP server) process, which inherits
+  // AGENTBRIDGE_PAIR_ID in multi-pair mode — so the suggested commands carry
+  // `--pair <id>` and don't send the user to a different pair / kill all pairs.
+  const claudeCmd = pairScopedCommand("claude");
   switch (reason) {
     case "rejected":
-      return "AgentBridge rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset.";
+      return `AgentBridge rejected this session — another Claude Code session is already connected. Close the other session first, or run \`${pairScopedCommand("kill")}\` to reset.`;
     case "evicted":
-      return "AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude`.";
+      return `AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with \`${claudeCmd}\`.`;
     case "probe_in_progress":
-      return "AgentBridge rejected this session — a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with `agentbridge claude`.";
+      return `AgentBridge rejected this session — a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with \`${claudeCmd}\`.`;
     case "auto_recovery_exhausted":
-      return "AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`.";
+      return `AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${claudeCmd}\`.`;
     case "killed":
-      return "AgentBridge is disabled by `agentbridge kill`. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.";
+      return `AgentBridge is disabled by \`agentbridge kill\`. Restart Claude Code (\`${claudeCmd}\`), switch to a new conversation, or run \`/resume\` to reconnect.`;
   }
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,6 +7,7 @@ import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
 import { ConfigService } from "./config-service";
 import { disabledReplyError, type BridgeDisabledReason } from "./bridge-disabled-state";
+import { pairScopedCommand } from "./pair-command";
 import {
   CLOSE_CODE_EVICTED_STALE,
   CLOSE_CODE_PROBE_IN_PROGRESS,
@@ -115,17 +116,17 @@ daemonClient.on("rejected", async (code: number) => {
     case CLOSE_CODE_EVICTED_STALE:
       reason = "evicted";
       notificationId = "system_bridge_evicted";
-      notificationContent = "⚠️ AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge 因此会话未响应存活探测而将其驱逐——更新的 Claude Code 会话已接管。如需重连，请关闭此会话并运行 `agentbridge claude` 启动新会话。";
+      notificationContent = `⚠️ AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with \`${pairScopedCommand("claude")}\` if you want to reconnect. AgentBridge 因此会话未响应存活探测而将其驱逐——更新的 Claude Code 会话已接管。如需重连，请关闭此会话并运行 \`${pairScopedCommand("claude")}\` 启动新会话。`;
       break;
     case CLOSE_CODE_PROBE_IN_PROGRESS:
       reason = "probe_in_progress";
       notificationId = "system_bridge_probe_in_progress";
-      notificationContent = "⚠️ AgentBridge rejected this session — a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with `agentbridge claude`. AgentBridge 拒绝了此会话——正在通过存活探测检查现有 Claude 会话是否仍然在线。请稍后用 `agentbridge claude` 重试。";
+      notificationContent = `⚠️ AgentBridge rejected this session — a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with \`${pairScopedCommand("claude")}\`. AgentBridge 拒绝了此会话——正在通过存活探测检查现有 Claude 会话是否仍然在线。请稍后用 \`${pairScopedCommand("claude")}\` 重试。`;
       break;
     default:
       reason = "rejected";
       notificationId = "system_bridge_replaced";
-      notificationContent = "⚠️ AgentBridge daemon rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge 守护进程拒绝了此会话——另一个 Claude Code 会话已在连接中。请先关闭另一个会话，或运行 `agentbridge kill` 重置。";
+      notificationContent = `⚠️ AgentBridge daemon rejected this session — another Claude Code session is already connected. Close the other session first, or run \`${pairScopedCommand("kill")}\` to reset. AgentBridge 守护进程拒绝了此会话——另一个 Claude Code 会话已在连接中。请先关闭另一个会话，或运行 \`${pairScopedCommand("kill")}\` 重置。`;
       break;
   }
   log(`Daemon rejected this session (close code ${code}, reason=${reason})`);
@@ -150,7 +151,7 @@ claude.on("ready", async () => {
   if (daemonLifecycle.wasKilled()) {
     await enterDisabledState(
       "Killed sentinel found — bridge staying idle",
-      "⛔ AgentBridge was stopped by `agentbridge kill`. Bridge is staying idle. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.",
+      `⛔ AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`,
     );
     return;
   }
@@ -171,7 +172,7 @@ async function connectToDaemon(isReconnect = false) {
     if (!isReconnect) {
       void claude.pushNotification(systemMessage(
         "system_bridge_ready",
-        "✅ AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: agentbridge codex",
+        `✅ AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: ${pairScopedCommand("codex")}`,
       ));
     }
   } catch (err: any) {
@@ -205,7 +206,7 @@ async function notifyIfDaemonKilled(logMessage: string) {
 
   await enterDisabledState(
     logMessage,
-    "⛔ AgentBridge was stopped by `agentbridge kill`. Bridge is staying idle. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.",
+    `⛔ AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`,
   );
   return true;
 }
@@ -311,7 +312,7 @@ async function pollDisabledRecovery() {
           stopDisabledRecoveryPoller();
           void claude.pushNotification(systemMessage(
             "system_bridge_auto_recovery_gave_up",
-            "⚠️ AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`. AgentBridge 自动恢复已放弃——存活探测争用的重试预算已用尽。请使用 `agentbridge claude` 手动重试。",
+            `⚠️ AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${pairScopedCommand("claude")}\`. AgentBridge 自动恢复已放弃——存活探测争用的重试预算已用尽。请使用 \`${pairScopedCommand("claude")}\` 手动重试。`,
           ));
           return;
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,11 @@ async function main() {
       break;
     case "kill":
       const { runKill } = await import("./cli/kill");
-      await runKill();
+      await runKill(restArgs);
+      break;
+    case "pairs":
+      const { runPairs } = await import("./cli/pairs");
+      await runPairs(restArgs);
       break;
     case "--help":
     case "-h":
@@ -66,23 +70,33 @@ Usage:
   abg <command> [args...]
 
 Commands:
-  init              Install plugin, check dependencies, generate project config
-  dev               Register local marketplace + install plugin (for local dev)
-  claude [args...]  Start Claude Code with push channel enabled
-  codex [args...]   Start Codex TUI connected to AgentBridge daemon
-  kill              Force kill all AgentBridge processes
+  init               Install plugin, check dependencies, generate project config
+  dev                Register local marketplace + install plugin (for local dev)
+  claude [args...]   Start Claude Code with push channel enabled
+  codex [args...]    Start Codex TUI connected to AgentBridge daemon
+  pairs [rm <id>]    List running Claude+Codex pairs (or remove one)
+  kill [--pair <id>] Stop all pairs, or just one with --pair (alias: --all)
 
 Options:
-  --help, -h        Show this help message
-  --version, -v     Show version
+  --pair <name>      Run claude/codex in a named pair (multiple pairs per machine).
+                     Without it, the pair is derived from the current directory.
+  --help, -h         Show this help message
+  --version, -v      Show version
+
+Multi-pair:
+  Each pair is an isolated daemon with its own port triple. The first pair uses
+  the classic ports 4500/4501/4502; each additional pair steps +10.
 
 Examples:
   abg init                     # First-time setup
-  abg claude                   # Start Claude Code
-  abg claude --resume          # Start Claude Code and resume session
-  abg codex                    # Start Codex TUI
-  abg codex --model o3         # Start Codex with specific model
-  abg kill                     # Emergency: kill all processes
+  abg claude                   # Start Claude Code (pair derived from cwd)
+  abg claude --pair work       # Start a named pair "work"
+  abg codex  --pair work       # Connect Codex to the "work" pair
+  abg claude --pair review     # A second, parallel pair
+  abg pairs                    # List all pairs and their ports/status
+  abg pairs rm work            # Stop the "work" pair and free its slot
+  abg kill --pair work         # Stop only the "work" pair
+  abg kill                     # Stop ALL pairs
 `.trim());
 }
 

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -1,22 +1,43 @@
 import { spawn } from "node:child_process";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { DaemonLifecycle } from "../daemon-lifecycle";
-import { StateDirResolver } from "../state-dir";
+import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
 
 /** Flags that AgentBridge owns and will inject automatically. */
 const OWNED_FLAGS = ["--channels", "--dangerously-load-development-channels"];
 
 export async function runClaude(args: string[]) {
-  // Check for owned flag conflicts
-  checkOwnedFlagConflicts(args, "agentbridge claude", OWNED_FLAGS);
+  // Strip `--pair <name>` before anything else; the rest flows through to claude.
+  const { pairFlag, rest } = parsePairFlag(args);
 
-  const stateDir = new StateDirResolver();
-  const controlPort = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
+  // Check for owned flag conflicts (on the real claude args, not the pair flag).
+  checkOwnedFlagConflicts(rest, "agentbridge claude", OWNED_FLAGS);
+
+  // Resolve the pair and inject its env (state dir + ports) BEFORE building the
+  // lifecycle or spawning claude, so the daemon, the spawned `claude`, and its
+  // plugin MCP server all target this pair's state dir + control port.
+  let pair: PairResolution;
+  try {
+    pair = await applyPairEnv({ pairFlag });
+  } catch (err: any) {
+    console.error(`[agentbridge] ${err.message}`);
+    process.exit(1);
+  }
+
+  const stateDir = pair.stateDir;
+  const controlPort = pair.ports.controlPort;
   const lifecycle = new DaemonLifecycle({
     stateDir,
     controlPort,
     log: (msg) => console.error(`[agentbridge] ${msg}`),
   });
+
+  if (!pair.manual) {
+    console.error(
+      `[agentbridge] pair "${pair.pairId}" (slot ${pair.slot}) — control :${controlPort}, ` +
+        `codex :${pair.ports.appPort}/:${pair.ports.proxyPort}`,
+    );
+  }
 
   lifecycle.clearKilled();
 
@@ -31,7 +52,7 @@ export async function runClaude(args: string[]) {
   // Once published to the official marketplace, switch to --channels.
   const fullArgs = [
     "--dangerously-load-development-channels", channelEntry,
-    ...args,
+    ...rest,
   ];
 
   const child = spawn("claude", fullArgs, {

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -10,9 +10,10 @@ import {
   mkdirSync,
 } from "node:fs";
 import { dirname } from "node:path";
-import { StateDirResolver } from "../state-dir";
 import { ConfigService } from "../config-service";
 import { DaemonLifecycle } from "../daemon-lifecycle";
+import { pairScopedCommand } from "../pair-command";
+import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
 import { StderrRingBuffer } from "../stderr-ring-buffer";
 import { checkOwnedFlagConflicts } from "./claude";
 
@@ -125,19 +126,22 @@ export function buildCodexArgs(userArgs: string[], proxyUrl: string): BuildArgsR
 }
 
 export async function runCodex(args: string[]) {
-  // Check for owned flag conflicts
-  checkOwnedFlagConflicts(args, "agentbridge codex", OWNED_FLAGS);
+  // Strip `--pair <name>` first; the rest flows through to codex.
+  const { pairFlag, rest } = parsePairFlag(args);
+
+  // Check for owned flag conflicts (on the real codex args, not the pair flag).
+  checkOwnedFlagConflicts(rest, "agentbridge codex", OWNED_FLAGS);
 
   // Specifically check for --enable tui_app_server (not all --enable values)
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--enable" && args[i + 1] === "tui_app_server") {
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === "--enable" && rest[i + 1] === "tui_app_server") {
       console.error(`Error: "--enable tui_app_server" is automatically set by agentbridge codex.`);
       console.error("");
       console.error("If you need full control over these flags, use the native command directly:");
       console.error("  codex [your flags here]");
       process.exit(1);
     }
-    if (args[i] === "--enable=tui_app_server") {
+    if (rest[i] === "--enable=tui_app_server") {
       console.error(`Error: "--enable=tui_app_server" is automatically set by agentbridge codex.`);
       console.error("");
       console.error("If you need full control over these flags, use the native command directly:");
@@ -146,16 +150,31 @@ export async function runCodex(args: string[]) {
     }
   }
 
-  const stateDir = new StateDirResolver();
-  const configService = new ConfigService();
-  const config = configService.loadOrDefault();
-  const controlPort = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
+  // Resolve the pair and inject its env BEFORE ensureRunning, so the daemon this
+  // launches binds this pair's Codex app-server / proxy / control ports.
+  let pair: PairResolution;
+  try {
+    pair = await applyPairEnv({ pairFlag });
+  } catch (err: any) {
+    console.error(`[agentbridge] ${err.message}`);
+    process.exit(1);
+  }
+
+  const stateDir = pair.stateDir;
+  const controlPort = pair.ports.controlPort;
 
   const lifecycle = new DaemonLifecycle({
     stateDir,
     controlPort,
     log: (msg) => console.error(`[agentbridge] ${msg}`),
   });
+
+  if (!pair.manual) {
+    console.error(
+      `[agentbridge] pair "${pair.pairId}" (slot ${pair.slot}) — control :${controlPort}, ` +
+        `codex :${pair.ports.appPort}/:${pair.ports.proxyPort}`,
+    );
+  }
 
   // Ensure daemon is running
   console.error("[agentbridge] Ensuring daemon is running...");
@@ -165,7 +184,7 @@ export async function runCodex(args: string[]) {
     console.error("[agentbridge] Daemon is ready.");
   } catch (err: any) {
     console.error(`[agentbridge] Failed to start daemon: ${err.message}`);
-    console.error("[agentbridge] Try: agentbridge kill && agentbridge claude");
+    console.error(`[agentbridge] Try: ${pairScopedCommand("kill")} && ${pairScopedCommand("claude")}`);
     process.exit(1);
   }
 
@@ -175,8 +194,13 @@ export async function runCodex(args: string[]) {
   if (status?.proxyUrl) {
     proxyUrl = status.proxyUrl;
   } else {
-    proxyUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
-    console.error(`[agentbridge] No daemon status found, using config default: ${proxyUrl}`);
+    // Mirror exactly how the daemon resolves its proxy port (daemon.ts:39):
+    // CODEX_PROXY_PORT (set by applyPairEnv in pair mode; user-set in manual mode)
+    // else the project config. This is correct for BOTH multi-pair (env carries
+    // the slot's port) and manual/legacy mode (config may be a custom port).
+    const fallbackProxyPort = process.env.CODEX_PROXY_PORT ?? String(new ConfigService().loadOrDefault().codex.proxyPort);
+    proxyUrl = `ws://127.0.0.1:${fallbackProxyPort}`;
+    console.error(`[agentbridge] No daemon status found, using fallback proxy port: ${proxyUrl}`);
   }
 
   try {
@@ -239,7 +263,7 @@ export async function runCodex(args: string[]) {
     }
   }
 
-  const { fullArgs } = buildCodexArgs(args, proxyUrl);
+  const { fullArgs } = buildCodexArgs(rest, proxyUrl);
 
   // Capture the last 64KB of child stderr so the "ERROR: ..." line from
   // codex-rs on ExitReason::Fatal survives even when stdio is inherited by

--- a/src/cli/kill.ts
+++ b/src/cli/kill.ts
@@ -1,39 +1,190 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync, unlinkSync } from "node:fs";
-import { StateDirResolver } from "../state-dir";
+import { join } from "node:path";
 import { DaemonLifecycle, isProcessAlive } from "../daemon-lifecycle";
+import { PairError, detectLegacyRootDaemon, type PairEntry, type PairPorts } from "../pair-registry";
+import {
+  computeBaseDir,
+  findPair,
+  listPairs,
+  parseKillArgs,
+  portsForEntry,
+} from "../pair-resolver";
+import { StateDirResolver } from "../state-dir";
 
-export async function runKill() {
-  console.log("AgentBridge Kill — stopping daemon and managed Codex TUI\n");
+type LogFn = (msg: string) => void;
 
-  const stateDir = new StateDirResolver();
-  const controlPort = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
+export interface StopResult {
+  label: string;
+  daemonKilled: boolean;
+  tuiKilled: boolean;
+  error?: unknown;
+}
 
-  const lifecycle = new DaemonLifecycle({
-    stateDir,
-    controlPort,
-    log: (msg) => console.log(`  ${msg}`),
-  });
-
-  // Mark the daemon as intentionally stopped before terminating the process.
-  // This closes the reconnect race where the frontend sees the disconnect
-  // before the sentinel is written and relaunches the daemon.
-  lifecycle.markKilled();
-  const tuiKilled = await killManagedCodexTui(stateDir, (msg) => console.log(`  ${msg}`));
-  const killed = await lifecycle.kill();
-
-  if (killed || tuiKilled) {
-    console.log("\nAgentBridge stopped.");
-    console.log("Please restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to fully disconnect.");
-  } else {
-    console.log("\nNo running AgentBridge daemon or managed Codex TUI found.");
-    console.log("Stale state files cleaned up (if any).");
+export async function runKill(args: string[] = []) {
+  const argError = validateKillArgs(args);
+  if (argError === "help") {
+    printKillUsage();
+    return;
   }
+  if (argError) {
+    console.error(`Error: ${argError}`);
+    printKillUsage();
+    process.exit(1);
+  }
+
+  const parsed = parseKillArgs(args);
+
+  if (parsed.pairFlag !== undefined && parsed.all) {
+    console.error('Error: use either "--pair <name>" or "--all", not both.');
+    process.exit(1);
+  }
+
+  const base = computeBaseDir();
+  console.log("AgentBridge Kill — stopping AgentBridge pair processes\n");
+
+  const results: StopResult[] = [];
+  let restartCommand = "agentbridge claude";
+  if (parsed.pairFlag !== undefined) {
+    const pair = findPair(base, parsed.pairFlag);
+    if (!pair) {
+      console.log(`No such pair: ${parsed.pairFlag}`);
+      printKnownPairs(base);
+      return;
+    }
+    restartCommand = `agentbridge claude --pair ${parsed.pairFlag}`;
+    results.push(await stopPairEntry(base, pair));
+  } else {
+    for (const pair of listPairs(base)) {
+      results.push(await stopPairEntry(base, pair));
+    }
+    const legacy = detectLegacyRootDaemon(base);
+    if (legacy) {
+      results.push(await stopStateDir("(legacy-root)", new StateDirResolver(base), {
+        appPort: 4500,
+        proxyPort: 4501,
+        controlPort: legacy.controlPort,
+      }));
+    }
+  }
+
+  printSummary(results, restartCommand);
+}
+
+function validateKillArgs(args: string[]): string | "help" | null {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--help" || arg === "-h") return "help";
+    if (arg === "--all") continue;
+    if (arg === "--pair") {
+      const value = args[i + 1];
+      if (value === undefined || value.startsWith("-")) {
+        return 'Missing value for "--pair".';
+      }
+      i++;
+      continue;
+    }
+    if (arg.startsWith("--pair=")) {
+      if (arg.slice("--pair=".length).length === 0) {
+        return 'Missing value for "--pair".';
+      }
+      continue;
+    }
+    return `Unknown kill argument: ${arg}`;
+  }
+  return null;
+}
+
+function printKillUsage() {
+  console.log(`
+Usage: abg kill [--all]
+       abg kill --pair <id>
+
+Stops AgentBridge daemon/TUI processes.
+
+Options:
+  --pair <id>   Stop only one registered pair.
+  --all         Stop all registered pairs and any legacy-root daemon.
+  --help, -h    Show this help message.
+
+No arguments are equivalent to --all.
+`.trim());
+}
+
+export async function stopPairEntry(base: string, pair: PairEntry): Promise<StopResult> {
+  const ports = portsForEntry(pair);
+  const stateDir = new StateDirResolver(join(base, "pairs", pair.pairId));
+  return stopStateDir(pair.pairId, stateDir, ports);
+}
+
+async function stopStateDir(label: string, stateDir: StateDirResolver, ports: PairPorts): Promise<StopResult> {
+  const prefix = `  [${label} ${ports.appPort}/${ports.proxyPort}/${ports.controlPort}]`;
+  const log: LogFn = (msg) => console.log(`${prefix} ${msg}`);
+
+  console.log(`${prefix} stopping`);
+  try {
+    const lifecycle = new DaemonLifecycle({
+      stateDir,
+      controlPort: ports.controlPort,
+      log,
+    });
+
+    lifecycle.markKilled();
+    const tuiKilled = await killManagedCodexTui(stateDir, log);
+    const daemonKilled = await lifecycle.kill();
+    return { label, daemonKilled, tuiKilled };
+  } catch (error) {
+    log(`ERROR: ${error instanceof Error ? error.message : String(error)}`);
+    return { label, daemonKilled: false, tuiKilled: false, error };
+  }
+}
+
+function printKnownPairs(base: string) {
+  try {
+    const pairs = listPairs(base);
+    if (pairs.length === 0) {
+      console.log("No pairs registered.");
+      return;
+    }
+    console.log("Known pairs:");
+    for (const pair of pairs) {
+      const ports = portsForEntry(pair);
+      console.log(`  ${pair.pairId} (slot ${pair.slot}, ports ${ports.appPort}/${ports.proxyPort}/${ports.controlPort})`);
+    }
+  } catch (error) {
+    if (error instanceof PairError) {
+      console.log(`Could not read pair registry: ${error.message}`);
+      return;
+    }
+    throw error;
+  }
+}
+
+function printSummary(results: StopResult[], restartCommand: string) {
+  if (results.length === 0) {
+    console.log("No pairs registered.");
+    return;
+  }
+
+  const stopped = results.filter((r) => r.daemonKilled || r.tuiKilled).length;
+  const failed = results.filter((r) => r.error).length;
+  console.log("");
+  if (stopped > 0) {
+    console.log("AgentBridge stopped.");
+    console.log(`Please restart Claude Code (\`${restartCommand}\`), switch to a new conversation, or run \`/resume\` to fully disconnect.`);
+  } else {
+    console.log("No running AgentBridge daemon or managed Codex TUI found.");
+  }
+  console.log(`Stopped ${stopped}/${results.length} target${results.length === 1 ? "" : "s"}.`);
+  if (failed > 0) {
+    console.log(`${failed} target${failed === 1 ? "" : "s"} reported errors; see log lines above.`);
+  }
+  console.log("Registry entries were preserved. Use `abg pairs rm <id>` to stop and release a slot.");
 }
 
 async function killManagedCodexTui(
   stateDir: StateDirResolver,
-  log: (msg: string) => void,
+  log: LogFn,
   gracefulTimeoutMs = 3000,
 ): Promise<boolean> {
   const pid = readTuiPid(stateDir);
@@ -103,10 +254,10 @@ function isManagedCodexTuiProcess(pid: number): boolean {
   try {
     const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
     return (
-      cmd.includes("codex")
-      && cmd.includes("--enable")
-      && cmd.includes("tui_app_server")
-      && cmd.includes("--remote")
+      cmd.includes("codex") &&
+      cmd.includes("--enable") &&
+      cmd.includes("tui_app_server") &&
+      cmd.includes("--remote")
     );
   } catch {
     return false;

--- a/src/cli/pairs.ts
+++ b/src/cli/pairs.ts
@@ -1,0 +1,186 @@
+import { join } from "node:path";
+import { DaemonLifecycle } from "../daemon-lifecycle";
+import { detectLegacyRootDaemon, type PairEntry, type PairPorts } from "../pair-registry";
+import {
+  computeBaseDir,
+  findPair,
+  listPairs,
+  portsForEntry,
+  removePair,
+} from "../pair-resolver";
+import { StateDirResolver } from "../state-dir";
+import { stopPairEntry } from "./kill";
+
+interface PairRow {
+  pairId: string;
+  slot: number | null;
+  ports: PairPorts;
+  source: PairEntry["source"] | "legacy";
+  cwd: string;
+  running: boolean;
+  pid: number | null;
+}
+
+export async function runPairs(args: string[] = []) {
+  const [command, ...rest] = args;
+
+  if (command === "rm") {
+    await runRemove(rest);
+    return;
+  }
+
+  if (command && command !== "list" && command !== "--json") {
+    console.error(`Unknown pairs command: ${command}`);
+    console.error("Usage: abg pairs [--json] | abg pairs rm <id>");
+    process.exit(1);
+  }
+
+  const json = command === "--json" || rest.includes("--json");
+  const rows = await collectRows();
+  if (json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+  printTable(rows);
+}
+
+async function runRemove(args: string[]) {
+  const pairId = args[0];
+  if (!pairId) {
+    console.error("Error: `abg pairs rm <id>` requires a pair id.");
+    process.exit(1);
+  }
+
+  const base = computeBaseDir();
+  const pair = findPair(base, pairId);
+  if (!pair) {
+    console.log(`No such pair: ${pairId}`);
+    printKnownPairs(base);
+    return;
+  }
+
+  await stopPairEntry(base, pair);
+  const removed = await removePair(base, pair.pairId);
+  if (removed) {
+    console.log(`Removed pair ${removed.pairId}; slot ${removed.slot} is now available.`);
+  } else {
+    console.log(`Pair ${pair.pairId} was already absent from the registry.`);
+  }
+}
+
+async function collectRows(): Promise<PairRow[]> {
+  const base = computeBaseDir();
+  const rows = await Promise.all(listPairs(base).map((pair) => rowForPair(base, pair)));
+  const legacy = detectLegacyRootDaemon(base);
+  if (legacy) {
+    rows.push({
+      pairId: "(legacy-root)",
+      slot: null,
+      ports: { appPort: 4500, proxyPort: 4501, controlPort: legacy.controlPort },
+      source: "legacy",
+      cwd: base,
+      running: true,
+      pid: legacy.pid,
+    });
+  }
+  return rows;
+}
+
+async function rowForPair(base: string, pair: PairEntry): Promise<PairRow> {
+  const ports = portsForEntry(pair);
+  const stateDir = new StateDirResolver(join(base, "pairs", pair.pairId));
+  const lifecycle = new DaemonLifecycle({
+    stateDir,
+    controlPort: ports.controlPort,
+    log: () => {},
+  });
+  const [running, status] = await Promise.all([
+    lifecycle.isHealthy(),
+    Promise.resolve(lifecycle.readStatus()),
+  ]);
+
+  return {
+    pairId: pair.pairId,
+    slot: pair.slot,
+    ports,
+    source: pair.source,
+    cwd: pair.cwd,
+    running,
+    pid: typeof status?.pid === "number" ? status.pid : null,
+  };
+}
+
+function printTable(rows: PairRow[]) {
+  if (rows.length === 0) {
+    console.log("No pairs registered.");
+    return;
+  }
+
+  const data = rows.map((row) => ({
+    pairId: row.pairId,
+    slot: row.slot === null ? "-" : String(row.slot),
+    ports: `${row.ports.appPort}/${row.ports.proxyPort}/${row.ports.controlPort}`,
+    source: row.source,
+    cwd: row.cwd,
+    status: row.running ? "running" : "stopped",
+    pid: row.pid === null ? "-" : String(row.pid),
+  }));
+
+  const headers = {
+    pairId: "pairId",
+    slot: "slot",
+    ports: "app/proxy/control",
+    source: "source",
+    status: "status",
+    pid: "pid",
+    cwd: "cwd",
+  };
+  const widths = Object.fromEntries(
+    Object.keys(headers).map((key) => [
+      key,
+      Math.max(
+        headers[key as keyof typeof headers].length,
+        ...data.map((row) => row[key as keyof typeof row].length),
+      ),
+    ]),
+  ) as Record<keyof typeof headers, number>;
+
+  const line = (row: Record<keyof typeof headers, string>) =>
+    [
+      row.pairId.padEnd(widths.pairId),
+      row.slot.padEnd(widths.slot),
+      row.ports.padEnd(widths.ports),
+      row.source.padEnd(widths.source),
+      row.status.padEnd(widths.status),
+      row.pid.padEnd(widths.pid),
+      row.cwd,
+    ].join("  ");
+
+  console.log(line(headers));
+  console.log(
+    [
+      "-".repeat(widths.pairId),
+      "-".repeat(widths.slot),
+      "-".repeat(widths.ports),
+      "-".repeat(widths.source),
+      "-".repeat(widths.status),
+      "-".repeat(widths.pid),
+      "-".repeat(widths.cwd),
+    ].join("  "),
+  );
+  for (const row of data) {
+    console.log(line(row));
+  }
+}
+
+function printKnownPairs(base: string) {
+  const pairs = listPairs(base);
+  if (pairs.length === 0) {
+    console.log("No pairs registered.");
+    return;
+  }
+  console.log("Known pairs:");
+  for (const pair of pairs) {
+    console.log(`  ${pair.pairId}`);
+  }
+}

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -8,6 +8,8 @@ export interface DaemonStatus {
   proxyUrl: string;
   appServerUrl: string;
   pid: number;
+  /** Multi-pair identity for diagnostics; null in legacy/manual single-pair mode. */
+  pairId?: string | null;
 }
 
 export type ControlClientMessage =

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -3,9 +3,11 @@ import { existsSync, readFileSync, unlinkSync, writeFileSync, openSync, closeSyn
 import { fileURLToPath } from "node:url";
 import { StateDirResolver } from "./state-dir";
 
-// When bundled into a Claude Code plugin, the frontend runs from the plugin
-// cache directory and must launch the sibling daemon bundle from there.
-const DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
+// In source/dev mode this module is loaded from src/*.ts and can launch the
+// sibling daemon.ts directly. In bundled CLI/plugin mode it is loaded from a
+// generated *.js bundle, so the daemon must be a sibling daemon.js artifact.
+const DEFAULT_DAEMON_ENTRY = import.meta.url.endsWith(".ts") ? "./daemon.ts" : "./daemon.js";
+const DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 const DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 
 export interface DaemonLifecycleOptions {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -734,6 +734,8 @@ function writeStatusFile() {
     appServerUrl: codex.appServerUrl,
     controlPort: CONTROL_PORT,
     pid: process.pid,
+    // Pair identity for diagnostics (null in legacy/manual single-pair mode).
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
   });
 }
 

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -541,6 +541,99 @@ describe("E2E: CLI surface", () => {
     });
   }, 20000);
 
+  test("agentbridge kill --pair scopes the restart hint to that pair", async () => {
+    await withHarness(async (harness) => {
+      const pairId = "work";
+      const pairStateDir = join(harness.stateDir, "pairs", pairId);
+      mkdirSync(pairStateDir, { recursive: true });
+      writeFileSync(
+        join(harness.stateDir, "pairs", "registry.json"),
+        JSON.stringify(
+          {
+            version: 1,
+            pairs: [
+              {
+                pairId,
+                slot: 0,
+                cwd: harness.projectDir,
+                source: "flag",
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      );
+
+      const pairPorts = await Promise.all([reservePort(), reservePort(), reservePort()]);
+      const [controlPort, appPort, proxyPort] = pairPorts.map((reservation) => reservation.port);
+      for (const reservation of pairPorts) {
+        await reservation.release();
+      }
+
+      const daemon = spawn(process.execPath, ["run", harness.fakeDaemonPath], {
+        cwd: harness.projectDir,
+        env: {
+          ...harness.env,
+          AGENTBRIDGE_STATE_DIR: pairStateDir,
+          AGENTBRIDGE_CONTROL_PORT: String(controlPort),
+          CODEX_WS_PORT: String(appPort),
+          CODEX_PROXY_PORT: String(proxyPort),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const trackedDaemon: TrackedProcess = { child: daemon, stdout: [], stderr: [] };
+      daemon.stdout?.on("data", (chunk) => trackedDaemon.stdout.push(chunk.toString()));
+      daemon.stderr?.on("data", (chunk) => trackedDaemon.stderr.push(chunk.toString()));
+
+      try {
+        await waitFor(() => existsSync(join(pairStateDir, "daemon.pid")), 80, 50);
+
+        const result = await harness.runCli(["kill", "--pair", pairId]);
+
+        expect(result.code).toBe(0);
+        expect(result.stdout).toContain("AgentBridge stopped.");
+        expect(result.stdout).toContain("Please restart Claude Code (`agentbridge claude --pair work`)");
+        expect(result.stdout).not.toContain("Please restart Claude Code (`agentbridge claude`)");
+      } finally {
+        await stopProcess(trackedDaemon);
+      }
+    });
+  }, 20000);
+
+  test("agentbridge kill --help prints usage without stopping a running daemon", async () => {
+    await withHarness(async (harness) => {
+      await harness.startManagedFakeDaemon();
+      const pid = harness.readPid();
+      expect(pid).not.toBeNull();
+
+      const result = await harness.runCli(["kill", "--help"]);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("Usage: abg kill");
+      expect(result.stdout).toContain("--pair <id>");
+      expect(pid && isProcessAlive(pid)).toBe(true);
+      expect(existsSync(join(harness.stateDir, "killed"))).toBe(false);
+    });
+  }, 20000);
+
+  test("agentbridge kill rejects unknown flags without stopping a running daemon", async () => {
+    await withHarness(async (harness) => {
+      await harness.startManagedFakeDaemon();
+      const pid = harness.readPid();
+      expect(pid).not.toBeNull();
+
+      const result = await harness.runCli(["kill", "--badflag"]);
+
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("Unknown kill argument: --badflag");
+      expect(pid && isProcessAlive(pid)).toBe(true);
+      expect(existsSync(join(harness.stateDir, "killed"))).toBe(false);
+    });
+  }, 20000);
+
   test("bridge stays idle and does not relaunch daemon after kill writes the killed sentinel", async () => {
     await withHarness(async (harness) => {
       const bridge = await harness.spawnBridge();

--- a/src/pair-command.ts
+++ b/src/pair-command.ts
@@ -1,0 +1,24 @@
+/**
+ * Render a user-facing `agentbridge` command suggestion scoped to the current
+ * pair.
+ *
+ * In multi-pair mode the resolver sets `AGENTBRIDGE_PAIR_ID`, and that env is
+ * inherited by the daemon, the plugin MCP server (bridge), and the codex
+ * wrapper. User-facing hints ("start Codex with…", "restart with…", "run kill
+ * to reset") MUST carry `--pair <id>` in that mode — otherwise a user following
+ * the hint in a named-pair session would connect to a different (cwd-derived)
+ * pair, or run a bare `agentbridge kill` that stops ALL pairs.
+ *
+ * In legacy/manual single-pair mode `AGENTBRIDGE_PAIR_ID` is unset, so the bare
+ * command is returned (unchanged behaviour).
+ *
+ * @param cmd the subcommand + its own args, e.g. "codex" or "claude --resume".
+ */
+export function pairScopedCommand(cmd: string): string {
+  const pairId = process.env.AGENTBRIDGE_PAIR_ID;
+  if (!pairId) return `agentbridge ${cmd}`;
+  // Insert `--pair <id>` right after the subcommand so it precedes any extra args.
+  const [sub, ...rest] = cmd.split(" ");
+  const tail = rest.length > 0 ? ` ${rest.join(" ")}` : "";
+  return `agentbridge ${sub} --pair ${pairId}${tail}`;
+}

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -1,0 +1,673 @@
+import { execFileSync } from "node:child_process";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  linkSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:net";
+import { createHash, randomUUID } from "node:crypto";
+import { hostname, userInfo } from "node:os";
+import { basename, join } from "node:path";
+
+/**
+ * Pair registry — the single shared resource of the multi-pair feature.
+ *
+ * Each Claude+Codex pair runs as an isolated daemon instance with its own
+ * port triple (slot) and state dir. This module owns:
+ *   - deterministic slot -> port arithmetic (slot 0 == the classic 4500/4501/4502)
+ *   - cross-process slot allocation guarded by an atomic lock file (temp + link(2))
+ *   - pairId validation / derivation (filesystem-path safe)
+ *   - legacy-root daemon detection (pre-multi-pair installs)
+ *   - port probing to surface external squatters without silently shifting slots
+ *
+ * It is intentionally free of any process.env / argv / StateDirResolver coupling
+ * so it can be unit-tested with a temp base dir and real concurrent processes.
+ * The base dir is always passed in explicitly.
+ */
+
+export const PAIR_BASE_PORT = 4500;
+export const PAIR_SLOT_STRIDE = 10;
+export const PAIR_ID_REGEX = /^[A-Za-z0-9._-]{1,64}$/;
+
+const LOCK_FILE_NAME = ".registry.lock";
+const REGISTRY_FILE_NAME = "registry.json";
+const LOCK_DEADLINE_MS = 10_000;
+/** Grace before a lock file with unreadable owner content is treated as orphaned (vs corrupt/transient). */
+const ORPHAN_GRACE_MS = 3_000;
+const LEGACY_ROOT_CONTROL_PORT = 4502;
+
+/** Windows reserved device names — rejected so a pairId is portable as a path segment. */
+const WINDOWS_RESERVED_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
+export interface PairPorts {
+  /** Codex app-server port (CODEX_WS_PORT). */
+  appPort: number;
+  /** Codex proxy port (CODEX_PROXY_PORT). */
+  proxyPort: number;
+  /** Control WS / health port (AGENTBRIDGE_CONTROL_PORT). */
+  controlPort: number;
+}
+
+export interface PairEntry {
+  pairId: string;
+  slot: number;
+  cwd: string;
+  source: "flag" | "cwd";
+  createdAt: string;
+}
+
+export interface RegistryFile {
+  version: 1;
+  pairs: PairEntry[];
+}
+
+export interface ResolvedPair {
+  pairId: string;
+  slot: number;
+  ports: PairPorts;
+  stateDir: string;
+  entry: PairEntry;
+}
+
+export type PairErrorCode =
+  | "PAIR_PORTS_BUSY"
+  | "PAIR_ID_INVALID"
+  | "PAIR_LOCK_TIMEOUT"
+  | "PAIR_REGISTRY_CORRUPT"
+  | "PAIR_LEGACY_ROOT_DAEMON";
+
+export class PairError extends Error {
+  readonly code: PairErrorCode;
+  readonly details?: Record<string, unknown>;
+
+  constructor(code: PairErrorCode, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.name = "PairError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Highest slot whose control port (base + slot*stride + 2) still fits in a uint16. */
+export const MAX_PAIR_SLOT = Math.floor((65535 - 2 - PAIR_BASE_PORT) / PAIR_SLOT_STRIDE);
+
+/** Deterministic slot -> port triple. slot 0 == classic 4500/4501/4502. */
+export function portsForSlot(slot: number): PairPorts {
+  if (!Number.isInteger(slot) || slot < 0) {
+    throw new PairError("PAIR_ID_INVALID", `Invalid slot: ${slot}`);
+  }
+  if (slot > MAX_PAIR_SLOT) {
+    throw new PairError(
+      "PAIR_ID_INVALID",
+      `Slot ${slot} exceeds the maximum (${MAX_PAIR_SLOT}); ports would overflow 65535.`,
+      { slot, maxSlot: MAX_PAIR_SLOT },
+    );
+  }
+  const base = PAIR_BASE_PORT + slot * PAIR_SLOT_STRIDE;
+  return { appPort: base, proxyPort: base + 1, controlPort: base + 2 };
+}
+
+/**
+ * Validate an explicit `--pair <name>`. Returns the canonical id.
+ * Rejects path separators, `.`/`..`, whitespace, empty, and over-length names
+ * so the id is always safe to use as a directory name.
+ */
+export function validatePairId(raw: string): string {
+  const id = raw.trim();
+  // Windows treats `CON`, `CON.txt`, `NUL.log`, … all as the reserved device —
+  // check the segment before the first dot, not just the whole string.
+  const deviceBase = id.split(".")[0] ?? "";
+  if (
+    id === "." ||
+    id === ".." ||
+    !PAIR_ID_REGEX.test(id) ||
+    id.endsWith(".") || // trailing dot is illegal on Windows path segments
+    WINDOWS_RESERVED_RE.test(deviceBase)
+  ) {
+    throw new PairError(
+      "PAIR_ID_INVALID",
+      `Invalid --pair name: ${JSON.stringify(raw)}. Allowed: letters, digits, "." "_" "-", 1-64 chars ` +
+        `(not "." / ".." / a trailing dot / a reserved name like CON, NUL, COM1).`,
+      { raw },
+    );
+  }
+  return id;
+}
+
+/**
+ * Derive a stable, fs-safe pairId from the current working directory.
+ * Uses realpath so symlinked cwds map to the same id; appends a short hash
+ * of the real path to guarantee uniqueness across same-basename projects.
+ */
+export function derivePairIdFromCwd(cwd: string): string {
+  let real: string;
+  try {
+    real = realpathSync(cwd);
+  } catch {
+    real = cwd;
+  }
+  const hash = createHash("sha256").update(real).digest("hex").slice(0, 8);
+  const rawBase = basename(real) || "root";
+  // Slugify the basename through the allowed charset; collapse runs of illegal chars.
+  const slug = rawBase
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  const id = slug ? `${slug}-${hash}` : hash;
+  // Guaranteed to satisfy validatePairId by construction.
+  return id;
+}
+
+/**
+ * Smallest non-negative slot not present in the entry set.
+ * Uses the SET of used slots (not entry count) so a freed middle slot is reused.
+ */
+export function pickLowestFreeSlot(entries: readonly PairEntry[]): number {
+  const used = new Set(entries.map((e) => e.slot));
+  let slot = 0;
+  while (used.has(slot)) slot++;
+  return slot;
+}
+
+// ---------------------------------------------------------------------------
+// Registry file I/O (integrity only — concurrency is the lock's job)
+// ---------------------------------------------------------------------------
+
+function pairsDir(base: string): string {
+  return join(base, "pairs");
+}
+
+function registryPath(base: string): string {
+  return join(pairsDir(base), REGISTRY_FILE_NAME);
+}
+
+/** Read the registry, returning an empty one if absent. Throws on corruption. */
+export function readRegistry(base: string): RegistryFile {
+  const path = registryPath(base);
+  if (!existsSync(path)) return { version: 1, pairs: [] };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (err) {
+    throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry JSON is not parseable at ${path}: ${(err as Error).message}`, {
+      path,
+    });
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    (parsed as RegistryFile).version !== 1 ||
+    !Array.isArray((parsed as RegistryFile).pairs)
+  ) {
+    throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry shape is invalid at ${path}`, { path });
+  }
+
+  // Validate entries: a tampered/corrupt registry with duplicate slots or pairIds
+  // would silently put two pairs on the same ports — reject it loudly instead.
+  const entries = (parsed as RegistryFile).pairs;
+  const seenSlots = new Set<number>();
+  const seenIds = new Set<string>();
+  for (const e of entries) {
+    // Charset-validate the stored pairId too: a tampered registry with
+    // `"pairId": "../.."` flows straight into join(base,"pairs",pairId) in kill/pairs.
+    const idValid =
+      e && typeof e.pairId === "string" && e.pairId !== "." && e.pairId !== ".." && PAIR_ID_REGEX.test(e.pairId);
+    if (!idValid || !Number.isInteger(e.slot) || e.slot < 0) {
+      throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry has a malformed entry at ${path}`, { path, entry: e });
+    }
+    const lower = e.pairId.toLowerCase();
+    if (seenSlots.has(e.slot) || seenIds.has(lower)) {
+      throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry has duplicate slot/pairId at ${path}`, {
+        path,
+        pairId: e.pairId,
+        slot: e.slot,
+      });
+    }
+    seenSlots.add(e.slot);
+    seenIds.add(lower);
+  }
+  return parsed as RegistryFile;
+}
+
+/** Atomically replace the registry file (temp + fsync + rename). */
+export function writeRegistry(base: string, reg: RegistryFile): void {
+  mkdirSync(pairsDir(base), { recursive: true });
+  const target = registryPath(base);
+  const tmp = `${target}.tmp.${process.pid}`;
+  const data = JSON.stringify(reg, null, 2) + "\n";
+  const fd = openSync(tmp, "w");
+  try {
+    writeFileSync(fd, data);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(tmp, target);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-process lock
+// ---------------------------------------------------------------------------
+
+interface LockOwner {
+  pid: number;
+  createdAt: number;
+  nonce: string;
+  hostname?: string;
+  uid?: number;
+}
+
+function lockFilePath(base: string): string {
+  return join(pairsDir(base), LOCK_FILE_NAME);
+}
+
+function readLockOwner(lockFile: string): LockOwner | null {
+  try {
+    const parsed = JSON.parse(readFileSync(lockFile, "utf-8")) as LockOwner;
+    if (typeof parsed.pid === "number" && typeof parsed.nonce === "string") return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** `process.kill(pid, 0)` liveness, but treat EPERM (exists, not signalable by us) as ALIVE. */
+function pidLooksAlive(pid: number): boolean {
+  // pid <= 0 is never a real holder: process.kill(0, 0) targets the current
+  // process GROUP and "succeeds", which would wrongly mark a corrupt
+  // `{pid:0}` lock as live and deadlock acquisition. Negatives are signal-broadcast
+  // semantics, not a pid. Treat all of these as dead so the lock is reclaimable.
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: any) {
+    return err?.code === "EPERM";
+  }
+}
+
+function lockFileAgeMs(lockFile: string): number {
+  try {
+    return Date.now() - statSync(lockFile).mtimeMs;
+  } catch {
+    return Number.POSITIVE_INFINITY; // gone — let the caller re-attempt acquire
+  }
+}
+
+function safeHostname(): string | undefined {
+  try {
+    return hostname();
+  } catch {
+    return undefined;
+  }
+}
+
+function safeUid(): number | undefined {
+  try {
+    return userInfo().uid;
+  } catch {
+    return undefined;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Whether the lock currently at `lockFile` is reclaimable: a DEAD owner, or
+ * (defensively) unreadable content older than the orphan grace. A LIVE owner is
+ * never stale — we never steal a live holder's lock.
+ */
+function lockIsStale(lockFile: string): boolean {
+  const owner = readLockOwner(lockFile);
+  if (owner) return !pidLooksAlive(owner.pid);
+  // Atomic link-acquire means a live lock always has complete content, so an
+  // unreadable owner is corruption — reclaim only once it's older than the grace.
+  return lockFileAgeMs(lockFile) > ORPHAN_GRACE_MS;
+}
+
+/**
+ * Remove a stale primary lock — race-free against a fresh acquirer, even when a
+ * reclaimer stalls or crashes mid-reclaim.
+ *
+ * Earlier fixes could not close the hazard: a reclaimer's "owner is dead"
+ * decision can go stale, and removing the primary lock can evict a lock a fresh
+ * holder just acquired (duplicate-slot bug). The TTL-force-remove of the reclaim
+ * lock reopened it for a >grace-stalled reclaimer.
+ *
+ * Final design (no TTL stealing anywhere):
+ *   1. Serialize reclaimers through a reclaim lock acquired by atomic `link`,
+ *      whose owner carries a pid + nonce — exactly like the primary lock.
+ *   2. The reclaim lock is itself reclaimed ONLY when its owner is DEAD (or its
+ *      content is unreadable and old) — NEVER stolen from a live (even wedged)
+ *      reclaimer. A contended-but-live reclaim lock just makes us wait.
+ *   3. While holding it, verify we still own it (nonce), then unlink the primary
+ *      lock only if it is still stale.
+ *
+ * Why a stale unlink can never delete a LIVE primary lock:
+ *   - A reclaimer wedged (alive) before its unlink is never preempted (rule 2),
+ *     so its eventual unlink is still valid — the primary was the same dead lock
+ *     the whole time (no one else could reclaim or acquire it while held).
+ *   - A reclaimer that DIES before its unlink simply cannot resume to run a stale
+ *     unlink; a later reclaimer reclaims the (now dead) reclaim lock and re-checks.
+ *   There is no path where a preempted reclaimer resumes and removes a live lock.
+ */
+function attemptReclaim(lockFile: string): void {
+  const reclaimLock = `${lockFile}.reclaim`;
+  const myNonce = randomUUID();
+  const ownerJson = JSON.stringify({
+    pid: process.pid,
+    createdAt: Date.now(),
+    nonce: myNonce,
+    hostname: safeHostname(),
+    uid: safeUid(),
+  } satisfies LockOwner);
+
+  const tmp = `${reclaimLock}.acq.${process.pid}.${randomUUID()}`;
+  let held = false;
+  try {
+    writeFileSync(tmp, ownerJson);
+    try {
+      linkSync(tmp, reclaimLock); // atomic; EEXIST if another reclaimer holds it
+      held = true;
+    } catch (err: any) {
+      if (err?.code === "EEXIST") {
+        // Clear it ONLY if its owner is dead/orphaned (never a live reclaimer),
+        // then return so the next loop iteration re-acquires it cleanly — we never
+        // unlink-then-link in one step, so two clearers can't both end up holding.
+        if (lockIsStale(reclaimLock)) {
+          try {
+            unlinkSync(reclaimLock);
+          } catch {}
+        }
+        return;
+      }
+      throw err;
+    }
+  } finally {
+    try {
+      unlinkSync(tmp);
+    } catch {}
+  }
+
+  if (!held) return;
+  try {
+    // Confirm we still own the reclaim lock (guards the dead-lock acquisition
+    // race), then remove the primary lock only if it is still stale.
+    if (readLockOwner(reclaimLock)?.nonce !== myNonce) return;
+    if (lockIsStale(lockFile)) {
+      try {
+        unlinkSync(lockFile);
+      } catch {}
+    }
+  } finally {
+    if (readLockOwner(reclaimLock)?.nonce === myNonce) {
+      try {
+        unlinkSync(reclaimLock);
+      } catch {}
+    }
+  }
+}
+
+/**
+ * Run `fn` while holding a cross-process lock on the registry.
+ *
+ * Acquire is a single atomic step with NO publication gap: the owner metadata is
+ * written to a unique temp file first, then `link(2)`'d onto the canonical lock
+ * path. `link` fails EEXIST if the lock is held, and the instant the lock path
+ * exists its content (the owner) is already complete — so a contender can never
+ * observe an "ownerless" live lock and wrongly reclaim it.
+ *
+ * Correctness rules (hardened via cross-review):
+ *   - NEVER steal a lock from a LIVE owner — even a long-held one — because a
+ *     paused/stalled owner could resume mid-critical-section and write a stale
+ *     registry (lost update). A live holder past the deadline ⇒ PAIR_LOCK_TIMEOUT.
+ *   - Reclaim only a DEAD owner, or (defensively) a lock whose content is
+ *     unreadable AND older than ORPHAN_GRACE_MS (corruption / partial crash).
+ *   - Reclamation is serialized through a dedicated reclaim lock and re-confirms
+ *     staleness before removing the primary lock (see attemptReclaim), so racing
+ *     reclaimers can't evict a fresh holder's lock.
+ */
+export async function withRegistryLock<T>(base: string, fn: () => Promise<T> | T): Promise<T> {
+  mkdirSync(pairsDir(base), { recursive: true });
+  const lockFile = lockFilePath(base);
+  const deadline = Date.now() + LOCK_DEADLINE_MS;
+  const myNonce = randomUUID();
+  const ownerJson = JSON.stringify({
+    pid: process.pid,
+    createdAt: Date.now(),
+    nonce: myNonce,
+    hostname: safeHostname(),
+    uid: safeUid(),
+  } satisfies LockOwner);
+
+  for (;;) {
+    // Atomic acquire: write owner to a unique temp file, then link it onto the
+    // canonical lock path. The temp name is unique per attempt so concurrent
+    // acquirers never clash on it.
+    const tmp = `${lockFile}.acq.${process.pid}.${randomUUID()}`;
+    let acquired = false;
+    try {
+      writeFileSync(tmp, ownerJson);
+      try {
+        linkSync(tmp, lockFile); // atomic test-and-set; EEXIST if held
+        acquired = true;
+      } catch (err: any) {
+        if (err?.code !== "EEXIST") throw err;
+      }
+    } finally {
+      try {
+        unlinkSync(tmp);
+      } catch {}
+    }
+
+    if (acquired) {
+      try {
+        return await fn();
+      } finally {
+        // A live owner is never reclaimed, so this is normally still our lock —
+        // only remove it if we still own it (defense in depth).
+        const current = readLockOwner(lockFile);
+        if (!current || current.nonce === myNonce) {
+          try {
+            unlinkSync(lockFile);
+          } catch {}
+        }
+      }
+    }
+
+    // Held by someone — reclaim if stale (serialized + re-confirmed under a
+    // reclaim lock so we can't evict a fresh holder), otherwise wait.
+    if (lockIsStale(lockFile)) {
+      attemptReclaim(lockFile);
+    }
+
+    if (Date.now() >= deadline) {
+      throw new PairError("PAIR_LOCK_TIMEOUT", `Timed out acquiring registry lock at ${lockFile}`, {
+        holderPid: readLockOwner(lockFile)?.pid,
+      });
+    }
+    await sleep(25 + Math.floor(Math.random() * 50));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy-root daemon detection
+// ---------------------------------------------------------------------------
+
+function isDaemonProcess(pid: number): boolean {
+  try {
+    const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
+    return cmd.includes("daemon") && (cmd.includes("agentbridge") || cmd.includes("agent_bridge"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect a pre-multi-pair daemon that wrote its pid directly at <base>/daemon.pid
+ * (the classic single-pair layout) and is still alive on control port 4502.
+ * Returns its pid, or null.
+ */
+export function detectLegacyRootDaemon(base: string): { pid: number; controlPort: number } | null {
+  const rootPidFile = join(base, "daemon.pid");
+  if (!existsSync(rootPidFile)) return null;
+  let pid: number;
+  try {
+    const raw = readFileSync(rootPidFile, "utf-8").trim();
+    pid = Number.parseInt(raw, 10);
+  } catch {
+    return null;
+  }
+  if (!Number.isFinite(pid) || !pidLooksAlive(pid) || !isDaemonProcess(pid)) return null;
+  return { pid, controlPort: LEGACY_ROOT_CONTROL_PORT };
+}
+
+// ---------------------------------------------------------------------------
+// Port probing
+// ---------------------------------------------------------------------------
+
+/** Resolve true if the TCP port is free to bind on 127.0.0.1. */
+export function probePortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+function pidOnPort(port: number): number | undefined {
+  try {
+    const out = execFileSync("lsof", ["-ti", `:${port}`, "-sTCP:LISTEN"], { encoding: "utf-8" }).trim();
+    const first = out.split(/\s+/)[0];
+    const pid = Number.parseInt(first ?? "", 10);
+    return Number.isFinite(pid) ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public allocation entrypoint
+// ---------------------------------------------------------------------------
+
+export interface ResolvePairOptions {
+  pairFlag?: string;
+  cwd: string;
+  /**
+   * Probe the allocated ports for an external squatter after allocation
+   * (default true). Production always probes; tests that exercise pure slot
+   * allocation set this false so they don't depend on which ports happen to be
+   * free on the host.
+   */
+  probePorts?: boolean;
+}
+
+/**
+ * Resolve (and, if new, allocate) the pair for this invocation.
+ *
+ * Allocation happens under the cross-process lock; port probing happens after
+ * releasing it (probing is slow and must not serialize all CLI starts). Re-running
+ * for the same pair is idempotent — the slot is reused and a healthy daemon on the
+ * control port is treated as "already running", not a conflict.
+ */
+export async function resolvePair(base: string, opts: ResolvePairOptions): Promise<ResolvedPair> {
+  // `pairFlag != null` (rather than truthiness) so an explicit-but-empty `--pair`
+  // (a missing value) surfaces a clear PAIR_ID_INVALID instead of silently
+  // falling back to cwd derivation.
+  const hasFlag = opts.pairFlag != null;
+  const pairId = hasFlag ? validatePairId(opts.pairFlag as string) : derivePairIdFromCwd(opts.cwd);
+  const source: PairEntry["source"] = hasFlag ? "flag" : "cwd";
+  const lower = pairId.toLowerCase();
+
+  const { slot, entry, isNew } = await withRegistryLock(base, () => {
+    const reg = readRegistry(base);
+    const existing = reg.pairs.find((p) => p.pairId.toLowerCase() === lower);
+    if (existing) return { slot: existing.slot, entry: existing, isNew: false };
+
+    const newSlot = pickLowestFreeSlot(reg.pairs);
+    if (newSlot === 0) {
+      const legacy = detectLegacyRootDaemon(base);
+      if (legacy) {
+        throw new PairError(
+          "PAIR_LEGACY_ROOT_DAEMON",
+          `A pre-multi-pair AgentBridge daemon is running at the legacy location ` +
+            `(pid ${legacy.pid}, control port ${legacy.controlPort}). Run "abg kill" to stop it, then retry — ` +
+            `your new session would otherwise collide on port ${legacy.controlPort}.`,
+          { pid: legacy.pid, controlPort: legacy.controlPort },
+        );
+      }
+    }
+    // Validate the slot's ports BEFORE persisting, so slot exhaustion throws
+    // without leaving an invalid (out-of-range) entry in the registry.
+    portsForSlot(newSlot);
+    const newEntry: PairEntry = {
+      pairId,
+      slot: newSlot,
+      cwd: opts.cwd,
+      source,
+      createdAt: new Date().toISOString(),
+    };
+    writeRegistry(base, { version: 1, pairs: [...reg.pairs, newEntry] });
+    return { slot: newSlot, entry: newEntry, isNew: true };
+  });
+
+  const ports = portsForSlot(slot);
+
+  // Probe ports ONLY for a brand-new slot allocation. For an existing pair
+  // (idempotent re-run) the daemon may already own these ports, or a concurrent
+  // same-pair launch may be mid-bind — so we defer conflict detection to the
+  // daemon's own bind + health check rather than risk a false PAIR_PORTS_BUSY.
+  //
+  // Note: a new entry is durably committed (under the lock) before this probe.
+  // A probe failure leaves a reserved "ghost" slot that a re-run reuses
+  // idempotently or that `abg pairs rm` clears. Probing is a best-effort
+  // external-squatter check, not a correctness guarantee (port use is TOCTOU);
+  // the daemon's bind is the final arbiter.
+  if (isNew && opts.probePorts !== false) {
+    for (const port of [ports.appPort, ports.proxyPort, ports.controlPort]) {
+      if (!(await probePortFree(port))) {
+        throw new PairError(
+          "PAIR_PORTS_BUSY",
+          `Port ${port} (pair "${pairId}", slot ${slot}) is already in use by another process. ` +
+            `Free it or remove the conflicting pair; AgentBridge will not silently move slots.`,
+          { port, slot, pairId, pid: pidOnPort(port) },
+        );
+      }
+    }
+  }
+
+  // Use the registry's canonical pairId (case preserved from first registration),
+  // NOT the caller's casing — otherwise `--pair Foo` then `--pair foo` would split
+  // one logical pair across two state dirs on a case-sensitive filesystem.
+  return { pairId: entry.pairId, slot, ports, stateDir: join(pairsDir(base), entry.pairId), entry };
+}
+
+/** Remove a pair entry from the registry (frees its slot). Returns the removed entry or null. */
+export async function removePairEntry(base: string, pairId: string): Promise<PairEntry | null> {
+  const lower = pairId.toLowerCase();
+  return withRegistryLock(base, () => {
+    const reg = readRegistry(base);
+    const found = reg.pairs.find((p) => p.pairId.toLowerCase() === lower) ?? null;
+    if (!found) return null;
+    writeRegistry(base, { version: 1, pairs: reg.pairs.filter((p) => p.pairId.toLowerCase() !== lower) });
+    return found;
+  });
+}

--- a/src/pair-resolver.ts
+++ b/src/pair-resolver.ts
@@ -1,0 +1,179 @@
+import { StateDirResolver } from "./state-dir";
+import {
+  type PairEntry,
+  type PairPorts,
+  portsForSlot,
+  readRegistry,
+  removePairEntry,
+  resolvePair,
+} from "./pair-registry";
+
+/**
+ * Pair resolution glue — the env-injection seam between the pure pair registry
+ * and the CLI's process-env world.
+ *
+ * The CLI entrypoints (`runClaude` / `runCodex`) call `applyPairEnv` at the very
+ * top: it allocates/looks-up the pair's slot and sets the four env vars that the
+ * rest of the system already reads (state dir + the three ports). The existing
+ * StateDirResolver / DaemonLifecycle / daemon then "just work", and the spawned
+ * `claude` / `codex` children inherit the env, so the plugin's MCP server and
+ * the Codex proxy connect to the right per-pair daemon.
+ */
+
+export interface PairResolution {
+  pairId: string;
+  slot: number | null;
+  ports: PairPorts;
+  stateDir: StateDirResolver;
+  /** True when running in legacy/manual single-pair mode (env pinned, no --pair). */
+  manual: boolean;
+}
+
+/**
+ * The registry base dir (the dir that contains `pairs/`).
+ *
+ * `AGENTBRIDGE_BASE_DIR` is the dedicated, unambiguous base override. It is
+ * preferred over `AGENTBRIDGE_STATE_DIR` precisely because `applyPairEnv`
+ * rewrites `AGENTBRIDGE_STATE_DIR` to the PER-PAIR dir (`<base>/pairs/<id>`):
+ * a child process (`abg pairs`, `abg kill`) that inherits the pair env must
+ * still resolve the registry at the real base, not at the pair's own state dir.
+ * Falls back to `AGENTBRIDGE_STATE_DIR` (relocated single base) then the platform default.
+ */
+export function computeBaseDir(): string {
+  // `||` (not `??`) so an empty-string env is treated as unset rather than a
+  // valid relative path.
+  return (
+    process.env.AGENTBRIDGE_BASE_DIR ||
+    process.env.AGENTBRIDGE_STATE_DIR ||
+    StateDirResolver.platformBaseDir()
+  );
+}
+
+/** Extract `--pair <name>` / `--pair=<name>`, returning the remaining args untouched. */
+export function parsePairFlag(args: string[]): { pairFlag?: string; rest: string[] } {
+  const rest: string[] = [];
+  let pairFlag: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--pair") {
+      const next = args[i + 1];
+      // Consume the value only if it looks like a value (not another flag / EOL).
+      // A missing value becomes "" so resolution throws a clear PAIR_ID_INVALID
+      // instead of silently falling back to a cwd-derived pair.
+      if (next !== undefined && !next.startsWith("-")) {
+        pairFlag = next;
+        i++;
+      } else {
+        pairFlag = "";
+      }
+      continue;
+    }
+    if (a.startsWith("--pair=")) {
+      pairFlag = a.slice("--pair=".length);
+      continue;
+    }
+    rest.push(a);
+  }
+  return { pairFlag, rest };
+}
+
+/** Parse `abg kill` flags: `--all` and/or `--pair <name>`. No flag ⇒ kill all. */
+export function parseKillArgs(args: string[]): { all: boolean; pairFlag?: string } {
+  let all = false;
+  let pairFlag: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--all") {
+      all = true;
+      continue;
+    }
+    if (a === "--pair") {
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith("-")) {
+        pairFlag = next;
+        i++;
+      } else {
+        pairFlag = "";
+      }
+      continue;
+    }
+    if (a.startsWith("--pair=")) {
+      pairFlag = a.slice("--pair=".length);
+    }
+  }
+  return { all, pairFlag };
+}
+
+/**
+ * Resolve the pair for this invocation and inject its env so downstream code and
+ * spawned children pick up the right state dir + ports.
+ *
+ * Manual/legacy mode: if the caller explicitly pinned the state dir or any port
+ * via env AND gave no `--pair`, behave exactly like the classic single pair
+ * (no registry, no slot) — this preserves power-user overrides and the existing
+ * e2e harness. An explicit `--pair` always forces multi-pair resolution.
+ */
+export async function applyPairEnv(opts: { pairFlag?: string }): Promise<PairResolution> {
+  // Truthiness (not `!= null`) so an empty-string env counts as unset.
+  const explicitEnv =
+    !!process.env.AGENTBRIDGE_STATE_DIR ||
+    !!process.env.AGENTBRIDGE_CONTROL_PORT ||
+    !!process.env.CODEX_WS_PORT ||
+    !!process.env.CODEX_PROXY_PORT;
+
+  if (opts.pairFlag === undefined && explicitEnv) {
+    const stateDir = new StateDirResolver();
+    const controlPort = Number.parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
+    const appPort = Number.parseInt(process.env.CODEX_WS_PORT ?? "4500", 10);
+    const proxyPort = Number.parseInt(process.env.CODEX_PROXY_PORT ?? "4501", 10);
+    return {
+      pairId: "(manual)",
+      slot: null,
+      ports: { appPort, proxyPort, controlPort },
+      stateDir,
+      manual: true,
+    };
+  }
+
+  const base = computeBaseDir();
+  const resolved = await resolvePair(base, { pairFlag: opts.pairFlag, cwd: process.cwd() });
+
+  // Pin the base explicitly so child processes (abg pairs / kill, spawned tools)
+  // resolve the SAME registry even though AGENTBRIDGE_STATE_DIR below is rewritten
+  // to the per-pair dir.
+  process.env.AGENTBRIDGE_BASE_DIR = base;
+  process.env.AGENTBRIDGE_PAIR_ID = resolved.pairId;
+  process.env.AGENTBRIDGE_STATE_DIR = resolved.stateDir;
+  process.env.AGENTBRIDGE_CONTROL_PORT = String(resolved.ports.controlPort);
+  process.env.CODEX_WS_PORT = String(resolved.ports.appPort);
+  process.env.CODEX_PROXY_PORT = String(resolved.ports.proxyPort);
+
+  return {
+    pairId: resolved.pairId,
+    slot: resolved.slot,
+    ports: resolved.ports,
+    stateDir: new StateDirResolver(resolved.stateDir),
+    manual: false,
+  };
+}
+
+/** All registered pairs (for `abg pairs`). */
+export function listPairs(base: string): PairEntry[] {
+  return readRegistry(base).pairs;
+}
+
+/** Look up a single pair entry by id (case-insensitive), without allocating. */
+export function findPair(base: string, pairId: string): PairEntry | null {
+  const lower = pairId.toLowerCase();
+  return readRegistry(base).pairs.find((p) => p.pairId.toLowerCase() === lower) ?? null;
+}
+
+/** Ports for a pair entry (convenience for kill/pairs). */
+export function portsForEntry(entry: PairEntry): PairPorts {
+  return portsForSlot(entry.slot);
+}
+
+/** Remove a pair entry from the registry, freeing its slot. */
+export async function removePair(base: string, pairId: string): Promise<PairEntry | null> {
+  return removePairEntry(base, pairId);
+}

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -15,16 +15,26 @@ import { homedir, platform } from "node:os";
 export class StateDirResolver {
   private readonly stateDir: string;
 
+  /**
+   * The platform default base directory, with NO override applied.
+   *
+   * Single source of truth for both the resolver and the multi-pair layer
+   * (`pair-resolver.ts`), which nests each pair under `<base>/pairs/<id>/`.
+   * Keeping this static avoids the base-dir logic drifting between the two.
+   */
+  static platformBaseDir(): string {
+    if (platform() === "darwin") {
+      return join(homedir(), "Library", "Application Support", "AgentBridge");
+    }
+    const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+    return join(xdgState, "agentbridge");
+  }
+
   constructor(envOverride?: string) {
     const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
-    if (override) {
-      this.stateDir = override;
-    } else if (platform() === "darwin") {
-      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
-    } else {
-      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-      this.stateDir = join(xdgState, "agentbridge");
-    }
+    // Treat an empty string as "unset" (master behaviour) — `??` alone would
+    // accept "" and resolve all state files relative to cwd.
+    this.stateDir = override && override.length > 0 ? override : StateDirResolver.platformBaseDir();
   }
 
   /** Ensure the state directory exists. */

--- a/src/unit-test/pair-command.test.ts
+++ b/src/unit-test/pair-command.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { pairScopedCommand } from "../pair-command";
+
+describe("pairScopedCommand", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env.AGENTBRIDGE_PAIR_ID;
+    delete process.env.AGENTBRIDGE_PAIR_ID;
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.AGENTBRIDGE_PAIR_ID;
+    else process.env.AGENTBRIDGE_PAIR_ID = saved;
+  });
+
+  test("legacy/manual mode (no AGENTBRIDGE_PAIR_ID) → bare command", () => {
+    expect(pairScopedCommand("codex")).toBe("agentbridge codex");
+    expect(pairScopedCommand("claude")).toBe("agentbridge claude");
+    expect(pairScopedCommand("kill")).toBe("agentbridge kill");
+  });
+
+  test("pair mode → injects --pair <id> right after the subcommand", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "work";
+    expect(pairScopedCommand("codex")).toBe("agentbridge codex --pair work");
+    expect(pairScopedCommand("claude")).toBe("agentbridge claude --pair work");
+    expect(pairScopedCommand("kill")).toBe("agentbridge kill --pair work");
+  });
+
+  test("--pair is placed before the subcommand's own extra args", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "review";
+    expect(pairScopedCommand("claude --resume")).toBe("agentbridge claude --pair review --resume");
+  });
+
+  test("an empty-string AGENTBRIDGE_PAIR_ID is treated as unset (no --pair)", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "";
+    expect(pairScopedCommand("codex")).toBe("agentbridge codex");
+  });
+
+  test("a cwd-derived id (with a hash suffix) renders verbatim", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "myproj-1a2b3c4d";
+    expect(pairScopedCommand("codex")).toBe("agentbridge codex --pair myproj-1a2b3c4d");
+  });
+});

--- a/src/unit-test/pair-registry.concurrency.test.ts
+++ b/src/unit-test/pair-registry.concurrency.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readRegistry, resolvePair } from "../pair-registry";
+
+// Absolute path to the module under test, so the throwaway child script can
+// import it regardless of where the OS drops the temp dir.
+const PAIR_REGISTRY_PATH = fileURLToPath(new URL("../pair-registry.ts", import.meta.url));
+
+const tempBases: string[] = [];
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "agentbridge-pair-conc-"));
+  tempBases.push(base);
+  return base;
+}
+
+afterEach(() => {
+  while (tempBases.length > 0) {
+    const base = tempBases.pop();
+    if (base) {
+      rmSync(base, { recursive: true, force: true });
+    }
+  }
+});
+
+interface ChildResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function waitForChild(child: ChildProcess, timeoutMs: number): Promise<ChildResult> {
+  return new Promise((resolve, reject) => {
+    const out: string[] = [];
+    const err: string[] = [];
+    let settled = false;
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {}
+    }, timeoutMs);
+
+    child.stdout?.on("data", (chunk) => out.push(chunk.toString()));
+    child.stderr?.on("data", (chunk) => err.push(chunk.toString()));
+
+    child.once("error", (e) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(e);
+    });
+
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (timedOut) {
+        reject(new Error(`Child timed out after ${timeoutMs}ms\nstdout: ${out.join("")}\nstderr: ${err.join("")}`));
+        return;
+      }
+      resolve({ code, stdout: out.join(""), stderr: err.join("") });
+    });
+  });
+}
+
+/**
+ * Throwaway script run by an independent `bun` process. It calls resolvePair
+ * against the shared base and prints the resolved slot. A port-probe failure
+ * (PAIR_PORTS_BUSY) is caught and reported with the slot that *was* allocated
+ * in the registry, so the test can distinguish "allocation collided" (a real
+ * bug) from "a real daemon already squats the probed port" (environmental).
+ */
+function buildChildScript(): string {
+  // JSON.stringify the import path so backslashes / quotes survive embedding.
+  const importPath = JSON.stringify(PAIR_REGISTRY_PATH);
+  return `import { resolvePair, PairError } from ${importPath};
+
+const base = process.env.PAIR_BASE;
+const pairFlag = process.argv[2];
+const cwd = process.argv[3];
+
+if (!base) {
+  console.error("PAIR_BASE env is required");
+  process.exit(2);
+}
+
+try {
+  // probePorts:false — this test exercises pure slot-allocation mutual
+  // exclusion, not port binding, so it must not depend on which ports happen
+  // to be free on the host (a real local daemon may squat 4500-4502).
+  const resolved = await resolvePair(base, { pairFlag, cwd, probePorts: false });
+  process.stdout.write(JSON.stringify({ slot: resolved.slot, pairId: resolved.pairId }));
+  process.exit(0);
+} catch (err) {
+  if (err instanceof PairError) {
+    const slot = typeof err.details?.slot === "number" ? err.details.slot : null;
+    process.stdout.write(JSON.stringify({ slot, error: err.code }));
+    // Exit 0 even on PairError: the test inspects parsed stdout, and the
+    // registry (read by the parent) is the source of truth for allocation.
+    process.exit(0);
+  }
+  console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+  process.exit(3);
+}
+`;
+}
+
+interface ChildOutput {
+  slot: number | null;
+  pairId?: string;
+  error?: string;
+}
+
+describe("pair-registry concurrency", () => {
+  test(
+    "parallel independent processes never collide on a slot",
+    async () => {
+      const base = makeBase();
+      const scriptPath = join(base, "resolve-pair-child.ts");
+      writeFileSync(scriptPath, buildChildScript(), "utf-8");
+
+      const CHILD_COUNT = 8;
+      // Distinct deterministic pair ids => each child is a distinct pair and
+      // must therefore receive a distinct slot.
+      const children: ChildProcess[] = [];
+      for (let i = 0; i < CHILD_COUNT; i++) {
+        const childCwd = join(base, `proj-${i}`);
+        mkdirSync(childCwd, { recursive: true });
+        // Spawn ALL at once — do NOT await between spawns — to actually
+        // exercise the cross-process lock under contention.
+        children.push(
+          spawn(process.execPath, ["run", scriptPath, `p${i}`, childCwd], {
+            cwd: base,
+            env: { ...process.env, PAIR_BASE: base },
+            stdio: ["ignore", "pipe", "pipe"],
+          }),
+        );
+      }
+
+      const results = await Promise.all(children.map((c) => waitForChild(c, 25000)));
+
+      // All children exited cleanly (PairError is caught and exits 0 in the script).
+      for (let i = 0; i < results.length; i++) {
+        const r = results[i]!;
+        expect(r.code, `child p${i} exit code (stderr: ${r.stderr})`).toBe(0);
+      }
+
+      const outputs: ChildOutput[] = results.map((r, i) => {
+        try {
+          return JSON.parse(r.stdout.trim()) as ChildOutput;
+        } catch {
+          throw new Error(`child p${i} produced unparseable stdout: ${JSON.stringify(r.stdout)}`);
+        }
+      });
+
+      // Only PAIR_PORTS_BUSY is environmentally tolerated (a real daemon may
+      // already squat slot-0's ports 4500-4502 on a dev machine). Any other
+      // PairError code is a real failure — surface it loudly.
+      const errored = outputs.filter((o) => o.error !== undefined);
+      for (let i = 0; i < outputs.length; i++) {
+        const o = outputs[i]!;
+        if (o.error !== undefined) {
+          expect(
+            o.error,
+            `child p${i} returned an unexpected error code: ${JSON.stringify(o)}`,
+          ).toBe("PAIR_PORTS_BUSY");
+        }
+      }
+
+      // ===== THE CRITICAL CORRECTNESS PROPERTY =====
+      // Each child's *returned* slot is the authoritative record of what the
+      // allocator assigned it (captured at return, before any later writer can
+      // clobber the on-disk registry). 8 distinct pairs MUST receive 8 DISTINCT
+      // slots. Two children sharing a slot means two pairs would bind the same
+      // port triple — a real cross-process-lock failure. We assert on the child
+      // return values (not the on-disk registry) because a lost-write race can
+      // hide a duplicate-allocation by clobbering one of the colliding entries,
+      // making the registry *look* clean while the collision really happened.
+      const childSlots = outputs
+        .map((o) => o.slot)
+        .filter((s): s is number => typeof s === "number");
+
+      // Every child resolved to a numeric slot (busy children still report the
+      // slot they were allocated via PairError.details.slot).
+      expect(
+        childSlots.length,
+        `every child must report an allocated slot. outputs: ${JSON.stringify(outputs)}`,
+      ).toBe(CHILD_COUNT);
+
+      const sortedChildSlots = [...childSlots].sort((a, b) => a - b);
+      expect(
+        new Set(childSlots).size,
+        `SLOT COLLISION — two independent processes were assigned the SAME slot. ` +
+          `This is a real cross-process-lock bug (mutual exclusion failed). ` +
+          `assigned slots: ${JSON.stringify(sortedChildSlots)}`,
+      ).toBe(CHILD_COUNT);
+
+      // With no collision, the 8 distinct slots are exactly {0..7}.
+      expect(
+        sortedChildSlots,
+        `assigned slots must be exactly 0..7. got: ${JSON.stringify(sortedChildSlots)}`,
+      ).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+
+      // ===== Registry consistency (secondary) =====
+      // The on-disk registry is the persisted view of allocation. In the
+      // absence of any lock race it should hold all 8 entries with slots
+      // {0..7}. We assert NO DUPLICATE slot in the registry (a duplicate here
+      // would be an even more severe corruption than a lost write). The exact
+      // entry count is verified above via child return values; if the registry
+      // holds fewer than CHILD_COUNT entries that indicates a lost-write race
+      // (entries silently clobbered), so we surface it as an explicit failure
+      // rather than masking it.
+      const reg = readRegistry(base);
+      const registrySlots = reg.pairs.map((p) => p.slot);
+      expect(
+        new Set(registrySlots).size,
+        `DUPLICATE SLOT persisted in registry — registry corruption. ` +
+          `pairs: ${JSON.stringify(reg.pairs)}`,
+      ).toBe(registrySlots.length);
+      expect(
+        reg.pairs.length,
+        `registry lost entries (lost-write race under the registry lock). ` +
+          `expected ${CHILD_COUNT}, got ${reg.pairs.length}. pairs: ${JSON.stringify(reg.pairs)}`,
+      ).toBe(CHILD_COUNT);
+
+      // Sanity: errored children, if any, were only the slot-0 port squatter.
+      for (const e of errored) {
+        expect(e.slot === null || typeof e.slot === "number").toBe(true);
+      }
+    },
+    30000,
+  );
+
+  // The lock is a FILE (created via temp + linkSync), not a directory. Seeding a
+  // file with a DEAD owner pid exercises the dead-pid reclaim branch specifically
+  // (not the orphan-grace fallback).
+  test("reclaims a stale lock held by a DEAD owner pid and succeeds", async () => {
+    const base = makeBase();
+    const pairsDir = join(base, "pairs");
+    mkdirSync(pairsDir, { recursive: true });
+    const lockFile = join(pairsDir, ".registry.lock");
+    // 2147483646 is effectively never a live pid → dead-pid reclaim.
+    writeFileSync(lockFile, JSON.stringify({ pid: 2147483646, createdAt: 0, nonce: "stale-owner" }), "utf-8");
+
+    const cwd = join(base, "stale-proj");
+    mkdirSync(cwd, { recursive: true });
+
+    const resolved = await resolvePair(base, { pairFlag: "x", cwd, probePorts: false });
+
+    expect(resolved.pairId).toBe("x");
+    expect(resolved.slot).toBe(0);
+    expect(resolved.ports.appPort).toBe(4500);
+    // The lock must be released after the call returns.
+    expect(existsSync(lockFile)).toBe(false);
+    expect(readRegistry(base).pairs.map((p) => p.pairId)).toContain("x");
+  });
+
+  // A corrupt lock with pid:0 must be treated as dead (process.kill(0,0) targets
+  // the process GROUP and would otherwise falsely look "alive" → deadlock).
+  test("reclaims a corrupt lock with pid:0 instead of deadlocking", async () => {
+    const base = makeBase();
+    const pairsDir = join(base, "pairs");
+    mkdirSync(pairsDir, { recursive: true });
+    writeFileSync(join(pairsDir, ".registry.lock"), JSON.stringify({ pid: 0, createdAt: 0, nonce: "bad" }), "utf-8");
+
+    const cwd = join(base, "pid0-proj");
+    mkdirSync(cwd, { recursive: true });
+
+    const resolved = await resolvePair(base, { pairFlag: "y", cwd, probePorts: false });
+    expect(resolved.pairId).toBe("y");
+    expect(existsSync(join(pairsDir, ".registry.lock"))).toBe(false);
+  });
+
+  test("same cwd resolves idempotently to one slot / one registry entry", async () => {
+    const base = makeBase();
+    const cwd = join(base, "same-proj");
+    mkdirSync(cwd, { recursive: true });
+
+    const first = await resolvePair(base, { cwd, probePorts: false });
+    const second = await resolvePair(base, { cwd, probePorts: false });
+
+    expect(second.slot).toBe(first.slot);
+    expect(second.pairId).toBe(first.pairId);
+
+    const reg = readRegistry(base);
+    expect(reg.pairs.length).toBe(1);
+    expect(reg.pairs[0]?.pairId).toBe(first.pairId);
+  });
+
+  // Regression for the round-2 finding: a PRE-EXISTING dead lock + many concurrent
+  // acquirers previously let two reclaimers evict each other's fresh lock and enter
+  // the critical section together (duplicate slot). The serialized reclaim lock must
+  // make the dead lock reclaimed exactly once with NO slot collision.
+  test(
+    "concurrent acquirers with a seeded DEAD lock never collide on a slot",
+    async () => {
+      const base = makeBase();
+      const pairsDir = join(base, "pairs");
+      mkdirSync(pairsDir, { recursive: true });
+      // Seed a stale primary lock held by a dead pid — forces the reclaim path.
+      writeFileSync(
+        join(pairsDir, ".registry.lock"),
+        JSON.stringify({ pid: 2147483646, createdAt: 0, nonce: "dead-seed" }),
+        "utf-8",
+      );
+
+      const scriptPath = join(base, "resolve-pair-child.ts");
+      writeFileSync(scriptPath, buildChildScript(), "utf-8");
+
+      const CHILD_COUNT = 8;
+      const children: ChildProcess[] = [];
+      for (let i = 0; i < CHILD_COUNT; i++) {
+        const childCwd = join(base, `dproj-${i}`);
+        mkdirSync(childCwd, { recursive: true });
+        children.push(
+          spawn(process.execPath, ["run", scriptPath, `d${i}`, childCwd], {
+            cwd: base,
+            env: { ...process.env, PAIR_BASE: base },
+            stdio: ["ignore", "pipe", "pipe"],
+          }),
+        );
+      }
+
+      const results = await Promise.all(children.map((c) => waitForChild(c, 25000)));
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i]!.code, `child d${i} (stderr: ${results[i]!.stderr})`).toBe(0);
+      }
+
+      const slots = results
+        .map((r) => (JSON.parse(r.stdout.trim()) as ChildOutput).slot)
+        .filter((s): s is number => typeof s === "number");
+
+      expect(slots.length, `outputs: ${JSON.stringify(results.map((r) => r.stdout))}`).toBe(CHILD_COUNT);
+      expect(
+        new Set(slots).size,
+        `SLOT COLLISION under dead-lock reclaim — got ${JSON.stringify([...slots].sort((a, b) => a - b))}`,
+      ).toBe(CHILD_COUNT);
+
+      // Registry is the persisted truth: 8 entries, no duplicate slot, dead lock gone.
+      const reg = readRegistry(base);
+      expect(reg.pairs.length).toBe(CHILD_COUNT);
+      expect(new Set(reg.pairs.map((p) => p.slot)).size).toBe(CHILD_COUNT);
+      expect(existsSync(join(pairsDir, ".registry.lock"))).toBe(false);
+    },
+    30000,
+  );
+});

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -1,0 +1,540 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, type Server } from "node:net";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  derivePairIdFromCwd,
+  detectLegacyRootDaemon,
+  MAX_PAIR_SLOT,
+  PairError,
+  pickLowestFreeSlot,
+  portsForSlot,
+  probePortFree,
+  readRegistry,
+  removePairEntry,
+  resolvePair,
+  validatePairId,
+  writeRegistry,
+  type PairEntry,
+  type RegistryFile,
+} from "../pair-registry";
+
+// Helper: build a minimal PairEntry with a given slot (other fields are
+// irrelevant for slot-allocation logic).
+function entry(slot: number, pairId = `p${slot}`): PairEntry {
+  return {
+    pairId,
+    slot,
+    cwd: `/tmp/${pairId}`,
+    source: "cwd",
+    createdAt: new Date().toISOString(),
+  };
+}
+
+// Helper: bind a TCP port on 127.0.0.1 and resolve once listening.
+function bindPort(port: number): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("portsForSlot", () => {
+  test("slot 0 maps to the classic 4500/4501/4502 triple", () => {
+    expect(portsForSlot(0)).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
+  });
+
+  test("slot 1 maps to 4510/4511/4512", () => {
+    expect(portsForSlot(1)).toEqual({ appPort: 4510, proxyPort: 4511, controlPort: 4512 });
+  });
+
+  test("slot 3 maps to 4530/4531/4532", () => {
+    expect(portsForSlot(3)).toEqual({ appPort: 4530, proxyPort: 4531, controlPort: 4532 });
+  });
+
+  test("negative slot throws PairError", () => {
+    expect(() => portsForSlot(-1)).toThrow(PairError);
+  });
+
+  test("non-integer slot throws PairError", () => {
+    expect(() => portsForSlot(1.5)).toThrow(PairError);
+  });
+
+  test("the thrown error is a PairError (slot guard reuses PAIR_ID_INVALID code)", () => {
+    try {
+      portsForSlot(-1);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      // NOTE: the source reuses code "PAIR_ID_INVALID" for invalid slots
+      // (there is no dedicated slot code). Asserting the actual behavior.
+      expect((err as PairError).code).toBe("PAIR_ID_INVALID");
+    }
+  });
+});
+
+describe("pickLowestFreeSlot", () => {
+  test("empty set returns 0", () => {
+    expect(pickLowestFreeSlot([])).toBe(0);
+  });
+
+  test("slot 0 used returns 1", () => {
+    expect(pickLowestFreeSlot([entry(0)])).toBe(1);
+  });
+
+  test("slots {0,2} used fills the gap -> 1 (not 3)", () => {
+    expect(pickLowestFreeSlot([entry(0), entry(2)])).toBe(1);
+  });
+
+  test("slots {1,2} used returns 0", () => {
+    expect(pickLowestFreeSlot([entry(1), entry(2)])).toBe(0);
+  });
+});
+
+describe("validatePairId", () => {
+  test.each(["foo", "foo-bar_1.2", "A1"])("accepts valid id %p", (id) => {
+    expect(validatePairId(id)).toBe(id);
+  });
+
+  test.each(["..", ".", "a/b", "a b", "", "foo/../bar"])(
+    "throws PAIR_ID_INVALID for %p",
+    (bad) => {
+      try {
+        validatePairId(bad);
+        throw new Error(`expected throw for ${JSON.stringify(bad)}`);
+      } catch (err) {
+        expect(err).toBeInstanceOf(PairError);
+        expect((err as PairError).code).toBe("PAIR_ID_INVALID");
+      }
+    },
+  );
+
+  test("throws PAIR_ID_INVALID for a 65-char string", () => {
+    const tooLong = "a".repeat(65);
+    try {
+      validatePairId(tooLong);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      expect((err as PairError).code).toBe("PAIR_ID_INVALID");
+    }
+  });
+
+  test("accepts a 64-char string (boundary)", () => {
+    const ok = "a".repeat(64);
+    expect(validatePairId(ok)).toBe(ok);
+  });
+});
+
+describe("derivePairIdFromCwd", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("is stable for the same path (two calls are equal)", () => {
+    const a = derivePairIdFromCwd(base);
+    const b = derivePairIdFromCwd(base);
+    expect(a).toBe(b);
+  });
+
+  test("two different paths produce different ids", () => {
+    const dirA = mkdtempSync(join(tmpdir(), "abg-pair-test-A-"));
+    const dirB = mkdtempSync(join(tmpdir(), "abg-pair-test-B-"));
+    try {
+      expect(derivePairIdFromCwd(dirA)).not.toBe(derivePairIdFromCwd(dirB));
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  test("result always passes validatePairId without throwing", () => {
+    const id = derivePairIdFromCwd(base);
+    expect(() => validatePairId(id)).not.toThrow();
+    expect(validatePairId(id)).toBe(id);
+  });
+
+  test("resolves symlinks: a symlink to a dir yields the same id as the real dir", () => {
+    const realDir = mkdtempSync(join(tmpdir(), "abg-pair-test-real-"));
+    const linkPath = join(base, "link-to-real");
+    try {
+      symlinkSync(realDir, linkPath);
+      // Confirm the symlink actually points at the real dir.
+      expect(realpathSync(linkPath)).toBe(realpathSync(realDir));
+      expect(derivePairIdFromCwd(linkPath)).toBe(derivePairIdFromCwd(realDir));
+    } finally {
+      rmSync(realDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("readRegistry / writeRegistry", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("missing file returns an empty registry", () => {
+    expect(readRegistry(base)).toEqual({ version: 1, pairs: [] });
+  });
+
+  test("round-trips a registry with 2 entries", () => {
+    const reg: RegistryFile = { version: 1, pairs: [entry(0, "alpha"), entry(1, "beta")] };
+    writeRegistry(base, reg);
+    expect(readRegistry(base)).toEqual(reg);
+  });
+
+  test("corrupt JSON throws PAIR_REGISTRY_CORRUPT", () => {
+    // Seed a valid registry first so the pairs dir exists, then clobber the file.
+    writeRegistry(base, { version: 1, pairs: [] });
+    const regPath = join(base, "pairs", "registry.json");
+    writeFileSync(regPath, "{ not valid json ");
+    try {
+      readRegistry(base);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      expect((err as PairError).code).toBe("PAIR_REGISTRY_CORRUPT");
+    }
+  });
+
+  test("wrong shape ({version:2}) throws PAIR_REGISTRY_CORRUPT", () => {
+    writeRegistry(base, { version: 1, pairs: [] });
+    const regPath = join(base, "pairs", "registry.json");
+    writeFileSync(regPath, JSON.stringify({ version: 2 }));
+    try {
+      readRegistry(base);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      expect((err as PairError).code).toBe("PAIR_REGISTRY_CORRUPT");
+    }
+  });
+
+  test("no leftover *.tmp.* files remain after writeRegistry", () => {
+    writeRegistry(base, { version: 1, pairs: [entry(0)] });
+    const files = readdirSync(join(base, "pairs"));
+    const tmpFiles = files.filter((f) => f.includes(".tmp."));
+    expect(tmpFiles).toEqual([]);
+  });
+});
+
+describe("probePortFree", () => {
+  // Use a high port unlikely to collide; bind it to confirm busy detection.
+  const probePort = 47213;
+
+  test("a freshly chosen high port is free", async () => {
+    expect(await probePortFree(probePort)).toBe(true);
+  });
+
+  test("a bound port reports as not free, and frees up after close", async () => {
+    const server = await bindPort(probePort);
+    try {
+      expect(await probePortFree(probePort)).toBe(false);
+    } finally {
+      await closeServer(server);
+    }
+    // After close the port is free again.
+    expect(await probePortFree(probePort)).toBe(true);
+  });
+});
+
+describe("detectLegacyRootDaemon", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("empty base returns null", () => {
+    expect(detectLegacyRootDaemon(base)).toBeNull();
+  });
+
+  test("daemon.pid with a definitely-dead pid returns null", () => {
+    writeFileSync(join(base, "daemon.pid"), "2147483646");
+    expect(detectLegacyRootDaemon(base)).toBeNull();
+  });
+});
+
+describe("resolvePair", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  // resolvePair probes the slot's ports AFTER releasing the lock. Slot 0 maps
+  // to 4500/4501/4502, which may be occupied by a real dev-machine daemon — in
+  // that case resolvePair throws PAIR_PORTS_BUSY. The registry/slot allocation
+  // happens under the lock BEFORE probing, so allocation is durable regardless
+  // of the probe outcome. These helpers assert allocation via the registry and
+  // tolerate a PAIR_PORTS_BUSY thrown by the port probe.
+
+  // Run resolvePair, returning either the resolved pair or the PairError it
+  // threw. Re-throws anything that is not a PAIR_PORTS_BUSY PairError so real
+  // failures still surface.
+  async function resolveTolerant(
+    cwd: string,
+    pairFlag?: string,
+  ): Promise<{ ok: true; resolved: Awaited<ReturnType<typeof resolvePair>> } | { ok: false; busy: PairError }> {
+    try {
+      const resolved = await resolvePair(base, pairFlag ? { pairFlag, cwd } : { cwd });
+      return { ok: true, resolved };
+    } catch (err) {
+      if (err instanceof PairError && err.code === "PAIR_PORTS_BUSY") {
+        return { ok: false, busy: err };
+      }
+      throw err;
+    }
+  }
+
+  test("fresh base + cwd -> slot 0, ports 4500/4501/4502, stateDir ends with pairId, 1 entry", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
+    try {
+      const expectedId = derivePairIdFromCwd(tmpA);
+      const r = await resolveTolerant(tmpA);
+
+      // Allocation must have happened regardless of probe result.
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(1);
+      expect(reg.pairs[0]!.slot).toBe(0);
+      expect(reg.pairs[0]!.pairId).toBe(expectedId);
+      expect(reg.pairs[0]!.source).toBe("cwd");
+
+      if (r.ok) {
+        expect(r.resolved.slot).toBe(0);
+        expect(r.resolved.pairId).toBe(expectedId);
+        expect(r.resolved.ports).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
+        expect(r.resolved.stateDir.endsWith(expectedId)).toBe(true);
+      } else {
+        // Ports 4500-4502 busy on this machine; allocation still correct.
+        expect(r.busy.details?.slot).toBe(0);
+      }
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
+
+  test("calling again with the SAME cwd is idempotent (same pairId/slot, still 1 entry)", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
+    try {
+      const expectedId = derivePairIdFromCwd(tmpA);
+      await resolveTolerant(tmpA);
+      await resolveTolerant(tmpA);
+
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(1);
+      expect(reg.pairs[0]!.slot).toBe(0);
+      expect(reg.pairs[0]!.pairId).toBe(expectedId);
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
+
+  test("a second distinct cwd allocates slot 1", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
+    const tmpB = mkdtempSync(join(tmpdir(), "abg-pair-cwd-B-"));
+    try {
+      const idA = derivePairIdFromCwd(tmpA);
+      const idB = derivePairIdFromCwd(tmpB);
+      await resolveTolerant(tmpA);
+      const rB = await resolveTolerant(tmpB);
+
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(2);
+      const entryA = reg.pairs.find((p) => p.pairId === idA)!;
+      const entryB = reg.pairs.find((p) => p.pairId === idB)!;
+      expect(entryA.slot).toBe(0);
+      expect(entryB.slot).toBe(1);
+
+      // Slot 1 ports are 4510-4512, almost certainly free on a dev machine, so
+      // this resolve normally succeeds — but stay tolerant just in case.
+      if (rB.ok) {
+        expect(rB.resolved.slot).toBe(1);
+        expect(rB.resolved.ports).toEqual({ appPort: 4510, proxyPort: 4511, controlPort: 4512 });
+      } else {
+        expect(rB.busy.details?.slot).toBe(1);
+      }
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+      rmSync(tmpB, { recursive: true, force: true });
+    }
+  });
+
+  test("explicit pairFlag uses that name verbatim", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
+    try {
+      const r = await resolveTolerant(tmpA, "myname");
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(1);
+      expect(reg.pairs[0]!.pairId).toBe("myname");
+      expect(reg.pairs[0]!.source).toBe("flag");
+      if (r.ok) {
+        expect(r.resolved.pairId).toBe("myname");
+      }
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("removePairEntry", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  // Drive allocation through the registry directly (writeRegistry) so the test
+  // is independent of port-probe outcome for slot 0. removePairEntry only
+  // touches the registry under the lock, never probes ports.
+  test("removes the slot-0 entry and returns it; a new cwd then reuses slot 0", async () => {
+    const idA = derivePairIdFromCwd("/tmp/projectA");
+    const idB = derivePairIdFromCwd("/tmp/projectB");
+    writeRegistry(base, {
+      version: 1,
+      pairs: [
+        { pairId: idA, slot: 0, cwd: "/tmp/projectA", source: "cwd", createdAt: new Date().toISOString() },
+        { pairId: idB, slot: 1, cwd: "/tmp/projectB", source: "cwd", createdAt: new Date().toISOString() },
+      ],
+    });
+
+    const removed = await removePairEntry(base, idA);
+    expect(removed).not.toBeNull();
+    expect(removed!.slot).toBe(0);
+    expect(removed!.pairId).toBe(idA);
+
+    // Slot 0 is now free; the lowest-free-slot logic should hand it to a new pair.
+    const reg = readRegistry(base);
+    expect(reg.pairs.map((p) => p.slot).sort()).toEqual([1]);
+    expect(pickLowestFreeSlot(reg.pairs)).toBe(0);
+  });
+
+  test("removing a non-existent pair returns null", async () => {
+    writeRegistry(base, { version: 1, pairs: [] });
+    expect(await removePairEntry(base, "nope")).toBeNull();
+  });
+});
+
+// Regression coverage for the cross-review round-1 fixes.
+describe("cross-review regression fixes", () => {
+  const bases: string[] = [];
+  afterEach(() => {
+    while (bases.length > 0) {
+      const b = bases.pop();
+      if (b) rmSync(b, { recursive: true, force: true });
+    }
+  });
+  function tmpBase(): string {
+    const b = mkdtempSync(join(tmpdir(), "abg-rgr-"));
+    bases.push(b);
+    return b;
+  }
+
+  test("#3 case-insensitive match returns the registry's canonical pairId/state dir", async () => {
+    const base = tmpBase();
+    writeRegistry(base, { version: 1, pairs: [entry(0, "Foo")] });
+    // Resolve with different casing — must canonicalize to "Foo", not "foo".
+    const r = await resolvePair(base, { pairFlag: "foo", cwd: "/tmp/x", probePorts: false });
+    expect(r.pairId).toBe("Foo");
+    expect(r.slot).toBe(0);
+    expect(r.stateDir).toBe(join(base, "pairs", "Foo"));
+  });
+
+  test("#5 slot exhaustion throws WITHOUT persisting an invalid entry", async () => {
+    const base = tmpBase();
+    const full: PairEntry[] = [];
+    for (let s = 0; s <= MAX_PAIR_SLOT; s++) full.push(entry(s, `p${s}`));
+    writeRegistry(base, { version: 1, pairs: full });
+    const before = readRegistry(base).pairs.length;
+    await expect(resolvePair(base, { pairFlag: "overflow", cwd: "/tmp/x", probePorts: false })).rejects.toThrow();
+    // The failed allocation must not leave an out-of-range slot in the registry.
+    expect(readRegistry(base).pairs.length).toBe(before);
+    expect(readRegistry(base).pairs.some((p) => p.slot > MAX_PAIR_SLOT)).toBe(false);
+  });
+
+  test("#6 validatePairId rejects Windows reserved device names with extensions", () => {
+    expect(() => validatePairId("CON.txt")).toThrow(PairError);
+    expect(() => validatePairId("NUL.log")).toThrow(PairError);
+    expect(() => validatePairId("com1.x")).toThrow(PairError);
+    // Not reserved: the device-base check only matches exact device words.
+    expect(validatePairId("conduit")).toBe("conduit");
+    expect(validatePairId("console")).toBe("console");
+  });
+
+  test("#7 readRegistry rejects a tampered pairId that could escape the pairs dir", () => {
+    const base = tmpBase();
+    const pairsDir = join(base, "pairs");
+    mkdirSync(pairsDir, { recursive: true });
+    writeFileSync(
+      join(pairsDir, "registry.json"),
+      JSON.stringify({ version: 1, pairs: [{ pairId: "../../etc", slot: 0, cwd: "/", source: "flag", createdAt: "x" }] }),
+      "utf-8",
+    );
+    expect(() => readRegistry(base)).toThrow(PairError);
+    try {
+      readRegistry(base);
+    } catch (e) {
+      expect((e as PairError).code).toBe("PAIR_REGISTRY_CORRUPT");
+    }
+  });
+
+  test("a brand-new pair whose port is squatted reports PAIR_PORTS_BUSY (deterministic)", async () => {
+    const base = tmpBase();
+    // Occupy slots 0 and 1 so the new pair deterministically lands on slot 2.
+    writeRegistry(base, { version: 1, pairs: [entry(0, "a"), entry(1, "b")] });
+    const slot2 = portsForSlot(2);
+    const server = await bindPort(slot2.appPort); // squat 4520
+    try {
+      let caught: unknown;
+      try {
+        await resolvePair(base, { pairFlag: "c", cwd: "/tmp/x" }); // probePorts defaults true
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(PairError);
+      expect((caught as PairError).code).toBe("PAIR_PORTS_BUSY");
+      expect((caught as PairError).details?.port).toBe(slot2.appPort);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/src/unit-test/pair-resolver.test.ts
+++ b/src/unit-test/pair-resolver.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { writeRegistry, type PairEntry } from "../pair-registry";
+import {
+  applyPairEnv,
+  computeBaseDir,
+  findPair,
+  listPairs,
+  parseKillArgs,
+  parsePairFlag,
+  portsForEntry,
+  removePair,
+} from "../pair-resolver";
+
+// ---------------------------------------------------------------------------
+// Env isolation: pair env vars leak across tests otherwise.
+// ---------------------------------------------------------------------------
+const ENV_KEYS = [
+  "AGENTBRIDGE_BASE_DIR",
+  "AGENTBRIDGE_STATE_DIR",
+  "AGENTBRIDGE_CONTROL_PORT",
+  "AGENTBRIDGE_PAIR_ID",
+  "CODEX_WS_PORT",
+  "CODEX_PROXY_PORT",
+] as const;
+
+let savedEnv: Record<string, string | undefined> = {};
+const tempBases: string[] = [];
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  while (tempBases.length > 0) {
+    const base = tempBases.pop();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "agentbridge-resolver-"));
+  tempBases.push(base);
+  return base;
+}
+
+function entry(pairId: string, slot: number): PairEntry {
+  return { pairId, slot, cwd: `/tmp/${pairId}`, source: "flag", createdAt: "2026-01-01T00:00:00.000Z" };
+}
+
+describe("parsePairFlag", () => {
+  test("extracts --pair <name> and leaves the rest in order", () => {
+    const { pairFlag, rest } = parsePairFlag(["--pair", "work", "--resume", "-x"]);
+    expect(pairFlag).toBe("work");
+    expect(rest).toEqual(["--resume", "-x"]);
+  });
+
+  test("extracts --pair=<name>", () => {
+    const { pairFlag, rest } = parsePairFlag(["--model", "o3", "--pair=review"]);
+    expect(pairFlag).toBe("review");
+    expect(rest).toEqual(["--model", "o3"]);
+  });
+
+  test("no flag → undefined, rest untouched", () => {
+    const { pairFlag, rest } = parsePairFlag(["--resume", "foo"]);
+    expect(pairFlag).toBeUndefined();
+    expect(rest).toEqual(["--resume", "foo"]);
+  });
+
+  test("--pair with a missing value → empty string (forces a clear error downstream)", () => {
+    const { pairFlag, rest } = parsePairFlag(["--pair"]);
+    expect(pairFlag).toBe("");
+    expect(rest).toEqual([]);
+  });
+
+  test("--pair followed by another flag does not consume the flag as a value", () => {
+    const { pairFlag, rest } = parsePairFlag(["--pair", "--resume"]);
+    expect(pairFlag).toBe("");
+    expect(rest).toEqual(["--resume"]);
+  });
+});
+
+describe("parseKillArgs", () => {
+  test("no args → all:false, no pair (router treats as kill-all)", () => {
+    expect(parseKillArgs([])).toEqual({ all: false, pairFlag: undefined });
+  });
+  test("--all", () => {
+    expect(parseKillArgs(["--all"])).toEqual({ all: true, pairFlag: undefined });
+  });
+  test("--pair X", () => {
+    expect(parseKillArgs(["--pair", "work"])).toEqual({ all: false, pairFlag: "work" });
+  });
+  test("--pair=X", () => {
+    expect(parseKillArgs(["--pair=review"])).toEqual({ all: false, pairFlag: "review" });
+  });
+});
+
+describe("computeBaseDir", () => {
+  test("honours AGENTBRIDGE_STATE_DIR", () => {
+    process.env.AGENTBRIDGE_STATE_DIR = "/tmp/custom-base";
+    expect(computeBaseDir()).toBe("/tmp/custom-base");
+  });
+  test("falls back to the platform base dir when unset", () => {
+    // Platform base ends in AgentBridge (macOS) or agentbridge (linux).
+    expect(computeBaseDir().toLowerCase()).toContain("agentbridge");
+  });
+});
+
+describe("applyPairEnv — manual/legacy mode", () => {
+  test("explicit port env + no --pair → manual, ports from env, registry untouched", async () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    process.env.AGENTBRIDGE_CONTROL_PORT = "4502";
+    process.env.CODEX_WS_PORT = "4500";
+    process.env.CODEX_PROXY_PORT = "4501";
+
+    const res = await applyPairEnv({});
+
+    expect(res.manual).toBe(true);
+    expect(res.pairId).toBe("(manual)");
+    expect(res.slot).toBeNull();
+    expect(res.ports).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
+    // Manual mode does not allocate a slot: no registry written under the base.
+    expect(listPairs(base)).toEqual([]);
+  });
+});
+
+describe("applyPairEnv — pair mode env injection", () => {
+  test("an existing pair injects its slot's ports + state dir + pair id (no port probe)", async () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    // Seed the pair as already-registered at slot 3 so resolvePair takes the
+    // existing branch (no port probe → deterministic regardless of host ports).
+    writeRegistry(base, { version: 1, pairs: [entry("work", 3)] });
+
+    const res = await applyPairEnv({ pairFlag: "work" });
+
+    expect(res.manual).toBe(false);
+    expect(res.pairId).toBe("work");
+    expect(res.slot).toBe(3);
+    expect(res.ports).toEqual({ appPort: 4530, proxyPort: 4531, controlPort: 4532 });
+
+    // The env vars + pair id are injected for downstream / spawned children.
+    expect(process.env.AGENTBRIDGE_PAIR_ID).toBe("work");
+    expect(process.env.AGENTBRIDGE_CONTROL_PORT).toBe("4532");
+    expect(process.env.CODEX_WS_PORT).toBe("4530");
+    expect(process.env.CODEX_PROXY_PORT).toBe("4531");
+    expect(process.env.AGENTBRIDGE_STATE_DIR).toBe(join(base, "pairs", "work"));
+    expect(res.stateDir.dir).toBe(join(base, "pairs", "work"));
+    // BASE_DIR is pinned to the registry base (NOT the per-pair state dir) so a
+    // child `abg pairs`/`abg kill` resolves the same registry.
+    expect(process.env.AGENTBRIDGE_BASE_DIR).toBe(base);
+  });
+
+  test("a child inheriting the pair env still resolves the registry base", async () => {
+    // Simulate a child of `abg claude --pair work`: BASE_DIR=base, STATE_DIR=pair dir.
+    const base = makeBase();
+    writeRegistry(base, { version: 1, pairs: [entry("work", 0)] });
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+    process.env.AGENTBRIDGE_STATE_DIR = join(base, "pairs", "work");
+    // computeBaseDir must prefer BASE_DIR over the (per-pair) STATE_DIR.
+    expect(computeBaseDir()).toBe(base);
+    expect(findPair(computeBaseDir(), "work")?.pairId).toBe("work");
+  });
+
+  test("an invalid --pair name is rejected", async () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    await expect(applyPairEnv({ pairFlag: "../escape" })).rejects.toThrow();
+  });
+
+  test("an explicit-but-empty --pair (missing value) is rejected, not cwd-derived", async () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    await expect(applyPairEnv({ pairFlag: "" })).rejects.toThrow();
+  });
+});
+
+describe("registry helpers", () => {
+  test("listPairs / findPair / portsForEntry / removePair", async () => {
+    const base = makeBase();
+    writeRegistry(base, { version: 1, pairs: [entry("a", 0), entry("b", 1)] });
+
+    expect(listPairs(base).map((p) => p.pairId).sort()).toEqual(["a", "b"]);
+
+    const b = findPair(base, "B"); // case-insensitive
+    expect(b?.pairId).toBe("b");
+    expect(b?.slot).toBe(1);
+    expect(portsForEntry(b!)).toEqual({ appPort: 4510, proxyPort: 4511, controlPort: 4512 });
+
+    expect(findPair(base, "missing")).toBeNull();
+
+    const removed = await removePair(base, "a");
+    expect(removed?.pairId).toBe("a");
+    expect(listPairs(base).map((p) => p.pairId)).toEqual(["b"]);
+  });
+});


### PR DESCRIPTION
## 概要 / Summary

实现**单机多对 Claude+Codex 并行**(砍掉第三 agent,先做多对)。采用**路线 A —— 多实例 / shared-nothing**:每对作为独立 daemon 实例运行,各自端口三元组 + state 目录,**daemon 内部零改动**。`slot 0` 仍用经典 `4500/4501/4502`,单对老用户行为完全不变。

Implements **single-machine multi-pair Claude+Codex** via **Route A (shared-nothing multi-instance)**: each pair is an isolated daemon with its own port triple + state dir; daemon internals are unchanged. Slot 0 keeps the classic `4500/4501/4502`, so existing single-pair users are unaffected.

> 与路线 B(单 daemon + pairs map + 跨对路由)的对比:路线 A **没有跨对路由** —— 对之间靠端口/state 物理隔离,因此结构上规避了路线 B 的全局状态生命周期 leak。
> Unlike Route B (one daemon + a `pairs` map + cross-pair routing), Route A has **no cross-pair routing** — pairs are physically isolated by port/state, which structurally avoids Route B's shared-global lifecycle leaks.

## 用法 / Usage

```bash
abg claude --pair work     # 终端1:命名一对 / name a pair
abg codex  --pair work     # 终端2:连同一对 / connect to it
abg claude --pair review   # 第二对,自动分到 slot1 → 4510/11/12
abg claude                 # 无 --pair:按 cwd(realpath+hash)自动派生 pairId
abg pairs                  # 列出所有对(slot/端口/状态/pid),--json 可选
abg pairs rm <id>          # 停一对并释放 slot
abg kill --pair work       # 只停一对 / stop one pair
abg kill                   # 停所有对 + legacy-root daemon / stop all
```

身份规则:`--pair <名>` 优先;无 flag 则按目录派生(同目录无名 = 同一对,要并行多对需显式命名)。

## 工作原理 / How it works (env-injection seam)

每个 CLI 命令顶端跑一个 pair resolver:在跨进程锁里到 `<base>/pairs/registry.json` 分配/查找 slot,然后注入 env(`AGENTBRIDGE_BASE_DIR` / `AGENTBRIDGE_STATE_DIR`=pair 目录 / `AGENTBRIDGE_PAIR_ID` / 三端口)。既有的 claude/codex/kill 代码和 daemon 因为本来就从 env 读这些值,无需改动即"自动工作";spawn 的 claude 让插件 MCP server 继承 env → 连到对的 daemon。**靠 env 注入,不动核心代码。**

## 实现 / Implementation

- `src/pair-registry.ts` — 跨进程锁(temp+`link(2)` 原子获取、**dead-pid-only** reclaim + 串行化 reclaim-lock + nonce、`pid<=0` 视为死防 `kill(0,0)` 进程组假活)、slot→端口派生、registry + entry 校验(防 traversal)。
- `src/pair-resolver.ts` — env-injection seam;manual 模式(显式 env 无 `--pair`)向后兼容现有 e2e harness;空字符串 env 当 unset。
- `src/pair-command.ts` — pair-scoped 用户提示(bridge / disabled-state / codex / kill / SessionStart health-check hook),避免在命名对会话里把用户导向**别的对**或诱导 `kill` 全部。
- `src/cli/pairs.ts` + `cli/kill.ts` 重写 + claude/codex/cli.ts/daemon.ts 接线。
- `build:cli` 现在产出 `dist/daemon.js`;daemon entry 默认按源码(`.ts`)/打包(`.js`)模式区分。
- 测试:`pair-registry`(含 8 进程 + seeded-dead-lock 并发测试)、`pair-resolver`、`pair-command`,+ 扩展 `e2e-cli.test.ts`,+ `scripts/runtime-dual-pair-e2e.py`(`--reserve-slots` 避开占用端口)。

## 验证 / Verification

- `bun run check`:**334 pass / 0 fail**,plugin bundles in sync,manifests version-aligned 0.1.6。
- **真·双对运行时 E2E**(沙箱,仓库原脚本,无 workaround):pair `a`=slot2 `4520/4521/4522` (status pairId "a")、pair `b`=slot3 `4530/4531/4532` (status pairId "b");端口/state/日志隔离 ✓;`kill --pair a` 只停 a、b 仍 LISTEN ✓;`kill --all` 后 `4520-4532` 全清 ✓。
- **交叉评审 8 轮**(Claude×2 全新 reviewer + Codex / 轮),收敛到连续 2 轮 0 真实 issue + post-gate packaging delta focused 复审。

真实修掉的 bug(交叉评审捕获)/ Real bugs caught & fixed by cross-review:
- 跨进程锁竞争(3 轮迭代:发布窗口 → CAS → reclaim-lock 串行化 + dead-pid-only + nonce;实测从 ~27% slot 碰撞修到 0)
- `AGENTBRIDGE_STATE_DIR` 双重语义 → 引入 `AGENTBRIDGE_BASE_DIR`
- 空字符串 env 被当有效路径
- `abg kill --help` / 未知 flag 误落 kill-all(会停所有对)
- pair-scoped 命令提示(含 SessionStart hook)
- packaging:`build:cli` 未产 `dist/daemon.js` + daemon entry 默认

## 关联 / Related

替代方案 / Alternative to (Route B):
- #81 (feat: STM v2.3 multi-pair vertical upgrade) — 本 PR 是其 Route A 替代(shared-nothing 而非单 daemon 多路由)。
- #80 (feat: multi-Claude + multi-TUI parallel agent support, draft)。

路线 B 的生命周期 leak,路线 A 用 shared-nothing 结构性规避(每对独立进程,无共享全局)/ Route B lifecycle leaks structurally avoided by Route A:
- #82, #83, #84, #86, #87, #88 (multi-pair refactor / default-global leaks / async shutdown / docs)。

单独跟踪 / Tracked separately (not addressed here):
- #85 (Codex 0.131 移除 ws listen 的 transport 兼容) — Route A 仍用 ws listen,属独立 transport 议题。
- #24 (workspace config file)。

> 维护者请定夺路线 A 是否取代 #80/#81 与 #82–#88;本 PR 不自动 close 这些。
> Maintainer to decide whether Route A supersedes #80/#81 and #82–#88; this PR does not auto-close them.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test src` — 334 pass / 0 fail
- [x] `bun run check` (typecheck + tests + plugin sync + version align)
- [x] Real two-pair runtime E2E (two real Claude+Codex pairs, isolation + kill)
- [x] Cross-review: 8 rounds → 2 consecutive clean + post-gate focused review
- [] 维护者本地试跑 `abg claude --pair a` / `abg codex --pair a` + 第二对 / maintainer local smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude (Route A core + cross-review orchestration) & Codex (kill/pairs CLI, packaging fix, runtime E2E)
