### PR TITLE
feat: auto-update notifier + reliable release-on-merge publishing + in-session plugin reminder

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,9 +11,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Fail loudly if RELEASE_PAT is missing: a release created with GITHUB_TOKEN
+      # does NOT trigger publish.yml (GitHub recursion guard), which would strand
+      # a GitHub release with no npm publish. Better to stop with a clear message.
+      - name: Require RELEASE_PAT
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "::error::RELEASE_PAT secret is required: releases created with GITHUB_TOKEN do not trigger publish.yml, so npm publish would never run. Add a fine-grained PAT with contents:write as RELEASE_PAT. See docs/RELEASING.md."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Read version from package.json
         id: version
@@ -22,10 +35,17 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Check if tag already exists
+      - name: Check if the RELEASE already exists
         id: check
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          # Gate on the GitHub RELEASE, not just the tag. publish.yml fires on
+          # `release: published`, so a tag without a release means npm was never
+          # published. If a prior run pushed the tag but failed before creating
+          # the release, we MUST be able to recover on re-run — which only works
+          # if "exists" reflects the release, not the tag.
+          if gh release view "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -34,11 +54,29 @@ jobs:
       - name: Create tag and release
         if: steps.check.outputs.exists == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (required above) so the published release TRIGGERS publish.yml.
+          # Releases created with GITHUB_TOKEN do not start new workflow runs
+          # (GitHub recursion guard), which would strand the release without an
+          # npm publish. See docs/RELEASING.md.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-          git tag "$TAG"
-          git push origin "$TAG"
+          # Idempotent + safe. The tag may already exist from a prior partial run
+          # that pushed it but failed before creating the release. Reuse it ONLY
+          # if it points at THIS commit — a tag on a different commit would make
+          # `gh release create` (and then publish.yml) ship the WRONG code. Fail
+          # loudly on a mismatch instead of publishing the wrong commit.
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            TAG_SHA="$(git rev-parse "${TAG}^{commit}")"
+            HEAD_SHA="$(git rev-parse HEAD)"
+            if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+              echo "::error::Tag ${TAG} already exists at ${TAG_SHA} but this release is for ${HEAD_SHA}; refusing to publish a mismatched commit. Delete the stray tag or bump to a new version."
+              exit 1
+            fi
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
 
           # Generate changelog from commits since last tag
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Type check
-        run: bun run typecheck
-
-      - name: Run tests
-        run: bun test src
+      # Final integrity gate before publishing: typecheck + full test suite +
+      # plugin-bundle sync + version alignment. Never publish a build that can't
+      # pass `bun run check`. (When #90's release-form smoke lands, add
+      # `bun run smoke:built` + `bun run smoke:pack` here too.)
+      - name: Check (typecheck + tests + plugin sync + version align)
+        run: bun run check
 
       - name: Build
         run: bun run prepublishOnly

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,0 +1,134 @@
+name: Release on merge
+
+# Auto-publish cadence (user-chosen): every code merge to master is gated by the
+# full `bun run check` and, if green, bumps the patch version (synced across
+# package.json / plugin.json / marketplace.json). That version-bump commit then
+# drives the existing auto-release.yml -> publish.yml chain to publish to npm.
+#
+# IMPORTANT — requires a push token that re-triggers workflows:
+#   Pushes made with the default GITHUB_TOKEN do NOT trigger other workflows
+#   (GitHub's recursion guard), so the bump commit would never reach
+#   auto-release.yml. Set a repo secret RELEASE_PAT (a fine-grained PAT with
+#   `contents: write`) so the bump push fires auto-release -> publish. Without it
+#   the push still succeeds but the publish chain will not run.
+#   The same PAT must be allowed to push to master if branch protection is on.
+#
+# Loop/double-publish guards:
+#   - skip the bot's own `chore(release):` bump commit and any `[skip release]`
+#     commit (docs/chore), and pushes by github-actions[bot];
+#   - skip if the triggering push ALREADY changed the version (a manual bump or
+#     the existing release flow) — let that flow publish instead of double-bumping.
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-on-merge
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: >-
+      !startsWith(github.event.head_commit.message, 'chore(release):') &&
+      !contains(github.event.head_commit.message, '[skip release]') &&
+      github.actor != 'github-actions[bot]'
+    steps:
+      # Fail loudly if RELEASE_PAT is missing. A GITHUB_TOKEN fallback would push
+      # a bump commit that never triggers auto-release -> publish (GitHub
+      # recursion guard), stranding an un-published version bump. Better to stop
+      # before bumping with a clear message.
+      - name: Require RELEASE_PAT
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "::error::RELEASE_PAT secret is required for auto-publish-on-merge."
+            echo "::error::Pushes/releases made with GITHUB_TOKEN do not trigger the auto-release -> publish chain, so a bump would never reach npm. Add a fine-grained PAT with contents:write as the RELEASE_PAT secret. See docs/RELEASING.md."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # PAT (required above) so the bump push re-triggers auto-release.yml.
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Skip if this push already bumped the version
+        id: guard
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          CUR=$(node -p "require('./package.json').version")
+          # Compare against the branch tip BEFORE this push (github.event.before),
+          # not HEAD^ — covers multi-commit / rebase pushes where the version
+          # change may not be the immediately-preceding commit.
+          PREV=$(git show "$BEFORE_SHA:package.json" 2>/dev/null | node -p "try{JSON.parse(require('fs').readFileSync(0,'utf-8')).version}catch{''}" 2>/dev/null || echo "")
+          if [ -n "$PREV" ] && [ "$PREV" != "$CUR" ]; then
+            echo "Version already changed in this push ($PREV -> $CUR); the existing release flow will publish. Skipping auto-bump."
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "bump=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate, bump, commit, and push the release (race-safe)
+        if: steps.guard.outputs.bump == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Version this run STARTED from (the triggering commit's version).
+          INITIAL_VERSION="$(node -p "require('./package.json').version")"
+          # A concurrent human merge can either (a) edit package.json near the
+          # version line (so a rebase of our bump would CONFLICT) or (b) land
+          # between our fetch and push (non-fast-forward). On any push failure we
+          # discard our local bump, hard-reset to the latest origin/master, and
+          # retry from that new tip.
+          #
+          # CRITICAL: the integrity gate (bun install + bun run check) runs INSIDE
+          # the loop, on whatever tip we are about to bump+publish — never on a
+          # stale pre-reset tip. Otherwise a broken merge that landed during this
+          # job could be reset onto, bumped, and tagged/released before publish.yml
+          # rejects it, stranding a GitHub release/tag with no npm publish. Gating
+          # the candidate tip here guarantees we only ever tag a build that passes.
+          # (Once #90's release-form smoke lands, add smoke:built/smoke:pack here.)
+          for attempt in 1 2 3; do
+            # If the tip's version already differs from this run's starting
+            # version, another run (auto-bump OR a manual version bump with any
+            # commit message) already advanced and published past our base — our
+            # code is in that release. Exit cleanly instead of bumping a
+            # content-less version. (Version-compare, not commit-message match,
+            # so it also catches manual bumps. The bump only ever increases the
+            # version, so any difference means "already advanced".)
+            TIP_VERSION="$(node -p "require('./package.json').version")"
+            if [ "$TIP_VERSION" != "$INITIAL_VERSION" ]; then
+              echo "Version already advanced (${INITIAL_VERSION} -> ${TIP_VERSION}) since this run started; nothing to publish."
+              exit 0
+            fi
+            bun install --frozen-lockfile
+            bun run check
+            NEW="$(node scripts/bump-version.mjs patch)"
+            git add package.json \
+              plugins/agentbridge/.claude-plugin/plugin.json \
+              .claude-plugin/marketplace.json
+            git commit -m "chore(release): v${NEW}"
+            if git push origin HEAD:master; then
+              echo "Released v${NEW} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "push rejected (attempt ${attempt}); syncing to latest origin/master and retrying"
+            git fetch origin master
+            git reset --hard origin/master
+          done
+          echo "::error::release-on-merge could not push the version bump after 3 attempts"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ agent_bridge/
 | `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
 | `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |
+| `NO_UPDATE_NOTIFIER` | unset | Set to any value to disable the "update available" notice (ecosystem-standard opt-out) |
+| `AGENTBRIDGE_NO_UPDATE_NOTIFIER` | unset | Namespaced opt-out for the update notice (same effect as `NO_UPDATE_NOTIFIER`) |
+| `AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS` | `86400000` | How often `abg claude`/`abg codex` may check npm for a newer version (default once/day). The notice is otherwise printed from cache — zero network on most runs |
+
+### Update notifications
+
+`abg claude` and `abg codex` print a one-line notice to stderr when a newer **stable** AgentBridge is published to npm, e.g.:
+
+```
+⚠ AgentBridge update available: 0.1.6 → 0.1.7
+  CLI:    npm install -g @raysonmeng/agentbridge@latest
+  Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)
+```
+
+The check is best-effort and never blocks, delays, or fails your command: the notice is printed from a cached result, the npm check runs at most once per day in the background, and any network/registry failure is silently ignored. It is suppressed automatically for non-interactive (piped) output and in CI, and can be disabled with `NO_UPDATE_NOTIFIER=1`. The notifier never installs anything — it only shows you the command.
 
 ### State Directory
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,6 +250,21 @@ agent_bridge/
 | `AGENTBRIDGE_STATE_DIR` | 平台默认 | 状态目录（pid、status、日志）。macOS: `~/Library/Application Support/agentbridge/`，Linux: `$XDG_STATE_HOME/agentbridge/` |
 | `AGENTBRIDGE_MODE` | `push` | 消息投递模式（`push` 用于 channel，`pull` 用于 API key 模式） |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |
+| `NO_UPDATE_NOTIFIER` | 未设置 | 设为任意值即关闭「有新版本」提示（生态通用 opt-out） |
+| `AGENTBRIDGE_NO_UPDATE_NOTIFIER` | 未设置 | 命名空间化的关闭开关（效果同 `NO_UPDATE_NOTIFIER`） |
+| `AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS` | `86400000` | `abg claude`/`abg codex` 多久查一次 npm 新版本（默认每天一次）。其余时候只读缓存打印，大多数调用零网络 |
+
+### 更新提示
+
+`abg claude` 和 `abg codex` 在 npm 上有更新的**稳定**版本时,会向 stderr 打印一行提示,例如:
+
+```
+⚠ AgentBridge update available: 0.1.6 → 0.1.7
+  CLI:    npm install -g @raysonmeng/agentbridge@latest
+  Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)
+```
+
+该检查是 best-effort,绝不阻塞/拖慢/弄坏你的命令:提示从缓存打印,npm 检查每天最多在后台跑一次,任何网络/registry 失败都静默忽略。非交互(管道)输出和 CI 下自动抑制,可用 `NO_UPDATE_NOTIFIER=1` 关闭。notifier 永远不会自动安装任何东西——只告诉你升级命令。
 
 ### 状态目录
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,139 @@
+# Releasing AgentBridge / 发布流程
+
+AgentBridge auto-publishes to npm on every code merge to `master`, so the
+update-notifier always has a fresh, gated source. Every published version is
+gated by `bun run check` — we never publish a build that can't pass.
+
+AgentBridge 在每次代码合并到 `master` 时自动发布到 npm,让 update-notifier 始终有一个
+最新、经门禁把关的源。每个发布版本都被 `bun run check` 卡住——绝不发布无法通过检查的构建。
+
+## Pipeline / 管线
+
+```
+merge code PR to master
+        │
+        ▼
+release-on-merge.yml   ── gate: bun run check ──▶ (fail → no release)
+        │  (pass)
+        ▼
+bump patch in package.json + plugin.json + marketplace.json  (synced)
+        │
+        ▼  commit "chore(release): vX.Y.Z", push to master  (needs RELEASE_PAT)
+        ▼
+auto-release.yml       ── tag vX.Y.Z + GitHub release ──▶
+        │
+        ▼
+publish.yml            ── gate: bun run check → build → npm publish
+```
+
+- **`.github/workflows/release-on-merge.yml`** — on each push to `master`, runs
+  the full check and, if green, patch-bumps the version (synced across all three
+  manifests via `scripts/bump-version.mjs`) and pushes a `chore(release): vX.Y.Z`
+  commit.
+- **`.github/workflows/auto-release.yml`** — on a `package.json` version change,
+  creates the `vX.Y.Z` tag and GitHub release.
+- **`.github/workflows/publish.yml`** — on a published release, runs `bun run
+  check` again (final gate), builds, and `npm publish`es.
+
+## Required setup / 必需配置
+
+1. **`RELEASE_PAT` repo secret** — a fine-grained Personal Access Token with
+   `contents: write`. Used at **both** hops of the chain, because pushes/releases
+   made with the default `GITHUB_TOKEN` do **not** trigger other workflows
+   (GitHub's recursion guard):
+   - `release-on-merge.yml` pushes the bump commit with `RELEASE_PAT` → triggers
+     `auto-release.yml`. It **fails loudly** if `RELEASE_PAT` is missing (rather
+     than push an un-publishable bump with `GITHUB_TOKEN`).
+   - `auto-release.yml` creates the GitHub release with `RELEASE_PAT` → triggers
+     `publish.yml`. With only `GITHUB_TOKEN` the release would be created but
+     `npm publish` would never run.
+   必须配置 `RELEASE_PAT`(细粒度 PAT,`contents: write`),发布链的**两跳都用它**:
+   release-on-merge 推 bump commit、auto-release 建 release,都需要 PAT 才能触发下一跳
+   (默认 `GITHUB_TOKEN` 推送/建 release 不触发其它 workflow)。缺 PAT 时 release-on-merge
+   直接 fail,不会产生发不出去的版本 bump。
+2. **`NPM_TOKEN` repo secret** — for `npm publish` (already used by publish.yml).
+3. **Branch protection** — if `master` is protected, allow the PAT identity to push
+   (the `chore(release):` bump commit). 若 `master` 受保护,需允许该 PAT 推送 bump commit。
+
+## Skip / opt-out / 跳过
+
+- Put `[skip release]` in a commit message to skip the auto-bump (use for
+  docs-only / chore commits that should not produce a new npm version).
+  提交信息含 `[skip release]` 即跳过自动 bump(用于纯文档/杂务提交)。
+- `chore(release):` commits (the bot's own bumps) and `github-actions[bot]` pushes
+  are skipped automatically (loop guard).
+- If the triggering push already changed the version (a manual bump), the
+  auto-bump is skipped and the existing release flow publishes instead — no
+  double bump.
+
+## Manual release / 手动发布
+
+If you need to cut a release by hand (e.g. a coordinated minor/major bump):
+
+```bash
+bun run release:bump minor    # or patch | major — syncs all three manifests
+git commit -am "chore(release): v$(node -p "require('./package.json').version")"
+git push origin master        # triggers auto-release.yml -> publish.yml
+```
+
+## Artifact integrity / 产物可用性
+
+`bun run check` (typecheck + full test suite + plugin-bundle sync + version
+alignment) gates BOTH the bump and the publish, so a broken build can never be
+released. A stronger **release-form smoke** — launching the built `dist/cli.js`
+daemon and verifying `npm pack` completeness (`smoke:built` / `smoke:pack`) —
+lands with PR #90; once merged, add those as extra gate steps in
+`release-on-merge.yml` and `publish.yml`.
+
+`bun run check` 同时卡住 bump 和 publish,坏构建永远发不出去。更强的**发布形态 smoke**
+(真启打包 daemon + 查 npm 包完整性)随 PR #90 合入,届时把它们加进两处门禁。
+
+## Concurrency & limitations / 并发与已知限制
+
+- `release-on-merge.yml` uses a `concurrency` group so only one release runs at a
+  time. Pushing the bump is wrapped in a **retry loop**: on any push failure
+  (non-fast-forward, or a rebase conflict because a concurrent merge edited
+  `package.json` near the version line) it hard-resets to the latest
+  `origin/master` and recomputes the bump from that tip, up to 3 attempts. So a
+  concurrent human merge does not silently drop a release.
+- Edge case: with several merges in quick succession, a later merge's code may be
+  published under the FIRST run's version (it's already on master), and its own
+  run then skips bumping (version already changed). Nothing is lost — the code is
+  on `master` and ships in that release or the next bump. This is acceptable for a
+  patch-on-every-merge cadence; switch to a manual/batched release if you need one
+  npm version per PR exactly.
+  推送 bump 带 3 次重试:任何推送失败(非快进 / 并发改动 package.json 版本行附近导致 rebase
+  冲突)都会硬重置到最新 origin/master 并重算 bump,所以并发合并不会悄悄丢掉发布。
+  快速连续合并时,后一个 PR 的代码可能跟随前一次 run 的版本一起发布(不会丢失,代码已在 master),
+  只是版本归属可能合并。需要"每个 PR 精确一个 npm 版本"时改用手动/批量发布。
+
+## Installing a build globally (dogfooding) / 本地全局安装
+
+To replace the globally-installed `agentbridge`/`abg` CLI for testing:
+
+```bash
+bun run install:global:local   # build THIS checkout, pack it, then fully replace the global install
+bun run install:global:npm     # replace the global install with the npm `latest`
+```
+
+(`install:global` is an alias for `install:global:local`.) Both fully replace the
+global package, so afterward `npm install -g @raysonmeng/agentbridge@latest`
+cleanly overrides whatever you installed — there is no leftover `bun link` symlink
+to conflict with.
+
+The CLI and the Claude Code **plugin** are separate installs. `install:global:*`
+updates the CLI; the npm `postinstall` best-effort registers/installs the plugin,
+but an already-installed plugin cache and an active Claude session are NOT
+force-refreshed. To make the plugin match your source and reload it:
+
+```bash
+bun run install:global:local
+bun src/cli.ts dev        # build + sync the plugin from THIS checkout into Claude Code
+# then in Claude Code:
+/plugin marketplace update agentbridge   # (if installed via marketplace)
+/reload-plugins
+```
+
+> Run `bun src/cli.ts dev` (from the source checkout) rather than the globally
+> installed `agentbridge dev`, so the plugin is synced from your working tree, not
+> the global npm package dir.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "prepublishOnly": "bun run build:cli && bun run build:plugin",
     "validate:plugin": "claude plugin validate plugins/agentbridge && claude plugin validate .claude-plugin/marketplace.json",
     "test": "bun test src",
+    "install:global": "node scripts/install-global.mjs local",
+    "install:global:local": "node scripts/install-global.mjs local",
+    "install:global:npm": "node scripts/install-global.mjs npm",
+    "release:bump": "node scripts/bump-version.mjs",
     "typecheck": "tsc --noEmit",
     "validate:plugin-versions": "bun scripts/check-plugin-versions.js",
     "check": "tsc --noEmit && bun test src && bun run verify:plugin-sync && bun scripts/check-plugin-versions.js"

--- a/plugins/agentbridge/scripts/health-check.sh
+++ b/plugins/agentbridge/scripts/health-check.sh
@@ -27,6 +27,15 @@ fi
 
 printf '%s' "$now" >"$stamp_file" 2>/dev/null || true
 
+# In-session plugin-update reminder: compare the INSTALLED plugin version against
+# the latest npm version cached by the CLI notifier (src/update-notifier.ts). This
+# is how a user who updated the npm CLI but not the plugin learns of the mismatch
+# from inside Claude Code. Best-effort + silent: never blocks the hook.
+plugin_notice=""
+if command -v bun >/dev/null 2>&1 && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  plugin_notice="$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/plugin-update-notice.mjs" "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || true)"
+fi
+
 health_json="$(curl -fsS --max-time 1 "http://127.0.0.1:${port}/healthz" 2>/dev/null || true)"
 
 if [ -n "$health_json" ]; then
@@ -37,15 +46,15 @@ if [ -n "$health_json" ]; then
 
   if [ "$tui_connected" = "true" ]; then
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge is running. Daemon healthy, Codex TUI connected. Bridge is ready for communication."}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge is running. Daemon healthy, Codex TUI connected. Bridge is ready for communication.${plugin_notice:+ $plugin_notice}"}}
 EOF
   else
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex"}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex${plugin_notice:+ $plugin_notice}"}}
 EOF
   fi
 else
   cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude (this terminal) + agentbridge codex (another terminal). If you're already using agentbridge claude, the daemon may still be starting up."}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude (this terminal) + agentbridge codex (another terminal). If you're already using agentbridge claude, the daemon may still be starting up.${plugin_notice:+ $plugin_notice}"}}
 EOF
 fi

--- a/plugins/agentbridge/scripts/plugin-update-notice.mjs
+++ b/plugins/agentbridge/scripts/plugin-update-notice.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+/**
+ * In-session plugin-update reminder.
+ *
+ * The CLI notifier (src/update-notifier.ts) writes the latest npm version to the
+ * update-check cache. This script — invoked by the SessionStart hook
+ * (scripts/health-check.sh) — compares that `latest` against the INSTALLED
+ * plugin version (plugin.json, passed as argv[2]) and prints a one-line reminder
+ * to stdout if the plugin is behind. Prints NOTHING otherwise.
+ *
+ * Why a separate plugin-side reminder: the CLI prints its notice to the terminal
+ * before Claude Code's TUI takes over, so a user who updates npm but not the
+ * plugin would otherwise never see the mismatch from inside the session.
+ *
+ * Self-contained on purpose: the shipped plugin does not include src/, so the
+ * tiny state-dir resolution + stable-semver compare are inlined here. Keep them
+ * in sync with src/state-dir.ts (StateDirResolver) and src/version-utils.ts.
+ * Silent on ANY error — it must never break the SessionStart hook.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir, platform } from "node:os";
+
+/** Mirror of StateDirResolver (src/state-dir.ts). */
+function stateDir() {
+  const override = process.env.AGENTBRIDGE_STATE_DIR;
+  if (override) return override;
+  if (platform() === "darwin") {
+    return join(homedir(), "Library", "Application Support", "AgentBridge");
+  }
+  const xdg = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+  return join(xdg, "agentbridge");
+}
+
+const STABLE = /^\d+\.\d+\.\d+$/;
+
+/** Mirror of isStableUpgrade (src/version-utils.ts): stable latest strictly > stable current. */
+function isStableUpgrade(current, latest) {
+  if (!STABLE.test(current) || !STABLE.test(latest)) return false;
+  const a = current.split(".").map(Number);
+  const b = latest.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (b[i] > a[i]) return true;
+    if (b[i] < a[i]) return false;
+  }
+  return false;
+}
+
+try {
+  // Honor the same opt-out as the CLI notifier (src/update-notifier.ts): a user
+  // who silenced update notices must not still get the in-session reminder.
+  if (process.env.NO_UPDATE_NOTIFIER || process.env.AGENTBRIDGE_NO_UPDATE_NOTIFIER) {
+    process.exit(0);
+  }
+
+  const pluginJsonPath = process.argv[2];
+  if (!pluginJsonPath) process.exit(0);
+
+  const current = JSON.parse(readFileSync(pluginJsonPath, "utf-8")).version;
+  const cache = JSON.parse(readFileSync(join(stateDir(), "update-check.json"), "utf-8"));
+  const latest = cache?.latest;
+
+  if (typeof current === "string" && typeof latest === "string" && isStableUpgrade(current, latest)) {
+    process.stdout.write(
+      `AgentBridge plugin update available: ${current} -> ${latest}. ` +
+        `Update the plugin with /plugin marketplace update agentbridge then /reload-plugins ` +
+        `(and the CLI with npm install -g @raysonmeng/agentbridge@latest) so the CLI and plugin versions match.`,
+    );
+  }
+} catch {
+  // No cache yet / no plugin.json / malformed — stay silent.
+}
+process.exit(0);

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13714,6 +13714,9 @@ class StateDirResolver {
   get killedFile() {
     return join(this.stateDir, "killed");
   }
+  get updateCheckFile() {
+    return join(this.stateDir, "update-check.json");
+  }
 }
 
 // src/claude-adapter.ts

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -60,6 +60,9 @@ class StateDirResolver {
   get killedFile() {
     return join(this.stateDir, "killed");
   }
+  get updateCheckFile() {
+    return join(this.stateDir, "update-check.json");
+  }
 }
 
 // src/app-server-protocol.ts
@@ -1845,8 +1848,8 @@ var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 
 // src/env-utils.ts
-function parsePositiveIntEnv(name, fallback, log = () => {}) {
-  const raw = process.env[name];
+function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) {
+  const raw = env[name];
   if (raw == null || raw === "")
     return fallback;
   const parsed = Number(raw);

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Bump the AgentBridge version in lock-step across all three manifests that
+ * `scripts/check-plugin-versions.js` enforces equal:
+ *   - package.json                                  .version
+ *   - plugins/agentbridge/.claude-plugin/plugin.json .version
+ *   - .claude-plugin/marketplace.json                .plugins[name===plugin.name].version
+ *
+ * Usage:  node scripts/bump-version.mjs [patch|minor|major]   (default: patch)
+ * Prints a human line to STDERR and the new version (only) to STDOUT, so CI can
+ * capture it with `NEW=$(node scripts/bump-version.mjs patch)`.
+ *
+ * Refuses to run if the current version is not a clean stable `X.Y.Z` (so we
+ * never publish a prerelease/garbage version automatically).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkgPath = join(root, "package.json");
+const pluginPath = join(root, "plugins/agentbridge/.claude-plugin/plugin.json");
+const marketplacePath = join(root, ".claude-plugin/marketplace.json");
+
+const STABLE_RE = /^\d+\.\d+\.\d+$/;
+const LEVELS = ["patch", "minor", "major"];
+
+function readJson(p) {
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+function writeJson(p, obj) {
+  writeFileSync(p, JSON.stringify(obj, null, 2) + "\n", "utf-8");
+}
+function die(msg) {
+  process.stderr.write(`bump-version: ${msg}\n`);
+  process.exit(1);
+}
+
+const level = (process.argv[2] ?? "patch").toLowerCase();
+if (!LEVELS.includes(level)) die(`unknown bump level "${level}" (expected ${LEVELS.join("|")})`);
+
+const pkg = readJson(pkgPath);
+const current = pkg.version;
+if (typeof current !== "string" || !STABLE_RE.test(current)) {
+  die(`package.json version ${JSON.stringify(current)} is not a clean X.Y.Z stable version`);
+}
+
+const [major, minor, patch] = current.split(".").map(Number);
+const next =
+  level === "major" ? `${major + 1}.0.0`
+  : level === "minor" ? `${major}.${minor + 1}.0`
+  : `${major}.${minor}.${patch + 1}`;
+
+// package.json
+pkg.version = next;
+writeJson(pkgPath, pkg);
+
+// plugin.json
+const plugin = readJson(pluginPath);
+plugin.version = next;
+writeJson(pluginPath, plugin);
+
+// marketplace.json — the entry whose name matches the plugin's name
+const marketplace = readJson(marketplacePath);
+const entry = Array.isArray(marketplace.plugins)
+  ? marketplace.plugins.find((p) => p.name === plugin.name)
+  : null;
+if (!entry) die(`.claude-plugin/marketplace.json is missing the "${plugin.name}" plugin entry`);
+entry.version = next;
+writeJson(marketplacePath, marketplace);
+
+process.stderr.write(`bump-version: ${current} -> ${next} (package.json, plugin.json, marketplace.json)\n`);
+process.stdout.write(`${next}\n`);

--- a/scripts/install-global.mjs
+++ b/scripts/install-global.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Install AgentBridge globally in a way that is convenient for local testing.
+ *
+ * Modes:
+ *   local  build this checkout, pack it, uninstall the global package, install the tarball
+ *   npm    verify npm latest exists, uninstall the global package, install latest
+ *
+ * The uninstall step is intentionally ignored when the package is not installed:
+ * the goal is a clean replacement, not a brittle precondition.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"));
+const packageName = pkg.name;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const mode = args.find((arg) => !arg.startsWith("-"));
+
+function usage() {
+  process.stderr.write(`Usage: node scripts/install-global.mjs <local|npm> [--dry-run]
+
+Examples:
+  bun run install:global:local   # build this checkout, then fully replace the global install
+  bun run install:global:npm     # fully replace the global install with npm latest
+`);
+}
+
+function quote(arg) {
+  return /^[A-Za-z0-9_@%+=:,./<>-]+$/.test(arg) ? arg : JSON.stringify(arg);
+}
+
+function commandLine(cmd, commandArgs) {
+  return [cmd, ...commandArgs].map(quote).join(" ");
+}
+
+function printDry(cmd, commandArgs, suffix = "") {
+  process.stdout.write(`$ ${commandLine(cmd, commandArgs)}${suffix}\n`);
+}
+
+function run(cmd, commandArgs, options = {}) {
+  const { allowFailure = false, cwd = root, captureStdout = false } = options;
+  process.stdout.write(`$ ${commandLine(cmd, commandArgs)}\n`);
+  const res = spawnSync(cmd, commandArgs, {
+    cwd,
+    encoding: "utf-8",
+    stdio: captureStdout ? ["ignore", "pipe", "inherit"] : "inherit",
+  });
+
+  if (res.error) {
+    process.stderr.write(`install-global: failed to start ${cmd}: ${res.error.message}\n`);
+    if (!allowFailure) process.exit(1);
+  }
+  if (res.status !== 0 && !allowFailure) {
+    process.stderr.write(`install-global: command failed with exit code ${res.status}: ${commandLine(cmd, commandArgs)}\n`);
+    process.exit(res.status ?? 1);
+  }
+  return res;
+}
+
+function packedTarballFrom(stdout, destination) {
+  const file = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .pop();
+  if (!file) {
+    process.stderr.write("install-global: npm pack did not report a tarball name\n");
+    process.exit(1);
+  }
+  return isAbsolute(file) ? file : join(destination, file);
+}
+
+function installLocal() {
+  if (dryRun) {
+    printDry("bun", ["run", "prepublishOnly"]);
+    printDry("npm", ["pack", "--pack-destination", "<temp>"]);
+    printDry("npm", ["uninstall", "-g", packageName], "  # ignored if not installed");
+    printDry("npm", ["install", "-g", "--force", "<packed-tarball>"]);
+    return;
+  }
+
+  let packDir = "";
+  try {
+    run("bun", ["run", "prepublishOnly"]);
+    packDir = mkdtempSync(join(tmpdir(), "agentbridge-pack-"));
+    const packed = run("npm", ["pack", "--pack-destination", packDir], { captureStdout: true });
+    const tarball = packedTarballFrom(packed.stdout ?? "", packDir);
+    run("npm", ["uninstall", "-g", packageName], { allowFailure: true });
+    run("npm", ["install", "-g", "--force", tarball]);
+    process.stdout.write(`install-global: installed ${packageName} globally from local source\n`);
+  } finally {
+    if (packDir) rmSync(packDir, { recursive: true, force: true });
+  }
+}
+
+function installNpm() {
+  const spec = `${packageName}@latest`;
+  if (dryRun) {
+    printDry("npm", ["view", spec, "version"]);
+    printDry("npm", ["uninstall", "-g", packageName], "  # ignored if not installed");
+    printDry("npm", ["install", "-g", "--force", spec]);
+    return;
+  }
+
+  run("npm", ["view", spec, "version"]);
+  run("npm", ["uninstall", "-g", packageName], { allowFailure: true });
+  run("npm", ["install", "-g", "--force", spec]);
+  process.stdout.write(`install-global: installed ${packageName} globally from npm latest\n`);
+}
+
+if (mode === "local" || mode === "source") {
+  installLocal();
+} else if (mode === "npm" || mode === "registry") {
+  installNpm();
+} else {
+  usage();
+  process.exit(1);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,22 @@ const restArgs = args.slice(1);
 export const MARKETPLACE_NAME = "agentbridge";
 export const PLUGIN_NAME = "agentbridge";
 
+/** Commands that print an update notice. claude/codex also trigger the daily refresh. */
+const REFRESH_COMMANDS = new Set(["claude", "codex"]);
+const NOTIFY_COMMANDS = new Set(["claude", "codex", "init", "dev"]);
+
 async function main() {
+  // Best-effort, non-blocking update notice. Fully guarded — never blocks,
+  // delays, or fails the command (see src/update-notifier.ts).
+  if (command && NOTIFY_COMMANDS.has(command)) {
+    try {
+      const { maybeNotifyUpdate } = await import("./update-notifier");
+      maybeNotifyUpdate({ refresh: REFRESH_COMMANDS.has(command) });
+    } catch {
+      // ignore — the notifier must never affect the command
+    }
+  }
+
   switch (command) {
     case "init":
       const { runInit } = await import("./cli/init");

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -5,6 +5,7 @@ import { ConfigService } from "../config-service";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { findPackageRoot, registerMarketplace } from "./pkg-root";
 import { upsertMarkedSection } from "../marker-section";
+import { compareVersions } from "../version-utils";
 import {
   MARKER_ID,
   CLAUDE_MD_SECTION,
@@ -113,19 +114,6 @@ function checkCodex() {
     console.error("  Install Codex: https://github.com/openai/codex");
     process.exit(1);
   }
-}
-
-/** Compare semver strings. Returns -1, 0, or 1. */
-function compareVersions(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {
-    const va = pa[i] ?? 0;
-    const vb = pb[i] ?? 0;
-    if (va < vb) return -1;
-    if (va > vb) return 1;
-  }
-  return 0;
 }
 
 /**

--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -2,8 +2,9 @@ export function parsePositiveIntEnv(
   name: string,
   fallback: number,
   log: (message: string) => void = () => {},
+  env: NodeJS.ProcessEnv = process.env,
 ): number {
-  const raw = process.env[name];
+  const raw = env[name];
   if (raw == null || raw === "") return fallback;
 
   // Use Number() (not parseInt) so values like "1.5" and "10abc" fail validation

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -78,4 +78,13 @@ export class StateDirResolver {
   get killedFile(): string {
     return join(this.stateDir, "killed");
   }
+
+  /**
+   * Cache for the update-notifier: `{ lastCheckMs, latest }`. Machine/user-global
+   * (not per-project) so the daily npm check runs once per machine, not once per
+   * project — see src/update-notifier.ts.
+   */
+  get updateCheckFile(): string {
+    return join(this.stateDir, "update-check.json");
+  }
 }

--- a/src/unit-test/install-global-script.test.ts
+++ b/src/unit-test/install-global-script.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SCRIPT = join(process.cwd(), "scripts/install-global.mjs");
+const PACKAGE_NAME = "@raysonmeng/agentbridge";
+
+function runDry(mode: string): { status: number | null; stdout: string; stderr: string } {
+  const res = Bun.spawnSync(["node", SCRIPT, mode, "--dry-run"], {
+    env: process.env,
+  });
+  return {
+    status: res.exitCode,
+    stdout: res.stdout.toString(),
+    stderr: res.stderr.toString(),
+  };
+}
+
+function dryRunCommands(mode: string): string[] {
+  const res = runDry(mode);
+  expect(res.status).toBe(0);
+  return res.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("$ "));
+}
+
+describe("scripts/install-global.mjs", () => {
+  test("local mode builds and packs before replacing the global install", () => {
+    const commands = dryRunCommands("local");
+    expect(commands).toEqual([
+      "$ bun run prepublishOnly",
+      "$ npm pack --pack-destination <temp>",
+      `$ npm uninstall -g ${PACKAGE_NAME}  # ignored if not installed`,
+      "$ npm install -g --force <packed-tarball>",
+    ]);
+  });
+
+  test("npm mode verifies the registry package before replacing the global install", () => {
+    const commands = dryRunCommands("npm");
+    expect(commands).toEqual([
+      `$ npm view ${PACKAGE_NAME}@latest version`,
+      `$ npm uninstall -g ${PACKAGE_NAME}  # ignored if not installed`,
+      `$ npm install -g --force ${PACKAGE_NAME}@latest`,
+    ]);
+  });
+
+  test("package.json exposes one-line local and npm install commands", () => {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8"));
+    expect(pkg.scripts["install:global"]).toBe("node scripts/install-global.mjs local");
+    expect(pkg.scripts["install:global:local"]).toBe("node scripts/install-global.mjs local");
+    expect(pkg.scripts["install:global:npm"]).toBe("node scripts/install-global.mjs npm");
+  });
+
+  test("unknown mode fails with usage", () => {
+    const res = runDry("elsewhere");
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("Usage:");
+  });
+});

--- a/src/unit-test/plugin-update-notice.test.ts
+++ b/src/unit-test/plugin-update-notice.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Integration test for the shipped plugin-side reminder script that the
+// SessionStart hook invokes. It reads the update cache (written by the CLI
+// notifier) and compares to the installed plugin version.
+const SCRIPT = join(process.cwd(), "plugins/agentbridge/scripts/plugin-update-notice.mjs");
+
+const dirs: string[] = [];
+function setup(latest: string | null, pluginVersion: string): { stateDir: string; pluginJson: string } {
+  const base = mkdtempSync(join(tmpdir(), "abg-pcn-"));
+  dirs.push(base);
+  const stateDir = join(base, "state");
+  mkdirSync(stateDir, { recursive: true });
+  if (latest !== null) {
+    writeFileSync(join(stateDir, "update-check.json"), JSON.stringify({ lastCheckMs: 1, latest }));
+  }
+  const pluginJson = join(base, "plugin.json");
+  writeFileSync(pluginJson, JSON.stringify({ name: "agentbridge", version: pluginVersion }));
+  return { stateDir, pluginJson };
+}
+function run(stateDir: string, pluginJson: string, extraEnv: Record<string, string> = {}): string {
+  const res = Bun.spawnSync(["bun", SCRIPT, pluginJson], {
+    env: { ...process.env, AGENTBRIDGE_STATE_DIR: stateDir, ...extraEnv },
+  });
+  return res.stdout.toString();
+}
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe("plugin-update-notice.mjs", () => {
+  test("prints a reminder when npm latest is newer than the installed plugin", () => {
+    const { stateDir, pluginJson } = setup("0.1.9", "0.1.6");
+    const out = run(stateDir, pluginJson);
+    expect(out).toContain("plugin update available");
+    expect(out).toContain("0.1.6 -> 0.1.9");
+    expect(out).toContain("/plugin marketplace update agentbridge");
+    expect(out).toContain("/reload-plugins");
+  });
+
+  test("prints nothing when the plugin is already at the latest version", () => {
+    const { stateDir, pluginJson } = setup("0.1.6", "0.1.6");
+    expect(run(stateDir, pluginJson).trim()).toBe("");
+  });
+
+  test("prints nothing for a prerelease latest (no beta nag)", () => {
+    const { stateDir, pluginJson } = setup("0.2.0-beta.1", "0.1.6");
+    expect(run(stateDir, pluginJson).trim()).toBe("");
+  });
+
+  test("prints nothing (silent) when no cache exists yet", () => {
+    const { stateDir, pluginJson } = setup(null, "0.1.6");
+    expect(run(stateDir, pluginJson).trim()).toBe("");
+  });
+
+  test("respects the NO_UPDATE_NOTIFIER opt-out even when an upgrade is available", () => {
+    const { stateDir, pluginJson } = setup("0.1.9", "0.1.6");
+    expect(run(stateDir, pluginJson, { NO_UPDATE_NOTIFIER: "1" }).trim()).toBe("");
+    expect(run(stateDir, pluginJson, { AGENTBRIDGE_NO_UPDATE_NOTIFIER: "1" }).trim()).toBe("");
+    // sanity: without the opt-out it DOES remind (proves the opt-out is what silenced it)
+    expect(run(stateDir, pluginJson)).toContain("plugin update available");
+  });
+});

--- a/src/unit-test/state-dir.test.ts
+++ b/src/unit-test/state-dir.test.ts
@@ -28,6 +28,7 @@ describe("StateDirResolver", () => {
     expect(resolver.statusFile).toBe(join(tempDir, "status.json"));
     expect(resolver.portsFile).toBe(join(tempDir, "ports.json"));
     expect(resolver.logFile).toBe(join(tempDir, "agentbridge.log"));
+    expect(resolver.updateCheckFile).toBe(join(tempDir, "update-check.json"));
   });
 
   test("ensure() creates directory if it does not exist", () => {

--- a/src/unit-test/update-notifier.test.ts
+++ b/src/unit-test/update-notifier.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { StateDirResolver } from "../state-dir";
+import {
+  PACKAGE_NAME,
+  buildUpdateNotice,
+  isUpdateCheckSuppressed,
+  maybeNotifyUpdate,
+  parseLatestFromRegistry,
+  refreshUpdateCache,
+  type UpdateCache,
+} from "../update-notifier";
+
+const tmpDirs: string[] = [];
+function freshStateDir(): StateDirResolver {
+  const d = mkdtempSync(join(tmpdir(), "abg-upd-"));
+  tmpDirs.push(d);
+  return new StateDirResolver(d);
+}
+afterEach(() => {
+  while (tmpDirs.length) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+function writeCacheFile(sd: StateDirResolver, cache: UpdateCache): void {
+  sd.ensure();
+  writeFileSync(sd.updateCheckFile, JSON.stringify(cache), "utf-8");
+}
+function readCacheFile(sd: StateDirResolver): UpdateCache {
+  return JSON.parse(readFileSync(sd.updateCheckFile, "utf-8"));
+}
+/** A fetch that returns a 200 npm body and records call count. */
+function recordingFetch(body: unknown, status = 200): { fn: typeof fetch; calls: () => number } {
+  let n = 0;
+  const fn = (async () => {
+    n++;
+    return new Response(JSON.stringify(body), { status });
+  }) as unknown as typeof fetch;
+  return { fn, calls: () => n };
+}
+const tick = () => new Promise((r) => setTimeout(r, 10));
+const CLEAN_ENV = {} as NodeJS.ProcessEnv; // not suppressed by env
+
+describe("parseLatestFromRegistry", () => {
+  test("extracts a stable dist-tags.latest", () => {
+    expect(parseLatestFromRegistry({ "dist-tags": { latest: "0.2.0" } })).toBe("0.2.0");
+  });
+  test("rejects prerelease / missing / wrong-shape / non-string", () => {
+    expect(parseLatestFromRegistry({ "dist-tags": { latest: "0.2.0-beta.1" } })).toBeNull();
+    expect(parseLatestFromRegistry({ "dist-tags": {} })).toBeNull();
+    expect(parseLatestFromRegistry({ "dist-tags": { latest: 5 } })).toBeNull();
+    expect(parseLatestFromRegistry({})).toBeNull();
+    expect(parseLatestFromRegistry(null)).toBeNull();
+    expect(parseLatestFromRegistry("nope")).toBeNull();
+  });
+});
+
+describe("buildUpdateNotice", () => {
+  test("shows current → latest and both upgrade commands", () => {
+    const msg = buildUpdateNotice("0.1.6", "0.2.0", false);
+    expect(msg).toContain("0.1.6");
+    expect(msg).toContain("0.2.0");
+    expect(msg).toContain(`npm install -g ${PACKAGE_NAME}@latest`);
+    expect(msg).toContain("/plugin marketplace update agentbridge");
+  });
+  test("omits ANSI color when not a TTY, includes it on a TTY", () => {
+    expect(buildUpdateNotice("0.1.6", "0.2.0", false)).not.toContain("\x1b[");
+    expect(buildUpdateNotice("0.1.6", "0.2.0", true)).toContain("\x1b[");
+  });
+});
+
+describe("isUpdateCheckSuppressed", () => {
+  test("suppresses on opt-out env, CI, test, and non-TTY", () => {
+    expect(isUpdateCheckSuppressed({ NO_UPDATE_NOTIFIER: "1" } as any, true)).toBe(true);
+    expect(isUpdateCheckSuppressed({ AGENTBRIDGE_NO_UPDATE_NOTIFIER: "1" } as any, true)).toBe(true);
+    expect(isUpdateCheckSuppressed({ CI: "true" } as any, true)).toBe(true);
+    expect(isUpdateCheckSuppressed({ NODE_ENV: "test" } as any, true)).toBe(true);
+    expect(isUpdateCheckSuppressed({} as any, false)).toBe(true); // non-TTY
+  });
+  test("not suppressed on a clean TTY environment", () => {
+    expect(isUpdateCheckSuppressed({} as any, true)).toBe(false);
+  });
+});
+
+describe("maybeNotifyUpdate — printing", () => {
+  test("prints when cache has a newer stable version", () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1000, latest: "0.2.0" });
+    const out: string[] = [];
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m), now: () => 1000 });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("0.1.6");
+    expect(out[0]).toContain("0.2.0");
+  });
+
+  test("does NOT print when latest is equal/older/prerelease or cache absent", () => {
+    const out: string[] = [];
+    const run = (cache: UpdateCache | null, current = "0.1.6") => {
+      const sd = freshStateDir();
+      if (cache) writeCacheFile(sd, cache);
+      maybeNotifyUpdate({ current, stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m), now: () => 1000 });
+    };
+    run({ lastCheckMs: 1, latest: "0.1.6" }); // equal
+    run({ lastCheckMs: 1, latest: "0.1.5" }); // older
+    run({ lastCheckMs: 1, latest: "0.2.0-beta.1" }); // prerelease
+    run({ lastCheckMs: 1, latest: null }); // unknown
+    run(null); // no cache file
+    expect(out).toHaveLength(0);
+  });
+
+  test("does NOT print when suppressed even if a newer version is cached", () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1, latest: "9.9.9" });
+    const out: string[] = [];
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: { CI: "1" } as any, print: (m) => out.push(m) });
+    expect(out).toHaveLength(0);
+  });
+
+  test("never throws on a corrupt cache file", () => {
+    const sd = freshStateDir();
+    sd.ensure();
+    writeFileSync(sd.updateCheckFile, "{not json", "utf-8");
+    const out: string[] = [];
+    expect(() =>
+      maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m) }),
+    ).not.toThrow();
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe("maybeNotifyUpdate — refresh gating", () => {
+  test("refresh:true with a stale cache fires the network check", () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 0, latest: "0.1.6" }); // very stale
+    const f = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: () => {}, now: () => 10 * 24 * 60 * 60 * 1000, refresh: true, fetchImpl: f.fn });
+    expect(f.calls()).toBe(1);
+  });
+
+  test("refresh:true with a FRESH cache does NOT hit the network", () => {
+    const sd = freshStateDir();
+    const now = 1_000_000_000;
+    writeCacheFile(sd, { lastCheckMs: now - 1000, latest: "0.1.6" }); // checked 1s ago
+    const f = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: () => {}, now: () => now, refresh: true, fetchImpl: f.fn });
+    expect(f.calls()).toBe(0);
+  });
+
+  test("refresh:false never hits the network (one-shot commands)", () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 0, latest: "0.1.6" });
+    const f = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: () => {}, now: () => 10 ** 12, refresh: false, fetchImpl: f.fn });
+    expect(f.calls()).toBe(0);
+  });
+
+  test("honors AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS from the injected env (deps.env DI contract)", () => {
+    // With a 1000ms interval, a cache 2s old IS stale (fetch) but 500ms old is fresh (skip).
+    const now = 1_000_000_000;
+    const env = { AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS: "1000" } as unknown as NodeJS.ProcessEnv;
+
+    const sdStale = freshStateDir();
+    writeCacheFile(sdStale, { lastCheckMs: now - 2000, latest: "0.1.6" });
+    const fStale = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sdStale, isTTY: true, env, print: () => {}, now: () => now, refresh: true, fetchImpl: fStale.fn });
+    expect(fStale.calls()).toBe(1); // 2s > 1s interval → fetch
+
+    const sdFresh = freshStateDir();
+    writeCacheFile(sdFresh, { lastCheckMs: now - 500, latest: "0.1.6" });
+    const fFresh = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sdFresh, isTTY: true, env, print: () => {}, now: () => now, refresh: true, fetchImpl: fFresh.fn });
+    expect(fFresh.calls()).toBe(0); // 500ms < 1s interval → skip
+  });
+});
+
+describe("refreshUpdateCache", () => {
+  test("writes the fetched stable latest + a fresh timestamp", async () => {
+    const sd = freshStateDir();
+    const f = recordingFetch({ "dist-tags": { latest: "0.3.0" } });
+    await refreshUpdateCache({ stateDir: sd, now: () => 12345, fetchImpl: f.fn });
+    const cache = readCacheFile(sd);
+    expect(cache.latest).toBe("0.3.0");
+    expect(cache.lastCheckMs).toBe(12345);
+  });
+
+  test("preserves the previously-known latest on a transient fetch failure", async () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1, latest: "0.2.0" });
+    const failing = (async () => { throw new Error("offline"); }) as unknown as typeof fetch;
+    await refreshUpdateCache({ stateDir: sd, now: () => 99999, fetchImpl: failing });
+    const cache = readCacheFile(sd);
+    expect(cache.latest).toBe("0.2.0"); // preserved
+    expect(cache.lastCheckMs).toBe(99999); // but throttle advanced
+  });
+
+  test("never throws and records the check even with no prior cache on failure", async () => {
+    const sd = freshStateDir();
+    const failing = (async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
+    await refreshUpdateCache({ stateDir: sd, now: () => 7, fetchImpl: failing });
+    const cache = readCacheFile(sd);
+    expect(cache.latest).toBeNull();
+    expect(cache.lastCheckMs).toBe(7);
+  });
+
+  test("end-to-end: a stale refresh writes a cache a later run would notify from", async () => {
+    const sd = freshStateDir();
+    const f = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: () => {}, now: () => 10 ** 12, refresh: true, fetchImpl: f.fn });
+    await tick();
+    const out: string[] = [];
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m), now: () => 10 ** 12 });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("0.2.0");
+  });
+});

--- a/src/unit-test/version-utils.test.ts
+++ b/src/unit-test/version-utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { compareVersions, isStableVersion, isStableUpgrade } from "../version-utils";
+
+describe("compareVersions", () => {
+  test("orders by major, minor, patch", () => {
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareVersions("2.0.0", "1.9.9")).toBe(1);
+    expect(compareVersions("1.9.9", "2.0.0")).toBe(-1);
+    expect(compareVersions("1.2.0", "1.1.9")).toBe(1);
+    expect(compareVersions("0.1.7", "0.1.6")).toBe(1);
+    expect(compareVersions("0.1.6", "0.1.7")).toBe(-1);
+  });
+
+  test("treats missing trailing segments as 0", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+    expect(compareVersions("1", "1.0.0")).toBe(0);
+    expect(compareVersions("1.2.1", "1.2")).toBe(1);
+  });
+});
+
+describe("isStableVersion", () => {
+  test("accepts exactly three numeric segments", () => {
+    expect(isStableVersion("0.1.6")).toBe(true);
+    expect(isStableVersion("10.20.30")).toBe(true);
+    expect(isStableVersion(" 1.2.3 ")).toBe(true); // trimmed
+  });
+
+  test("rejects prerelease / build / prefixed / partial versions", () => {
+    expect(isStableVersion("0.2.0-beta.1")).toBe(false);
+    expect(isStableVersion("1.2.3+build")).toBe(false);
+    expect(isStableVersion("v1.2.3")).toBe(false);
+    expect(isStableVersion("1.2")).toBe(false);
+    expect(isStableVersion("1.2.3.4")).toBe(false);
+    expect(isStableVersion("latest")).toBe(false);
+    expect(isStableVersion("")).toBe(false);
+  });
+});
+
+describe("isStableUpgrade", () => {
+  test("true only when latest is a stable version strictly greater than current", () => {
+    expect(isStableUpgrade("0.1.6", "0.1.7")).toBe(true);
+    expect(isStableUpgrade("0.1.6", "0.2.0")).toBe(true);
+    expect(isStableUpgrade("0.1.6", "1.0.0")).toBe(true);
+  });
+
+  test("false for equal or older latest (no downgrade nag)", () => {
+    expect(isStableUpgrade("0.1.6", "0.1.6")).toBe(false);
+    expect(isStableUpgrade("0.1.7", "0.1.6")).toBe(false);
+  });
+
+  test("false when either side is prerelease or malformed (no beta nag)", () => {
+    expect(isStableUpgrade("0.1.6", "0.2.0-beta.1")).toBe(false);
+    expect(isStableUpgrade("0.1.6-rc.1", "0.1.7")).toBe(false);
+    expect(isStableUpgrade("0.1.6", "garbage")).toBe(false);
+    expect(isStableUpgrade("", "0.1.7")).toBe(false);
+  });
+});

--- a/src/update-notifier.ts
+++ b/src/update-notifier.ts
@@ -1,0 +1,191 @@
+/**
+ * Update notifier (#auto-update).
+ *
+ * Tells the user when a newer stable AgentBridge is available on npm. Designed to
+ * be correct-by-construction:
+ *   - ZERO network on most runs: a notice is printed from a cached `latest`
+ *     (populated by a prior run); the network is hit at most once per `interval`.
+ *   - NEVER blocks / delays / fails the command: printing is sync from cache; the
+ *     daily refresh is fired un-awaited and only on long-lived launchers (claude/
+ *     codex) whose parent process outlives the fetch — one-shot commands never
+ *     keep a pending fetch alive past their own exit.
+ *   - SILENT on any failure (offline, 404, proxy, malformed JSON, timeout).
+ *   - SUPPRESSED for non-TTY/CI/test and via opt-out env vars.
+ *   - STABLE-only: never nags about prereleases or downgrades (see version-utils).
+ *   - READ-ONLY: it only prints the upgrade command; it never installs anything.
+ *
+ * npm is queried as the single authoritative source: the user running `abg`
+ * installed the CLI from npm, and `scripts/check-plugin-versions.js` keeps the
+ * package/plugin/marketplace versions equal, so npm's `dist-tags.latest` is a
+ * faithful proxy for the plugin version too. The notice still surfaces both the
+ * CLI (`npm i -g`) and plugin (`/plugin marketplace update`) upgrade paths.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { StateDirResolver } from "./state-dir";
+import { isStableUpgrade, isStableVersion } from "./version-utils";
+import { parsePositiveIntEnv } from "./env-utils";
+
+export const PACKAGE_NAME = "@raysonmeng/agentbridge";
+/** Scope must be URL-encoded (`@scope%2Fname`) in the registry path. */
+const REGISTRY_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}`;
+/** Abbreviated metadata — smallest payload that still carries `dist-tags`. */
+const ABBREVIATED_ACCEPT = "application/vnd.npm.install-v1+json";
+const DEFAULT_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // once per day
+const FETCH_TIMEOUT_MS = 2500;
+const CHECK_INTERVAL_ENV = "AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS";
+
+export interface UpdateCache {
+  /** Epoch ms of the last completed network check. */
+  lastCheckMs: number;
+  /** Last-known stable `latest` from npm, or null if never/failed. */
+  latest: string | null;
+}
+
+export interface NotifierDeps {
+  /** Installed version. Defaults to the build-time package version. */
+  current?: string;
+  /** Whether to fire the daily background refresh. Only true for long-lived launchers. */
+  refresh?: boolean;
+  stateDir?: StateDirResolver;
+  now?: () => number;
+  /** Whether output goes to a TTY (defaults to stderr.isTTY). */
+  isTTY?: boolean;
+  env?: NodeJS.ProcessEnv;
+  print?: (msg: string) => void;
+  fetchImpl?: typeof fetch;
+}
+
+/** Installed version, inlined at build time by Bun's bundler (see printVersion). */
+export function getCurrentVersion(): string {
+  try {
+    return (require("../package.json") as { version: string }).version;
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/** Whether the notice should be fully suppressed for this environment. */
+export function isUpdateCheckSuppressed(env: NodeJS.ProcessEnv, isTTY: boolean): boolean {
+  // Ecosystem-standard opt-out + namespaced opt-out (any non-empty value disables).
+  if (env.NO_UPDATE_NOTIFIER) return true;
+  if (env.AGENTBRIDGE_NO_UPDATE_NOTIFIER) return true;
+  if (env.CI) return true; // don't nag in CI
+  if (env.NODE_ENV === "test") return true;
+  if (!isTTY) return true; // piped/redirected — keep output clean
+  return false;
+}
+
+function readCache(stateDir: StateDirResolver): UpdateCache | null {
+  try {
+    const parsed = JSON.parse(readFileSync(stateDir.updateCheckFile, "utf-8")) as Partial<UpdateCache>;
+    if (typeof parsed.lastCheckMs !== "number" || !Number.isFinite(parsed.lastCheckMs)) return null;
+    return {
+      lastCheckMs: parsed.lastCheckMs,
+      latest: typeof parsed.latest === "string" ? parsed.latest : null,
+    };
+  } catch {
+    return null; // missing / corrupt → treat as "no cache, recheck"
+  }
+}
+
+function writeCache(stateDir: StateDirResolver, cache: UpdateCache): void {
+  try {
+    stateDir.ensure();
+    writeFileSync(stateDir.updateCheckFile, JSON.stringify(cache, null, 2) + "\n", "utf-8");
+  } catch {
+    // best-effort; a failed cache write just means we recheck next time
+  }
+}
+
+/** Extract + validate the stable `dist-tags.latest` from an npm registry body. */
+export function parseLatestFromRegistry(body: unknown): string | null {
+  if (typeof body !== "object" || body === null) return null;
+  const distTags = (body as Record<string, unknown>)["dist-tags"];
+  if (typeof distTags !== "object" || distTags === null) return null;
+  const latest = (distTags as Record<string, unknown>).latest;
+  if (typeof latest !== "string" || !isStableVersion(latest)) return null;
+  return latest;
+}
+
+async function fetchLatest(fetchImpl: typeof fetch): Promise<string | null> {
+  try {
+    const res = await fetchImpl(REGISTRY_URL, {
+      headers: { Accept: ABBREVIATED_ACCEPT },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    return parseLatestFromRegistry(await res.json());
+  } catch {
+    return null; // offline / timeout / DNS / 4xx / malformed JSON — all silent
+  }
+}
+
+/**
+ * Refresh the cache from npm. On a transient failure the previously-known
+ * `latest` is preserved (only `lastCheckMs` advances) so we neither lose a good
+ * value nor hammer the registry. Swallows all errors.
+ */
+export async function refreshUpdateCache(deps: NotifierDeps = {}): Promise<void> {
+  const stateDir = deps.stateDir ?? new StateDirResolver();
+  const now = deps.now ?? Date.now;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  try {
+    const latest = await fetchLatest(fetchImpl);
+    const prev = readCache(stateDir);
+    writeCache(stateDir, { lastCheckMs: now(), latest: latest ?? prev?.latest ?? null });
+  } catch {
+    // never throw
+  }
+}
+
+/** The user-facing notice. TTY-aware (color only on a terminal). */
+export function buildUpdateNotice(current: string, latest: string, isTTY: boolean): string {
+  const yellow = isTTY ? "\x1b[33m" : "";
+  const bold = isTTY ? "\x1b[1m" : "";
+  const reset = isTTY ? "\x1b[0m" : "";
+  return [
+    `${yellow}⚠ AgentBridge update available: ${bold}${current}${reset}${yellow} → ${bold}${latest}${reset}`,
+    `  CLI:    npm install -g ${PACKAGE_NAME}@latest`,
+    `  Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)`,
+    `  (silence with NO_UPDATE_NOTIFIER=1)`,
+  ].join("\n");
+}
+
+function checkIntervalMs(env: NodeJS.ProcessEnv): number {
+  // Read from the injected env (not process.env) so the deps.env DI contract
+  // holds end-to-end and the interval is overridable/testable.
+  return parsePositiveIntEnv(CHECK_INTERVAL_ENV, DEFAULT_CHECK_INTERVAL_MS, undefined, env);
+}
+
+/**
+ * Best-effort update notice. Synchronously prints a notice from the cached
+ * `latest` (if a newer stable version exists), then — only when `refresh` is set
+ * — fires an un-awaited daily refresh. NEVER throws, blocks, or changes exit code.
+ */
+export function maybeNotifyUpdate(deps: NotifierDeps = {}): void {
+  try {
+    const env = deps.env ?? process.env;
+    const isTTY = deps.isTTY ?? Boolean(process.stderr.isTTY);
+    if (isUpdateCheckSuppressed(env, isTTY)) return;
+
+    const current = deps.current ?? getCurrentVersion();
+    const stateDir = deps.stateDir ?? new StateDirResolver();
+    const now = deps.now ?? Date.now;
+    const print = deps.print ?? ((m: string) => process.stderr.write(m + "\n"));
+
+    const cache = readCache(stateDir);
+    if (cache?.latest && isStableUpgrade(current, cache.latest)) {
+      print(buildUpdateNotice(current, cache.latest, isTTY));
+    }
+
+    // Daily refresh — only on long-lived launchers (deps.refresh), where the
+    // parent process outlives the fetch. One-shot commands skip this so a
+    // pending fetch can never delay their exit.
+    if (deps.refresh && (!cache || now() - cache.lastCheckMs >= checkIntervalMs(env))) {
+      void refreshUpdateCache({ stateDir, now, fetchImpl: deps.fetchImpl }).catch(() => {});
+    }
+  } catch {
+    // The notifier must never affect the command it precedes.
+  }
+}

--- a/src/version-utils.ts
+++ b/src/version-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared semver helpers. Kept dependency-free (AgentBridge has zero runtime
+ * deps) and deliberately conservative: we only ever reason about plain
+ * `MAJOR.MINOR.PATCH` stable versions. Prerelease/build metadata is treated as
+ * "not a stable version" so the update notifier never nags users about betas.
+ */
+
+/** A strict stable semver: exactly three numeric dot-segments, e.g. `0.1.6`. */
+const STABLE_SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+/** True when `v` is a clean stable `X.Y.Z` (no prerelease/build suffix, no `v` prefix). */
+export function isStableVersion(v: string): boolean {
+  return STABLE_SEMVER_RE.test(v.trim());
+}
+
+/**
+ * Compare two `X.Y.Z` version strings. Returns -1 if a<b, 0 if equal, 1 if a>b.
+ * Missing segments are treated as 0; non-numeric segments collapse to NaN which
+ * compares as neither `<` nor `>` (callers should pass stable versions — see
+ * `isStableVersion`). Matches the original comparator extracted from init.ts.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va < vb) return -1;
+    if (va > vb) return 1;
+  }
+  return 0;
+}
+
+/**
+ * True only when `latest` is a STABLE version strictly greater than a STABLE
+ * `current`. If either side is missing / prerelease / malformed, returns false —
+ * we never surface a downgrade, an equal version, a beta, or a garbage tag.
+ */
+export function isStableUpgrade(current: string, latest: string): boolean {
+  if (!isStableVersion(current) || !isStableVersion(latest)) return false;
+  return compareVersions(latest, current) === 1;
+}


### PR DESCRIPTION
## 概要 / Summary

让用户**及时发现并安装新版本**,并保证背后的发布管线**规律触发**且**产物绝对可用** — 三件事:CLI 更新提示、合并即自动发布(带 smoke/check 护栏)、会话内插件更新提醒。

Lets users discover & install new versions promptly, backed by a release pipeline that publishes regularly and only ever ships a build that passes the full check.

---

## Part A — CLI 更新提示 / CLI update notifier

`abg claude` / `abg codex` 启动时,若 npm 上有更新的**稳定**版本,在 spawn 子进程前向 stderr 打印:

```
⚠ AgentBridge update available: 0.1.6 → 0.1.7
  CLI:    npm install -g @raysonmeng/agentbridge@latest
  Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)
```

- **绝不阻塞/拖慢/弄坏命令**:从缓存同步打印;后台每日最多查一次 npm(`dist-tags.latest`),un-awaited,仅长命令(claude/codex)触发刷新;任何网络/registry 失败静默。
- **抑制**:非 TTY、`CI`、`NODE_ENV=test`、`NO_UPDATE_NOTIFIER`、`AGENTBRIDGE_NO_UPDATE_NOTIFIER`。
- **只读**:只查 npm、只提示升级命令,**绝不自动安装**;只提醒 stable(不 nag prerelease)。
- 新增 `src/version-utils.ts`(从 `init.ts` 提取 `compareVersions` + `isStableUpgrade`)、`src/update-notifier.ts`、`StateDirResolver.updateCheckFile` 缓存、`AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS`。

## Part B — 合并即自动发布 + 护栏 / auto-publish on merge, gated

用户选定「合并即自动发布」。每次代码合并到 master 都经门禁后自动 patch-bump 并发到 npm,给 notifier 一个稳定可检测的源。

- **`release-on-merge.yml`**:push 到 master → 重试循环(每个候选 tip 先 `bun install --frozen-lockfile` + `bun run check`,绿则三处版本同步 bump、commit、push;push 竞态 → reset 重试,最多 3 次)。版本已推进 / tip 已是 release commit → 跳过(防 double-publish + 防空版本)。需 `RELEASE_PAT`,缺则 **fail loud**。
- **`auto-release.yml` / `publish.yml`**:两跳都强制 `RELEASE_PAT`(`GITHUB_TOKEN` 推送/建 release 不触发下游 → 发不到 npm)。auto-release 按 **release 存在性**(非 tag)判幂等、复用 tag 前校验其指向 `HEAD`(**防发错 commit**)。`publish.yml` 在 `npm publish` 前再跑完整 `bun run check` —— **npm publish 的无条件最终门禁,坏代码绝不上 npm**。
- **`scripts/bump-version.mjs`**:同步 bump package.json / plugin.json / marketplace.json,拒绝非 stable。
- **`scripts/install-global.mjs`**(`install:global[:local|:npm]`):本地 build+pack+全局覆盖安装,或从 npm latest 覆盖安装;带 `--dry-run`;装完可被 `npm i -g @latest` 干净覆盖。
- `docs/RELEASING.md`:全流程 + `RELEASE_PAT` 两跳 + 并发/重试语义 + 本地安装/dogfooding。

## Part C — 会话内插件更新提醒 / in-session plugin reminder

解决「npm 更了但 Claude 插件没更 → 版本不一致」:SessionStart hook(`health-check.sh`)调用 `plugin-update-notice.mjs`,对比**已安装插件版本** vs 缓存的 npm latest,有新版就在 Claude 会话里注入提醒(`/plugin marketplace update agentbridge` + `/reload-plugins`)。尊重同样的 opt-out;版本号 digit/dot-only → JSON 注入安全;任何错误静默。

## 测试 / Tests

- 新增 `version-utils` / `update-notifier` / `plugin-update-notice` / `install-global` / `state-dir` 测试。`bun run check` 全绿(**293 tests**),关键回归 TDD red/green 验证。
- 三个禁止结局(坏代码上 npm / 错代码上 npm / 该发版本永久丢失)经**对抗性 review 确认全部 closed**;残留为罕见、fail-loud、可恢复的 tag/release 一致性边角(已在 RELEASING.md 文档化)。

## 部署要求 / Deployment

- 需配置仓库 secret **`RELEASE_PAT`**(细粒度 PAT,`contents: write`)—— 见 docs/RELEASING.md。缺失时 release-on-merge / auto-release **fail loud**(不会产生发不出去的 bump 或 stranded release)。`NPM_TOKEN` 已有。
- 若 master 受 branch protection,需允许该 PAT 推送 `chore(release):` bump commit。

## E2E 测试计划 / E2E test plan
- [ ] 设好 `RELEASE_PAT` 后,合并一个 PR → 确认 release-on-merge → auto-release → publish 链路真发到 npm。
- [ ] 旧全局 CLI(如 0.1.5)下 `abg claude` → 确认提示 0.1.5 → latest。
- [ ] `bun run install:global:local` 装本地版 → `abg --version` 对;`bun src/cli.ts dev` + `/reload-plugins` → 插件提醒消失。
- [ ] 设 `NO_UPDATE_NOTIFIER=1` → CLI + 会话内提醒都不出现。

## 交叉 review / Cross-review
经 **7 轮交叉 review**(多个独立 subagent + Codex)收敛到连续两轮 0 真实 issue。期间发现并修复的真 bug:PAT 两跳断链(发不到 npm)、re-gate 前坏 tip 被 tag(stranded)、stale 队列 run 的 double-publish、复用 tag 指向错 commit(发错代码)。`install-global.mjs` 由 Codex 实现、Claude review + 独立 reviewer 复核。

🤖 Generated with [Claude Code](https://claude.com/claude-code)