### PR TITLE
fix: turn watchdog + thread-switch ordering for Codex reliability (#69, #70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ agent_bridge/
 | `CODEX_PROXY_PORT` | `4501` | Bridge proxy port for the Codex TUI |
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | Control port between bridge.ts and daemon.ts |
 | `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | Maximum wait for incumbent Claude pong before evicting on contention (issue #68) |
+| `AGENTBRIDGE_TURN_WATCHDOG_MS` | `300000` | Per-turn inactivity watchdog: force-completes a turn after this many ms of app-server silence so a lost `turn/completed` can't lock injection forever (issue #69) |
 | `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
 | `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -247,6 +247,7 @@ agent_bridge/
 | `CODEX_PROXY_PORT` | `4501` | Bridge 代理端口，Codex TUI 连接此端口 |
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | bridge.ts 与 daemon.ts 之间的控制端口 |
 | `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | 等待在位 Claude pong 的最长时间，超时后在争用时驱逐（issue #68） |
+| `AGENTBRIDGE_TURN_WATCHDOG_MS` | `300000` | 单 turn 非活动看门狗：app-server 静默超过该毫秒数后强制完成该 turn，避免丢失 `turn/completed` 永久锁死注入（issue #69） |
 | `AGENTBRIDGE_STATE_DIR` | 平台默认 | 状态目录（pid、status、日志）。macOS: `~/Library/Application Support/agentbridge/`，Linux: `$XDG_STATE_HOME/agentbridge/` |
 | `AGENTBRIDGE_MODE` | `push` | 消息投递模式（`push` 用于 channel，`pull` 用于 API key 模式） |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -124,6 +124,8 @@ class CodexAdapter extends EventEmitter {
   pendingRequests = new Map;
   activeTurnIds = new Set;
   turnInProgress = false;
+  turnWatchdogs = new Map;
+  threadSwitchSeq = 0;
   nextProxyId = 1e5;
   upstreamToClient = new Map;
   serverRequestToProxy = new Map;
@@ -197,6 +199,7 @@ class CodexAdapter extends EventEmitter {
     this.proxyServer?.stop();
     this.proxyServer = null;
     this.clearResponseTrackingState();
+    this.resetTurnState("adapter disconnect");
   }
   stop() {
     this.intentionalDisconnect = true;
@@ -323,8 +326,7 @@ class CodexAdapter extends EventEmitter {
       } catch {}
     }
     this.clearResponseTrackingStateForAppServerReconnect();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server reconnect for new TUI session");
     try {
       await this.connectToAppServer(false);
       this.log("App-server reconnected for new TUI session \u2014 replaying buffered messages");
@@ -378,8 +380,7 @@ class CodexAdapter extends EventEmitter {
     this.log(`App-server connection closed (intentional=${intentional}, tuiConnected=${tuiConnected}, turnInProgress=${this.turnInProgress})`);
     this.appServerWs = null;
     this.clearResponseTrackingState();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server connection closed");
     if (!intentional) {
       this.scheduleReconnect();
     }
@@ -811,6 +812,9 @@ class CodexAdapter extends EventEmitter {
   handleAppServerPayload(raw) {
     try {
       const parsed = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null) {
+        this.refreshTurnWatchdogs();
+      }
       if (typeof parsed === "object" && parsed !== null && "id" in parsed) {
         if (this.tryConsumeReplayResponse(parsed)) {
           return null;
@@ -1039,6 +1043,9 @@ class CodexAdapter extends EventEmitter {
         pending.threadId = threadId;
       }
     }
+    if (method === "thread/start" || method === "thread/resume") {
+      pending.threadSwitchSeq = ++this.threadSwitchSeq;
+    }
     if (this.pendingRequests.has(key)) {
       this.log(`WARNING: overwriting pending request for key ${key}`);
     }
@@ -1062,6 +1069,10 @@ class CodexAdapter extends EventEmitter {
     }
     switch (pending.method) {
       case "thread/start": {
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(`Ignoring stale thread/start response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`);
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/start response ${key}`);
@@ -1070,6 +1081,10 @@ class CodexAdapter extends EventEmitter {
         break;
       }
       case "thread/resume": {
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(`Ignoring stale thread/resume response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`);
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/resume response ${key}`);
@@ -1082,10 +1097,17 @@ class CodexAdapter extends EventEmitter {
       }
       case "turn/start":
         if (pending.threadId) {
-          this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          if (this.threadId === null || this.threadId === pending.threadId) {
+            this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          } else {
+            this.log(`Ignoring turn/start response ${key} threadId=${pending.threadId} (active thread is ${this.threadId})`);
+          }
         }
         break;
     }
+  }
+  isLatestThreadSwitch(pending) {
+    return pending.threadSwitchSeq === this.threadSwitchSeq;
   }
   setActiveThreadId(threadId, reason) {
     if (this.threadId === threadId)
@@ -1101,11 +1123,9 @@ class CodexAdapter extends EventEmitter {
   }
   markTurnStarted(turnId) {
     const wasInProgress = this.turnInProgress;
-    if (typeof turnId === "string" && turnId.length > 0) {
-      this.activeTurnIds.add(turnId);
-    } else {
-      this.activeTurnIds.add(`unknown:${Date.now()}`);
-    }
+    const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
+    this.activeTurnIds.add(turnKey);
+    this.scheduleTurnWatchdog(turnKey);
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
       this.emit("turnStarted");
@@ -1114,10 +1134,67 @@ class CodexAdapter extends EventEmitter {
   markTurnCompleted(turnId) {
     if (typeof turnId === "string" && turnId.length > 0) {
       this.activeTurnIds.delete(turnId);
+      this.clearTurnWatchdog(turnId);
     } else {
       this.activeTurnIds.clear();
+      this.clearAllTurnWatchdogs();
     }
     this.turnInProgress = this.activeTurnIds.size > 0;
+  }
+  turnWatchdogMs() {
+    const v = Number(process.env.AGENTBRIDGE_TURN_WATCHDOG_MS);
+    return Number.isFinite(v) && v > 0 ? v : 300000;
+  }
+  scheduleTurnWatchdog(turnKey) {
+    this.clearTurnWatchdog(turnKey);
+    const timer = setTimeout(() => {
+      if (!this.activeTurnIds.has(turnKey))
+        return;
+      this.log(`WARNING: turn ${turnKey} watchdog fired after ${this.turnWatchdogMs()}ms of inactivity \u2014 ` + `assuming a lost turn/completed; force-completing to unblock injection`);
+      this.forceCompleteTurn(turnKey);
+    }, this.turnWatchdogMs());
+    timer.unref?.();
+    this.turnWatchdogs.set(turnKey, timer);
+  }
+  clearTurnWatchdog(turnKey) {
+    const timer = this.turnWatchdogs.get(turnKey);
+    if (timer) {
+      clearTimeout(timer);
+      this.turnWatchdogs.delete(turnKey);
+    }
+  }
+  clearAllTurnWatchdogs() {
+    for (const timer of this.turnWatchdogs.values())
+      clearTimeout(timer);
+    this.turnWatchdogs.clear();
+  }
+  refreshTurnWatchdogs() {
+    if (this.turnWatchdogs.size === 0)
+      return;
+    for (const turnKey of [...this.turnWatchdogs.keys()]) {
+      this.scheduleTurnWatchdog(turnKey);
+    }
+  }
+  forceCompleteTurn(turnKey) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.delete(turnKey);
+    this.clearTurnWatchdog(turnKey);
+    this.turnInProgress = this.activeTurnIds.size > 0;
+    if (wasInProgress && !this.turnInProgress) {
+      this.emit("turnCompleted");
+    }
+  }
+  resetTurnState(reason, emitCompleted = false) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.clear();
+    this.clearAllTurnWatchdogs();
+    this.turnInProgress = false;
+    if (emitCompleted && wasInProgress) {
+      this.emit("turnCompleted");
+    }
+    if (wasInProgress) {
+      this.log(`Turn state reset (${reason})`);
+    }
   }
   requestKey(id) {
     if (typeof id === "number" || typeof id === "string")

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -60,6 +60,12 @@ interface PendingServerResponse {
 interface PendingRequest {
   method: AppServerTrackedRequestMethod;
   threadId?: string;
+  /**
+   * Monotonic "thread switch" sequence (latest-issued) for thread/start and
+   * thread/resume. Used so an out-of-order OLD response can't clobber the active
+   * thread the user most recently switched to (#70).
+   */
+  threadSwitchSeq?: number;
 }
 
 export class CodexAdapter extends EventEmitter {
@@ -90,6 +96,14 @@ export class CodexAdapter extends EventEmitter {
   private pendingRequests = new Map<string, PendingRequest>();
   private activeTurnIds = new Set<string>();
   turnInProgress = false;
+  // #69: per-turn inactivity watchdog. A lost `turn/completed` would otherwise
+  // leave turnInProgress=true forever and permanently block injection. Each
+  // active turn gets a timer (keyed identically to activeTurnIds) that is
+  // refreshed on any app-server notification and, on expiry, force-completes the
+  // turn so Claude is never locked out.
+  private turnWatchdogs = new Map<string, ReturnType<typeof setTimeout>>();
+  // #70: latest-issued thread-switch sequence (see PendingRequest.threadSwitchSeq).
+  private threadSwitchSeq = 0;
 
   // Proxy-layer id rewriting: upstream uses globally unique ids
   private nextProxyId = 100000;
@@ -202,6 +216,14 @@ export class CodexAdapter extends EventEmitter {
     this.proxyServer?.stop();
     this.proxyServer = null;
     this.clearResponseTrackingState();
+    // #69: an intentional disconnect must synchronously drop turn state +
+    // watchdog timers. We cannot rely on handleAppServerClose for this: we set
+    // appServerWs=null above, and the close callback is async (and may be
+    // skipped entirely if the socket was already gone), so without this the
+    // turnInProgress flag and a pending watchdog timer leak past disconnect().
+    // emitCompleted stays false — an intentional teardown is not a real turn
+    // completion and must not signal "Codex finished" downstream.
+    this.resetTurnState("adapter disconnect");
   }
 
   /** Fully stop: disconnect bridge AND kill the Codex process. */
@@ -350,8 +372,7 @@ export class CodexAdapter extends EventEmitter {
     // pendingServerRequests — those must survive the intentional reconnect
     // so they can be replayed after the TUI completes thread/resume.
     this.clearResponseTrackingStateForAppServerReconnect();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server reconnect for new TUI session");
 
     try {
       await this.connectToAppServer(false);
@@ -430,8 +451,7 @@ export class CodexAdapter extends EventEmitter {
     // Approval request/response ids are scoped to the current app-server session.
     // If the socket reconnects, replaying old approval state would forward stale ids.
     this.clearResponseTrackingState();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server connection closed");
     if (!intentional) {
       this.scheduleReconnect();
     }
@@ -1053,6 +1073,19 @@ export class CodexAdapter extends EventEmitter {
   private handleAppServerPayload(raw: string): string | null {
     try {
       const parsed: unknown = JSON.parse(raw);
+      // #69: ANY inbound app-server message proves the turn is alive — refresh
+      // the inactivity watchdog(s) here, at the single inbound funnel. This
+      // MUST be broader than the modeled notification set: Codex streams many
+      // notification types we deliberately do NOT forward (item/agentReasoning/
+      // delta, item/commandExecution/*, item/fileChange/*, …). A long but
+      // actively-streaming turn (e.g. a multi-minute build) emits only these
+      // "unknown" notifications between turn/started and turn/completed; if we
+      // refreshed only on the handful in isAppServerNotification() we would
+      // force-complete a live turn. Responses and server requests count as
+      // activity too. (refreshTurnWatchdogs() no-ops when no turn is active.)
+      if (typeof parsed === "object" && parsed !== null) {
+        this.refreshTurnWatchdogs();
+      }
       // Short-circuit: response carries an id that matches a pending
       // session-restore replay? Consume it and suppress forwarding to
       // the TUI (which didn't send the request and would be confused).
@@ -1254,6 +1287,9 @@ export class CodexAdapter extends EventEmitter {
 
   private handleServerNotification(msg: AppServerNotification) {
     const { method, params } = msg;
+    // Note: the inactivity watchdog is refreshed for ALL inbound messages at
+    // the handleAppServerPayload funnel (see #69 there), not here — this method
+    // only runs for the modeled subset, which would miss the long-build case.
     switch (method) {
       case "turn/started":
         this.markTurnStarted(params?.turn?.id);
@@ -1327,6 +1363,12 @@ export class CodexAdapter extends EventEmitter {
         pending.threadId = threadId;
       }
     }
+    // #70: stamp explicit thread switches (thread/start, thread/resume) with the
+    // latest-issued sequence so an out-of-order OLD response can't clobber the
+    // thread the user most recently switched to.
+    if (method === "thread/start" || method === "thread/resume") {
+      pending.threadSwitchSeq = ++this.threadSwitchSeq;
+    }
 
     if (this.pendingRequests.has(key)) {
       this.log(`WARNING: overwriting pending request for key ${key}`);
@@ -1360,6 +1402,16 @@ export class CodexAdapter extends EventEmitter {
 
     switch (pending.method) {
       case "thread/start": {
+        // #70: ignore an out-of-order OLD thread switch. Only the response to
+        // the most-recently-issued thread/start|resume may mutate activeThreadId
+        // or drop orphans — a stale one would clobber the thread the user just
+        // switched to and re-orphan its in-flight approvals.
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(
+            `Ignoring stale thread/start response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`,
+          );
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/start response ${key}`);
@@ -1371,6 +1423,14 @@ export class CodexAdapter extends EventEmitter {
         break;
       }
       case "thread/resume": {
+        // #70: same staleness guard as thread/start — a late resume response
+        // must not steal activeThreadId back from a newer switch.
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(
+            `Ignoring stale thread/resume response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`,
+          );
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/resume response ${key}`);
@@ -1384,11 +1444,30 @@ export class CodexAdapter extends EventEmitter {
         break;
       }
       case "turn/start":
+        // #70: a turn/start response carries the threadId the turn ran against.
+        // Only adopt it when it agrees with the active thread (or none is set
+        // yet). If the user has already switched threads, a late turn/start must
+        // not drag activeThreadId back to the abandoned thread.
         if (pending.threadId) {
-          this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          if (this.threadId === null || this.threadId === pending.threadId) {
+            this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          } else {
+            this.log(
+              `Ignoring turn/start response ${key} threadId=${pending.threadId} (active thread is ${this.threadId})`,
+            );
+          }
         }
         break;
     }
+  }
+
+  /**
+   * #70: true only if this pending request is the most-recently-issued explicit
+   * thread switch (thread/start | thread/resume). Out-of-order responses to
+   * superseded switches return false and must not mutate activeThreadId.
+   */
+  private isLatestThreadSwitch(pending: PendingRequest): boolean {
+    return pending.threadSwitchSeq === this.threadSwitchSeq;
   }
 
   private setActiveThreadId(threadId: string, reason: string) {
@@ -1408,11 +1487,11 @@ export class CodexAdapter extends EventEmitter {
 
   private markTurnStarted(turnId?: string) {
     const wasInProgress = this.turnInProgress;
-    if (typeof turnId === "string" && turnId.length > 0) {
-      this.activeTurnIds.add(turnId);
-    } else {
-      this.activeTurnIds.add(`unknown:${Date.now()}`);
-    }
+    // Compute the key ONCE and use it for both the set and the watchdog so the
+    // two never diverge (incl. the no-turn-id `unknown:` fallback).
+    const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
+    this.activeTurnIds.add(turnKey);
+    this.scheduleTurnWatchdog(turnKey);
 
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
@@ -1423,11 +1502,89 @@ export class CodexAdapter extends EventEmitter {
   private markTurnCompleted(turnId?: string) {
     if (typeof turnId === "string" && turnId.length > 0) {
       this.activeTurnIds.delete(turnId);
+      this.clearTurnWatchdog(turnId);
     } else {
       this.activeTurnIds.clear();
+      this.clearAllTurnWatchdogs();
     }
 
     this.turnInProgress = this.activeTurnIds.size > 0;
+  }
+
+  /** Inactivity timeout for a turn (env-overridable; default 5 minutes). */
+  private turnWatchdogMs(): number {
+    const v = Number(process.env.AGENTBRIDGE_TURN_WATCHDOG_MS);
+    return Number.isFinite(v) && v > 0 ? v : 300_000;
+  }
+
+  /** (Re)arm the inactivity watchdog for a turn. Replaces any existing timer. */
+  private scheduleTurnWatchdog(turnKey: string) {
+    this.clearTurnWatchdog(turnKey);
+    const timer = setTimeout(() => {
+      if (!this.activeTurnIds.has(turnKey)) return;
+      this.log(
+        `WARNING: turn ${turnKey} watchdog fired after ${this.turnWatchdogMs()}ms of inactivity — ` +
+        `assuming a lost turn/completed; force-completing to unblock injection`,
+      );
+      this.forceCompleteTurn(turnKey);
+    }, this.turnWatchdogMs());
+    // Never keep the process/test runner alive on account of a watchdog.
+    timer.unref?.();
+    this.turnWatchdogs.set(turnKey, timer);
+  }
+
+  private clearTurnWatchdog(turnKey: string) {
+    const timer = this.turnWatchdogs.get(turnKey);
+    if (timer) {
+      clearTimeout(timer);
+      this.turnWatchdogs.delete(turnKey);
+    }
+  }
+
+  private clearAllTurnWatchdogs() {
+    for (const timer of this.turnWatchdogs.values()) clearTimeout(timer);
+    this.turnWatchdogs.clear();
+  }
+
+  /**
+   * Refresh every active turn's watchdog — called on any app-server notification
+   * so the watchdog measures INACTIVITY, not total turn duration (a genuinely
+   * long but active turn keeps streaming events and is never force-completed).
+   */
+  private refreshTurnWatchdogs() {
+    if (this.turnWatchdogs.size === 0) return;
+    for (const turnKey of [...this.turnWatchdogs.keys()]) {
+      this.scheduleTurnWatchdog(turnKey);
+    }
+  }
+
+  /** Force-complete a single turn (watchdog expiry path). */
+  private forceCompleteTurn(turnKey: string) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.delete(turnKey);
+    this.clearTurnWatchdog(turnKey);
+    this.turnInProgress = this.activeTurnIds.size > 0;
+    if (wasInProgress && !this.turnInProgress) {
+      this.emit("turnCompleted");
+    }
+  }
+
+  /**
+   * Clear all turn state (active ids + watchdogs) and recompute busy. Single
+   * source of truth used by app-server close / disconnect / stop so no path
+   * clears the ids without also clearing the watchdog timers.
+   */
+  private resetTurnState(reason: string, emitCompleted = false) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.clear();
+    this.clearAllTurnWatchdogs();
+    this.turnInProgress = false;
+    if (emitCompleted && wasInProgress) {
+      this.emit("turnCompleted");
+    }
+    if (wasInProgress) {
+      this.log(`Turn state reset (${reason})`);
+    }
   }
 
   private requestKey(id: unknown): string | null {

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -7,6 +7,24 @@ function createAdapter() {
   return new CodexAdapter(4510, 4511) as any;
 }
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withTurnWatchdogMs<T>(ms: number, fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+  process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = String(ms);
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+    } else {
+      process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = previous;
+    }
+  }
+}
+
 describe("CodexAdapter app-server response handling", () => {
   test("forwards active mapped responses back to the current TUI id", () => {
     const adapter = createAdapter();
@@ -321,6 +339,349 @@ describe("CodexAdapter turn state machine", () => {
     expect(forwarded).not.toBeNull();
     expect(adapter.activeThreadId).toBe("thread-from-request");
     expect(readyEvents).toEqual(["thread-from-request"]);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("stale turn/start response does not overwrite a newer active thread", () => {
+    const adapter = createAdapter();
+    adapter.threadId = "thread-new";
+    adapter.tuiConnId = 1;
+
+    adapter.trackPendingRequest({
+      id: "old-turn",
+      method: "turn/start",
+      params: {
+        threadId: "thread-old",
+        input: [{ type: "text", text: "stale" }],
+      },
+    }, adapter.tuiConnId);
+
+    adapter.handleTrackedResponse(
+      { id: "old-turn", result: { turn: { id: "turn-old" } } },
+      adapter.tuiConnId,
+    );
+
+    expect(adapter.activeThreadId).toBe("thread-new");
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("stale thread switch response does not overwrite latest thread or replay buffered requests", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+    adapter.tuiConnId = 1;
+    adapter.tuiWs = { send: (data: string) => sent.push(data) } as any;
+
+    adapter.trackPendingRequest({ id: "old-resume", method: "thread/resume" }, adapter.tuiConnId);
+    adapter.trackPendingRequest({ id: "new-resume", method: "thread/resume" }, adapter.tuiConnId);
+
+    adapter.handleTrackedResponse(
+      { id: "new-resume", result: { thread: { id: "thread-new" } } },
+      adapter.tuiConnId,
+    );
+    expect(adapter.activeThreadId).toBe("thread-new");
+
+    adapter.pendingServerRequests = [
+      {
+        raw: JSON.stringify({
+          id: 70,
+          method: "item/fileChange/requestApproval",
+          params: { threadId: "thread-old", file: "stale.ts" },
+        }),
+        serverId: 70,
+        method: "item/fileChange/requestApproval",
+        threadId: "thread-old",
+      },
+    ];
+
+    adapter.handleTrackedResponse(
+      { id: "old-resume", result: { thread: { id: "thread-old" } } },
+      adapter.tuiConnId,
+    );
+
+    expect(adapter.activeThreadId).toBe("thread-new");
+    expect(sent).toEqual([]);
+    expect(adapter.pendingServerRequests).toHaveLength(1);
+    expect(adapter.pendingServerRequests[0].threadId).toBe("thread-old");
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("stale thread/start response does not drop buffered requests for the latest session", () => {
+    const adapter = createAdapter();
+    adapter.tuiConnId = 1;
+
+    adapter.trackPendingRequest({ id: "old-start", method: "thread/start" }, adapter.tuiConnId);
+    adapter.trackPendingRequest({ id: "new-resume", method: "thread/resume" }, adapter.tuiConnId);
+
+    adapter.handleTrackedResponse(
+      { id: "new-resume", result: { thread: { id: "thread-new" } } },
+      adapter.tuiConnId,
+    );
+
+    adapter.pendingServerRequests = [
+      {
+        raw: JSON.stringify({
+          id: 71,
+          method: "item/commandExecution/requestApproval",
+          params: { threadId: "thread-new", command: "pwd" },
+        }),
+        serverId: 71,
+        method: "item/commandExecution/requestApproval",
+        threadId: "thread-new",
+      },
+    ];
+
+    adapter.handleTrackedResponse(
+      { id: "old-start", result: { thread: { id: "thread-old" } } },
+      adapter.tuiConnId,
+    );
+
+    expect(adapter.activeThreadId).toBe("thread-new");
+    expect(adapter.pendingServerRequests).toHaveLength(1);
+    expect(adapter.pendingServerRequests[0].threadId).toBe("thread-new");
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("turn watchdog releases busy state and emits turnCompleted after inactivity", async () => {
+    await withTurnWatchdogMs(40, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "watchdog-turn" } } });
+      expect(adapter.turnInProgress).toBe(true);
+
+      await sleep(90);
+
+      expect(adapter.turnInProgress).toBe(false);
+      expect(events).toEqual(["completed"]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("turn watchdog is refreshed by ANY inbound app-server message, incl. unforwarded notification types (#69)", async () => {
+    // Regression guard for the #69 watchdog-coverage bug: Codex streams many
+    // notification types the bridge does NOT forward (item/agentReasoning/delta,
+    // item/commandExecution/*, item/fileChange/*, …). A long but actively-
+    // streaming turn (e.g. a multi-minute build) emits only these between
+    // turn/started and turn/completed. The watchdog must treat them as activity,
+    // otherwise a live turn gets force-completed. We drive them through the real
+    // handleAppServerPayload funnel (NOT handleServerNotification, which only
+    // models the small forwarded subset and would mask the bug).
+    //
+    // Timing is chosen so the test actually CATCHES the bug, not just passes,
+    // with margins wide enough to be CI-safe (this repo has a history of timing
+    // flakes — see commit 11941e6):
+    // - 400ms watchdog, armed at turn/started (t≈0), original deadline t≈400.
+    // - refresh via the unforwarded delta at t≈250 (≈150ms before the original
+    //   deadline) pushes the deadline to t≈650.
+    // - "still active" is asserted at t≈500 — PAST the original t≈400 deadline
+    //   (so WITHOUT the fix the watchdog would already have force-completed and
+    //   this assertion fails) and ≈150ms before the refreshed t≈650 deadline.
+    // - "completed" is asserted at t≈750 (≈100ms past t≈650).
+    await withTurnWatchdogMs(400, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleAppServerPayload(JSON.stringify({
+        method: "turn/started",
+        params: { turn: { id: "refresh-turn" } },
+      }));
+      expect(adapter.turnInProgress).toBe(true);
+
+      await sleep(250);
+      // An UNFORWARDED notification type — the exact case that previously did
+      // NOT refresh the watchdog (only the 5 isAppServerNotification() methods
+      // did), so a live turn streaming only reasoning deltas got force-completed.
+      adapter.handleAppServerPayload(JSON.stringify({
+        method: "item/agentReasoning/delta",
+        params: { itemId: "reasoning-1", delta: "thinking…" },
+      }));
+      await sleep(250);
+
+      // Past the ORIGINAL deadline but before the refreshed one — still active.
+      expect(adapter.turnInProgress).toBe(true);
+      expect(events).toEqual([]);
+
+      await sleep(250);
+
+      expect(adapter.turnInProgress).toBe(false);
+      expect(events).toEqual(["completed"]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("disconnect() synchronously clears turn state and cancels the watchdog (no late turnCompleted)", async () => {
+    await withTurnWatchdogMs(40, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "disconnect-turn" } } });
+      expect(adapter.turnInProgress).toBe(true);
+      expect(adapter.activeTurnIds.size).toBe(1);
+      expect(adapter.turnWatchdogs.size).toBe(1);
+
+      // Intentional teardown must drop turn state + watchdog timer immediately.
+      adapter.disconnect();
+
+      expect(adapter.turnInProgress).toBe(false);
+      expect(adapter.activeTurnIds.size).toBe(0);
+      expect(adapter.turnWatchdogs.size).toBe(0);
+      // A teardown is not a real turn completion — it must not signal "finished".
+      expect(events).toEqual([]);
+
+      // And the cancelled watchdog must not fire a late turnCompleted.
+      await sleep(90);
+      expect(events).toEqual([]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("force-completing one of several active turns keeps busy state and defers the emit", () => {
+    const adapter = createAdapter();
+    const events: string[] = [];
+    adapter.on("turnCompleted", () => events.push("completed"));
+
+    // Two concurrent turns (driven via handleServerNotification so only their
+    // own watchdogs arm — no global refresh between them).
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t2" } } });
+    expect(adapter.activeTurnIds.size).toBe(2);
+    expect(adapter.turnInProgress).toBe(true);
+
+    // One turn's watchdog fires: forceCompleteTurn must drop ONLY that turn,
+    // recompute busy from the remaining set, and NOT emit while a turn remains.
+    adapter.forceCompleteTurn("t1");
+    expect(adapter.activeTurnIds.has("t1")).toBe(false);
+    expect(adapter.turnWatchdogs.has("t1")).toBe(false);
+    expect(adapter.turnInProgress).toBe(true);
+    expect(events).toEqual([]);
+
+    // The last turn completing flips to idle → exactly one emit.
+    adapter.forceCompleteTurn("t2");
+    expect(adapter.turnInProgress).toBe(false);
+    expect(events).toEqual(["completed"]);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("a normal turn/completed cancels the watchdog so it never force-completes later", async () => {
+    await withTurnWatchdogMs(40, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+      expect(adapter.turnWatchdogs.size).toBe(1);
+
+      adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
+      expect(adapter.turnInProgress).toBe(false);
+      expect(adapter.turnWatchdogs.size).toBe(0);
+      expect(events).toEqual(["completed"]);
+
+      // The watchdog was cleared on normal completion — no SECOND (force) emit.
+      await sleep(90);
+      expect(events).toEqual(["completed"]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("handleAppServerClose cancels turn watchdogs (no late force-completion after close)", async () => {
+    await withTurnWatchdogMs(40, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+      expect(adapter.turnWatchdogs.size).toBe(1);
+
+      // An app-server close routes through resetTurnState → clears ids + timers.
+      // (intentional avoids scheduleReconnect firing during the test.)
+      adapter.intentionalDisconnect = true;
+      adapter.handleAppServerClose();
+      expect(adapter.turnInProgress).toBe(false);
+      expect(adapter.activeTurnIds.size).toBe(0);
+      expect(adapter.turnWatchdogs.size).toBe(0);
+
+      // The cancelled watchdog must never force-complete after the connection closed.
+      await sleep(90);
+      expect(events).toEqual([]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("an inbound RESPONSE (not only a notification) refreshes the watchdog", async () => {
+    // The refresh sits ABOVE the id/notification branching in handleAppServerPayload,
+    // so responses count as turn activity too. Same robust margins as the
+    // notification-refresh test: 400ms watchdog, refresh at t≈250 (deadline→650),
+    // assert-active at t≈500 (past the original 400 deadline, before the refreshed one).
+    await withTurnWatchdogMs(400, async () => {
+      const adapter = createAdapter();
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+      await sleep(250);
+      adapter.handleAppServerPayload(JSON.stringify({ id: 987654, result: { ok: true } }));
+      await sleep(250);
+
+      expect(adapter.turnInProgress).toBe(true);
+
+      adapter.resetTurnState("test cleanup");
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("turnWatchdogMs() falls back to the 300s default for unset/invalid env values", () => {
+    const adapter = createAdapter();
+    const prev = process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+    try {
+      // "" / whitespace → 0, "0"/negative → not > 0, non-numeric → NaN,
+      // "Infinity" → !isFinite. All must fall back to the 300s default.
+      for (const bad of ["", "   ", "0", "-5", "abc", "Infinity", "NaN"]) {
+        process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = bad;
+        expect(adapter.turnWatchdogMs()).toBe(300_000);
+      }
+      delete process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+      expect(adapter.turnWatchdogMs()).toBe(300_000);
+      // A valid positive value is honored.
+      process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = "1234";
+      expect(adapter.turnWatchdogMs()).toBe(1234);
+    } finally {
+      if (prev === undefined) delete process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+      else process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = prev;
+    }
+  });
+
+  test("an error response to the LATEST thread switch leaves activeThreadId unchanged", () => {
+    const adapter = createAdapter();
+    adapter.tuiConnId = 1;
+
+    // Establish a current thread via a successful resume.
+    adapter.trackPendingRequest({ id: "r1", method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse({ id: "r1", result: { thread: { id: "thread-A" } } }, adapter.tuiConnId);
+    expect(adapter.activeThreadId).toBe("thread-A");
+
+    // The newest switch fails. The error carries a thread id too (a malformed
+    // server could) — handleTrackedResponse must return early on `error` BEFORE
+    // the switch, so this thread-B is never adopted and the active thread stays
+    // the last one that actually resolved. (Including result.thread.id here is
+    // what makes this a genuine guard for the error early-return: drop that
+    // early-return and the switch would adopt thread-B, failing this test.)
+    adapter.trackPendingRequest({ id: "r2", method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse(
+      { id: "r2", error: { code: -1, message: "boom" }, result: { thread: { id: "thread-B" } } },
+      adapter.tuiConnId,
+    );
+    expect(adapter.activeThreadId).toBe("thread-A");
 
     adapter.clearResponseTrackingState();
   });


### PR DESCRIPTION
## 概要 / Summary

修复两个会**锁死**或**错误路由** Claude↔Codex 桥接的可靠性活 bug。两者均由 `src/codex-adapter.ts`（Codex app-server WS 代理）的状态机缺陷引起。

Fixes two live reliability bugs that could **lock up** or **mis-route** the Claude↔Codex bridge. Both stem from state-machine flaws in `src/codex-adapter.ts` (the Codex app-server WS proxy).

Closes #69 · Closes #70

---

## #69 — 丢失 `turn/completed` 永久锁死注入 / lost `turn/completed` permanently blocks injection

**问题 / Problem:** 上游一旦丢失 `turn/completed`，`turnInProgress` 永真，busy-guard 永久挡住所有消息注入——只有 app-server 断连才会复位。
A lost upstream `turn/completed` left `turnInProgress` stuck `true`, so the busy-guard blocked **all** injection forever until the app-server reconnected.

**修复 / Fix:**
- 每个 turn 一个**非活动（inactivity）看门狗**。**任何**入站 app-server 消息都会在唯一入站漏斗 `handleAppServerPayload` 处刷新计时——因此一个长但**活跃**的 turn（包括桥接不转发的通知类型 `item/agentReasoning/delta`、`item/commandExecution/*`、`item/fileChange/*`）永远不会被误杀。只有真正静默超过 `AGENTBRIDGE_TURN_WATCHDOG_MS`（默认 300s）才 `forceComplete` 复位并 emit `turnCompleted`。计时器 `unref()`，不阻塞进程退出。
  A per-turn **inactivity** watchdog, refreshed by **any** inbound app-server message at the single `handleAppServerPayload` funnel — so a long but *actively-streaming* turn (incl. unforwarded notification types) is never force-completed. Only true silence past `AGENTBRIDGE_TURN_WATCHDOG_MS` (default 300s) force-completes and emits `turnCompleted`. Timers are `unref()`'d.
- 新增 `resetTurnState()` 作为 reconnect / close / **disconnect** 的**唯一**复位口，保证没有任何路径只清 turn ids 却漏清 watchdog 计时器。
  `resetTurnState()` is the **single** reset path for reconnect / close / **disconnect**, so no path clears turn ids while leaking a watchdog timer.

> ⚠️ 关键修复（交叉 review 第 3 轮发现）：refresh 最初只在 `handleServerNotification` 内、且被 `isAppServerNotification()` 的 5-method 集合门控，导致只流式"未知"通知的活跃长 turn（典型 >5min 的 build/test）被误判为 inactivity 而强杀。已上移到入站漏斗修复。
> Critical fix (found in cross-review round 3): the refresh was initially gated to only 5 modeled notification methods, so a live long turn streaming only *unforwarded* notifications got force-completed. Moved to the inbound funnel.

## #70 — 乱序 thread 切换 response 覆盖 `activeThreadId` / out-of-order thread-switch responses overwrite `activeThreadId`

**问题 / Problem:** resume/fork 风暴下，乱序到达的**旧** `thread/start` | `thread/resume` response 会把 `this.threadId` 覆盖成错误 thread → 消息被注入到错误的 thread。
Under a resume/fork storm, a stale `thread/start` | `thread/resume` response could overwrite `this.threadId` with the wrong thread → messages injected into the wrong thread.

**修复 / Fix:**
- 单调 `threadSwitchSeq`：仅"**最近发出**"的切换 response（`pending.threadSwitchSeq === this.threadSwitchSeq`）才能 `setActiveThreadId` / replay / drop-orphan，乱序旧 response 被跳过+记日志。
  Monotonic `threadSwitchSeq`: only the **latest-issued** switch response may mutate `activeThreadId` / replay / drop orphans; stale ones are skipped + logged.
- `turn/start` response 加 **expected-thread** 守卫：仅当 active thread 为 `null` 或与 `pending.threadId` 一致时才采纳。
  `turn/start` responses adopt their threadId only when the active thread is `null` or already matches.

---

## 测试 / Tests

`src/unit-test/codex-adapter.test.ts` 新增 **13 个测试**：
- **#70**: stale `thread/start` drop、stale `thread/resume` drop（无 replay / 无 orphan-drop）、latest applied、`turn/start` expected-thread reject/accept、error-response 守卫。
- **#69**: watchdog fire→emit、inactivity 释放、**未转发通知刷新**、**response 刷新**、多 turn `forceComplete` 重算（只完成一个不误清/误 emit）、normal-completion / `handleAppServerClose` / `disconnect()` 取消看门狗（无延迟 emit）、`turnWatchdogMs()` env 解析回退（`""`/`0`/负/NaN/Infinity → 300s 默认）。

关键回归测试经 **TDD red/green 验证**（去掉修复 → 测试失败；加回 → 绿）。
Key regression tests were TDD red/green verified.

文档 / Docs: README + README.zh-CN 补 `AGENTBRIDGE_TURN_WATCHDOG_MS`。

**验证 / Verification:** `bun run check` 全绿（typecheck + 271 tests + plugin sync + 版本对齐 0.1.6）。`bun run build:plugin` 已重建并提交同步的 bundle。

## E2E 测试计划 / E2E test plan
- [ ] 真机注入：丢失 `turn/completed`（杀掉/超时一个 turn），确认看门狗在 `AGENTBRIDGE_TURN_WATCHDOG_MS` 后释放 busy 并允许后续注入。
- [ ] 长活跃 turn（>watchdog 的 build，只流式 reasoning/command 通知）确认**不**被误杀。
- [ ] resume/fork 风暴：快速连续切 thread，确认消息始终注入到最新 thread。
- [ ] `disconnect()` / app-server 断连后无残留 busy / 无延迟 `turnCompleted`。

## 交叉 review / Cross-review
经 **6 轮交叉 review**（12 个独立 subagent + Codex 独立复核）收敛到连续两轮 0 真实 issue：
Converged over **6 cross-review rounds** (12 independent subagents + Codex) to two consecutive clean rounds:
- Codex 发现 #69 `disconnect()` 复位漏口（MED）→ 已修。
- 独立 reviewer 发现 watchdog refresh 仅覆盖 5 个 method 的 **HIGH** bug → 已修。
- reviewer 发现测试覆盖缺口 → 补齐 6 个测试。

### Backlog（非阻塞 / non-blocking, follow-up）
- `forceCompleteTurn` 可向 daemon 传一个 `forced` 标志，让其发 `system_turn_completed_forced` 而非"✅ Codex finished"（原 design doc 建议）。
- `agentMessageBuffers` 在 turn 被强杀时未清理（pre-existing，与本 PR 无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)