### PR TITLE
feat: integration-test → master — multi-pair + P0a–P5 reliability hardening (12-round cross-review)

### DIFF
--- a/.agentbridge/collaboration.md
+++ b/.agentbridge/collaboration.md
@@ -1,0 +1,22 @@
+# Collaboration Rules
+
+## Roles
+- Claude: Reviewer, Planner, Hypothesis Challenger
+- Codex: Implementer, Executor, Reproducer/Verifier
+
+## Thinking Patterns
+- Analytical/review tasks: Independent Analysis & Convergence
+- Implementation tasks: Architect -> Builder -> Critic
+- Debugging tasks: Hypothesis -> Experiment -> Interpretation
+
+## Communication
+- Use explicit phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:"
+- Tag messages with [IMPORTANT], [STATUS], or [FYI]
+
+## Review Process
+- Cross-review: author never reviews their own code
+- All changes go through feature/fix branches + PR
+- Merge via squash merge
+
+## Custom Rules
+<!-- Add your project-specific collaboration rules here -->

--- a/.agentbridge/config.json
+++ b/.agentbridge/config.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "daemon": {
+    "port": 4500,
+    "proxyPort": 4501
+  },
+  "agents": {
+    "claude": {
+      "role": "Reviewer, Planner",
+      "mode": "push"
+    },
+    "codex": {
+      "role": "Implementer, Executor"
+    }
+  },
+  "markers": [
+    "IMPORTANT",
+    "STATUS",
+    "FYI"
+  ],
+  "turnCoordination": {
+    "attentionWindowSeconds": 15,
+    "busyGuard": true
+  },
+  "idleShutdownSeconds": 30
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "code-review-graph": {
+      "command": "uvx",
+      "args": [
+        "code-review-graph",
+        "serve"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,38 @@
+<!-- code-review-graph MCP tools -->
+## MCP Tools: code-review-graph
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+|------|----------|
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,9 +11,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Fail loudly if RELEASE_PAT is missing: a release created with GITHUB_TOKEN
+      # does NOT trigger publish.yml (GitHub recursion guard), which would strand
+      # a GitHub release with no npm publish. Better to stop with a clear message.
+      - name: Require RELEASE_PAT
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "::error::RELEASE_PAT secret is required: releases created with GITHUB_TOKEN do not trigger publish.yml, so npm publish would never run. Add a fine-grained PAT with contents:write as RELEASE_PAT. See docs/RELEASING.md."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Read version from package.json
         id: version
@@ -22,10 +35,17 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Check if tag already exists
+      - name: Check if the RELEASE already exists
         id: check
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          # Gate on the GitHub RELEASE, not just the tag. publish.yml fires on
+          # `release: published`, so a tag without a release means npm was never
+          # published. If a prior run pushed the tag but failed before creating
+          # the release, we MUST be able to recover on re-run — which only works
+          # if "exists" reflects the release, not the tag.
+          if gh release view "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -34,11 +54,29 @@ jobs:
       - name: Create tag and release
         if: steps.check.outputs.exists == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (required above) so the published release TRIGGERS publish.yml.
+          # Releases created with GITHUB_TOKEN do not start new workflow runs
+          # (GitHub recursion guard), which would strand the release without an
+          # npm publish. See docs/RELEASING.md.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-          git tag "$TAG"
-          git push origin "$TAG"
+          # Idempotent + safe. The tag may already exist from a prior partial run
+          # that pushed it but failed before creating the release. Reuse it ONLY
+          # if it points at THIS commit — a tag on a different commit would make
+          # `gh release create` (and then publish.yml) ship the WRONG code. Fail
+          # loudly on a mismatch instead of publishing the wrong commit.
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            TAG_SHA="$(git rev-parse "${TAG}^{commit}")"
+            HEAD_SHA="$(git rev-parse HEAD)"
+            if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+              echo "::error::Tag ${TAG} already exists at ${TAG_SHA} but this release is for ${HEAD_SHA}; refusing to publish a mismatched commit. Delete the stray tag or bump to a new version."
+              exit 1
+            fi
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
 
           # Generate changelog from commits since last tag
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,9 @@ jobs:
 
       - name: Run full check
         run: bun run check
+
+      - name: Release smoke (built CLI artifacts)
+        run: bun run smoke:built
+
+      - name: Release smoke (npm pack completeness)
+        run: bun run smoke:pack

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Type check
-        run: bun run typecheck
-
-      - name: Run tests
-        run: bun test src
+      # Final integrity gate before publishing: typecheck + full test suite +
+      # plugin-bundle sync + version alignment. Never publish a build that can't
+      # pass `bun run check`. (When #90's release-form smoke lands, add
+      # `bun run smoke:built` + `bun run smoke:pack` here too.)
+      - name: Check (typecheck + tests + plugin sync + version align)
+        run: bun run check
 
       - name: Build
         run: bun run prepublishOnly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Build
         run: bun run prepublishOnly
 
+      - name: Release smoke (built CLI artifacts) — blocks publish if the package can't start a daemon
+        # --skip-build: reuse the exact dist/ from the Build step above (the bytes
+        # that will be published) instead of rebuilding.
+        run: bun scripts/smoke-built-cli.mjs --skip-build
+
+      - name: Release smoke (npm pack completeness) — blocks publish if a shipped artifact is missing
+        run: bun run smoke:pack
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,0 +1,134 @@
+name: Release on merge
+
+# Auto-publish cadence (user-chosen): every code merge to master is gated by the
+# full `bun run check` and, if green, bumps the patch version (synced across
+# package.json / plugin.json / marketplace.json). That version-bump commit then
+# drives the existing auto-release.yml -> publish.yml chain to publish to npm.
+#
+# IMPORTANT — requires a push token that re-triggers workflows:
+#   Pushes made with the default GITHUB_TOKEN do NOT trigger other workflows
+#   (GitHub's recursion guard), so the bump commit would never reach
+#   auto-release.yml. Set a repo secret RELEASE_PAT (a fine-grained PAT with
+#   `contents: write`) so the bump push fires auto-release -> publish. Without it
+#   the push still succeeds but the publish chain will not run.
+#   The same PAT must be allowed to push to master if branch protection is on.
+#
+# Loop/double-publish guards:
+#   - skip the bot's own `chore(release):` bump commit and any `[skip release]`
+#     commit (docs/chore), and pushes by github-actions[bot];
+#   - skip if the triggering push ALREADY changed the version (a manual bump or
+#     the existing release flow) — let that flow publish instead of double-bumping.
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-on-merge
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: >-
+      !startsWith(github.event.head_commit.message, 'chore(release):') &&
+      !contains(github.event.head_commit.message, '[skip release]') &&
+      github.actor != 'github-actions[bot]'
+    steps:
+      # Fail loudly if RELEASE_PAT is missing. A GITHUB_TOKEN fallback would push
+      # a bump commit that never triggers auto-release -> publish (GitHub
+      # recursion guard), stranding an un-published version bump. Better to stop
+      # before bumping with a clear message.
+      - name: Require RELEASE_PAT
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "::error::RELEASE_PAT secret is required for auto-publish-on-merge."
+            echo "::error::Pushes/releases made with GITHUB_TOKEN do not trigger the auto-release -> publish chain, so a bump would never reach npm. Add a fine-grained PAT with contents:write as the RELEASE_PAT secret. See docs/RELEASING.md."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # PAT (required above) so the bump push re-triggers auto-release.yml.
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Skip if this push already bumped the version
+        id: guard
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          CUR=$(node -p "require('./package.json').version")
+          # Compare against the branch tip BEFORE this push (github.event.before),
+          # not HEAD^ — covers multi-commit / rebase pushes where the version
+          # change may not be the immediately-preceding commit.
+          PREV=$(git show "$BEFORE_SHA:package.json" 2>/dev/null | node -p "try{JSON.parse(require('fs').readFileSync(0,'utf-8')).version}catch{''}" 2>/dev/null || echo "")
+          if [ -n "$PREV" ] && [ "$PREV" != "$CUR" ]; then
+            echo "Version already changed in this push ($PREV -> $CUR); the existing release flow will publish. Skipping auto-bump."
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "bump=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate, bump, commit, and push the release (race-safe)
+        if: steps.guard.outputs.bump == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Version this run STARTED from (the triggering commit's version).
+          INITIAL_VERSION="$(node -p "require('./package.json').version")"
+          # A concurrent human merge can either (a) edit package.json near the
+          # version line (so a rebase of our bump would CONFLICT) or (b) land
+          # between our fetch and push (non-fast-forward). On any push failure we
+          # discard our local bump, hard-reset to the latest origin/master, and
+          # retry from that new tip.
+          #
+          # CRITICAL: the integrity gate (bun install + bun run check) runs INSIDE
+          # the loop, on whatever tip we are about to bump+publish — never on a
+          # stale pre-reset tip. Otherwise a broken merge that landed during this
+          # job could be reset onto, bumped, and tagged/released before publish.yml
+          # rejects it, stranding a GitHub release/tag with no npm publish. Gating
+          # the candidate tip here guarantees we only ever tag a build that passes.
+          # (Once #90's release-form smoke lands, add smoke:built/smoke:pack here.)
+          for attempt in 1 2 3; do
+            # If the tip's version already differs from this run's starting
+            # version, another run (auto-bump OR a manual version bump with any
+            # commit message) already advanced and published past our base — our
+            # code is in that release. Exit cleanly instead of bumping a
+            # content-less version. (Version-compare, not commit-message match,
+            # so it also catches manual bumps. The bump only ever increases the
+            # version, so any difference means "already advanced".)
+            TIP_VERSION="$(node -p "require('./package.json').version")"
+            if [ "$TIP_VERSION" != "$INITIAL_VERSION" ]; then
+              echo "Version already advanced (${INITIAL_VERSION} -> ${TIP_VERSION}) since this run started; nothing to publish."
+              exit 0
+            fi
+            bun install --frozen-lockfile
+            bun run check
+            NEW="$(node scripts/bump-version.mjs patch)"
+            git add package.json \
+              plugins/agentbridge/.claude-plugin/plugin.json \
+              .claude-plugin/marketplace.json
+            git commit -m "chore(release): v${NEW}"
+            if git push origin HEAD:master; then
+              echo "Released v${NEW} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "push rejected (attempt ${attempt}); syncing to latest origin/master and retrying"
+            git fetch origin master
+            git reset --hard origin/master
+          done
+          echo "::error::release-on-merge could not push the version bump after 3 attempts"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ agentbridge-context.md
 V1_PROGRESS.md
 # Added by code-review-graph
 .code-review-graph/
+
+# Runtime E2E artifacts and python cache
+artifacts/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ agent_collab/
 codex-plugin-cc/
 /.mcp.json
 agentbridge-context.md
+.agentbridge/
 V1_PROGRESS.md
 # Added by code-review-graph
 .code-review-graph/

--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "code-review-graph": {
+      "command": "uvx",
+      "args": [
+        "code-review-graph",
+        "serve"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/.kiro/steering/code-review-graph.md
+++ b/.kiro/steering/code-review-graph.md
@@ -1,0 +1,38 @@
+<!-- code-review-graph MCP tools -->
+## MCP Tools: code-review-graph
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+|------|----------|
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.

--- a/.opencode.json
+++ b/.opencode.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "code-review-graph": {
+      "command": "uvx",
+      "args": [
+        "code-review-graph",
+        "serve"
+      ],
+      "type": "stdio",
+      "env": []
+    }
+  }
+}

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,38 @@
+<!-- code-review-graph MCP tools -->
+## MCP Tools: code-review-graph
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+|------|----------|
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+<!-- AgentBridge:start -->
+## AgentBridge — Multi-Agent Collaboration
+
+You are working in a **multi-agent environment** powered by AgentBridge.
+Another AI agent (Claude, by Anthropic) is available in a parallel session on this machine.
+Communication happens via AgentBridge MCP tools — Claude has `reply` and `get_messages` tools.
+
+### When to collaborate vs. work solo
+- **Collaborate** when the task benefits from a second perspective, parallel execution, or capabilities the other agent has.
+- **Work solo** for simple, self-contained tasks where the coordination overhead isn't worth it.
+- When in doubt, **propose a task split** to Claude rather than doing everything yourself.
+
+### Capability comparison
+| Capability | Codex (you) | Claude |
+|---|---|---|
+| Sandboxed code execution | Yes | No |
+| Reproduce & verify bugs | Strong | Limited |
+| Architecture & planning | Moderate | Strong |
+| Code review & analysis | Strong | Strong |
+| Web search & docs | Limited | Yes |
+| File editing & refactoring | Yes (via sandbox) | Yes (via tools) |
+
+### How to start collaborating
+1. When you receive a complex task, **proactively propose a division of labor**.
+2. State what you'll handle and what you'd like Claude to take on.
+3. Ask for Claude's agreement or counter-proposal before proceeding.
+4. After task completion, **cross-review** each other's work.
+<!-- AgentBridge:end -->
+
+<!-- code-review-graph MCP tools -->
+## MCP Tools: code-review-graph
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+|------|----------|
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## 语言 / Language
+
+- **强制使用中文回复**（用户明确要求 / 强制项目级规则）。所有面向用户的输出（解释、报告、问答、plan、commit message 中的中文部分、issue / report）使用中文。
+- 代码内的注释、变量名、提交信息中的英文部分、日志保持英文（与项目既有约定一致）。
+- 涉及给用户读的内容（README、用户文档、终端说明）必须中文优先。
+- 若用户用英文提问，仍**用中文回复**（除非他明确要求英文）。
+
 ## Commands
 
 Runtime is **Bun** — do not change the local Bun version.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,38 @@
+<!-- code-review-graph MCP tools -->
+## MCP Tools: code-review-graph
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+|------|----------|
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ agent_bridge/
 | `CODEX_PROXY_PORT` | `4501` | Bridge proxy port for the Codex TUI |
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | Control port between bridge.ts and daemon.ts |
 | `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | Maximum wait for incumbent Claude pong before evicting on contention (issue #68) |
+| `AGENTBRIDGE_TURN_WATCHDOG_MS` | `300000` | Per-turn inactivity watchdog: force-completes a turn after this many ms of app-server silence so a lost `turn/completed` can't lock injection forever (issue #69) |
+| `AGENTBRIDGE_CODEX_TRANSPORT` | `auto` | How the daemon reaches the Codex app-server: `auto` (probe `codex app-server --help`, use `ws://` if supported else fall back to a `unix://` socket via a transparent relay), `ws` (force ws), or `unix` (force unix socket + relay). For builds that drop `ws://` listen support (issue #85) |
 | `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
 | `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |

--- a/README.md
+++ b/README.md
@@ -254,6 +254,21 @@ agent_bridge/
 | `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
 | `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |
+| `NO_UPDATE_NOTIFIER` | unset | Set to any value to disable the "update available" notice (ecosystem-standard opt-out) |
+| `AGENTBRIDGE_NO_UPDATE_NOTIFIER` | unset | Namespaced opt-out for the update notice (same effect as `NO_UPDATE_NOTIFIER`) |
+| `AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS` | `86400000` | How often `abg claude`/`abg codex` may check npm for a newer version (default once/day). The notice is otherwise printed from cache — zero network on most runs |
+
+### Update notifications
+
+`abg claude` and `abg codex` print a one-line notice to stderr when a newer **stable** AgentBridge is published to npm, e.g.:
+
+```
+⚠ AgentBridge update available: 0.1.6 → 0.1.7
+  CLI:    npm install -g @raysonmeng/agentbridge@latest
+  Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)
+```
+
+The check is best-effort and never blocks, delays, or fails your command: the notice is printed from a cached result, the npm check runs at most once per day in the background, and any network/registry failure is silently ignored. It is suppressed automatically for non-interactive (piped) output and in CI, and can be disabled with `NO_UPDATE_NOTIFIER=1`. The notifier never installs anything — it only shows you the command.
 
 ### State Directory
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ agent_bridge/
 | `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
 | `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |
+| `NO_UPDATE_NOTIFIER` | unset | Set to any value to disable the "update available" notice (ecosystem-standard opt-out) |
+| `AGENTBRIDGE_NO_UPDATE_NOTIFIER` | unset | Namespaced opt-out for the update notice (same effect as `NO_UPDATE_NOTIFIER`) |
+| `AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS` | `86400000` | How often `abg claude`/`abg codex` may check npm for a newer version (default once/day). The notice is otherwise printed from cache — zero network on most runs |
+
+### Update notifications
+
+`abg claude` and `abg codex` print a one-line notice to stderr when a newer **stable** AgentBridge is published to npm, e.g.:
+
+```
+⚠ AgentBridge update available: 0.1.6 → 0.1.7
+  CLI:    npm install -g @raysonmeng/agentbridge@latest
+  Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)
+```
+
+The check is best-effort and never blocks, delays, or fails your command: the notice is printed from a cached result, the npm check runs at most once per day in the background, and any network/registry failure is silently ignored. It is suppressed automatically for non-interactive (piped) output and in CI, and can be disabled with `NO_UPDATE_NOTIFIER=1`. The notifier never installs anything — it only shows you the command.
 
 ### State Directory
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ agent_bridge/
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | Control port between bridge.ts and daemon.ts |
 | `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | Maximum wait for incumbent Claude pong before evicting on contention (issue #68) |
 | `AGENTBRIDGE_TURN_WATCHDOG_MS` | `300000` | Per-turn inactivity watchdog: force-completes a turn after this many ms of app-server silence so a lost `turn/completed` can't lock injection forever (issue #69) |
+| `AGENTBRIDGE_CODEX_TRANSPORT` | `auto` | How the daemon reaches the Codex app-server: `auto` (probe `codex app-server --help`, use `ws://` if supported else fall back to a `unix://` socket via a transparent relay), `ws` (force ws), or `unix` (force unix socket + relay). For builds that drop `ws://` listen support (issue #85) |
 | `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
 | `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ agent_bridge/
 | `CODEX_PROXY_PORT` | `4501` | Bridge proxy port for the Codex TUI |
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | Control port between bridge.ts and daemon.ts |
 | `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | Maximum wait for incumbent Claude pong before evicting on contention (issue #68) |
+| `AGENTBRIDGE_TURN_WATCHDOG_MS` | `300000` | Per-turn inactivity watchdog: force-completes a turn after this many ms of app-server silence so a lost `turn/completed` can't lock injection forever (issue #69) |
 | `AGENTBRIDGE_STATE_DIR` | Platform default | State directory for pid, status, logs (macOS: `~/Library/Application Support/agentbridge/`, Linux: `$XDG_STATE_HOME/agentbridge/`) |
 | `AGENTBRIDGE_MODE` | `push` | Message delivery mode (`push` for channels, `pull` for API key mode) |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -248,6 +248,7 @@ agent_bridge/
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | bridge.ts 与 daemon.ts 之间的控制端口 |
 | `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | 等待在位 Claude pong 的最长时间，超时后在争用时驱逐（issue #68） |
 | `AGENTBRIDGE_TURN_WATCHDOG_MS` | `300000` | 单 turn 非活动看门狗：app-server 静默超过该毫秒数后强制完成该 turn，避免丢失 `turn/completed` 永久锁死注入（issue #69） |
+| `AGENTBRIDGE_CODEX_TRANSPORT` | `auto` | daemon 连接 Codex app-server 的方式：`auto`（探测 `codex app-server --help`，支持 `ws://` 则用 ws，否则经透明中继回退到 `unix://` socket）、`ws`（强制 ws）、`unix`（强制 unix socket + 中继）。用于去掉 `ws://` listen 支持的 Codex 版本（issue #85） |
 | `AGENTBRIDGE_STATE_DIR` | 平台默认 | 状态目录（pid、status、日志）。macOS: `~/Library/Application Support/agentbridge/`，Linux: `$XDG_STATE_HOME/agentbridge/` |
 | `AGENTBRIDGE_MODE` | `push` | 消息投递模式（`push` 用于 channel，`pull` 用于 API key 模式） |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,6 +250,21 @@ agent_bridge/
 | `AGENTBRIDGE_STATE_DIR` | 平台默认 | 状态目录（pid、status、日志）。macOS: `~/Library/Application Support/agentbridge/`，Linux: `$XDG_STATE_HOME/agentbridge/` |
 | `AGENTBRIDGE_MODE` | `push` | 消息投递模式（`push` 用于 channel，`pull` 用于 API key 模式） |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |
+| `NO_UPDATE_NOTIFIER` | 未设置 | 设为任意值即关闭「有新版本」提示（生态通用 opt-out） |
+| `AGENTBRIDGE_NO_UPDATE_NOTIFIER` | 未设置 | 命名空间化的关闭开关（效果同 `NO_UPDATE_NOTIFIER`） |
+| `AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS` | `86400000` | `abg claude`/`abg codex` 多久查一次 npm 新版本（默认每天一次）。其余时候只读缓存打印，大多数调用零网络 |
+
+### 更新提示
+
+`abg claude` 和 `abg codex` 在 npm 上有更新的**稳定**版本时,会向 stderr 打印一行提示,例如:
+
+```
+⚠ AgentBridge update available: 0.1.6 → 0.1.7
+  CLI:    npm install -g @raysonmeng/agentbridge@latest
+  Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)
+```
+
+该检查是 best-effort,绝不阻塞/拖慢/弄坏你的命令:提示从缓存打印,npm 检查每天最多在后台跑一次,任何网络/registry 失败都静默忽略。非交互(管道)输出和 CI 下自动抑制,可用 `NO_UPDATE_NOTIFIER=1` 关闭。notifier 永远不会自动安装任何东西——只告诉你升级命令。
 
 ### 状态目录
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -247,6 +247,7 @@ agent_bridge/
 | `CODEX_PROXY_PORT` | `4501` | Bridge 代理端口，Codex TUI 连接此端口 |
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | bridge.ts 与 daemon.ts 之间的控制端口 |
 | `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | 等待在位 Claude pong 的最长时间，超时后在争用时驱逐（issue #68） |
+| `AGENTBRIDGE_TURN_WATCHDOG_MS` | `300000` | 单 turn 非活动看门狗：app-server 静默超过该毫秒数后强制完成该 turn，避免丢失 `turn/completed` 永久锁死注入（issue #69） |
 | `AGENTBRIDGE_STATE_DIR` | 平台默认 | 状态目录（pid、status、日志）。macOS: `~/Library/Application Support/agentbridge/`，Linux: `$XDG_STATE_HOME/agentbridge/` |
 | `AGENTBRIDGE_MODE` | `push` | 消息投递模式（`push` 用于 channel，`pull` 用于 API key 模式） |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -252,6 +252,21 @@ agent_bridge/
 | `AGENTBRIDGE_STATE_DIR` | 平台默认 | 状态目录（pid、status、日志）。macOS: `~/Library/Application Support/agentbridge/`，Linux: `$XDG_STATE_HOME/agentbridge/` |
 | `AGENTBRIDGE_MODE` | `push` | 消息投递模式（`push` 用于 channel，`pull` 用于 API key 模式） |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |
+| `NO_UPDATE_NOTIFIER` | 未设置 | 设为任意值即关闭「有新版本」提示（生态通用 opt-out） |
+| `AGENTBRIDGE_NO_UPDATE_NOTIFIER` | 未设置 | 命名空间化的关闭开关（效果同 `NO_UPDATE_NOTIFIER`） |
+| `AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS` | `86400000` | `abg claude`/`abg codex` 多久查一次 npm 新版本（默认每天一次）。其余时候只读缓存打印，大多数调用零网络 |
+
+### 更新提示
+
+`abg claude` 和 `abg codex` 在 npm 上有更新的**稳定**版本时,会向 stderr 打印一行提示,例如:
+
+```
+⚠ AgentBridge update available: 0.1.6 → 0.1.7
+  CLI:    npm install -g @raysonmeng/agentbridge@latest
+  Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)
+```
+
+该检查是 best-effort,绝不阻塞/拖慢/弄坏你的命令:提示从缓存打印,npm 检查每天最多在后台跑一次,任何网络/registry 失败都静默忽略。非交互(管道)输出和 CI 下自动抑制,可用 `NO_UPDATE_NOTIFIER=1` 关闭。notifier 永远不会自动安装任何东西——只告诉你升级命令。
 
 ### 状态目录
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -247,6 +247,8 @@ agent_bridge/
 | `CODEX_PROXY_PORT` | `4501` | Bridge 代理端口，Codex TUI 连接此端口 |
 | `AGENTBRIDGE_CONTROL_PORT` | `4502` | bridge.ts 与 daemon.ts 之间的控制端口 |
 | `AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS` | `3000` | 等待在位 Claude pong 的最长时间，超时后在争用时驱逐（issue #68） |
+| `AGENTBRIDGE_TURN_WATCHDOG_MS` | `300000` | 单 turn 非活动看门狗：app-server 静默超过该毫秒数后强制完成该 turn，避免丢失 `turn/completed` 永久锁死注入（issue #69） |
+| `AGENTBRIDGE_CODEX_TRANSPORT` | `auto` | daemon 连接 Codex app-server 的方式：`auto`（探测 `codex app-server --help`，支持 `ws://` 则用 ws，否则经透明中继回退到 `unix://` socket）、`ws`（强制 ws）、`unix`（强制 unix socket + 中继）。用于去掉 `ws://` listen 支持的 Codex 版本（issue #85） |
 | `AGENTBRIDGE_STATE_DIR` | 平台默认 | 状态目录（pid、status、日志）。macOS: `~/Library/Application Support/agentbridge/`，Linux: `$XDG_STATE_HOME/agentbridge/` |
 | `AGENTBRIDGE_MODE` | `push` | 消息投递模式（`push` 用于 channel，`pull` 用于 API key 模式） |
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,139 @@
+# Releasing AgentBridge / 发布流程
+
+AgentBridge auto-publishes to npm on every code merge to `master`, so the
+update-notifier always has a fresh, gated source. Every published version is
+gated by `bun run check` — we never publish a build that can't pass.
+
+AgentBridge 在每次代码合并到 `master` 时自动发布到 npm,让 update-notifier 始终有一个
+最新、经门禁把关的源。每个发布版本都被 `bun run check` 卡住——绝不发布无法通过检查的构建。
+
+## Pipeline / 管线
+
+```
+merge code PR to master
+        │
+        ▼
+release-on-merge.yml   ── gate: bun run check ──▶ (fail → no release)
+        │  (pass)
+        ▼
+bump patch in package.json + plugin.json + marketplace.json  (synced)
+        │
+        ▼  commit "chore(release): vX.Y.Z", push to master  (needs RELEASE_PAT)
+        ▼
+auto-release.yml       ── tag vX.Y.Z + GitHub release ──▶
+        │
+        ▼
+publish.yml            ── gate: bun run check → build → npm publish
+```
+
+- **`.github/workflows/release-on-merge.yml`** — on each push to `master`, runs
+  the full check and, if green, patch-bumps the version (synced across all three
+  manifests via `scripts/bump-version.mjs`) and pushes a `chore(release): vX.Y.Z`
+  commit.
+- **`.github/workflows/auto-release.yml`** — on a `package.json` version change,
+  creates the `vX.Y.Z` tag and GitHub release.
+- **`.github/workflows/publish.yml`** — on a published release, runs `bun run
+  check` again (final gate), builds, and `npm publish`es.
+
+## Required setup / 必需配置
+
+1. **`RELEASE_PAT` repo secret** — a fine-grained Personal Access Token with
+   `contents: write`. Used at **both** hops of the chain, because pushes/releases
+   made with the default `GITHUB_TOKEN` do **not** trigger other workflows
+   (GitHub's recursion guard):
+   - `release-on-merge.yml` pushes the bump commit with `RELEASE_PAT` → triggers
+     `auto-release.yml`. It **fails loudly** if `RELEASE_PAT` is missing (rather
+     than push an un-publishable bump with `GITHUB_TOKEN`).
+   - `auto-release.yml` creates the GitHub release with `RELEASE_PAT` → triggers
+     `publish.yml`. With only `GITHUB_TOKEN` the release would be created but
+     `npm publish` would never run.
+   必须配置 `RELEASE_PAT`(细粒度 PAT,`contents: write`),发布链的**两跳都用它**:
+   release-on-merge 推 bump commit、auto-release 建 release,都需要 PAT 才能触发下一跳
+   (默认 `GITHUB_TOKEN` 推送/建 release 不触发其它 workflow)。缺 PAT 时 release-on-merge
+   直接 fail,不会产生发不出去的版本 bump。
+2. **`NPM_TOKEN` repo secret** — for `npm publish` (already used by publish.yml).
+3. **Branch protection** — if `master` is protected, allow the PAT identity to push
+   (the `chore(release):` bump commit). 若 `master` 受保护,需允许该 PAT 推送 bump commit。
+
+## Skip / opt-out / 跳过
+
+- Put `[skip release]` in a commit message to skip the auto-bump (use for
+  docs-only / chore commits that should not produce a new npm version).
+  提交信息含 `[skip release]` 即跳过自动 bump(用于纯文档/杂务提交)。
+- `chore(release):` commits (the bot's own bumps) and `github-actions[bot]` pushes
+  are skipped automatically (loop guard).
+- If the triggering push already changed the version (a manual bump), the
+  auto-bump is skipped and the existing release flow publishes instead — no
+  double bump.
+
+## Manual release / 手动发布
+
+If you need to cut a release by hand (e.g. a coordinated minor/major bump):
+
+```bash
+bun run release:bump minor    # or patch | major — syncs all three manifests
+git commit -am "chore(release): v$(node -p "require('./package.json').version")"
+git push origin master        # triggers auto-release.yml -> publish.yml
+```
+
+## Artifact integrity / 产物可用性
+
+`bun run check` (typecheck + full test suite + plugin-bundle sync + version
+alignment) gates BOTH the bump and the publish, so a broken build can never be
+released. A stronger **release-form smoke** — launching the built `dist/cli.js`
+daemon and verifying `npm pack` completeness (`smoke:built` / `smoke:pack`) —
+lands with PR #90; once merged, add those as extra gate steps in
+`release-on-merge.yml` and `publish.yml`.
+
+`bun run check` 同时卡住 bump 和 publish,坏构建永远发不出去。更强的**发布形态 smoke**
+(真启打包 daemon + 查 npm 包完整性)随 PR #90 合入,届时把它们加进两处门禁。
+
+## Concurrency & limitations / 并发与已知限制
+
+- `release-on-merge.yml` uses a `concurrency` group so only one release runs at a
+  time. Pushing the bump is wrapped in a **retry loop**: on any push failure
+  (non-fast-forward, or a rebase conflict because a concurrent merge edited
+  `package.json` near the version line) it hard-resets to the latest
+  `origin/master` and recomputes the bump from that tip, up to 3 attempts. So a
+  concurrent human merge does not silently drop a release.
+- Edge case: with several merges in quick succession, a later merge's code may be
+  published under the FIRST run's version (it's already on master), and its own
+  run then skips bumping (version already changed). Nothing is lost — the code is
+  on `master` and ships in that release or the next bump. This is acceptable for a
+  patch-on-every-merge cadence; switch to a manual/batched release if you need one
+  npm version per PR exactly.
+  推送 bump 带 3 次重试:任何推送失败(非快进 / 并发改动 package.json 版本行附近导致 rebase
+  冲突)都会硬重置到最新 origin/master 并重算 bump,所以并发合并不会悄悄丢掉发布。
+  快速连续合并时,后一个 PR 的代码可能跟随前一次 run 的版本一起发布(不会丢失,代码已在 master),
+  只是版本归属可能合并。需要"每个 PR 精确一个 npm 版本"时改用手动/批量发布。
+
+## Installing a build globally (dogfooding) / 本地全局安装
+
+To replace the globally-installed `agentbridge`/`abg` CLI for testing:
+
+```bash
+bun run install:global:local   # build THIS checkout, pack it, then fully replace the global install
+bun run install:global:npm     # replace the global install with the npm `latest`
+```
+
+(`install:global` is an alias for `install:global:local`.) Both fully replace the
+global package, so afterward `npm install -g @raysonmeng/agentbridge@latest`
+cleanly overrides whatever you installed — there is no leftover `bun link` symlink
+to conflict with.
+
+The CLI and the Claude Code **plugin** are separate installs. `install:global:*`
+updates the CLI; the npm `postinstall` best-effort registers/installs the plugin,
+but an already-installed plugin cache and an active Claude session are NOT
+force-refreshed. To make the plugin match your source and reload it:
+
+```bash
+bun run install:global:local
+bun src/cli.ts dev        # build + sync the plugin from THIS checkout into Claude Code
+# then in Claude Code:
+/plugin marketplace update agentbridge   # (if installed via marketplace)
+/reload-plugins
+```
+
+> Run `bun src/cli.ts dev` (from the source checkout) rather than the globally
+> installed `agentbridge dev`, so the plugin is synced from your working tree, not
+> the global npm package dir.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -121,10 +121,51 @@ global package, so afterward `npm install -g @raysonmeng/agentbridge@latest`
 cleanly overrides whatever you installed — there is no leftover `bun link` symlink
 to conflict with.
 
+Both install modes (via `scripts/install-global.mjs`) first stop registered
+AgentBridge daemons and managed Codex TUIs directly (`install-safety.cjs
+stop-running`) using a scrubbed install environment, then replace the package.
+Local installs also rebuild `dist/` and plugin bundles, verify required
+artifacts on disk, pack a tarball, and verify the tarball before installing it.
+Use `node scripts/install-global.mjs local --dry-run` to inspect the sequence
+without stopping anything.
+
+### What stops running daemons (and what doesn't) / 谁会停掉运行中的 daemon
+
+Stopping all running AgentBridge daemons/TUIs is destructive, so it is **not**
+triggered by arbitrary installs. There are exactly two paths that stop them:
+
+1. **The intentional installer** — `scripts/install-global.mjs` (`bun run
+   install:global:*`) calls `install-safety.cjs stop-running` directly, in both
+   `local` and `npm` modes.
+2. **An explicit global self-install via npm `postinstall`** — `scripts/postinstall.cjs`
+   stops running daemons **only** when it detects an explicit global signal:
+   - `npm_config_global=true` (i.e. `npm install -g …`), or
+   - `npm_config_location=global`, or
+   - `AGENTBRIDGE_POSTINSTALL_STOP=1` (force override).
+
+   `AGENTBRIDGE_POSTINSTALL_STOP=0` forces the opposite (never stop), taking
+   precedence over the global signals.
+
+Crucially, **arbitrary `.tgz` / transitive-dependency installs do NOT stop
+running daemons** — a non-global `npm install`, or AgentBridge being pulled in as
+someone else's dependency, leaves every running pair untouched (postinstall logs
+a note pointing at `abg kill --all` / install-global). Stop-the-world is reserved
+for the two intentional paths above.
+
+停掉所有运行中的 daemon/TUI 是破坏性操作,因此**不会**被任意安装触发。只有两条路径会停:
+(1) **有意安装器** `scripts/install-global.mjs`(`bun run install:global:*`)在 `local` 与
+`npm` 两种模式下都直接调用 `install-safety.cjs stop-running`;(2) **经 npm `postinstall`
+的显式全局自安装**——`scripts/postinstall.cjs` 仅在检测到显式全局信号时才停
+(`npm_config_global=true` / `npm_config_location=global` / `AGENTBRIDGE_POSTINSTALL_STOP=1`;
+`AGENTBRIDGE_POSTINSTALL_STOP=0` 强制不停,优先级最高)。**任意 `.tgz` / 传递依赖安装
+不会停掉运行中的 daemon**——非全局 `npm install`、或被当作他人依赖拉入时,所有运行中的
+pair 都保持不动(postinstall 只打一条提示指向 `abg kill --all` / install-global)。
+
 The CLI and the Claude Code **plugin** are separate installs. `install:global:*`
 updates the CLI; the npm `postinstall` best-effort registers/installs the plugin,
-but an already-installed plugin cache and an active Claude session are NOT
-force-refreshed. To make the plugin match your source and reload it:
+but an active Claude Code session may still need a plugin reload or restart to
+pick up the newly installed plugin bundle. To make the plugin match your source
+and reload it:
 
 ```bash
 bun run install:global:local
@@ -137,3 +178,32 @@ bun src/cli.ts dev        # build + sync the plugin from THIS checkout into Clau
 > Run `bun src/cli.ts dev` (from the source checkout) rather than the globally
 > installed `agentbridge dev`, so the plugin is synced from your working tree, not
 > the global npm package dir.
+
+## Breaking changes / migration / 破坏性变更与迁移
+
+### `AGENTBRIDGE_MANUAL=1` now required for pinned-env classic single-pair mode
+
+**BREAKING (power users):** Previously, exporting a pinned `AGENTBRIDGE_STATE_DIR`
+and/or a pinned port (e.g. `AGENTBRIDGE_CONTROL_PORT`) **without** a `--pair` was
+enough to opt into classic single-pair mode — AgentBridge honored that pinned
+environment as-is.
+
+That is no longer true. With cwd-scoped pair resolution as the default, a pinned
+`AGENTBRIDGE_STATE_DIR` / port **without** `AGENTBRIDGE_MANUAL=1` is now treated as
+**stale** and **overwritten** by the cwd-derived pair (state dir + ports resolved
+from the current working directory). To keep the old behavior — i.e. force
+AgentBridge to use exactly the state dir / ports you pinned — you must now set:
+
+```bash
+export AGENTBRIDGE_MANUAL=1
+```
+
+explicitly, alongside your pinned `AGENTBRIDGE_STATE_DIR` / port env. Without it,
+your pins are ignored and cwd-scoped resolution wins.
+
+**迁移说明(破坏性,面向高级用户):** 以前只要导出固定的 `AGENTBRIDGE_STATE_DIR` 和/或
+固定端口(且**不带** `--pair`)就能进入经典单 pair 模式,AgentBridge 会原样沿用这些固定环境。
+现在不再如此:由于默认走 cwd 作用域的 pair 解析,**不带** `AGENTBRIDGE_MANUAL=1` 的固定
+`AGENTBRIDGE_STATE_DIR` / 端口会被视为**过期**并被 cwd 派生的 pair(按当前工作目录解析的
+state dir + 端口)**覆盖**。若想保留旧行为(强制使用你固定的 state dir / 端口),必须显式设置
+`export AGENTBRIDGE_MANUAL=1`,与固定环境变量一起使用;否则你的固定值会被忽略,cwd 作用域解析优先。

--- a/docs/design-codex-skill-integration.md
+++ b/docs/design-codex-skill-integration.md
@@ -1,0 +1,207 @@
+# Codex 原生 skill 集成设计
+
+> Status: draft
+> Author: Claude (起稿) / 待 Codex review
+> Date: 2026-04-24
+> Motivation: 解决 Codex 侧不理解"AgentBridge 透明代理机制"导致反复钻牛角尖找不存在的 reply API 的问题。
+
+## 1. 背景与问题
+
+今天协作时发现一个具体失败模式:Codex 为了给 Claude 发消息,花 1+ 分钟在 `daemon.js` 里搜索 `reply` / `sendStatus` / `claudeOnline` 等函数,试图找到"Codex 侧发消息给 Claude 的对称 API"。
+
+该 API **不存在**,这是 AgentBridge 的设计(codex-adapter 透明代理 agentMessage,Codex 只需正常输出即可)。但目前文档存在两个锅:
+
+1. `src/collaboration-content.ts` 里注入到 `AGENTS.md` 的内容只写 Claude 视角("Claude has reply and get_messages tools"),没写 Codex 视角的"你不用找工具"。
+2. 注入机制是**项目级**的 —— 每个项目都要跑 `abg init`,否则 Codex 完全没看到协作协议。即使项目级协议有,也会被淹没在几千字的项目 AGENTS.md 里。
+
+## 2. 参考:superpowers 的做法
+
+`~/repo/superpowers` 针对 Codex 的集成非常干净,值得抄:
+
+```
+~/.codex/superpowers/                        # git clone 的仓库
+~/.agents/skills/superpowers                 # 符号链接 → ~/.codex/superpowers/skills/
+```
+
+Codex TUI 启动时会**自动扫描 `~/.agents/skills/`**,读每个子目录的 `SKILL.md` frontmatter(`name` + `description`),按需触发。关键特征:
+
+- **入口 skill**:`using-superpowers/SKILL.md` 的 description 写成 "Use when starting ANY conversation" —— Codex 会话一开始就一定触发。
+- **跨 harness 复用**:skill 正文使用 Claude 的工具名(`Task` / `Skill` / `TodoWrite`),另配 `references/codex-tools.md` 做映射表(`Task → spawn_agent`,`TodoWrite → update_plan` 等)。
+- **安装极简**:`.codex/INSTALL.md` 只有 `git clone` + `ln -s` 两步,完全不改用户的 `AGENTS.md`。
+- **更新免重装**:`git pull` 即生效(symlink 永远活的)。
+
+## 3. 套到 AgentBridge 的设计
+
+### 3.1 目录结构(新增)
+
+```
+plugins/agentbridge/
+├── server/                         # 已有,不动
+├── .claude-plugin/                 # 已有,不动
+└── codex-skills/                   # 新增
+    └── agentbridge-collab/
+        ├── SKILL.md                # Codex 入口 skill
+        └── references/
+            ├── mechanism.md        # 透明代理机制详解
+            └── troubleshooting.md  # 常见误解 + 排查
+```
+
+### 3.2 安装位置
+
+```
+~/.agentbridge/codex-skills/agentbridge-collab/   # abg dev / abg init 写入
+~/.agents/skills/agentbridge-collab               # symlink → 上面
+```
+
+选 `~/.agentbridge/` 而不是 `~/.codex/agentbridge/`,因为:
+- AgentBridge 本身跨 harness(Claude + Codex),放在 `~/.codex/` 下语义不对。
+- `~/.agents/skills/` 是 Codex 认的,放哪里由 AgentBridge 自己定。
+
+### 3.3 `SKILL.md` 内容纲要
+
+```markdown
+---
+name: agentbridge-collab
+description: Use when AgentBridge daemon is detected (check ~/Library/Application Support/AgentBridge/daemon.pid or http://127.0.0.1:4502/healthz) — governs how to collaborate with the Claude agent running in parallel. MUST be consulted before searching code for any "send-message-to-Claude" API.
+---
+
+# AgentBridge Collaboration Protocol (Codex 视角)
+
+## 核心事实:Codex 侧无对称工具
+
+AgentBridge 是**透明代理**。你不需要调用任何工具来给 Claude 发消息。
+
+- 你正常输出回答 → codex-adapter 拦截你的 `agentMessage` 事件 → 自动转发到 Claude。
+- Claude 回复你 → AgentBridge 用 `turn/start` 把内容注入你当前 thread,像用户发了新一轮 turn。
+
+**不要**在 `daemon.js` / `bridge-server.js` / `codex-adapter.ts` 里搜索 "reply" / "sendStatus" / "send_to_claude" 之类的函数 —— 不存在。**唯一的工具调用发生在 Claude 侧**(`mcp__plugin_agentbridge_agentbridge__reply` 和 `get_messages`)。
+
+## 怎么用
+
+- 想给 Claude 发消息?**正常写回答就行**。
+- 想知道 Claude 是否在线?看 `http://127.0.0.1:4502/healthz` 的 `tuiConnected` 字段。
+- 看到 `⏳ Codex is working` 标志?别理,那是给 Claude 看的状态行。
+
+## 红旗 / 钻牛角尖信号
+
+如果你产生以下想法,**停**,你已经在钻牛角尖:
+- "让我查一下 daemon.js 里 Codex 是怎么给 Claude 发消息的"
+- "应该有个 sendMessageToClaude 函数我没找到"
+- "bridge 好像坏了,我得去 fix 代码"
+
+正确反应:直接写一段中文/英文文字作为你的回答,结束 turn。
+
+## 更多
+
+- 机制细节:`references/mechanism.md`
+- 常见误解排查:`references/troubleshooting.md`
+```
+
+### 3.4 `references/mechanism.md` 内容纲要
+
+- 画图说明 Claude ↔ AgentBridge ↔ Codex app-server 的数据流
+- 两端分别承担的职责
+- `agentMessage` 事件如何被拦截、`turn/start` 如何被注入
+- `tuiConnected` / `bridgeReady` / `queuedMessageCount` 字段含义
+
+### 3.5 `references/troubleshooting.md` 内容纲要
+
+- Claude 好像没回我:
+  - 检查 healthz `tuiConnected` 是 false → Claude 没上线,等待即可
+  - `queuedMessageCount > 0` → 消息已排队,Claude 会话未 attach
+- 我发的消息 Claude 收不到:
+  - 确认 daemon 在跑(4502 端口)
+  - 确认 bridge-server 在跑(Claude 侧)
+  - **不要**试图改 bridge 代码
+- "AgentBridge rejected this session":另一个 Claude 占着 bridge,跑 `agentbridge kill` 再重连
+
+### 3.6 CLI 改造
+
+`src/cli/init.ts` 和 `src/cli/dev.ts` 都要新增一步:
+
+```typescript
+async function installCodexSkill() {
+  const srcDir = resolveFromPluginRoot("codex-skills/agentbridge-collab");
+  const homeDir = process.env.HOME!;
+  const stagingDir = path.join(homeDir, ".agentbridge/codex-skills/agentbridge-collab");
+  const linkDir = path.join(homeDir, ".agents/skills/agentbridge-collab");
+
+  // 1. 把 skill 内容复制到用户目录(避免 plugin 根目录被改动时污染)
+  await fs.rm(stagingDir, { recursive: true, force: true });
+  await fs.cp(srcDir, stagingDir, { recursive: true });
+
+  // 2. 创建符号链接(幂等)
+  await fs.mkdir(path.dirname(linkDir), { recursive: true });
+  try {
+    await fs.symlink(stagingDir, linkDir, "dir");
+  } catch (err) {
+    if (err.code === "EEXIST") {
+      const current = await fs.readlink(linkDir).catch(() => null);
+      if (current !== stagingDir) {
+        await fs.rm(linkDir, { recursive: true, force: true });
+        await fs.symlink(stagingDir, linkDir, "dir");
+      }
+    } else throw err;
+  }
+}
+```
+
+`abg init` 运行结束后应该打印:
+```
+✓ Claude plugin installed
+✓ Codex skill linked → ~/.agents/skills/agentbridge-collab
+  (restart any running Codex TUI for it to take effect)
+```
+
+### 3.7 `abg kill` / `abg uninstall` 对应
+
+`agentbridge kill` 不动 skill(只停 daemon)。新增一个 `agentbridge uninstall`(或给 `kill` 加 `--purge` flag):
+
+```bash
+agentbridge uninstall
+# → 删除 ~/.agents/skills/agentbridge-collab symlink
+# → 删除 ~/.agentbridge/codex-skills/
+# → 停止 daemon,清 killed sentinel
+```
+
+## 4. 与现有 AGENTS.md 注入的关系
+
+**保留注入,叠加 skill 方案。**
+
+| 机制 | 角色 |
+|---|---|
+| `~/.agents/skills/agentbridge-collab` (新) | 主渠道。Codex 启动期自动触发,优先级最高,不被项目内容淹没。 |
+| `AGENTS.md` 注入 (现有) | 兜底。给不支持 skill 发现的老版 Codex / 其他 agent / IDE 用。 |
+| `CLAUDE.md` 注入 (现有) | 仍然保留。Claude 侧的协作约束继续通过项目文档表达。 |
+
+`collaboration-content.ts` 里的 `AGENTS_MD_SECTION` 也要同步修正(补 "Codex 侧透明代理" 一段),这是本次必做的文档修复。
+
+## 5. 非目标 / 后续项
+
+- 本设计**不涉及** Codex MCP server 注册 —— 那是另一个方向(让 Codex 能调用 AgentBridge 暴露的 MCP 工具),可以作为 phase 2。
+- 本设计**不解决**"同时多个 Claude 会话竞抢 bridge"的问题(今天遇到的 "rejected this session" 错误)。那个是锁管理问题,独立 issue。
+- 跨平台(Windows)的 junction 支持按 superpowers 的模板补。
+
+## 6. 验收标准
+
+1. `abg init` 在一个干净机器上跑完后:
+   - `ls -la ~/.agents/skills/agentbridge-collab` 是一条指向 `~/.agentbridge/codex-skills/agentbridge-collab` 的 symlink。
+   - `cat ~/.agents/skills/agentbridge-collab/SKILL.md` 能看到完整内容。
+2. 启动 Codex TUI,在没有任何项目级 AGENTS.md 的目录下问 "怎么给 Claude 发消息?" → Codex 应该直接回答"正常输出即可,透明代理",不再去翻源码。
+3. 故意问 "daemon.js 里 Codex 侧的 sendMessage 函数在哪?" → Codex 应该识别这是红旗模式,拒绝搜索,解释为啥不存在。
+
+## 7. 开工拆解
+
+- [ ] **P1** 修 `collaboration-content.ts` 的 `AGENTS_MD_SECTION`,立即补"透明代理"段(当场解决今天的问题)
+- [ ] **P1** 新建 `plugins/agentbridge/codex-skills/agentbridge-collab/SKILL.md`(+ references/)
+- [ ] **P2** 改造 `src/cli/init.ts` 和 `src/cli/dev.ts`,增加 `installCodexSkill()`
+- [ ] **P2** 对应单测(`src/unit-test/codex-skill-install.test.ts`)
+- [ ] **P3** 新增 `agentbridge uninstall` 命令
+- [ ] **P3** 更新 README + CLAUDE.md 描述新机制
+
+---
+
+**open questions**(请 review 时回复):
+1. 放 `~/.agentbridge/` 还是 `~/.codex/agentbridge/`?我倾向前者,理由见 3.2。
+2. `abg init` 在项目目录跑,还是 `abg dev` / 独立的 `abg setup` 做机器级安装?skill 是机器级的,和 per-project init 应该是不同 scope。
+3. SKILL.md description 里要不要强硬到 "MUST be consulted before..." 这种程度?superpowers 用了类似措辞,效果不错,但也可能让 Codex 过度触发。

--- a/docs/issue-37-server-request-passthrough-design.md
+++ b/docs/issue-37-server-request-passthrough-design.md
@@ -1,0 +1,402 @@
+# 设计：Server-to-Client Request 透传（Issue #37）
+
+**日期：** 2026-03-30
+**Issue：** https://github.com/raysonmeng/agent-bridge/issues/37
+**状态：** v5 — 已合并 Claude + Codex 最终并行 review 反馈，设计定稿
+
+## 问题
+
+Codex 通过 AgentBridge 运行时，遇到沙箱权限提示（文件写入、命令执行、网络访问）时，TUI 不显示审批 UI，Codex 无限期卡死。
+
+## 根因
+
+`codex-adapter.ts` 中的 WebSocket 代理将 **server-to-client request** 错误地归类为 response 并丢弃。
+
+### app-server → TUI 的 JSON-RPC 消息类型
+
+| 类型 | 结构 | 当前处理 | 正确处理 |
+|------|------|---------|---------|
+| **Notification** | `{ method, params }`（无 `id`） | 转发给 TUI | 转发给 TUI |
+| **Response** | `{ id, result/error }`（无 `method`） | ID 重映射后转发 | ID 重映射后转发 |
+| **Server request** | `{ id, method, params }` | **误判为 response，被丢弃** | 应转发给 TUI |
+
+### 丢弃 server request 的代码路径
+
+`codex-adapter.ts:343-397`：
+
+```
+handleAppServerPayload(raw)
+  ├─ parsed.id === undefined → notification → 转发 (OK)
+  └─ parsed.id !== undefined → handleAppServerResponse()
+       ├─ 找到 mapping → 重映射 id，转发 (OK，适用于 response)
+       ├─ bridge request id → 消费，丢弃 (OK)
+       ├─ stale proxy id → 丢弃 (OK)
+       └─ 无匹配 → "Dropping unmatched app-server response" → 丢弃 (BUG)
+```
+
+像 `item/permissions/requestApproval` 这类 server request 同时具有 `id` 和 `method`，但它们不是由 TUI 发起的请求的响应——因此没有 upstream mapping，在最终 fallback 处被丢弃。
+
+### Codex 二进制中的协议证据
+
+通过对 `@openai/codex` 二进制的字符串分析，发现 app-server 协议包含以下消息类型：
+
+**Server-to-client request（审批请求）：**
+
+- `item/commandExecution/requestApproval`
+- `item/fileChange/requestApproval`
+- `item/permissions/requestApproval`
+
+**Server-to-client notification（非审批，无需回复）：**
+
+- `TerminalInteractionNotification` — 终端交互通知，不是审批请求
+- `serverRequest/resolved` — server 端通知某个请求已解决，不是 TUI 发出的响应
+
+**TUI 对审批请求的响应类型：**
+
+- `CommandExecutionRequestApprovalResponse`
+- `FileChangeRequestApprovalResponse`
+- `PermissionsRequestApprovalResponse`
+
+> **注意：** 审批响应的具体 payload 结构未知（不是简单的 `{ approved: true/false }`），代理应原样透传，不做任何假设。
+
+### 卡死序列
+
+1. Codex turn 调用了需要审批的工具
+2. App-server 发送 `{ id: N, method: "item/permissions/requestApproval", params: {...} }` 给代理
+3. 代理判断：`parsed.id !== undefined` → `handleAppServerResponse()`
+4. 没有找到 id N 的 upstream mapping → "Dropping unmatched app-server response id N"
+5. TUI 收不到审批提示 → 不渲染审批 UI
+6. App-server 永远等不到对应的审批响应
+7. 用户看到 Codex 停在 "Working" 状态
+
+## 设计
+
+### 改动 1：在 `handleAppServerPayload` 中识别 server request
+
+在 `codex-adapter.ts:343-357` 增加判断：如果消息**同时**具有 `id` 和 `method`，则为 server-to-client request——转发给 TUI 并追踪 ID 用于回传。
+
+```typescript
+private handleAppServerPayload(raw: string): string | null {
+  try {
+    const parsed = JSON.parse(raw);
+
+    if (parsed.id === undefined) {
+      // Notification — 原样转发
+      const forwarded = this.patchResponse(parsed, raw);
+      this.interceptServerMessage(parsed);
+      return forwarded;
+    }
+
+    if (parsed.method !== undefined) {
+      // Server-to-client request（如审批提示）— 转发给 TUI
+      return this.handleServerRequest(parsed);
+    }
+
+    // 对先前 TUI 请求的 Response
+    return this.handleAppServerResponse(parsed, raw);
+  } catch {
+    return raw;
+  }
+}
+```
+
+### 改动 2：新增 `handleServerRequest` 方法
+
+将 server request 转发给 TUI，并追踪 ID 以便 TUI 的响应能正确回传到 app-server。mapping 按 `connId` 作用域隔离，与现有 response mapping 保持一致。
+
+```typescript
+interface PendingServerRequest {
+  serverId: number | string;
+  connId: number;       // 发送给哪个 TUI 连接
+  method: string;       // 用于日志和调试
+  timestamp: number;    // 用于超时清理
+}
+
+private serverRequestToProxy = new Map<number, PendingServerRequest>();
+
+private handleServerRequest(parsed: any): string | null {
+  const raw = JSON.stringify(parsed);
+  const serverId = parsed.id;
+  const method = parsed.method;
+
+  if (!this.tuiWs) {
+    // TUI 未连接，缓冲 server request 等待重连
+    this.pendingServerRequests.push({ raw, serverId, method });
+    this.log(`Server request buffered (no TUI): ${method} (server id=${serverId})`);
+    return null;
+  }
+
+  // 直接在此方法内发送给 TUI，而非返回 payload 让外层 handler 发送
+  // 这样可以在 send 失败时回退到缓冲，避免外层 handler 的 "log and drop" 路径丢失消息
+  const proxyId = this.nextProxyId++;
+  parsed.id = proxyId;
+
+  try {
+    this.tuiWs.send(JSON.stringify(parsed));
+  } catch (e: any) {
+    // TUI 连接在半关闭状态，send 失败 → 回退到缓冲
+    this.log(`Server request send failed, buffering: ${method} (server id=${serverId}): ${e.message}`);
+    this.pendingServerRequests.push({ raw, serverId, method });
+    return null;
+  }
+
+  // send 成功后才建立 mapping
+  this.serverRequestToProxy.set(proxyId, {
+    serverId,
+    connId: this.tuiConnId,
+    method,
+    timestamp: Date.now(),
+  });
+
+  this.log(`Server request: ${method} (server id=${serverId} → proxy id=${proxyId}, conn #${this.tuiConnId})`);
+
+  // 返回 null —— 已在此方法内完成发送，外层 handler 不需要再发
+  return null;
+}
+```
+
+### 改动 3：在 `onTuiMessage` 中处理 TUI 对 server request 的响应
+
+在 `onTuiMessage` 中，在现有的 client-request ID 重写逻辑之前，检查消息是否为 **server request 的响应**（有 `id` 但无 `method`）。**增加 connId 验证**，拒绝来自旧 TUI 连接的过期响应。
+
+```typescript
+private onTuiMessage(ws, msg) {
+  const parsed = JSON.parse(data);
+  const connId = ws.data.connId;
+
+  // 检查是否为对 server request 的响应
+  if (parsed.id !== undefined && !parsed.method) {
+    // 归一化 ID 类型：TUI 可能返回 string "100050" 而非 number 100050
+    const rawId = parsed.id;
+    const normalizedId = typeof rawId === "number"
+      ? rawId
+      : (typeof rawId === "string" && /^-?\d+$/.test(rawId) ? Number(rawId) : NaN);
+    const pending = !isNaN(normalizedId) ? this.serverRequestToProxy.get(normalizedId) : undefined;
+    if (pending !== undefined) {
+      // 先验证 connId，再决定是否删除 mapping
+      if (pending.connId !== connId) {
+        // 不删除 mapping —— 正确的 TUI 连接可能稍后回复
+        this.log(`Dropping stale server request response (proxy id=${normalizedId}, expected conn #${pending.connId}, got #${connId})`);
+        return;
+      }
+
+      // connId 匹配，尝试转发给 app-server
+      parsed.id = pending.serverId;
+      try {
+        this.appServerWs.send(JSON.stringify(parsed));
+        // 发送成功，安全删除 mapping
+        this.serverRequestToProxy.delete(normalizedId);
+        this.log(`TUI → app-server: ${pending.method} response (proxy id=${normalizedId} → server id=${pending.serverId})`);
+      } catch (e: any) {
+        // 发送失败，mapping 保留至 TTL 过期清理（无主动重试机制——TUI 不会重发用户操作）
+        parsed.id = normalizedId;
+        this.log(`Failed to forward approval response to app-server (proxy id=${normalizedId}): ${e.message}`);
+      }
+      return; // 不走正常的请求转发流程
+    }
+  }
+
+  // ... 现有的 client request 转发逻辑 ...
+}
+```
+
+### 改动 4：TUI 重连时的处理
+
+TUI 重连时采用以下策略：
+
+1. **重放缓冲的 server request**：TUI 断连期间到达的 server request 被缓冲在 `pendingServerRequests` 中，重连后立即用新 proxyId 发送给新 TUI
+2. **不重发已发给旧 TUI 的 request**：已经发送但未收到响应的 server request 不主动重发——因为 app-server 可能会在 TUI 重连后重新发送审批请求（以新 id），代理不应假设重发行为。旧 mapping 保留至 TTL 超时，connId 检查会拒绝旧连接的过期响应
+
+```typescript
+private pendingServerRequests: Array<{ raw: string; serverId: number | string; method: string }> = [];
+
+private onTuiConnect(ws) {
+  // ... 现有逻辑 ...
+
+  // 重放缓冲的 server request —— 逐条尝试发送，失败的保留在队列中
+  const remaining: typeof this.pendingServerRequests = [];
+  for (const buffered of this.pendingServerRequests) {
+    const proxyId = this.nextProxyId++;
+    try {
+      const parsed = JSON.parse(buffered.raw);
+      parsed.id = proxyId;
+      ws.send(JSON.stringify(parsed));
+      // send 成功后才建立 mapping（避免 send 失败时产生幽灵条目）
+      this.serverRequestToProxy.set(proxyId, {
+        serverId: buffered.serverId,
+        connId: this.tuiConnId,
+        method: buffered.method,
+        timestamp: Date.now(),
+      });
+      this.log(`Replayed buffered server request: ${buffered.method} (server id=${buffered.serverId} → proxy id=${proxyId})`);
+    } catch (e: any) {
+      // send 失败，不建立 mapping，request 保留在队列中等待下次重连
+      this.log(`Failed to replay buffered server request: ${buffered.method} (server id=${buffered.serverId}): ${e.message}`);
+      remaining.push(buffered);
+    }
+  }
+  this.pendingServerRequests = remaining;
+
+  // 注意：已发送给旧 TUI 的 pending server request 不主动重发
+  // 因为我们不确定 app-server 是否会重新发送
+  // 旧的 mapping 保留，但 connId 检查会拒绝来自旧连接的响应
+  // 如果 app-server 重发审批请求，将以新的 id 进入，走正常流程
+}
+```
+
+### 改动 5：断连清理策略
+
+TUI 断连时**不立即清空** `serverRequestToProxy`，而是保留一段时间（与现有的 `RESPONSE_TRACKING_TTL_MS` 一致，30 秒），之后超时清理：
+
+```typescript
+private retireConnectionState(connId: number) {
+  // ... 现有清理逻辑 ...
+
+  // 对于 serverRequestToProxy 中属于此 connId 的条目，
+  // 不立即删除，保留用于拒绝可能到来的过期响应
+  // 超时后由定期清理任务移除
+  for (const [proxyId, pending] of this.serverRequestToProxy.entries()) {
+    if (pending.connId === connId) {
+      setTimeout(() => {
+        if (this.serverRequestToProxy.get(proxyId)?.connId === connId) {
+          this.serverRequestToProxy.delete(proxyId);
+          this.log(`Expired stale server request mapping (proxy id=${proxyId}, method=${pending.method})`);
+        }
+      }, RESPONSE_TRACKING_TTL_MS);
+    }
+  }
+}
+```
+
+### 改动 7：app-server 重连时清理审批状态
+
+当 app-server 连接关闭并重新连接时，所有 pending 的审批请求 ID 失效（新 session 的 ID 空间独立）。需要在现有的 app-server close handler 中同步清理 `serverRequestToProxy` 和 `pendingServerRequests`：
+
+```typescript
+private onAppServerClose() {
+  // ... 现有清理逻辑（reset turn state, clear response tracking）...
+
+  // 审批状态是 session-scoped，app-server 重连后旧 ID 无效
+  const pendingCount = this.serverRequestToProxy.size;
+  const bufferedCount = this.pendingServerRequests.length;
+  this.serverRequestToProxy.clear();
+  this.pendingServerRequests = [];
+  if (pendingCount > 0 || bufferedCount > 0) {
+    this.log(`App-server reconnect: discarded ${pendingCount} pending + ${bufferedCount} buffered server requests`);
+  }
+}
+```
+
+### 改动 8：日志
+
+为所有审批相关消息添加结构化日志：
+
+```
+[CodexAdapter] Server request: item/permissions/requestApproval (server id=42 → proxy id=100050, conn #3)
+[CodexAdapter] Server request buffered (no TUI): item/fileChange/requestApproval (server id=43)
+[CodexAdapter] Replayed buffered server request: item/fileChange/requestApproval (server id=43 → proxy id=100051)
+[CodexAdapter] TUI → app-server: item/permissions/requestApproval response (proxy id=100050 → server id=42)
+[CodexAdapter] Dropping stale server request response (proxy id=100050, expected conn #3, got #4)
+[CodexAdapter] Expired stale server request mapping (proxy id=100050, method=item/permissions/requestApproval)
+```
+
+## 改动文件
+
+| 文件 | 改动内容 |
+|------|---------|
+| `src/codex-adapter.ts` | 新增 server request 检测、`handleServerRequest()` 方法、TUI 响应回传路由（含 connId 验证）、缓冲与重放、TTL 清理 |
+
+## 测试
+
+### 单元测试
+
+**Happy path：**
+
+1. **Server request 被转发** — 具有 `{ id, method }` 的 app-server 消息被转发给 TUI（不被丢弃）
+2. **Server request ID 被重映射** — server id 被替换为 proxy id 发给 TUI，mapping 被存储（含 connId）
+3. **TUI 响应正确回传** — TUI 用 proxy id 的响应被重映射为 server id 发回 app-server
+4. **原有 response 处理不受影响** — 现有的 response 处理逻辑仍然正常工作
+
+**重连与边界情况：**
+
+5. **TUI 未连接时 server request 被缓冲** — 消息存入 `pendingServerRequests`，不丢弃
+6. **TUI 重连后缓冲的 server request 被重放** — 重连时立即发送，mapping 正确建立
+7. **旧 TUI 连接的过期响应被拒绝** — connId 不匹配时 drop 并打日志
+8. **重连后 app-server 重发审批请求** — 新 request 以新 id 正常处理，不与旧 mapping 冲突
+9. **TTL 超时清理** — 超过 30 秒的 stale mapping 被自动清除
+
+**并发与 ID 安全：**
+
+10. **server request 和 client request 并发** — 两者共用 `nextProxyId` 计数器，ID 不冲突
+11. **重复/未知 TUI 响应 ID** — 不在 `serverRequestToProxy` 中的响应 ID 不影响现有逻辑，走正常的 client response 路径
+12. **notification 不受影响** — `TerminalInteractionNotification` 等无 `id` 的消息仍走现有 notification 路径
+
+**Transport failure：**
+
+13. **重放 send 失败** — 缓冲重放时 `ws.send` 抛异常，失败的 request 保留在 `pendingServerRequests` 中等待下次重连，**不产生幽灵 mapping**
+14. **审批响应 send 失败** — `appServerWs.send` 失败时 mapping 不被删除，日志记录错误
+15. **server request 发送失败回退到缓冲** — TUI 半关闭状态下 `handleServerRequest` 内 send 失败，request 回退到 `pendingServerRequests`
+16. **ID 类型归一化** — TUI 返回 string 类型 ID（如 `"100050"`）时正确匹配到 number 类型的 mapping key
+17. **app-server 重连清理** — app-server 连接关闭后 `serverRequestToProxy` 和 `pendingServerRequests` 被清空
+
+### E2E 测试
+
+**场景 1：正常审批流程**
+1. 启动 AgentBridge 和 Codex
+2. 让 Codex 执行需要审批的操作（如在 suggest 模式下运行 shell 命令）
+3. **验收标准：** 审批提示必须出现在 TUI 中，用户可以操作
+4. 批准后 Codex 继续执行并完成 turn；拒绝后 Codex 中止当前操作并返回可交互状态
+
+**场景 2：重连期间的审批**
+1. 在审批等待期间断开 TUI
+2. 重连 TUI
+3. **验收标准：** 以下两种结果之一均可接受：
+   - 审批 UI 重新出现，用户可以继续审批操作
+   - turn 被确定性地中断/失败，TUI 显示明确的错误状态（非无限 "Working"）
+4. **不可接受：** Codex 无限期卡在 "Working" 状态且无任何用户可见的反馈
+
+## 风险
+
+- **ID 冲突**：server request 和 client request 共用 `nextProxyId` 单调递增计数器，不会冲突。app-server 的原始 server request ID 被重映射后不参与 proxy 命名空间。
+- **未知的 server request method**：可能存在我们尚未发现的 server-to-client request。修复是通用的（任何 `{ id, method }` 消息），因此可以处理所有情况。
+- **app-server 重连行为未知**：我们不确定 app-server 在 TUI 重连后是否会重发 pending 的审批请求。当前设计采用防御性策略：缓冲断连期间到达的 server request 并在重连时重放，但不主动重发已经发给旧 TUI 的 request。如果 app-server 重发，新 request 会以新 id 正常处理。
+- **缓冲区大小**：`pendingServerRequests` 理论上可能无限增长。实际场景中，TUI 断连窗口很短（2.5 秒 grace period），且审批请求频率低，不太可能积压。可选加上限（如 50 条）。
+
+## 后续跟进项
+
+- **`serverRequest/resolved` 清理语义**：当代理收到 `serverRequest/resolved` notification 时，可能应该清理对应的 `serverRequestToProxy` mapping（而非仅依赖 TTL）。需要先确认该 notification 的 payload 是否包含对应的 request id，以及它和 TUI response 的时序关系。建议在实现核心修复后，通过抓取实际协议流量来验证。
+
+## 不在本次范围内
+
+- 将审批请求转发给 Claude（未来增强）
+- stderr 镜像到 TUI/Claude（次要的可观测性改进）
+- 通过 `--approval` 参数配置审批策略（互补功能，单独 PR）
+
+## Review 记录
+
+### v1 → v2 变更（基于 Codex 第一轮 review）
+
+1. **[High] 修复重连期间审批请求丢失**：新增 `pendingServerRequests` 缓冲区，TUI 断连时缓冲 server request，重连后重放
+2. **[Medium] 修正协议模型**：区分 server request（需回复）和 notification（无需回复），`TerminalInteractionNotification` 和 `serverRequest/resolved` 归类为 notification，审批响应 payload 不做假设（原样透传）
+3. **[Medium] mapping 增加 connId 作用域**：`serverRequestToProxy` 存储 `connId`，拒绝来自旧连接的过期响应，与现有 response mapping 的隔离策略一致
+4. **[Medium] 补充边界测试**：新增 TUI 未连接时缓冲、重连重放、过期响应拒绝、TTL 清理、并发 ID 安全等测试用例
+
+### v2 → v3 变更（基于 Codex 第二轮 review）
+
+1. **[High] 修复 delete-before-validate bug**：`onTuiMessage` 中 `serverRequestToProxy.delete()` 移到 connId 验证通过之后，避免旧连接的过期响应错误删除 mapping 导致正确响应无法匹配
+2. **[Medium] 统一重连语义**：移除"迁移 pending request 到新 connId"的描述，明确策略为仅重放缓冲的 server request，不重发已发给旧 TUI 的 request
+3. **[Medium] 收紧 E2E 验收标准**：明确两种可接受的重连结果（审批 UI 恢复 或 确定性失败），明确不可接受的结果（无限卡死）
+4. **[Low] `serverRequest/resolved` 提升为跟进项**：从"不在范围内"移到"后续跟进项"，说明需要协议流量验证后决定清理策略
+
+### v3 → v4 变更（基于 Codex 第三轮 review）
+
+1. **[Medium] 缓冲重放逐条容错**：`pendingServerRequests` 重放改为逐条 try-catch，send 失败的保留在队列中等待下次重连，不再整体清空
+2. **[Low] 审批响应发送容错**：`appServerWs.send` 失败时不删除 mapping（保留以便重试），记录错误日志
+
+### v4 → v5 变更（基于 Claude + Codex 最终并行 review）
+
+1. **[High, Claude] ID 类型归一化**：`onTuiMessage` 中 server request 响应的 ID 查找增加 string→number 归一化，与现有 `handleAppServerResponse` 的处理一致。不修复会导致 TUI 返回 string ID 时 lookup 失败，重现卡死
+2. **[High, Codex] server request 内部发送**：`handleServerRequest` 改为内部直接 `tuiWs.send()`，send 失败时回退到缓冲。不再返回 payload 给外层 handler（避免外层 "log and drop" 路径丢失审批请求）。send 成功后才建立 mapping（避免失败时产生幽灵条目）
+3. **[Medium, Codex] 重放 mapping 顺序修正**：重放时 `serverRequestToProxy.set()` 移到 `ws.send()` 成功之后，失败时不产生幽灵 mapping
+4. **[Medium, Codex] app-server 重连清理**：新增改动 7，app-server 连接关闭时清空 `serverRequestToProxy` 和 `pendingServerRequests`（审批状态是 session-scoped，旧 ID 在新 session 中无效）
+5. **[Low, Claude] 注释修正**：审批响应发送失败时的注释从"以便重试"改为"保留至 TTL 过期清理"（实际无主动重试机制）

--- a/docs/issues-2026-04-18-codex-stuck-and-resume.md
+++ b/docs/issues-2026-04-18-codex-stuck-and-resume.md
@@ -1,0 +1,143 @@
+# Issues — 2026-04-18: Codex 卡死 + resume 启动失败
+
+背景：用户在 `~/repo/quilin-agent` 使用 `agent-bridge` 时，Codex 在长任务中静默 1h+，按 Esc 后 TUI 进程猝死；随后反复重启 Claude Code 均被 daemon 4001 拒绝；最终用 `abg codex resume <thread>` 也无法启动。
+
+日志证据：`~/Library/Application Support/agentbridge/agentbridge.log`，thread `019d9a2e-15a7-7841-a7d2-ca0e14a61f40`，时间窗 `2026-04-17T06:43 – 09:14` UTC。
+
+---
+
+## Issue A — daemon 的 stale frontend 无法被驱逐（P0）
+
+**Symptom**
+Claude Code 异常退出后，daemon 侧仍认为旧 frontend `#1` `readyState=1`，新 Claude 实例（`#2 – #19`，13 次）全部被 `code=4001 reason="another Claude session is already connected"` 拒绝。
+
+日志：
+```
+07:56:29 Frontend socket opened (#2)
+07:56:29 Rejecting Claude frontend #2 — another session (#1) is already attached (readyState=1)
+... 连续 13 次 ...
+09:07:56 Frontend socket opened (#19)  — 同样被拒
+```
+
+**Root Cause**
+`src/daemon.ts` 的 frontend WS 服务**只看 `ws.readyState`** 判断旧连接是否仍然活着。Claude Code 进程异常退出时 OS 未发 FIN，socket 残留 OPEN。daemon 没有启用应用层 keepalive ping / idle timeout，老连接永远不会被回收。
+
+**Fix**
+- 给 frontend WS 加 `ping/pong` 保活（例如 15s ping，30s 未 pong 即 `ws.terminate()`）
+- 或者新连接到达时对现有 `#1` 发送一个 liveness challenge 消息，超时无响应则驱逐老连接、接纳新连接（"last writer wins"）
+
+**Files**
+- `src/daemon.ts`（frontend WS 接入与 reject 逻辑）
+
+---
+
+## Issue B — `turnInProgress` 缺少 watchdog，Codex 静默导致 Claude 永远 busy（P1）
+
+**Symptom**
+`07:38:13` Codex turn 启动，随后连续收到 3 条 `Agent message completed`（07:39/07:43/07:45），但 **`agentTurnComplete` 事件从未到达**。`CodexAdapter.turnInProgress` 保持 `true`，Claude 侧 reply 连续 3 次被 `Rejected injection: Codex turn is in progress`（07:42/07:57/08:18）。
+
+这段时间 `conn #1` 上 **1h21m 完全静默**（07:45:05 – 09:06:29），无任何 TUI↔app-server 流量。说明 Codex 自身 stream 停止推进（模型后端断流或 app-server 卡住）。
+
+**Root Cause**
+`src/codex-adapter.ts` 的 `turnInProgress` 只在收到 `agentTurnComplete` 事件时复位，一旦事件丢失就永远 stuck。
+
+**Fix**
+- 给每个活跃 turn 挂一个 watchdog：`lastEventAt + N 分钟静默` 即强制复位 `turnInProgress`
+- 复位时通过 control WS 发 `system_turn_completed_forced` 通知 daemon → Claude，让用户知道是兜底复位、不是真正完成
+- N 推荐 3–5 分钟，避开正常长推理（`06:45 – 07:27` 那轮正常 turn 持续 1m18s；历史日志里看到最长一轮是 15m，所以不能太短）
+
+**Files**
+- `src/codex-adapter.ts`（turn 生命周期、事件超时）
+- `src/control-protocol.ts`（如需新事件类型）
+
+---
+
+## Issue C — `activeThreadId` 被响应字段覆盖，resume + thread/start 交错导致 pending 失配（P2）
+
+**Symptom**
+用户在 Codex TUI 重连后（`09:08 – 09:14`），日志出现 thread 风暴：
+```
+09:09:28 Active thread changed: 019d9ab3 → 019d9a2e (thread/resume response 3:8)
+09:09:39 Active thread changed: 019d9a2e → 019d9a6d (thread/resume response 3:9)
+09:10:43 Active thread changed: 019d9ab3 → 019d9a2e (thread/resume response 3:29)
+09:10:59 Active thread changed: 019d9a2e → 019d9a6d (thread/resume response 3:30)
+...
+```
+夹杂大量 `[track-resp] Unmatched response with thread.id=019d9a2e..., pending keys=[]`。
+
+**Root Cause**
+`CodexAdapter` 用响应里 `thread.id` 字段直接更新 `activeThreadId`。当 TUI conn #2 `thread/resume` 老 thread、conn #3 又 `thread/start` 新 thread 时，两路响应交错到达，`activeThreadId` 被反复覆盖。
+
+pending 响应表的 key 形如 `threadId:reqId`。thread 切换后旧 thread 的响应到达时找不到对应 entry，`pending keys=[]` → 响应无法 correlate。这是"resume 后 thread 再也恢复不回来"的直接原因。
+
+**Fix**
+- `activeThreadId` 变更必须由 **显式请求**（`thread/start` / `thread/resume` 的 request 侧）驱动，而不是被任意响应里的 `thread.id` 覆盖
+- pending map 不应把 threadId 当作 partition key（或 resume 时显式迁移 key）
+- 对多连接的 TUI 场景（conn #2 / #3 同时存在）需要有明确语义：是 last-wins、reject 还是 multiplex
+
+**Files**
+- `src/codex-adapter.ts`（thread tracking、pending response map）
+
+---
+
+## Issue D — `abg codex resume <session-id>` 无法启动（P1）
+
+**Symptom**
+用户报告 `abg codex resume xxxxx` 无法启动。
+
+**Root Cause**
+`src/cli/codex.ts:126-130` 对所有子命令用同一个 args 拼接策略：
+
+```typescript
+const fullArgs = [
+  "--enable", "tui_app_server",
+  "--remote", proxyUrl,
+  ...args,   // 用户传的是 ["resume", "xxxxx"]
+];
+// 结果：codex --enable tui_app_server --remote ws://127.0.0.1:4501 resume xxxxx
+```
+
+问题在 clap 的 subcommand 解析规则：
+- `codex --help` 与 `codex resume --help` 输出显示，`--enable` 和 `--remote` 在**顶层**与 **resume 子命令**下**分别各自定义**（不是 `global = true`）
+- 当前拼法把 `--enable tui_app_server --remote ws://...` 放在 `resume` 之前 → clap 把它们当作**顶层 codex 命令**的 options 消化
+- 然后看到 `resume` 切换到 resume 子命令 → **resume 子命令自己的 `--remote` / `--enable` 是 None**
+- 结果：resume 子命令不会连到 bridge proxy `:4501`，也没启用 `tui_app_server` feature，行为退化为"在没有 bridge 的环境下 resume"——可能直接失败、或起了个孤立的 TUI（跟 Claude 侧完全不通）
+
+**Fix**
+wrapper 需要识别 codex 的 TUI-mode 子命令（`resume` / `fork`），把 owned flags 插到子命令之后：
+
+```typescript
+const TUI_SUBCOMMANDS = new Set(["resume", "fork"]);
+let fullArgs: string[];
+if (args[0] && TUI_SUBCOMMANDS.has(args[0])) {
+  fullArgs = [args[0], "--enable", "tui_app_server", "--remote", proxyUrl, ...args.slice(1)];
+} else {
+  fullArgs = ["--enable", "tui_app_server", "--remote", proxyUrl, ...args];
+}
+```
+
+边界 case：非 TUI 子命令（`exec` / `review` / `login` 等）本来就不该加这两个 flag —— 当前实现对这些命令也会错误地注入，应该一并限定只对 "裸 `codex`"（进 TUI）和 `resume` / `fork` 生效。
+
+**Workaround（用户马上可用）**
+直接跑原生 codex 命令，绕开 wrapper：
+```bash
+codex resume --enable tui_app_server --remote ws://127.0.0.1:4501 <session-id>
+```
+daemon 仍由 `abg claude` / `abg codex`（首次启动时）管理，proxy port `4501` 已开，resume 能连上。
+
+**Files**
+- `src/cli/codex.ts`（args 拼接逻辑）
+- `src/cli/claude.ts`（可能也有类似问题，需一起检查 `--resume` 位置）
+
+---
+
+## 优先级与顺序
+
+| 优先级 | Issue | 用户体验收益 |
+|---|---|---|
+| P0 | A — stale frontend 驱逐 | 根治"重启 Claude 连不上" |
+| P1 | D — resume 子命令参数位置 | 根治"`abg codex resume` 无法启动" |
+| P1 | B — turn watchdog | Codex 静默后 Claude 不被锁死 |
+| P2 | C — thread tracking 语义修正 | resume 风暴时 bridge 状态不乱 |
+
+建议开 4 个独立 PR（单一职责，独立 review）。A、D 改动小、风险低，可并行先落。B、C 涉及状态机语义，需要额外单测覆盖。

--- a/docs/multi-pair-guide.html
+++ b/docs/multi-pair-guide.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AgentBridge · 单机多对 Claude+Codex / Single-Machine Multi-Pair</title>
+<style>
+  :root {
+    color-scheme: dark light;
+    --bg:        #0d1117;
+    --bg-elev:   #161b22;
+    --bg-elev-2: #1c2230;
+    --border:    #2a313c;
+    --border-2:  #353d4a;
+    --fg:        #e6edf3;
+    --fg-muted:  #9aa7b5;
+    --fg-dim:    #6e7b8a;
+    --accent:    #58a6ff;
+    --accent-2:  #7ee787;
+    --accent-3:  #d2a8ff;
+    --warn-bg:   #2b2113;
+    --warn-bd:   #6b4f1d;
+    --warn-fg:   #f0c674;
+    --key-bg:    #0f2a1c;
+    --key-bd:    #1f6f43;
+    --key-fg:    #7ee787;
+    --code-bg:   #0a0e14;
+    --radius:    12px;
+    --mono: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg:#f6f8fa; --bg-elev:#ffffff; --bg-elev-2:#f0f3f6; --border:#d0d7de; --border-2:#c0c8d0;
+      --fg:#1f2328; --fg-muted:#57606a; --fg-dim:#8c959f; --accent:#0969da; --accent-2:#1a7f37;
+      --accent-3:#8250df; --warn-bg:#fff8e6; --warn-bd:#e6c259; --warn-fg:#7a5b00;
+      --key-bg:#eafbf0; --key-bd:#56c781; --key-fg:#1a7f37; --code-bg:#0d1117;
+    }
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: var(--sans); line-height: 1.7; font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { font-family: var(--mono); font-size: 0.88em; }
+
+  /* ---- Header ---- */
+  header.hero {
+    background: linear-gradient(135deg, #0d1117 0%, #15233a 55%, #1a2f24 100%);
+    border-bottom: 1px solid var(--border);
+    padding: 56px 24px 44px;
+  }
+  @media (prefers-color-scheme: light) {
+    header.hero { background: linear-gradient(135deg,#ffffff 0%,#eaf2ff 55%,#eafbf0 100%); }
+  }
+  .hero-inner { max-width: 960px; margin: 0 auto; }
+  .badge {
+    display: inline-block; font-family: var(--mono); font-size: 12px; letter-spacing: .5px;
+    color: var(--accent-2); background: var(--key-bg); border: 1px solid var(--key-bd);
+    padding: 4px 12px; border-radius: 999px; margin-bottom: 18px;
+  }
+  h1 { margin: 0 0 8px; font-size: 2.2rem; line-height: 1.2; letter-spacing: -0.5px; }
+  h1 .en { display: block; font-size: 1.15rem; font-weight: 500; color: var(--fg-muted); margin-top: 6px; }
+  .approach {
+    margin-top: 18px; font-size: 1.02rem; color: var(--fg-muted);
+    border-left: 3px solid var(--accent-3); padding: 4px 0 4px 16px;
+  }
+  .approach strong { color: var(--accent-3); }
+
+  /* ---- Layout ---- */
+  main { max-width: 960px; margin: 0 auto; padding: 0 24px 80px; }
+
+  /* ---- TOC nav ---- */
+  nav.toc {
+    position: sticky; top: 0; z-index: 5;
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border);
+    margin: 0 -24px 36px; padding: 12px 24px;
+    display: flex; flex-wrap: wrap; gap: 6px 4px;
+  }
+  nav.toc a {
+    font-size: 13px; color: var(--fg-muted); padding: 4px 10px; border-radius: 6px;
+    border: 1px solid transparent; white-space: nowrap;
+  }
+  nav.toc a:hover { color: var(--fg); background: var(--bg-elev); border-color: var(--border); text-decoration: none; }
+
+  section { margin: 48px 0; scroll-margin-top: 64px; }
+  h2 {
+    font-size: 1.5rem; margin: 0 0 6px; padding-bottom: 10px;
+    border-bottom: 1px solid var(--border); display: flex; align-items: baseline; gap: 12px;
+  }
+  h2 .num {
+    font-family: var(--mono); font-size: 0.85rem; color: var(--accent);
+    border: 1px solid var(--border-2); border-radius: 6px; padding: 1px 8px;
+  }
+  h2 .en { font-size: 0.95rem; font-weight: 500; color: var(--fg-dim); }
+  h3 { font-size: 1.12rem; margin: 28px 0 8px; color: var(--fg); }
+  h3 .en { font-weight: 500; color: var(--fg-dim); font-size: .92rem; }
+  p { margin: 10px 0; }
+  .lead { color: var(--fg-muted); }
+  ul, ol { padding-left: 22px; }
+  li { margin: 6px 0; }
+
+  /* ---- Code blocks ---- */
+  pre {
+    background: var(--code-bg); color: #e6edf3; border: 1px solid var(--border-2);
+    border-radius: var(--radius); padding: 16px 18px; overflow-x: auto;
+    font-family: var(--mono); font-size: 13.5px; line-height: 1.65; margin: 14px 0;
+    position: relative;
+  }
+  pre.diagram { font-size: 13px; line-height: 1.55; color: #cdd9e5; }
+  pre .cmd { color: #7ee787; }      /* command */
+  pre .flag { color: #79c0ff; }     /* flags / args */
+  pre .cmt { color: #768390; font-style: italic; } /* comments */
+  pre .dim { color: #8b98a5; }
+  .codecap {
+    font-family: var(--mono); font-size: 11px; color: var(--fg-dim);
+    text-transform: uppercase; letter-spacing: 1px; margin: 18px 0 -6px;
+  }
+  p code, li code, td code {
+    background: var(--bg-elev-2); border: 1px solid var(--border);
+    padding: 1px 6px; border-radius: 5px; color: var(--accent);
+  }
+
+  /* ---- Tables ---- */
+  table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 14.5px; }
+  th, td { padding: 10px 14px; text-align: left; border: 1px solid var(--border); }
+  th { background: var(--bg-elev-2); font-weight: 600; color: var(--fg); }
+  tbody tr:nth-child(odd) { background: var(--bg-elev); }
+  td code { font-size: 0.9em; }
+  .port-table td:first-child, .port-table th:first-child { text-align: center; font-weight: 600; }
+  .slot0 td { color: var(--accent-2); }
+  .pending { color: var(--warn-fg); font-family: var(--mono); font-size: 0.85em; }
+
+  /* ---- Callouts ---- */
+  .callout {
+    border-radius: var(--radius); padding: 16px 20px; margin: 20px 0;
+    border: 1px solid var(--border-2); background: var(--bg-elev);
+  }
+  .callout .title {
+    font-weight: 700; display: flex; align-items: center; gap: 8px; margin-bottom: 6px;
+  }
+  .callout.key { background: var(--key-bg); border-color: var(--key-bd); }
+  .callout.key .title { color: var(--key-fg); }
+  .callout.warn { background: var(--warn-bg); border-color: var(--warn-bd); }
+  .callout.warn .title { color: var(--warn-fg); }
+  .callout p { margin: 6px 0; }
+  .callout p:first-of-type { margin-top: 0; }
+
+  .en-line { color: var(--fg-dim); font-size: 0.93em; }
+
+  /* ---- Footer ---- */
+  footer {
+    max-width: 960px; margin: 0 auto; padding: 28px 24px 48px;
+    border-top: 1px solid var(--border); color: var(--fg-dim); font-size: 13px;
+  }
+  footer code { color: var(--fg-muted); }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="hero-inner">
+    <span class="badge">AgentBridge · feat/multi-pair</span>
+    <h1>
+      单机多对 Claude + Codex
+      <span class="en">Single-Machine Multi-Pair Collaboration</span>
+    </h1>
+    <div class="approach">
+      <strong>Approach A — Shared-Nothing Multi-Instance</strong><br>
+      每一对 Claude↔Codex 都是完全隔离的实例：独立 daemon + 独立端口三元组 + 独立状态目录。<br>
+      <span class="en-line">Each Claude↔Codex pair is a fully isolated instance: its own daemon, its own port triple, and its own state directory.</span>
+    </div>
+  </div>
+</header>
+
+<main>
+  <nav class="toc" aria-label="Table of contents">
+    <a href="#built">1 · 背景与方案</a>
+    <a href="#arch">2 · 架构</a>
+    <a href="#ports">3 · Slot → Port</a>
+    <a href="#usage">4 · 用法 Usage</a>
+    <a href="#how">5 · 底层原理</a>
+    <a href="#concurrency">6 · 并发安全</a>
+    <a href="#migration">7 · 升级迁移</a>
+    <a href="#verify">8 · 验证状态</a>
+  </nav>
+
+  <!-- ===================== 1 ===================== -->
+  <section id="built">
+    <h2><span class="num">01</span> 背景与方案 <span class="en">What Was Built</span></h2>
+
+    <h3>问题 <span class="en">/ Problem</span></h3>
+    <p>AgentBridge 此前每台机器只能运行 <strong>一对</strong> Claude↔Codex：单个 daemon，固定端口 <code>4500 / 4501 / 4502</code>。想同时跑两份协作（比如一份写功能、一份做 review）就会端口冲突、状态互相覆盖。</p>
+    <p class="en-line">Previously AgentBridge ran only <strong>one</strong> Claude↔Codex pair per machine: a single daemon on fixed ports <code>4500 / 4501 / 4502</code>. Running two collaborations at once caused port collisions and state clobbering.</p>
+
+    <h3>方案 <span class="en">/ Solution</span></h3>
+    <p>每一对 = <strong>一个隔离的 daemon + 它自己的端口三元组 + 它自己的状态目录</strong>。</p>
+    <ul>
+      <li><strong>无需改动 daemon 内部逻辑</strong> —— 所有多对（multi-pair）逻辑都落在一个全新的「解析层（resolution layer）」+ CLI 里。<br>
+      <span class="en-line">No daemon-internal changes — all multi-pair logic lives in a new resolution layer + CLI.</span></li>
+      <li>对比已废弃的 <strong>PR #81「单 daemon 多 router」（route B）</strong>：路线 B 让多对共享一个 daemon，导致生命周期状态泄漏（kill/restart 一对会污染另一对）。本方案的 shared-nothing 隔离从根上避免了这类 bug。<br>
+      <span class="en-line">Contrast with the abandoned PR #81 "single daemon multi-router" (route B), which leaked lifecycle state. Shared-nothing isolation eliminates that class of bug.</span></li>
+    </ul>
+
+    <div class="callout key">
+      <div class="title">🔑 关键洞察（运行时已验证） / Key Insight (runtime-verified)</div>
+      <p><strong>Claude Code 会把继承到的环境变量原样传给它的 plugin MCP server。</strong> 因此选择「跑哪一对」纯粹靠在启动前设置环境变量即可完成 —— <strong><code>.mcp.json</code> 完全不用改</strong>。</p>
+      <p class="en-line">Claude Code passes inherited environment variables straight through to its plugin MCP server. A pair is therefore selected purely by setting env vars before launch — <code>.mcp.json</code> is unchanged.</p>
+    </div>
+  </section>
+
+  <!-- ===================== 2 ===================== -->
+  <section id="arch">
+    <h2><span class="num">02</span> 架构 <span class="en">Architecture</span></h2>
+    <p class="lead">两对并排运行，互不干扰 / Two pairs side by side, fully isolated:</p>
+
+    <pre class="diagram">  <span class="cmd">abg claude</span> <span class="flag">--pair work</span>            <span class="cmd">abg claude</span> <span class="flag">--pair review</span>
+  <span class="cmt">(env: ports + statedir = work)</span>    <span class="cmt">(env: ports + statedir = review)</span>
+           │                                  │
+           ▼                                  ▼
+  daemon(<span class="flag">work</span>)  <span class="dim">4500/01/02</span>          daemon(<span class="flag">review</span>)  <span class="dim">4510/11/12</span>
+           │                                  │
+           ▼                                  ▼
+  <span class="cmd">codex</span> <span class="flag">--pair work</span>                 <span class="cmd">codex</span> <span class="flag">--pair review</span>
+    <span class="flag">--remote :4501</span>                    <span class="flag">--remote :4511</span></pre>
+
+    <p>每一对都完全隔离，各自拥有独立的 <code>daemon.pid</code> / <code>status.json</code> / 日志 / <code>killed</code> sentinel，统一放在 <code>&lt;stateDir&gt;/pairs/&lt;pairId&gt;/</code> 下。</p>
+    <p class="en-line">Each pair is fully isolated, with its own <code>daemon.pid</code> / <code>status.json</code> / logs / <code>killed</code> sentinel under <code>&lt;stateDir&gt;/pairs/&lt;pairId&gt;/</code>.</p>
+  </section>
+
+  <!-- ===================== 3 ===================== -->
+  <section id="ports">
+    <h2><span class="num">03</span> Slot → Port 映射 <span class="en">Slot → Port Table</span></h2>
+    <p class="lead">每一对占据一个 <strong>slot</strong>，slot 决定端口三元组。规律：第 N 个 slot 在经典基址上 <code>+ N*10</code>。<br>
+    <span class="en-line">Each pair occupies a <strong>slot</strong>, which determines its port triple. Rule: slot N is offset <code>+ N*10</code> from the classic base.</span></p>
+
+    <table class="port-table">
+      <thead>
+        <tr>
+          <th>slot</th>
+          <th>appPort<br><code>CODEX_WS_PORT</code></th>
+          <th>proxyPort<br><code>CODEX_PROXY_PORT</code></th>
+          <th>controlPort<br><code>AGENTBRIDGE_CONTROL_PORT</code></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="slot0"><td>0 <span style="font-weight:400">(第一对 / first pair)</span></td><td><code>4500</code></td><td><code>4501</code></td><td><code>4502</code></td></tr>
+        <tr><td>1</td><td><code>4510</code></td><td><code>4511</code></td><td><code>4512</code></td></tr>
+        <tr><td>2</td><td><code>4520</code></td><td><code>4521</code></td><td><code>4522</code></td></tr>
+        <tr><td>N</td><td><code>4500 + N*10</code></td><td><code>+1</code></td><td><code>+2</code></td></tr>
+      </tbody>
+    </table>
+
+    <div class="callout">
+      <div class="title">📌 注意 / Note</div>
+      <p>slot 0 = 经典端口（the classic ports）。所以 <strong>单对用户 100% 不受影响</strong> —— 行为与升级前完全一致。</p>
+      <p class="en-line">slot 0 = the classic ports, so a single-pair user is 100% unchanged.</p>
+    </div>
+  </section>
+
+  <!-- ===================== 4 ===================== -->
+  <section id="usage">
+    <h2><span class="num">04</span> 用法 <span class="en">Usage</span></h2>
+    <p class="lead">这是最重要的一节。下面所有命令都可以直接复制粘贴。<br>
+    <span class="en-line">This is the most important section. Every command below is copy-pasteable.</span></p>
+
+    <h3>启动一个命名对 <span class="en">/ Start a named pair</span></h3>
+    <p>终端 1 启动 Claude 侧，终端 2 启动 Codex 侧（两者用同一个 <code>--pair</code> 名字配对）：</p>
+    <div class="codecap">Terminal 1 &amp; Terminal 2</div>
+    <pre><span class="cmt"># Terminal 1</span>
+<span class="cmd">abg claude</span> <span class="flag">--pair work</span>
+
+<span class="cmt"># Terminal 2</span>
+<span class="cmd">abg codex</span> <span class="flag">--pair work</span></pre>
+
+    <h3>第二个对（自动分配下一个 slot）<span class="en">/ A second pair, auto-assigned next slot</span></h3>
+    <pre><span class="cmt"># Terminal 3</span>
+<span class="cmd">abg claude</span> <span class="flag">--pair review</span>
+
+<span class="cmt"># Terminal 4</span>
+<span class="cmd">abg codex</span> <span class="flag">--pair review</span></pre>
+    <p><code>review</code> 这一对会自动拿到下一个空闲 slot（例如 slot 1 → 端口 <code>4510/11/12</code>），与 <code>work</code> 对完全隔离。</p>
+    <p class="en-line">The <code>review</code> pair automatically takes the next free slot (e.g. slot 1 → ports 4510/11/12), fully isolated from <code>work</code>.</p>
+
+    <h3>不带参数：按目录自动推导 <span class="en">/ No flag: pair derived from cwd</span></h3>
+    <pre><span class="cmd">abg claude</span></pre>
+    <p>不带 <code>--pair</code> 时，<strong>对的身份由当前目录自动推导</strong>（realpath + 短 hash）。在同一个项目目录里再次运行，会 <strong>重连到同一个对</strong>。</p>
+    <p class="en-line">Without <code>--pair</code>, the pair identity is auto-derived from the current directory (realpath + short hash). Running it again in the same project reconnects to the same pair.</p>
+
+    <h3>列出所有对 <span class="en">/ List all pairs</span></h3>
+    <pre><span class="cmd">abg pairs</span>           <span class="cmt"># pairId, slot, ports, cwd, running/stopped, pid</span>
+<span class="cmd">abg pairs</span> <span class="flag">--json</span>    <span class="cmt"># machine-readable output for scripting</span>
+<span class="cmd">abg pairs rm</span> <span class="flag">&lt;id&gt;</span>   <span class="cmt"># stop a pair and free its slot</span></pre>
+
+    <h3>停止 <span class="en">/ Kill</span></h3>
+    <pre><span class="cmt"># 停止所有对（以及任何遗留的旧版单对 daemon）</span>
+<span class="cmt"># Stop ALL pairs (and any legacy single-pair daemon)</span>
+<span class="cmd">abg kill</span>
+
+<span class="cmt"># 只停 "work" 这一对（保留它的注册表条目 / slot）</span>
+<span class="cmt"># Stop only the "work" pair (keeps its registry entry / slot)</span>
+<span class="cmd">abg kill</span> <span class="flag">--pair work</span></pre>
+
+    <h3>对身份规则 <span class="en">/ Pair identity rules</span></h3>
+    <ul>
+      <li><strong>显式 <code>--pair &lt;name&gt;</code> 优先</strong> / explicit <code>--pair &lt;name&gt;</code> wins。</li>
+      <li>否则由<strong>目录决定</strong> / otherwise the directory decides。</li>
+      <li><strong>命名对是全局的</strong> / named pairs are global —— 跨目录共享同一组端口。</li>
+      <li><strong>目录推导的对是按目录的</strong> / directory-derived pairs are per-directory —— 每个目录一个独立的对。</li>
+    </ul>
+  </section>
+
+  <!-- ===================== 5 ===================== -->
+  <section id="how">
+    <h2><span class="num">05</span> 底层原理 <span class="en">How It Works · env-injection seam</span></h2>
+    <p>每个 CLI 命令的最顶端都会先跑一个 <strong>「对解析器（pair resolver）」</strong>：</p>
+    <ol>
+      <li>在跨进程锁（cross-process lock）保护下，到注册表 <code>&lt;base&gt;/pairs/registry.json</code> 里 <strong>分配 / 查找</strong> 这个对的 slot。</li>
+      <li>然后设置这些环境变量：<code>AGENTBRIDGE_STATE_DIR</code>（该对的 state 目录）、<code>AGENTBRIDGE_CONTROL_PORT</code>、<code>CODEX_WS_PORT</code>、<code>CODEX_PROXY_PORT</code>，外加 <code>AGENTBRIDGE_BASE_DIR</code>（注册表 base —— 子进程 <code>abg pairs</code>/<code>kill</code> 据此解析正确的 registry）和 <code>AGENTBRIDGE_PAIR_ID</code>（对 id，用于诊断 / status.json）。</li>
+      <li>既有的 <code>claude</code> / <code>codex</code> / <code>kill</code> 代码，以及 daemon，因为<strong>本来就从环境变量读取这些值</strong>，所以无需任何改动就「自动工作」。</li>
+    </ol>
+    <p class="en-line">A "pair resolver" runs at the top of each CLI command: under a cross-process lock it allocates/looks up the pair's slot in <code>&lt;base&gt;/pairs/registry.json</code>, then sets <code>AGENTBRIDGE_STATE_DIR</code> (the pair dir), <code>AGENTBRIDGE_CONTROL_PORT</code>, <code>CODEX_WS_PORT</code>, <code>CODEX_PROXY_PORT</code>, plus <code>AGENTBRIDGE_BASE_DIR</code> (the registry base, so child <code>abg pairs</code>/<code>kill</code> resolve the real registry) and <code>AGENTBRIDGE_PAIR_ID</code>. The existing claude/codex/kill code and the daemon then just work, because they already read these from env.</p>
+    <div class="callout">
+      <div class="title">🧩 这就是整个特性的接缝 / The seam</div>
+      <p><strong>靠环境变量注入，而不是改动核心代码。</strong> <span class="en-line">Env-injection, not core-code surgery.</span></p>
+    </div>
+  </section>
+
+  <!-- ===================== 6 ===================== -->
+  <section id="concurrency">
+    <h2><span class="num">06</span> 并发安全 <span class="en">Concurrency Safety</span></h2>
+    <ul>
+      <li><strong>两个 <code>abg claude</code> 同时启动不会撞车。</strong> Slot 分配由一个 <strong>原子锁文件（atomic lock file，靠 <code>link(2)</code>：写临时文件再 link 到锁路径）</strong> 串行化，锁内含 owner pid + nonce。陈旧锁回收<strong>只针对已死的 owner</strong>（绝不抢活进程的锁，以免 lost update），且回收经一个独立 reclaim lock 串行化 + 重新确认 dead 后才删。陈旧判定靠<strong>进程存活性，不是 TTL</strong>。<br>
+      <span class="en-line">Two <code>abg claude</code> started at the same time can't collide: slot allocation is serialized by an atomic <code>link(2)</code> lock file (write temp → link onto the lock path) carrying owner pid + nonce. Stale reclaim targets only a DEAD owner (never steals a live lock — that would risk a lost update), is itself serialized through a dedicated reclaim lock, and re-confirms death before removing. Staleness is by process liveness, not TTL.</span></li>
+      <li><strong>端口会被探测。</strong> 如果某个外部进程占用了目标端口，你会得到清晰的 <code>PAIR_PORTS_BUSY</code> 错误，而不是悄悄连到错误的端口。<br>
+      <span class="en-line">Allocated ports are probed; if an external process squats a port, you get a clear <code>PAIR_PORTS_BUSY</code> error instead of a silent wrong-port connection.</span></li>
+    </ul>
+  </section>
+
+  <!-- ===================== 7 ===================== -->
+  <section id="migration">
+    <h2><span class="num">07</span> 升级迁移 <span class="en">Migration Note</span></h2>
+    <div class="callout warn">
+      <div class="title">⚠️ 升级后请执行一次 / Run once after upgrading</div>
+      <p>升级到多对版本后，如果还有一个 <strong>旧版（pre-multi-pair）daemon</strong> 在跑，请执行一次：</p>
+      <pre style="margin:10px 0;"><span class="cmd">abg kill</span></pre>
+      <p>新代码会 <strong>检测到这个 legacy-root daemon 并给出引导</strong>。</p>
+      <p class="en-line">After upgrading, if an old (pre-multi-pair) daemon is still running, run <code>abg kill</code> once — the new code detects the legacy-root daemon and guides you.</p>
+    </div>
+  </section>
+
+  <!-- ===================== 8 ===================== -->
+  <section id="verify">
+    <h2><span class="num">08</span> 验证状态 <span class="en">Verification</span></h2>
+    <p class="lead">全部通过。 / All green.</p>
+    <table>
+      <thead>
+        <tr><th>项 / Item</th><th>状态 / Status</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>单元测试（pair-registry / concurrency / resolver / command）<br><span class="en-line">Unit tests</span></td><td>✅ pass — 含 8 进程并发 + seeded-dead-lock 锁测试，20+ 次 stress 0 碰撞<br><span class="en-line">incl. an 8-process + seeded-dead-lock concurrency test, 0 collisions over 20+ stress runs</span></td></tr>
+        <tr><td>类型检查 + 全量测试 + 插件同步（<code>bun run check</code>）<br><span class="en-line">Type check + full suite + plugin sync</span></td><td>✅ 334 pass / 0 fail，typecheck clean，bundles in sync，version-aligned 0.1.6</td></tr>
+        <tr><td>真实双对运行时 E2E（Codex sandbox，仓库原脚本）<br><span class="en-line">Real two-pair runtime E2E</span></td><td>✅ pass — pair <code>a</code>=slot2 (4520/4521/4522, status pairId "a")、pair <code>b</code>=slot3 (4530/4531/4532, status pairId "b")；端口/state/日志隔离 ✓；<code>kill --pair a</code> 只停 a、b 仍 LISTEN ✓；<code>kill --all</code> 后 4520-4532 全清 ✓</td></tr>
+        <tr><td>交叉评审（Claude×2 全新 reviewer + Codex / 轮）<br><span class="en-line">Cross-review</span></td><td>✅ 8 轮迭代收敛到连续 2 轮 0 真实 issue（第 7、8 轮）+ post-gate packaging delta focused 复审 0 issue。修掉的真实 bug：跨进程锁竞争（3 次迭代）、<code>AGENTBRIDGE_STATE_DIR</code> 双重语义、空串 env、<code>kill --help</code> 误杀、pair-scoped 命令提示（含 SessionStart hook）</td></tr>
+      </tbody>
+    </table>
+  </section>
+</main>
+
+<footer>
+  AgentBridge · 单机多对 / Single-Machine Multi-Pair · <code>feat/multi-pair</code> ·
+  Approach A — Shared-Nothing Multi-Instance.
+  生成于 / generated 2026-05-30. 离线可用，双击打开即可 / works offline, just double-click.
+</footer>
+
+</body>
+</html>

--- a/docs/multi-pair.md
+++ b/docs/multi-pair.md
@@ -1,0 +1,247 @@
+# 单机多对 Claude+Codex / Single-Machine Multi-Pair
+
+> **Approach A — Shared-Nothing Multi-Instance**
+> 每一对 Claude↔Codex 都是完全隔离的实例：独立 daemon + 独立端口三元组 + 独立状态目录。
+> Each Claude↔Codex pair is a fully isolated instance: its own daemon, its own port triple, and its own state directory.
+
+---
+
+## 目录 / Table of Contents
+
+1. [背景与方案 / What Was Built](#背景与方案--what-was-built)
+2. [架构 / Architecture](#架构--architecture)
+3. [Slot → Port 映射 / Slot → Port Table](#slot--port-映射--slot--port-table)
+4. [用法 / Usage](#用法--usage)
+5. [底层原理 / How It Works](#底层原理--how-it-works)
+6. [并发安全 / Concurrency Safety](#并发安全--concurrency-safety)
+7. [升级迁移 / Migration Note](#升级迁移--migration-note)
+8. [验证状态 / Verification](#验证状态--verification)
+
+---
+
+## 背景与方案 / What Was Built
+
+### 问题 / Problem
+
+AgentBridge 此前每台机器只能运行 **一对** Claude↔Codex：单个 daemon，固定端口 `4500 / 4501 / 4502`。想同时跑两份协作（比如一份写功能、一份做 review）就会端口冲突、状态互相覆盖。
+
+Previously AgentBridge ran only **one** Claude↔Codex pair per machine: a single daemon on fixed ports `4500 / 4501 / 4502`. Running two collaborations at once (e.g. one for feature work, one for review) caused port collisions and state clobbering.
+
+### 方案 / Solution
+
+每一对 = **一个隔离的 daemon + 它自己的端口三元组 + 它自己的状态目录**。
+
+- **无需改动 daemon 内部逻辑** —— 所有多对（multi-pair）逻辑都落在一个全新的「解析层（resolution layer）」+ CLI 里。
+- 这与已废弃的 **PR #81「单 daemon 多 router」（路线 B）** 形成对比：路线 B 让多对共享一个 daemon，导致生命周期状态泄漏（一对的 kill/restart 会污染另一对）。本方案的 shared-nothing 隔离从根上避免了这个问题。
+
+Each pair = **one isolated daemon + its own port triple + its own state dir**.
+
+- **No daemon-internal changes** — all multi-pair logic lives in a new resolution layer + CLI.
+- This contrasts with the abandoned **PR #81 "single daemon multi-router" (route B)**, where pairs shared one daemon and lifecycle state leaked between them (killing/restarting one pair corrupted another). Shared-nothing isolation eliminates that class of bug.
+
+> ### 🔑 关键洞察（运行时已验证）/ Key Insight (runtime-verified)
+>
+> **Claude Code 会把继承到的环境变量原样传给它的 plugin MCP server。** 因此选择「跑哪一对」纯粹靠在启动前设置环境变量即可完成 —— **`.mcp.json` 完全不用改**。
+>
+> **Claude Code passes inherited environment variables straight through to its plugin MCP server.** A pair is therefore selected purely by setting env vars before launch — **`.mcp.json` is unchanged.**
+
+---
+
+## 架构 / Architecture
+
+两对并排运行，互不干扰 / Two pairs side by side, fully isolated:
+
+```
+   abg claude --pair work            abg claude --pair review
+   (env: ports + statedir = work)    (env: ports + statedir = review)
+            │                                  │
+            ▼                                  ▼
+   daemon(work)  4500/01/02          daemon(review)  4510/11/12
+            │                                  │
+            ▼                                  ▼
+   codex --pair work                 codex --pair review
+     --remote :4501                    --remote :4511
+```
+
+每一对都完全隔离，各自拥有独立的 `daemon.pid` / `status.json` / 日志 / `killed` sentinel，统一放在：
+
+Each pair is fully isolated, with its own `daemon.pid` / `status.json` / logs / `killed` sentinel under:
+
+```
+<stateDir>/pairs/<pairId>/
+```
+
+---
+
+## Slot → Port 映射 / Slot → Port Table
+
+每一对占据一个 **slot**，slot 决定它的端口三元组。规律：第 N 个 slot 在经典基址上 `+ N*10`。
+
+Each pair occupies a **slot**, and the slot determines its port triple. Rule: slot N is offset `+ N*10` from the classic base.
+
+| slot | appPort (`CODEX_WS_PORT`) | proxyPort (`CODEX_PROXY_PORT`) | controlPort (`AGENTBRIDGE_CONTROL_PORT`) |
+|:----:|:-------------------------:|:------------------------------:|:----------------------------------------:|
+| **0** (第一对 / first pair) | `4500` | `4501` | `4502` |
+| **1** | `4510` | `4511` | `4512` |
+| **2** | `4520` | `4521` | `4522` |
+| **N** | `4500 + N*10` | `+1` | `+2` |
+
+> **注意 / Note：** slot 0 = 经典端口（the classic ports）。所以**单对用户 100% 不受影响** —— 行为与升级前完全一致。
+> slot 0 = the classic ports, so a single-pair user is **100% unchanged**.
+
+---
+
+## 用法 / Usage
+
+> 这是最重要的一节。下面所有命令都可以直接复制粘贴。
+> This is the most important section. Every command below is copy-pasteable.
+
+### 启动一个命名对 / Start a named pair
+
+终端 1 启动 Claude 侧，终端 2 启动 Codex 侧（两者用同一个 `--pair` 名字配对）：
+
+Terminal 1 starts the Claude side, terminal 2 starts the Codex side (both use the same `--pair` name):
+
+```bash
+# Terminal 1
+abg claude --pair work
+
+# Terminal 2
+abg codex --pair work
+```
+
+### 第二个对（自动分配下一个 slot）/ A second pair (auto-assigned next slot)
+
+```bash
+# Terminal 3
+abg claude --pair review
+
+# Terminal 4
+abg codex --pair review
+```
+
+`review` 这一对会自动拿到下一个空闲 slot（例如 slot 1 → 端口 `4510/11/12`），与 `work` 对完全隔离。
+
+The `review` pair automatically takes the next free slot (e.g. slot 1 → ports `4510/11/12`), fully isolated from `work`.
+
+### 不带参数：按目录自动推导 / No flag: pair derived from the current directory
+
+```bash
+abg claude
+```
+
+不带 `--pair` 时，**对的身份由当前目录自动推导**（realpath + 短 hash）。在同一个项目目录里再次运行，会**重连到同一个对**。
+
+Without `--pair`, the pair identity is **auto-derived from the current directory** (realpath + short hash). Running it again in the same project **reconnects to the same pair**.
+
+### 列出所有对 / List all pairs
+
+```bash
+abg pairs
+```
+
+输出每个对的 `pairId`、slot、端口、cwd、运行/停止状态、pid。脚本场景用 JSON：
+
+Shows each pair's `pairId`, slot, ports, cwd, running/stopped state, and pid. For scripting:
+
+```bash
+abg pairs --json
+```
+
+停止某个对并释放它的 slot：
+
+Stop a pair and free its slot:
+
+```bash
+abg pairs rm <id>
+```
+
+### 停止 / Kill
+
+```bash
+# 停止所有对（以及任何遗留的旧版单对 daemon）
+# Stop ALL pairs (and any legacy single-pair daemon)
+abg kill
+
+# 只停 "work" 这一对（保留它的注册表条目 / slot）
+# Stop only the "work" pair (keeps its registry entry / slot)
+abg kill --pair work
+```
+
+### 对身份规则 / Pair identity rules
+
+- **显式 `--pair <name>` 优先 / explicit `--pair <name>` wins。**
+- 否则由**目录决定 / otherwise the directory decides。**
+- **命名对是全局的 / named pairs are global** —— 跨目录共享同一组端口。
+- **目录推导的对是按目录的 / directory-derived pairs are per-directory** —— 每个目录一个独立的对。
+
+---
+
+## 底层原理 / How It Works (env-injection seam)
+
+每个 CLI 命令的最顶端都会先跑一个 **「对解析器（pair resolver）」**：
+
+1. 在跨进程锁（cross-process lock）保护下，到注册表 `<base>/pairs/registry.json` 里**分配 / 查找**这个对的 slot。
+2. 然后设置这些环境变量：
+   - `AGENTBRIDGE_STATE_DIR`（该对的 state 目录 `<base>/pairs/<id>`）
+   - `AGENTBRIDGE_CONTROL_PORT`
+   - `CODEX_WS_PORT`
+   - `CODEX_PROXY_PORT`
+   - `AGENTBRIDGE_BASE_DIR`（注册表 base —— 子进程 `abg pairs`/`kill` 据此解析正确的 registry，而不会误把 per-pair 目录当 base）
+   - `AGENTBRIDGE_PAIR_ID`（对的 id，用于诊断 / 写入 status.json）
+3. 既有的 `claude` / `codex` / `kill` 代码，以及 daemon，因为**本来就从环境变量读取这些值**，所以无需任何改动就「自动工作」。
+
+A **"pair resolver"** runs at the top of each CLI command:
+
+1. Under a cross-process lock, it **allocates / looks up** the pair's slot in the registry `<base>/pairs/registry.json`.
+2. It then sets these env vars: `AGENTBRIDGE_STATE_DIR` (the pair dir `<base>/pairs/<id>`), `AGENTBRIDGE_CONTROL_PORT`, `CODEX_WS_PORT`, `CODEX_PROXY_PORT`, plus `AGENTBRIDGE_BASE_DIR` (the registry base, so child `abg pairs`/`kill` resolve the real registry rather than the per-pair dir) and `AGENTBRIDGE_PAIR_ID` (the pair id, for diagnostics / status.json).
+3. The existing claude / codex / kill code and the daemon **just work**, because they already read these from env.
+
+这就是整个特性的接缝（seam）：**靠环境变量注入，而不是改动核心代码。**
+
+This is the entire seam of the feature: **env-injection, not core-code surgery.**
+
+---
+
+## 并发安全 / Concurrency Safety
+
+- **两个 `abg claude` 同时启动不会撞车 / Two `abg claude` started at the same time can't collide。** Slot 分配由一个**原子锁文件（atomic lock file，靠 `link(2)`：先写临时文件,再 `link` 到锁路径,EEXIST 即已持有)**串行化,锁内含 owner pid + nonce。陈旧锁回收**只针对已死的 owner**(绝不抢占活进程的锁,以免恢复后写回旧 registry 造成 lost update);回收本身还经一个独立的 serialized reclaim lock + 重新确认 owner 已死后才删,杜绝并发 evict 活锁。Stale recovery is by **process liveness, not TTL**.
+- **端口会被探测 / allocated ports are probed。** 如果某个外部进程占用了目标端口，你会得到一个清晰的 **`PAIR_PORTS_BUSY`** 错误，而不是悄悄连到错误的端口（silent wrong-port connection）。
+
+---
+
+## 升级迁移 / Migration Note
+
+> ### ⚠️ 升级后请执行一次 / Run once after upgrading
+>
+> 升级到多对版本后，如果还有一个**旧版（pre-multi-pair）daemon** 在跑，请执行一次：
+>
+> After upgrading, if an old (pre-multi-pair) daemon is still running, run once:
+>
+> ```bash
+> abg kill
+> ```
+>
+> 新代码会**检测到这个 legacy-root daemon 并给出引导**。
+> The new code detects the legacy-root daemon and guides you.
+
+---
+
+## 验证状态 / Verification
+
+全部通过。 / All green.
+
+| 项 / Item | 状态 / Status |
+|---|---|
+| 单元测试（pair-registry / concurrency / resolver / command）/ Unit tests | ✅ pass — 含 8 进程并发 + seeded-dead-lock 锁测试，20+ 次 stress 0 碰撞 |
+| 类型检查 + 全量测试 + 插件同步（`bun run check`）/ Type check + full suite + plugin sync | ✅ 334 pass / 0 fail，typecheck clean，bundles in sync，version-aligned 0.1.6 |
+| 真实双对运行时 E2E（Codex sandbox，仓库原脚本无 workaround）/ Real two-pair runtime E2E | ✅ pass — pair `a`=slot2 (4520/4521/4522, pairId "a")、pair `b`=slot3 (4530/4531/4532, pairId "b")；端口/state/日志隔离；`kill --pair a` 只停 a，b 仍 LISTEN；`kill --all` 后 4520-4532 全清 |
+| 交叉评审（Claude×2 全新 reviewer + Codex / 轮）/ Cross-review | ✅ 8 轮迭代收敛到连续 2 轮 0 真实 issue（第 7、8 轮）+ post-gate packaging delta focused 复审 0 issue |
+
+真实修掉的 bug（交叉评审捕获）/ Real bugs caught & fixed by cross-review:
+- 跨进程锁竞争（3 次迭代：发布窗口 → CAS → reclaim-lock 串行化 + dead-pid-only + nonce）
+- `AGENTBRIDGE_STATE_DIR` 双重语义（引入 `AGENTBRIDGE_BASE_DIR`）
+- 空字符串 env 被当有效路径
+- `kill --help` / 未知 flag 误落 kill-all
+- pair-scoped 命令提示（bridge / disabled-state / codex / kill / SessionStart health-check.sh）
+- packaging：`build:cli` 未产 `dist/daemon.js` + daemon entry 默认

--- a/docs/superpowers/plans/2026-03-30-server-request-passthrough.md
+++ b/docs/superpowers/plans/2026-03-30-server-request-passthrough.md
@@ -1,0 +1,666 @@
+# Server-to-Client Request Passthrough 实现计划
+
+> **执行模式：AgentBridge 双 Agent 协作**
+> - **Codex（Builder）**：实现代码 + 写测试，在主目录 `/Users/raysonmeng/agent_bridge` 工作
+> - **Claude（Critic）**：review 每个 Task 产出、跑验证、处理 git 操作（commit/push/PR）
+> - 每个 Task 完成后 Claude review → 通过则 commit → 进入下一个 Task
+> - Codex 不做 git 操作（sandbox 限制）
+
+**Goal:** 修复 issue #37 — Codex 审批请求被代理丢弃导致 TUI 无法显示审批 UI、Codex 卡死
+
+**Architecture:** 在 `codex-adapter.ts` 的 `handleAppServerPayload` 中新增 server-to-client request 分支（同时具有 `id` + `method` 的消息），内部直接发送给 TUI 并建立双向 ID mapping；TUI 的审批响应通过 `onTuiMessage` 回传给 app-server。TUI 断连时缓冲 server request，重连后重放。
+
+**Tech Stack:** TypeScript, Bun, WebSocket, JSON-RPC
+
+**Spec:** `docs/issue-37-server-request-passthrough-design.md` (v5)
+
+---
+
+## 文件结构
+
+| 文件 | 职责 |
+|------|------|
+| `src/codex-adapter.ts` | 修改：新增 server request 检测、转发、响应路由、缓冲重放、清理 |
+| `src/codex-adapter.test.ts` | 修改：新增测试用例 |
+
+---
+
+## Phase 1: 核心修复（Task 1 + 2）
+
+> Codex 实现 Task 1 和 Task 2 的全部代码和测试。完成后通知 Claude review。
+
+### Task 1: Server request 识别与转发
+
+**角色：Codex 实现**
+**Files:**
+- Modify: `src/codex-adapter.ts:19-30`（新增类型）, `src/codex-adapter.ts:343-357`（handleAppServerPayload）
+- Modify: `src/codex-adapter.test.ts`
+
+- [ ] **Step 1: 新增 `PendingServerRequest` 类型和属性**
+
+在 `src/codex-adapter.ts` 的 `TuiSocketData` interface 后面添加：
+
+```typescript
+interface PendingServerRequest {
+  serverId: number | string;
+  connId: number;
+  method: string;
+  timestamp: number;
+}
+```
+
+在 `CodexAdapter` class 的属性区域（`private nextProxyId` 附近）添加：
+
+```typescript
+private serverRequestToProxy = new Map<number, PendingServerRequest>();
+private pendingServerRequests: Array<{ raw: string; serverId: number | string; method: string }> = [];
+```
+
+- [ ] **Step 2: 修改 `handleAppServerPayload` 添加 server request 分支**
+
+修改 `src/codex-adapter.ts:343-357`，在 `parsed.id === undefined` 检查之后、`handleAppServerResponse` 调用之前，插入 server request 检测：
+
+```typescript
+private handleAppServerPayload(raw: string): string | null {
+  try {
+    const parsed = JSON.parse(raw);
+
+    if (parsed.id === undefined) {
+      const forwarded = this.patchResponse(parsed, raw);
+      this.interceptServerMessage(parsed);
+      return forwarded;
+    }
+
+    // Server-to-client request（如审批提示）— 内部直接发送给 TUI
+    if (parsed.method !== undefined) {
+      this.handleServerRequest(parsed);
+      return null;
+    }
+
+    return this.handleAppServerResponse(parsed, raw);
+  } catch {
+    return raw;
+  }
+}
+```
+
+- [ ] **Step 3: 实现 `handleServerRequest` 方法**
+
+在 `handleAppServerResponse` 方法之前添加：
+
+```typescript
+private handleServerRequest(parsed: any): void {
+  const raw = JSON.stringify(parsed);
+  const serverId = parsed.id;
+  const method = parsed.method;
+
+  if (!this.tuiWs) {
+    this.pendingServerRequests.push({ raw, serverId, method });
+    this.log(`Server request buffered (no TUI): ${method} (server id=${serverId})`);
+    return;
+  }
+
+  const proxyId = this.nextProxyId++;
+  parsed.id = proxyId;
+
+  try {
+    this.tuiWs.send(JSON.stringify(parsed));
+  } catch (e: any) {
+    this.log(`Server request send failed, buffering: ${method} (server id=${serverId}): ${e.message}`);
+    this.pendingServerRequests.push({ raw, serverId, method });
+    return;
+  }
+
+  this.serverRequestToProxy.set(proxyId, {
+    serverId,
+    connId: this.tuiConnId,
+    method,
+    timestamp: Date.now(),
+  });
+
+  this.log(`Server request: ${method} (server id=${serverId} → proxy id=${proxyId}, conn #${this.tuiConnId})`);
+}
+```
+
+- [ ] **Step 4: 写测试并验证**
+
+在 `src/codex-adapter.test.ts` 末尾新增：
+
+```typescript
+describe("CodexAdapter server-to-client request passthrough", () => {
+  test("forwards server request (id + method) to TUI instead of dropping", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+    adapter.tuiWs = { send: (data: string) => sent.push(data) } as any;
+    adapter.tuiConnId = 1;
+
+    const serverRequest = JSON.stringify({
+      id: 42,
+      method: "item/permissions/requestApproval",
+      params: { permission: "network" },
+    });
+
+    const result = adapter.handleAppServerPayload(serverRequest);
+
+    expect(result).toBeNull();
+    expect(sent.length).toBe(1);
+    const parsed = JSON.parse(sent[0]);
+    expect(parsed.method).toBe("item/permissions/requestApproval");
+    expect(parsed.params).toEqual({ permission: "network" });
+    expect(parsed.id).not.toBe(42);
+    expect(adapter.serverRequestToProxy.size).toBe(1);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("existing response handling is not affected by server request passthrough", () => {
+    const adapter = createAdapter();
+    adapter.tuiConnId = 1;
+    adapter.upstreamToClient.set(100200, { connId: 1, clientId: "c1" });
+
+    const forwarded = adapter.handleAppServerPayload(JSON.stringify({
+      id: 100200,
+      result: { ok: true },
+    }));
+
+    expect(forwarded).not.toBeNull();
+    expect(JSON.parse(forwarded!).id).toBe("c1");
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("notifications without id still forwarded as before", () => {
+    const adapter = createAdapter();
+    const raw = JSON.stringify({ method: "item/started", params: { item: { id: "i1", type: "text" } } });
+    const forwarded = adapter.handleAppServerPayload(raw);
+    expect(forwarded).toBe(raw);
+    adapter.clearResponseTrackingState();
+  });
+
+  test("buffers server request when no TUI connected", () => {
+    const adapter = createAdapter();
+    adapter.tuiWs = null;
+
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: 50,
+      method: "item/fileChange/requestApproval",
+      params: { file: "test.ts" },
+    }));
+
+    expect(adapter.pendingServerRequests.length).toBe(1);
+    expect(adapter.pendingServerRequests[0].serverId).toBe(50);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("falls back to buffer when TUI send fails", () => {
+    const adapter = createAdapter();
+    adapter.tuiWs = { send: () => { throw new Error("broken pipe"); } } as any;
+    adapter.tuiConnId = 1;
+
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: 90,
+      method: "item/commandExecution/requestApproval",
+      params: {},
+    }));
+
+    expect(adapter.pendingServerRequests.length).toBe(1);
+    expect(adapter.pendingServerRequests[0].serverId).toBe(90);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+});
+```
+
+Run: `bun test src/codex-adapter.test.ts`
+Expected: 全部 PASS
+
+---
+
+### Task 2: TUI 审批响应回传 + ID 归一化
+
+**角色：Codex 实现**
+**Files:**
+- Modify: `src/codex-adapter.ts:303-339`（onTuiMessage）
+- Modify: `src/codex-adapter.test.ts`
+
+- [ ] **Step 1: 修改 `onTuiMessage` 添加 server request 响应路由**
+
+在 `onTuiMessage` 方法中，在 `let forwarded = data;` 之前，添加 server request response 检查。**注意 ID 类型归一化**（TUI 可能返回 string 类型 ID）：
+
+```typescript
+private onTuiMessage(ws: ServerWebSocket<TuiSocketData>, msg: string | Buffer) {
+  const data = typeof msg === "string" ? msg : msg.toString();
+  const connId = ws.data.connId;
+
+  if (connId !== this.tuiConnId) {
+    this.log(`Dropping message from stale TUI conn #${connId} (current is #${this.tuiConnId})`);
+    return;
+  }
+
+  // Check if this is a response to a server-originated request
+  try {
+    const parsed = JSON.parse(data);
+    if (parsed.id !== undefined && !parsed.method) {
+      const rawId = parsed.id;
+      const normalizedId = typeof rawId === "number"
+        ? rawId
+        : (typeof rawId === "string" && /^-?\d+$/.test(rawId) ? Number(rawId) : NaN);
+      const pending = !isNaN(normalizedId) ? this.serverRequestToProxy.get(normalizedId) : undefined;
+      if (pending !== undefined) {
+        if (pending.connId !== connId) {
+          this.log(`Dropping stale server request response (proxy id=${normalizedId}, expected conn #${pending.connId}, got #${connId})`);
+          return;
+        }
+
+        parsed.id = pending.serverId;
+        try {
+          this.appServerWs!.send(JSON.stringify(parsed));
+          this.serverRequestToProxy.delete(normalizedId);
+          this.log(`TUI → app-server: ${pending.method} response (proxy id=${normalizedId} → server id=${pending.serverId})`);
+        } catch (e: any) {
+          parsed.id = normalizedId;
+          this.log(`Failed to forward approval response to app-server (proxy id=${normalizedId}): ${e.message}`);
+        }
+        return;
+      }
+    }
+  } catch {
+    // fall through to existing forwarding
+  }
+
+  // ... existing client request forwarding logic below (unchanged) ...
+  let forwarded = data;
+  try {
+    const parsed = JSON.parse(data);
+    // ... rest unchanged ...
+```
+
+- [ ] **Step 2: 写测试并验证**
+
+在 `src/codex-adapter.test.ts` 的 server request passthrough describe block 中追加：
+
+```typescript
+  test("routes TUI approval response back to app-server with original server id", () => {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    adapter.tuiConnId = 1;
+
+    adapter.serverRequestToProxy.set(100300, {
+      serverId: 42,
+      connId: 1,
+      method: "item/permissions/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: 100300, result: { approved: true } }));
+
+    expect(appSent.length).toBe(1);
+    expect(JSON.parse(appSent[0]).id).toBe(42);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("rejects stale response from old TUI without deleting mapping", () => {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    adapter.tuiConnId = 2;
+
+    adapter.serverRequestToProxy.set(100301, {
+      serverId: 43,
+      connId: 1,
+      method: "item/fileChange/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    const ws = { data: { connId: 2 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: 100301, result: { approved: true } }));
+
+    expect(appSent.length).toBe(0);
+    expect(adapter.serverRequestToProxy.has(100301)).toBe(true);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("normalizes string ID to number when matching server request response", () => {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    adapter.tuiConnId = 1;
+
+    adapter.serverRequestToProxy.set(100302, {
+      serverId: 44,
+      connId: 1,
+      method: "item/commandExecution/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: "100302", result: { approved: false } }));
+
+    expect(appSent.length).toBe(1);
+    expect(JSON.parse(appSent[0]).id).toBe(44);
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("unknown TUI response id falls through to normal client forwarding", () => {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    adapter.tuiConnId = 1;
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({ id: 999, result: { ok: true } }));
+
+    expect(appSent.length).toBe(1);
+
+    adapter.clearResponseTrackingState();
+  });
+```
+
+Run: `bun test src/codex-adapter.test.ts`
+Expected: 全部 PASS
+
+---
+
+**Phase 1 完成后：**
+- [ ] **Claude review**: 读 Codex 的代码改动，验证 typecheck + 全量测试
+- [ ] **Claude commit**: `git add` + `git commit` Task 1 + 2 的改动
+- [ ] **通知 Codex**: 进入 Phase 2
+
+---
+
+## Phase 2: 重连与清理（Task 3 + 4）
+
+> Codex 实现 Task 3 和 Task 4 的全部代码和测试。完成后通知 Claude review。
+
+### Task 3: TUI 重连重放
+
+**角色：Codex 实现**
+**Files:**
+- Modify: `src/codex-adapter.ts:281-287`（onTuiConnect）
+- Modify: `src/codex-adapter.test.ts`
+
+- [ ] **Step 1: 修改 `onTuiConnect` 添加重放逻辑**
+
+在 `onTuiConnect` 方法末尾添加：
+
+```typescript
+private onTuiConnect(ws: ServerWebSocket<TuiSocketData>) {
+  this.tuiConnId++;
+  ws.data.connId = this.tuiConnId;
+  this.tuiWs = ws;
+  this.log(`TUI connected (conn #${this.tuiConnId})`);
+  this.emit("tuiConnected", this.tuiConnId);
+
+  // 重放缓冲的 server request
+  const remaining: typeof this.pendingServerRequests = [];
+  for (const buffered of this.pendingServerRequests) {
+    const proxyId = this.nextProxyId++;
+    try {
+      const parsed = JSON.parse(buffered.raw);
+      parsed.id = proxyId;
+      ws.send(JSON.stringify(parsed));
+      this.serverRequestToProxy.set(proxyId, {
+        serverId: buffered.serverId,
+        connId: this.tuiConnId,
+        method: buffered.method,
+        timestamp: Date.now(),
+      });
+      this.log(`Replayed buffered server request: ${buffered.method} (server id=${buffered.serverId} → proxy id=${proxyId})`);
+    } catch (e: any) {
+      this.log(`Failed to replay buffered server request: ${buffered.method} (server id=${buffered.serverId}): ${e.message}`);
+      remaining.push(buffered);
+    }
+  }
+  this.pendingServerRequests = remaining;
+}
+```
+
+- [ ] **Step 2: 写测试并验证**
+
+```typescript
+  test("replays buffered server requests on TUI reconnect", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+
+    adapter.pendingServerRequests = [
+      { raw: JSON.stringify({ id: 50, method: "item/fileChange/requestApproval", params: { file: "test.ts" } }), serverId: 50, method: "item/fileChange/requestApproval" },
+    ];
+
+    const ws = { data: { connId: 0 }, send: (data: string) => sent.push(data) } as any;
+    adapter.onTuiConnect(ws);
+
+    expect(adapter.pendingServerRequests.length).toBe(0);
+    expect(sent.length).toBe(1);
+    const parsed = JSON.parse(sent[0]);
+    expect(parsed.method).toBe("item/fileChange/requestApproval");
+    expect(parsed.id).not.toBe(50);
+    expect(adapter.serverRequestToProxy.size).toBe(1);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("replay send failure: no phantom mapping, request stays buffered", () => {
+    const adapter = createAdapter();
+
+    adapter.pendingServerRequests = [
+      { raw: JSON.stringify({ id: 60, method: "item/permissions/requestApproval", params: {} }), serverId: 60, method: "item/permissions/requestApproval" },
+    ];
+
+    const ws = { data: { connId: 0 }, send: () => { throw new Error("connection reset"); } } as any;
+    adapter.onTuiConnect(ws);
+
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+    expect(adapter.pendingServerRequests.length).toBe(1);
+
+    adapter.clearResponseTrackingState();
+  });
+```
+
+Run: `bun test src/codex-adapter.test.ts`
+Expected: 全部 PASS
+
+---
+
+### Task 4: TTL 清理 + app-server 重连清理
+
+**角色：Codex 实现**
+**Files:**
+- Modify: `src/codex-adapter.ts:610-621`（retireConnectionState）, `src/codex-adapter.ts:663-676`（clearResponseTrackingState）
+- Modify: `src/codex-adapter.test.ts`
+
+- [ ] **Step 1: 修改 `retireConnectionState` 添加 TTL 清理**
+
+在 `retireConnectionState` 方法末尾添加：
+
+```typescript
+  // TTL cleanup for server request mappings belonging to this connection
+  for (const [proxyId, pending] of this.serverRequestToProxy.entries()) {
+    if (pending.connId === connId) {
+      const timer = setTimeout(() => {
+        if (this.serverRequestToProxy.get(proxyId)?.connId === connId) {
+          this.serverRequestToProxy.delete(proxyId);
+          this.log(`Expired stale server request mapping (proxy id=${proxyId}, method=${pending.method})`);
+        }
+      }, CodexAdapter.RESPONSE_TRACKING_TTL_MS);
+      timer.unref?.();
+    }
+  }
+```
+
+- [ ] **Step 2: 修改 `clearResponseTrackingState` 添加 server request 清理**
+
+在 `clearResponseTrackingState` 末尾添加：
+
+```typescript
+  // Clear server request state (session-scoped)
+  this.serverRequestToProxy.clear();
+  this.pendingServerRequests = [];
+```
+
+- [ ] **Step 3: 写测试并验证**
+
+```typescript
+  test("server request mappings survive TUI disconnect (TTL cleanup)", () => {
+    const adapter = createAdapter();
+    adapter.tuiConnId = 1;
+
+    adapter.serverRequestToProxy.set(100400, {
+      serverId: 70,
+      connId: 1,
+      method: "item/permissions/requestApproval",
+      timestamp: Date.now(),
+    });
+
+    adapter.retireConnectionState(1);
+    expect(adapter.serverRequestToProxy.has(100400)).toBe(true);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("app-server close clears all server request state", () => {
+    const adapter = createAdapter();
+
+    adapter.serverRequestToProxy.set(100401, {
+      serverId: 71,
+      connId: 1,
+      method: "item/permissions/requestApproval",
+      timestamp: Date.now(),
+    });
+    adapter.pendingServerRequests = [
+      { raw: "{}", serverId: 72, method: "item/fileChange/requestApproval" },
+    ];
+
+    adapter.clearResponseTrackingState();
+    adapter.activeTurnIds.clear();
+    adapter.turnInProgress = false;
+
+    expect(adapter.serverRequestToProxy.size).toBe(0);
+    expect(adapter.pendingServerRequests.length).toBe(0);
+  });
+
+  test("server request and client request share nextProxyId without collision", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+    adapter.tuiWs = { send: (data: string) => sent.push(data) } as any;
+    adapter.tuiConnId = 1;
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: 80,
+      method: "item/permissions/requestApproval",
+      params: {},
+    }));
+
+    const ws = { data: { connId: 1 } } as any;
+    adapter.onTuiMessage(ws, JSON.stringify({
+      id: "client-1",
+      method: "thread/start",
+      params: {},
+    }));
+
+    const serverProxyId = JSON.parse(sent[0]).id;
+    const clientMapping = [...adapter.upstreamToClient.entries()];
+    expect(clientMapping.length).toBe(1);
+    expect(clientMapping[0][0]).not.toBe(serverProxyId);
+
+    adapter.clearResponseTrackingState();
+  });
+```
+
+Run: `bun test src/codex-adapter.test.ts`
+Expected: 全部 PASS
+
+---
+
+**Phase 2 完成后：**
+- [ ] **Claude review**: 读 Codex 的代码改动，验证 typecheck + 全量测试
+- [ ] **Claude commit**: `git add` + `git commit` Task 3 + 4 的改动
+- [ ] **通知 Codex**: 进入 Phase 3
+
+---
+
+## Phase 3: 最终验证与发布（Claude + Codex 协作）
+
+### Task 5: 集成验证
+
+**角色：Claude 主导，Codex 辅助**
+
+- [ ] **Step 1: Claude 运行 typecheck**
+
+Run: `bun run typecheck`
+Expected: 无错误
+
+- [ ] **Step 2: Claude 运行全量测试**
+
+Run: `bun test src/`
+Expected: 全部 PASS（原有 133 + 新增测试）
+
+- [ ] **Step 3: Claude 创建 PR**
+
+```bash
+git checkout -b fix/server-request-passthrough
+git push -u origin fix/server-request-passthrough
+gh pr create --title "fix: passthrough server-to-client requests for approval UI (issue #37)" ...
+```
+
+- [ ] **Step 4: Codex review PR diff**
+
+Claude 发 PR diff 给 Codex 做交叉 review
+
+- [ ] **Step 5: E2E 验证（手动）**
+
+1. 启动 AgentBridge 和 Codex
+2. 让 Codex 执行需要审批的操作
+3. 验证审批提示出现在 TUI 中
+4. 批准/拒绝后验证 Codex 正确继续/停止
+
+---
+
+## 协作协议
+
+### 通信格式
+
+Codex 完成一个 Phase 后发送：
+```
+[IMPORTANT] Phase N 完成。改动文件：src/codex-adapter.ts, src/codex-adapter.test.ts
+请 review 并 commit。
+```
+
+Claude review 后发送：
+```
+Phase N review 通过。已 commit: <commit hash>
+进入 Phase N+1，请实现 Task X + Y。
+```
+
+### 错误处理
+
+- Codex 测试失败 → Codex 自行修复，修复后重新通知 Claude
+- Claude review 发现问题 → 发给 Codex 具体行号和修复建议
+- typecheck 失败 → Claude 发错误信息给 Codex 修复
+
+### Git 操作（仅 Claude 执行）
+
+- 所有 commit 由 Claude 在 worktree 或当前分支上执行
+- 每个 Phase 一个 commit（squash Task 1+2 为一个，Task 3+4 为一个）
+- PR 由 Claude 创建，Codex review
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec 覆盖**: v5 设计文档的全部改动点都有对应 Task
+- [x] **无占位符**: 所有 step 包含完整代码
+- [x] **类型一致**: `PendingServerRequest`, `serverRequestToProxy`, `pendingServerRequests` 全文一致
+- [x] **角色分工明确**: 每个 Task 标注了由谁执行
+- [x] **Phase 边界清晰**: 每个 Phase 结束有明确的 review + commit checkpoint

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "validate:plugin": "claude plugin validate plugins/agentbridge && claude plugin validate .claude-plugin/marketplace.json",
     "test": "bun test src",
     "e2e:transport": "bun scripts/e2e-codex-transport.mjs",
+    "install:global": "node scripts/install-global.mjs local",
+    "install:global:local": "node scripts/install-global.mjs local",
+    "install:global:npm": "node scripts/install-global.mjs npm",
+    "release:bump": "node scripts/bump-version.mjs",
     "typecheck": "tsc --noEmit",
     "validate:plugin-versions": "bun scripts/check-plugin-versions.js",
     "check": "tsc --noEmit && bun test src && bun run verify:plugin-sync && bun scripts/check-plugin-versions.js"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "prepublishOnly": "bun run build:cli && bun run build:plugin",
     "validate:plugin": "claude plugin validate plugins/agentbridge && claude plugin validate .claude-plugin/marketplace.json",
     "test": "bun test src",
+    "install:global": "node scripts/install-global.mjs local",
+    "install:global:local": "node scripts/install-global.mjs local",
+    "install:global:npm": "node scripts/install-global.mjs npm",
+    "release:bump": "node scripts/bump-version.mjs",
     "typecheck": "tsc --noEmit",
     "validate:plugin-versions": "bun scripts/check-plugin-versions.js",
     "check": "tsc --noEmit && bun test src && bun run verify:plugin-sync && bun scripts/check-plugin-versions.js"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prepublishOnly": "bun run build:cli && bun run build:plugin",
     "validate:plugin": "claude plugin validate plugins/agentbridge && claude plugin validate .claude-plugin/marketplace.json",
     "test": "bun test src",
+    "e2e:transport": "bun scripts/e2e-codex-transport.mjs",
     "typecheck": "tsc --noEmit",
     "validate:plugin-versions": "bun scripts/check-plugin-versions.js",
     "check": "tsc --noEmit && bun test src && bun run verify:plugin-sync && bun scripts/check-plugin-versions.js"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "start": "bun run src/bridge.ts",
     "build:cli": "mkdir -p dist && bun build src/cli.ts --outfile dist/cli.js --target bun && bun build src/daemon.ts --outfile dist/daemon.js --target bun && chmod +x dist/cli.js",
     "build:plugin": "mkdir -p plugins/agentbridge/server && bun build src/bridge.ts --outfile plugins/agentbridge/server/bridge-server.js --target bun && bun build src/daemon.ts --outfile plugins/agentbridge/server/daemon.js --target bun",
+    "smoke:built": "bun scripts/smoke-built-cli.mjs",
+    "smoke:pack": "bun scripts/smoke-pack.mjs",
     "verify:plugin-sync": "node scripts/verify-plugin-sync.cjs",
     "postinstall": "node scripts/postinstall.cjs",
     "prepublishOnly": "bun run build:cli && bun run build:plugin",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prepublishOnly": "bun run build:cli && bun run build:plugin",
     "validate:plugin": "claude plugin validate plugins/agentbridge && claude plugin validate .claude-plugin/marketplace.json",
     "test": "bun test src",
+    "e2e:transport": "bun scripts/e2e-codex-transport.mjs",
     "typecheck": "tsc --noEmit",
     "validate:plugin-versions": "bun scripts/check-plugin-versions.js",
     "check": "tsc --noEmit && bun test src && bun run verify:plugin-sync && bun scripts/check-plugin-versions.js"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.6",
   "description": "Bridge between Claude Code and Codex — bidirectional agent communication via MCP Channel + JSON-RPC",
   "type": "module",
+  "packageManager": "bun@1.3.11",
+  "engines": {
+    "bun": ">=1.3.11"
+  },
   "bin": {
     "agentbridge": "dist/cli.js",
     "abg": "dist/cli.js"
@@ -12,18 +16,19 @@
     "plugins/",
     ".claude-plugin/",
     "scripts/postinstall.cjs",
+    "scripts/install-safety.cjs",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
     "start": "bun run src/bridge.ts",
-    "build:cli": "mkdir -p dist && bun build src/cli.ts --outfile dist/cli.js --target bun && bun build src/daemon.ts --outfile dist/daemon.js --target bun && chmod +x dist/cli.js",
-    "build:plugin": "mkdir -p plugins/agentbridge/server && bun build src/bridge.ts --outfile plugins/agentbridge/server/bridge-server.js --target bun && bun build src/daemon.ts --outfile plugins/agentbridge/server/daemon.js --target bun",
+    "build:cli": "node scripts/build-bundles.mjs cli daemon",
+    "build:plugin": "node scripts/build-bundles.mjs bridge-plugin daemon-plugin",
     "smoke:built": "bun scripts/smoke-built-cli.mjs",
     "smoke:pack": "bun scripts/smoke-pack.mjs",
     "verify:plugin-sync": "node scripts/verify-plugin-sync.cjs",
     "postinstall": "node scripts/postinstall.cjs",
-    "prepublishOnly": "bun run build:cli && bun run build:plugin",
+    "prepublishOnly": "bun run build:cli && bun run build:plugin && bun run verify:plugin-sync && bun scripts/check-plugin-versions.js",
     "validate:plugin": "claude plugin validate plugins/agentbridge && claude plugin validate .claude-plugin/marketplace.json",
     "test": "bun test src",
     "e2e:transport": "bun scripts/e2e-codex-transport.mjs",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "start": "bun run src/bridge.ts",
-    "build:cli": "mkdir -p dist && bun build src/cli.ts --outfile dist/cli.js --target bun && chmod +x dist/cli.js",
+    "build:cli": "mkdir -p dist && bun build src/cli.ts --outfile dist/cli.js --target bun && bun build src/daemon.ts --outfile dist/daemon.js --target bun && chmod +x dist/cli.js",
     "build:plugin": "mkdir -p plugins/agentbridge/server && bun build src/bridge.ts --outfile plugins/agentbridge/server/bridge-server.js --target bun && bun build src/daemon.ts --outfile plugins/agentbridge/server/daemon.js --target bun",
     "verify:plugin-sync": "node scripts/verify-plugin-sync.cjs",
     "postinstall": "node scripts/postinstall.cjs",

--- a/plugins/agentbridge/scripts/health-check.sh
+++ b/plugins/agentbridge/scripts/health-check.sh
@@ -37,6 +37,15 @@ fi
 
 printf '%s' "$now" >"$stamp_file" 2>/dev/null || true
 
+# In-session plugin-update reminder: compare the INSTALLED plugin version against
+# the latest npm version cached by the CLI notifier (src/update-notifier.ts). This
+# is how a user who updated the npm CLI but not the plugin learns of the mismatch
+# from inside Claude Code. Best-effort + silent: never blocks the hook.
+plugin_notice=""
+if command -v bun >/dev/null 2>&1 && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  plugin_notice="$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/plugin-update-notice.mjs" "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || true)"
+fi
+
 health_json="$(curl -fsS --max-time 1 "http://127.0.0.1:${port}/healthz" 2>/dev/null || true)"
 
 if [ -n "$health_json" ]; then
@@ -47,15 +56,15 @@ if [ -n "$health_json" ]; then
 
   if [ "$tui_connected" = "true" ]; then
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge is running. Daemon healthy, Codex TUI connected. Bridge is ready for communication."}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge is running. Daemon healthy, Codex TUI connected. Bridge is ready for communication.${plugin_notice:+ $plugin_notice}"}}
 EOF
   else
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex${pair_arg}"}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex${pair_arg}${plugin_notice:+ $plugin_notice}"}}
 EOF
   fi
 else
   cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude${pair_arg} (this terminal) + agentbridge codex${pair_arg} (another terminal). If you're already using agentbridge claude${pair_arg}, the daemon may still be starting up."}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude${pair_arg} (this terminal) + agentbridge codex${pair_arg} (another terminal). If you're already using agentbridge claude${pair_arg}, the daemon may still be starting up.${plugin_notice:+ $plugin_notice}"}}
 EOF
 fi

--- a/plugins/agentbridge/scripts/health-check.sh
+++ b/plugins/agentbridge/scripts/health-check.sh
@@ -27,6 +27,15 @@ fi
 
 printf '%s' "$now" >"$stamp_file" 2>/dev/null || true
 
+# In-session plugin-update reminder: compare the INSTALLED plugin version against
+# the latest npm version cached by the CLI notifier (src/update-notifier.ts). This
+# is how a user who updated the npm CLI but not the plugin learns of the mismatch
+# from inside Claude Code. Best-effort + silent: never blocks the hook.
+plugin_notice=""
+if command -v bun >/dev/null 2>&1 && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  plugin_notice="$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/plugin-update-notice.mjs" "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || true)"
+fi
+
 health_json="$(curl -fsS --max-time 1 "http://127.0.0.1:${port}/healthz" 2>/dev/null || true)"
 
 if [ -n "$health_json" ]; then
@@ -37,15 +46,15 @@ if [ -n "$health_json" ]; then
 
   if [ "$tui_connected" = "true" ]; then
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge is running. Daemon healthy, Codex TUI connected. Bridge is ready for communication."}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge is running. Daemon healthy, Codex TUI connected. Bridge is ready for communication.${plugin_notice:+ $plugin_notice}"}}
 EOF
   else
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex"}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex${plugin_notice:+ $plugin_notice}"}}
 EOF
   fi
 else
   cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude (this terminal) + agentbridge codex (another terminal). If you're already using agentbridge claude, the daemon may still be starting up."}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude (this terminal) + agentbridge codex (another terminal). If you're already using agentbridge claude, the daemon may still be starting up.${plugin_notice:+ $plugin_notice}"}}
 EOF
 fi

--- a/plugins/agentbridge/scripts/health-check.sh
+++ b/plugins/agentbridge/scripts/health-check.sh
@@ -9,6 +9,16 @@ cooldown_seconds="${AGENTBRIDGE_HEALTH_HOOK_COOLDOWN_SECONDS:-120}"
 state_root="${AGENTBRIDGE_HOOK_STATE_DIR:-${TMPDIR:-/tmp}/agentbridge-hooks}"
 port="${AGENTBRIDGE_CONTROL_PORT:-4502}"
 
+# In multi-pair mode the resolver exports AGENTBRIDGE_PAIR_ID, inherited here via
+# the SessionStart hook env. Scope the suggested commands to that pair so the
+# user is not sent to a different (cwd-derived) pair. Guard the charset (the
+# resolver already restricts it) so nothing unsafe is interpolated into the JSON.
+pair_id="${AGENTBRIDGE_PAIR_ID:-}"
+pair_arg=""
+if printf '%s' "$pair_id" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+  pair_arg=" --pair ${pair_id}"
+fi
+
 if ! command -v curl >/dev/null 2>&1; then
   exit 0
 fi
@@ -41,11 +51,11 @@ if [ -n "$health_json" ]; then
 EOF
   else
     cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex"}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is running but Codex TUI is not connected yet. Start Codex in another terminal with: agentbridge codex${pair_arg}"}}
 EOF
   fi
 else
   cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude (this terminal) + agentbridge codex (another terminal). If you're already using agentbridge claude, the daemon may still be starting up."}}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge daemon is not reachable on http://127.0.0.1:${port}/healthz yet. Start the bridge with: agentbridge claude${pair_arg} (this terminal) + agentbridge codex${pair_arg} (another terminal). If you're already using agentbridge claude${pair_arg}, the daemon may still be starting up."}}
 EOF
 fi

--- a/plugins/agentbridge/scripts/plugin-update-notice.mjs
+++ b/plugins/agentbridge/scripts/plugin-update-notice.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+/**
+ * In-session plugin-update reminder.
+ *
+ * The CLI notifier (src/update-notifier.ts) writes the latest npm version to the
+ * update-check cache. This script — invoked by the SessionStart hook
+ * (scripts/health-check.sh) — compares that `latest` against the INSTALLED
+ * plugin version (plugin.json, passed as argv[2]) and prints a one-line reminder
+ * to stdout if the plugin is behind. Prints NOTHING otherwise.
+ *
+ * Why a separate plugin-side reminder: the CLI prints its notice to the terminal
+ * before Claude Code's TUI takes over, so a user who updates npm but not the
+ * plugin would otherwise never see the mismatch from inside the session.
+ *
+ * Self-contained on purpose: the shipped plugin does not include src/, so the
+ * tiny state-dir resolution + stable-semver compare are inlined here. Keep them
+ * in sync with src/state-dir.ts (StateDirResolver) and src/version-utils.ts.
+ * Silent on ANY error — it must never break the SessionStart hook.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir, platform } from "node:os";
+
+/** Mirror of StateDirResolver (src/state-dir.ts). */
+function stateDir() {
+  const override = process.env.AGENTBRIDGE_STATE_DIR;
+  if (override) return override;
+  if (platform() === "darwin") {
+    return join(homedir(), "Library", "Application Support", "AgentBridge");
+  }
+  const xdg = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+  return join(xdg, "agentbridge");
+}
+
+const STABLE = /^\d+\.\d+\.\d+$/;
+
+/** Mirror of isStableUpgrade (src/version-utils.ts): stable latest strictly > stable current. */
+function isStableUpgrade(current, latest) {
+  if (!STABLE.test(current) || !STABLE.test(latest)) return false;
+  const a = current.split(".").map(Number);
+  const b = latest.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (b[i] > a[i]) return true;
+    if (b[i] < a[i]) return false;
+  }
+  return false;
+}
+
+try {
+  // Honor the same opt-out as the CLI notifier (src/update-notifier.ts): a user
+  // who silenced update notices must not still get the in-session reminder.
+  if (process.env.NO_UPDATE_NOTIFIER || process.env.AGENTBRIDGE_NO_UPDATE_NOTIFIER) {
+    process.exit(0);
+  }
+
+  const pluginJsonPath = process.argv[2];
+  if (!pluginJsonPath) process.exit(0);
+
+  const current = JSON.parse(readFileSync(pluginJsonPath, "utf-8")).version;
+  const cache = JSON.parse(readFileSync(join(stateDir(), "update-check.json"), "utf-8"));
+  const latest = cache?.latest;
+
+  if (typeof current === "string" && typeof latest === "string" && isStableUpgrade(current, latest)) {
+    process.stdout.write(
+      `AgentBridge plugin update available: ${current} -> ${latest}. ` +
+        `Update the plugin with /plugin marketplace update agentbridge then /reload-plugins ` +
+        `(and the CLI with npm install -g @raysonmeng/agentbridge@latest) so the CLI and plugin versions match.`,
+    );
+  }
+} catch {
+  // No cache yet / no plugin.json / malformed — stay silent.
+}
+process.exit(0);

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14578,12 +14578,102 @@ class ConfigService {
   }
 }
 
+// src/pair-registry.ts
+import {
+  closeSync as closeSync2,
+  existsSync as existsSync4,
+  fsyncSync,
+  linkSync,
+  mkdirSync as mkdirSync3,
+  openSync as openSync2,
+  readFileSync as readFileSync3,
+  realpathSync,
+  renameSync,
+  statSync,
+  unlinkSync as unlinkSync2,
+  writeFileSync as writeFileSync3
+} from "fs";
+import { basename, join as join3 } from "path";
+var PAIR_BASE_PORT = 4500;
+var PAIR_SLOT_STRIDE = 10;
+var PAIR_ID_REGEX = /^[A-Za-z0-9._-]{1,64}$/;
+var REGISTRY_FILE_NAME = "registry.json";
+class PairError extends Error {
+  code;
+  details;
+  constructor(code, message, details) {
+    super(message);
+    this.name = "PairError";
+    this.code = code;
+    this.details = details;
+  }
+}
+var MAX_PAIR_SLOT = Math.floor((65535 - 2 - PAIR_BASE_PORT) / PAIR_SLOT_STRIDE);
+function pairsDir(base) {
+  return join3(base, "pairs");
+}
+function registryPath(base) {
+  return join3(pairsDir(base), REGISTRY_FILE_NAME);
+}
+function readRegistry(base) {
+  const path = registryPath(base);
+  if (!existsSync4(path))
+    return { version: 1, pairs: [] };
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync3(path, "utf-8"));
+  } catch (err) {
+    throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry JSON is not parseable at ${path}: ${err.message}`, {
+      path
+    });
+  }
+  if (!parsed || typeof parsed !== "object" || parsed.version !== 1 || !Array.isArray(parsed.pairs)) {
+    throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry shape is invalid at ${path}`, { path });
+  }
+  const entries = parsed.pairs;
+  const seenSlots = new Set;
+  const seenIds = new Set;
+  for (const e of entries) {
+    const idValid = e && typeof e.pairId === "string" && e.pairId !== "." && e.pairId !== ".." && PAIR_ID_REGEX.test(e.pairId);
+    if (!idValid || !Number.isInteger(e.slot) || e.slot < 0) {
+      throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry has a malformed entry at ${path}`, { path, entry: e });
+    }
+    const lower = e.pairId.toLowerCase();
+    if (seenSlots.has(e.slot) || seenIds.has(lower)) {
+      throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry has duplicate slot/pairId at ${path}`, {
+        path,
+        pairId: e.pairId,
+        slot: e.slot
+      });
+    }
+    seenSlots.add(e.slot);
+    seenIds.add(lower);
+  }
+  return parsed;
+}
+
+// src/pair-resolver.ts
+function computeBaseDir() {
+  return process.env.AGENTBRIDGE_BASE_DIR || process.env.AGENTBRIDGE_STATE_DIR || StateDirResolver.platformBaseDir();
+}
+function findPair(base, pairId) {
+  const lower = pairId.toLowerCase();
+  return readRegistry(base).pairs.find((p) => p.pairId.toLowerCase() === lower) ?? null;
+}
+
 // src/pair-command.ts
 function pairScopedCommand(cmd) {
   const pairId = process.env.AGENTBRIDGE_PAIR_ID;
   if (!pairId)
     return `agentbridge ${cmd}`;
-  const selector = process.env.AGENTBRIDGE_PAIR_NAME || pairId;
+  let selector = process.env.AGENTBRIDGE_PAIR_NAME;
+  if (!selector) {
+    try {
+      selector = findPair(computeBaseDir(), pairId)?.name || pairId;
+    } catch {
+      selector = pairId;
+    }
+  }
   return `agentbridge --pair ${selector} ${cmd}`;
 }
 

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13714,6 +13714,9 @@ class StateDirResolver {
   get killedFile() {
     return join(this.stateDir, "killed");
   }
+  get updateCheckFile() {
+    return join(this.stateDir, "update-check.json");
+  }
 }
 
 // src/claude-adapter.ts

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14091,6 +14091,38 @@ class DaemonClient extends EventEmitter2 {
       }
     });
   }
+  async probeIncumbent(timeoutMs = 3000) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return { connected: false, alive: false };
+    }
+    return await new Promise((resolve) => {
+      let settled = false;
+      let timer = null;
+      const finish = (value) => {
+        if (settled)
+          return;
+        settled = true;
+        if (timer)
+          clearTimeout(timer);
+        this.off("incumbentStatus", onStatus);
+        this.off("disconnect", onDisconnect);
+        this.off("rejected", onRejected);
+        resolve(value);
+      };
+      const onStatus = (s) => finish(s);
+      const onDisconnect = () => finish({ connected: false, alive: false });
+      const onRejected = () => finish({ connected: false, alive: false });
+      this.on("incumbentStatus", onStatus);
+      this.on("disconnect", onDisconnect);
+      this.on("rejected", onRejected);
+      timer = setTimeout(() => finish({ connected: false, alive: false }), timeoutMs);
+      try {
+        this.send({ type: "probe_incumbent" });
+      } catch {
+        finish({ connected: false, alive: false });
+      }
+    });
+  }
   async disconnect() {
     if (!this.ws)
       return;
@@ -14146,6 +14178,9 @@ class DaemonClient extends EventEmitter2 {
         }
         case "status":
           this.emit("status", message.status);
+          return;
+        case "incumbent_status":
+          this.emit("incumbentStatus", { connected: message.connected, alive: message.alive });
           return;
       }
     };
@@ -14545,9 +14580,8 @@ function pairScopedCommand(cmd) {
   const pairId = process.env.AGENTBRIDGE_PAIR_ID;
   if (!pairId)
     return `agentbridge ${cmd}`;
-  const [sub, ...rest] = cmd.split(" ");
-  const tail = rest.length > 0 ? ` ${rest.join(" ")}` : "";
-  return `agentbridge ${sub} --pair ${pairId}${tail}`;
+  const selector = process.env.AGENTBRIDGE_PAIR_NAME || pairId;
+  return `agentbridge --pair ${selector} ${cmd}`;
 }
 
 // src/bridge-disabled-state.ts

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13671,16 +13671,16 @@ import { homedir, platform } from "os";
 
 class StateDirResolver {
   stateDir;
+  static platformBaseDir() {
+    if (platform() === "darwin") {
+      return join(homedir(), "Library", "Application Support", "AgentBridge");
+    }
+    const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+    return join(xdgState, "agentbridge");
+  }
   constructor(envOverride) {
     const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
-    if (override) {
-      this.stateDir = override;
-    } else if (platform() === "darwin") {
-      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
-    } else {
-      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-      this.stateDir = join(xdgState, "agentbridge");
-    }
+    this.stateDir = override && override.length > 0 ? override : StateDirResolver.platformBaseDir();
   }
   ensure() {
     if (!existsSync(this.stateDir)) {
@@ -14187,7 +14187,8 @@ class DaemonClient extends EventEmitter2 {
 import { spawn, execFileSync } from "child_process";
 import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
-var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
+var DEFAULT_DAEMON_ENTRY = import.meta.url.endsWith(".ts") ? "./daemon.ts" : "./daemon.js";
+var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 
 class DaemonLifecycle {
@@ -14539,19 +14540,30 @@ class ConfigService {
   }
 }
 
+// src/pair-command.ts
+function pairScopedCommand(cmd) {
+  const pairId = process.env.AGENTBRIDGE_PAIR_ID;
+  if (!pairId)
+    return `agentbridge ${cmd}`;
+  const [sub, ...rest] = cmd.split(" ");
+  const tail = rest.length > 0 ? ` ${rest.join(" ")}` : "";
+  return `agentbridge ${sub} --pair ${pairId}${tail}`;
+}
+
 // src/bridge-disabled-state.ts
 function disabledReplyError(reason) {
+  const claudeCmd = pairScopedCommand("claude");
   switch (reason) {
     case "rejected":
-      return "AgentBridge rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset.";
+      return `AgentBridge rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run \`${pairScopedCommand("kill")}\` to reset.`;
     case "evicted":
-      return "AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude`.";
+      return `AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with \`${claudeCmd}\`.`;
     case "probe_in_progress":
-      return "AgentBridge rejected this session \u2014 a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with `agentbridge claude`.";
+      return `AgentBridge rejected this session \u2014 a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with \`${claudeCmd}\`.`;
     case "auto_recovery_exhausted":
-      return "AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`.";
+      return `AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${claudeCmd}\`.`;
     case "killed":
-      return "AgentBridge is disabled by `agentbridge kill`. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.";
+      return `AgentBridge is disabled by \`agentbridge kill\`. Restart Claude Code (\`${claudeCmd}\`), switch to a new conversation, or run \`/resume\` to reconnect.`;
   }
 }
 
@@ -14633,17 +14645,17 @@ daemonClient.on("rejected", async (code) => {
     case CLOSE_CODE_EVICTED_STALE:
       reason = "evicted";
       notificationId = "system_bridge_evicted";
-      notificationContent = "\u26A0\uFE0F AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge \u56E0\u6B64\u4F1A\u8BDD\u672A\u54CD\u5E94\u5B58\u6D3B\u63A2\u6D4B\u800C\u5C06\u5176\u9A71\u9010\u2014\u2014\u66F4\u65B0\u7684 Claude Code \u4F1A\u8BDD\u5DF2\u63A5\u7BA1\u3002\u5982\u9700\u91CD\u8FDE\uFF0C\u8BF7\u5173\u95ED\u6B64\u4F1A\u8BDD\u5E76\u8FD0\u884C `agentbridge claude` \u542F\u52A8\u65B0\u4F1A\u8BDD\u3002";
+      notificationContent = `\u26A0\uFE0F AgentBridge evicted this session because it stopped responding to liveness probes \u2014 a newer Claude Code session has taken over. Close this session and start a new one with \`${pairScopedCommand("claude")}\` if you want to reconnect. AgentBridge \u56E0\u6B64\u4F1A\u8BDD\u672A\u54CD\u5E94\u5B58\u6D3B\u63A2\u6D4B\u800C\u5C06\u5176\u9A71\u9010\u2014\u2014\u66F4\u65B0\u7684 Claude Code \u4F1A\u8BDD\u5DF2\u63A5\u7BA1\u3002\u5982\u9700\u91CD\u8FDE\uFF0C\u8BF7\u5173\u95ED\u6B64\u4F1A\u8BDD\u5E76\u8FD0\u884C \`${pairScopedCommand("claude")}\` \u542F\u52A8\u65B0\u4F1A\u8BDD\u3002`;
       break;
     case CLOSE_CODE_PROBE_IN_PROGRESS:
       reason = "probe_in_progress";
       notificationId = "system_bridge_probe_in_progress";
-      notificationContent = "\u26A0\uFE0F AgentBridge rejected this session \u2014 a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with `agentbridge claude`. AgentBridge \u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u6B63\u5728\u901A\u8FC7\u5B58\u6D3B\u63A2\u6D4B\u68C0\u67E5\u73B0\u6709 Claude \u4F1A\u8BDD\u662F\u5426\u4ECD\u7136\u5728\u7EBF\u3002\u8BF7\u7A0D\u540E\u7528 `agentbridge claude` \u91CD\u8BD5\u3002";
+      notificationContent = `\u26A0\uFE0F AgentBridge rejected this session \u2014 a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with \`${pairScopedCommand("claude")}\`. AgentBridge \u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u6B63\u5728\u901A\u8FC7\u5B58\u6D3B\u63A2\u6D4B\u68C0\u67E5\u73B0\u6709 Claude \u4F1A\u8BDD\u662F\u5426\u4ECD\u7136\u5728\u7EBF\u3002\u8BF7\u7A0D\u540E\u7528 \`${pairScopedCommand("claude")}\` \u91CD\u8BD5\u3002`;
       break;
     default:
       reason = "rejected";
       notificationId = "system_bridge_replaced";
-      notificationContent = "\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge \u5B88\u62A4\u8FDB\u7A0B\u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u53E6\u4E00\u4E2A Claude Code \u4F1A\u8BDD\u5DF2\u5728\u8FDE\u63A5\u4E2D\u3002\u8BF7\u5148\u5173\u95ED\u53E6\u4E00\u4E2A\u4F1A\u8BDD\uFF0C\u6216\u8FD0\u884C `agentbridge kill` \u91CD\u7F6E\u3002";
+      notificationContent = `\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 another Claude Code session is already connected. Close the other session first, or run \`${pairScopedCommand("kill")}\` to reset. AgentBridge \u5B88\u62A4\u8FDB\u7A0B\u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u53E6\u4E00\u4E2A Claude Code \u4F1A\u8BDD\u5DF2\u5728\u8FDE\u63A5\u4E2D\u3002\u8BF7\u5148\u5173\u95ED\u53E6\u4E00\u4E2A\u4F1A\u8BDD\uFF0C\u6216\u8FD0\u884C \`${pairScopedCommand("kill")}\` \u91CD\u7F6E\u3002`;
       break;
   }
   log(`Daemon rejected this session (close code ${code}, reason=${reason})`);
@@ -14659,7 +14671,7 @@ daemonClient.on("rejected", async (code) => {
 claude.on("ready", async () => {
   log(`MCP server ready (delivery mode: ${claude.getDeliveryMode()}) \u2014 ensuring AgentBridge daemon...`);
   if (daemonLifecycle.wasKilled()) {
-    await enterDisabledState("Killed sentinel found \u2014 bridge staying idle", "\u26D4 AgentBridge was stopped by `agentbridge kill`. Bridge is staying idle. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.");
+    await enterDisabledState("Killed sentinel found \u2014 bridge staying idle", `\u26D4 AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`);
     return;
   }
   await connectToDaemon();
@@ -14675,7 +14687,7 @@ async function connectToDaemon(isReconnect = false) {
     daemonClient.attachClaude();
     daemonDisabledReason = null;
     if (!isReconnect) {
-      claude.pushNotification(systemMessage("system_bridge_ready", "\u2705 AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: agentbridge codex"));
+      claude.pushNotification(systemMessage("system_bridge_ready", `\u2705 AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: ${pairScopedCommand("codex")}`));
     }
   } catch (err) {
     log(`Failed to connect to daemon: ${err.message}`);
@@ -14698,7 +14710,7 @@ var reconnectTask = null;
 async function notifyIfDaemonKilled(logMessage) {
   if (!daemonLifecycle.wasKilled())
     return false;
-  await enterDisabledState(logMessage, "\u26D4 AgentBridge was stopped by `agentbridge kill`. Bridge is staying idle. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.");
+  await enterDisabledState(logMessage, `\u26D4 AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`);
   return true;
 }
 function reconnectToDaemon() {
@@ -14779,7 +14791,7 @@ async function pollDisabledRecovery() {
           daemonDisabledReason = "auto_recovery_exhausted";
           disabledRecoveryAttempts = 0;
           stopDisabledRecoveryPoller();
-          claude.pushNotification(systemMessage("system_bridge_auto_recovery_gave_up", "\u26A0\uFE0F AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`. AgentBridge \u81EA\u52A8\u6062\u590D\u5DF2\u653E\u5F03\u2014\u2014\u5B58\u6D3B\u63A2\u6D4B\u4E89\u7528\u7684\u91CD\u8BD5\u9884\u7B97\u5DF2\u7528\u5C3D\u3002\u8BF7\u4F7F\u7528 `agentbridge claude` \u624B\u52A8\u91CD\u8BD5\u3002"));
+          claude.pushNotification(systemMessage("system_bridge_auto_recovery_gave_up", `\u26A0\uFE0F AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${pairScopedCommand("claude")}\`. AgentBridge \u81EA\u52A8\u6062\u590D\u5DF2\u653E\u5F03\u2014\u2014\u5B58\u6D3B\u63A2\u6D4B\u4E89\u7528\u7684\u91CD\u8BD5\u9884\u7B97\u5DF2\u7528\u5C3D\u3002\u8BF7\u4F7F\u7528 \`${pairScopedCommand("claude")}\` \u624B\u52A8\u91CD\u8BD5\u3002`));
           return;
         }
         disabledRecoveryAttempts += 1;

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14094,6 +14094,38 @@ class DaemonClient extends EventEmitter2 {
       }
     });
   }
+  async probeIncumbent(timeoutMs = 3000) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return { connected: false, alive: false };
+    }
+    return await new Promise((resolve) => {
+      let settled = false;
+      let timer = null;
+      const finish = (value) => {
+        if (settled)
+          return;
+        settled = true;
+        if (timer)
+          clearTimeout(timer);
+        this.off("incumbentStatus", onStatus);
+        this.off("disconnect", onDisconnect);
+        this.off("rejected", onRejected);
+        resolve(value);
+      };
+      const onStatus = (s) => finish(s);
+      const onDisconnect = () => finish({ connected: false, alive: false });
+      const onRejected = () => finish({ connected: false, alive: false });
+      this.on("incumbentStatus", onStatus);
+      this.on("disconnect", onDisconnect);
+      this.on("rejected", onRejected);
+      timer = setTimeout(() => finish({ connected: false, alive: false }), timeoutMs);
+      try {
+        this.send({ type: "probe_incumbent" });
+      } catch {
+        finish({ connected: false, alive: false });
+      }
+    });
+  }
   async disconnect() {
     if (!this.ws)
       return;
@@ -14149,6 +14181,9 @@ class DaemonClient extends EventEmitter2 {
         }
         case "status":
           this.emit("status", message.status);
+          return;
+        case "incumbent_status":
+          this.emit("incumbentStatus", { connected: message.connected, alive: message.alive });
           return;
       }
     };
@@ -14548,9 +14583,8 @@ function pairScopedCommand(cmd) {
   const pairId = process.env.AGENTBRIDGE_PAIR_ID;
   if (!pairId)
     return `agentbridge ${cmd}`;
-  const [sub, ...rest] = cmd.split(" ");
-  const tail = rest.length > 0 ? ` ${rest.join(" ")}` : "";
-  return `agentbridge ${sub} --pair ${pairId}${tail}`;
+  const selector = process.env.AGENTBRIDGE_PAIR_NAME || pairId;
+  return `agentbridge --pair ${selector} ${cmd}`;
 }
 
 // src/bridge-disabled-state.ts

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -6517,9 +6517,6 @@ var require_dist = __commonJS((exports, module) => {
   exports.default = formatsPlugin;
 });
 
-// src/bridge.ts
-import { appendFileSync as appendFileSync2 } from "fs";
-
 // node_modules/zod/v4/core/core.js
 var NEVER = Object.freeze({
   status: "aborted"
@@ -13662,10 +13659,43 @@ class StdioServerTransport {
 // src/claude-adapter.ts
 import { EventEmitter } from "events";
 import { randomUUID } from "crypto";
-import { appendFileSync } from "fs";
+
+// src/rotating-log.ts
+import { appendFileSync, existsSync, mkdirSync, renameSync, statSync, unlinkSync } from "fs";
+import { dirname } from "path";
+var DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+var DEFAULT_KEEP = 3;
+function appendRotatingLog(path, content, options = {}) {
+  const maxBytes = options.maxBytes ?? Number(process.env.AGENTBRIDGE_LOG_MAX_BYTES || DEFAULT_MAX_BYTES);
+  const keep = options.keep ?? Number(process.env.AGENTBRIDGE_LOG_ROTATE_KEEP || DEFAULT_KEEP);
+  mkdirSync(dirname(path), { recursive: true });
+  rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep);
+  appendFileSync(path, content, "utf-8");
+}
+function rotateIfNeeded(path, incomingBytes, maxBytes, keep) {
+  if (!Number.isFinite(maxBytes) || maxBytes <= 0 || keep <= 0)
+    return;
+  if (!existsSync(path))
+    return;
+  const size = statSync(path).size;
+  if (size + incomingBytes <= maxBytes)
+    return;
+  for (let index = keep;index >= 1; index--) {
+    const current = `${path}.${index}`;
+    const next = `${path}.${index + 1}`;
+    if (!existsSync(current))
+      continue;
+    if (index === keep) {
+      unlinkSync(current);
+    } else {
+      renameSync(current, next);
+    }
+  }
+  renameSync(path, `${path}.1`);
+}
 
 // src/state-dir.ts
-import { mkdirSync, existsSync } from "fs";
+import { mkdirSync as mkdirSync2, existsSync as existsSync2 } from "fs";
 import { join } from "path";
 import { homedir, platform } from "os";
 
@@ -13683,8 +13713,8 @@ class StateDirResolver {
     this.stateDir = override && override.length > 0 ? override : StateDirResolver.platformBaseDir();
   }
   ensure() {
-    if (!existsSync(this.stateDir)) {
-      mkdirSync(this.stateDir, { recursive: true });
+    if (!existsSync2(this.stateDir)) {
+      mkdirSync2(this.stateDir, { recursive: true });
     }
   }
   get dir() {
@@ -13704,6 +13734,9 @@ class StateDirResolver {
   }
   get portsFile() {
     return join(this.stateDir, "ports.json");
+  }
+  get currentThreadFile() {
+    return join(this.stateDir, "current-thread.json");
   }
   get logFile() {
     return join(this.stateDir, "agentbridge.log");
@@ -13987,9 +14020,38 @@ ${formatted}`
 `;
     process.stderr.write(line);
     try {
-      appendFileSync(this.logFile, line);
+      appendRotatingLog(this.logFile, line);
     } catch {}
   }
+}
+
+// src/build-info.ts
+function defineString(value, fallback) {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+function defineBundle(value) {
+  if (value === "source" || value === "dist" || value === "plugin")
+    return value;
+  return import.meta.url.endsWith(".ts") ? "source" : "dist";
+}
+function defineNumber(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+var BUILD_INFO = Object.freeze({
+  version: defineString("0.1.6", "0.0.0-source"),
+  commit: defineString("6c24127", "source"),
+  bundle: defineBundle("plugin"),
+  contractVersion: defineNumber(1, 1)
+});
+function sameRuntimeContract(a, b) {
+  if (!a || !b)
+    return false;
+  return a.version === b.version && a.commit === b.commit && a.contractVersion === b.contractVersion;
+}
+function formatBuildInfo(build) {
+  if (!build)
+    return "<unknown>";
+  return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}`;
 }
 
 // src/daemon-client.ts
@@ -13999,19 +14061,22 @@ import { EventEmitter as EventEmitter2 } from "events";
 var CLOSE_CODE_REPLACED = 4001;
 var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
+var CLOSE_CODE_PAIR_MISMATCH = 4004;
 
 // src/daemon-client.ts
 var nextSocketId = 0;
 
 class DaemonClient extends EventEmitter2 {
   url;
+  options;
   ws = null;
   wsId = 0;
   nextRequestId = 1;
   pendingReplies = new Map;
-  constructor(url) {
+  constructor(url, options = {}) {
     super();
     this.url = url;
+    this.options = options;
   }
   async connect() {
     if (this.ws?.readyState === WebSocket.OPEN) {
@@ -14053,11 +14118,14 @@ class DaemonClient extends EventEmitter2 {
     });
   }
   attachClaude() {
-    this.send({ type: "claude_connect" });
+    this.send({
+      type: "claude_connect",
+      ...this.options.identity ? { identity: this.options.identity } : {}
+    });
   }
   async attachClaudeAndWaitForStatus(timeoutMs = 1000) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      return false;
+      return null;
     }
     return await new Promise((resolve) => {
       let settled = false;
@@ -14078,19 +14146,19 @@ class DaemonClient extends EventEmitter2 {
         cleanup();
         resolve(value);
       };
-      const onStatus = () => finish(true);
-      const onRejected = () => finish(false);
-      const onDisconnect = () => finish(false);
+      const onStatus = (status) => finish(status);
+      const onRejected = () => finish(null);
+      const onDisconnect = () => finish(null);
       this.on("status", onStatus);
       this.on("rejected", onRejected);
       this.on("disconnect", onDisconnect);
       timer = setTimeout(() => {
-        finish(false);
+        finish(null);
       }, timeoutMs);
       try {
         this.attachClaude();
       } catch {
-        finish(false);
+        finish(null);
       }
     });
   }
@@ -14193,7 +14261,7 @@ class DaemonClient extends EventEmitter2 {
       if (isCurrent) {
         this.ws = null;
         this.rejectPendingReplies("AgentBridge daemon disconnected.");
-        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE || event.code === CLOSE_CODE_PROBE_IN_PROGRESS) {
+        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE || event.code === CLOSE_CODE_PROBE_IN_PROGRESS || event.code === CLOSE_CODE_PAIR_MISMATCH) {
           this.emit("rejected", event.code);
         } else {
           this.emit("disconnect");
@@ -14223,7 +14291,7 @@ class DaemonClient extends EventEmitter2 {
 
 // src/daemon-lifecycle.ts
 import { spawn, execFileSync } from "child_process";
-import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
+import { existsSync as existsSync3, readFileSync, unlinkSync as unlinkSync2, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 
 // src/env-utils.ts
@@ -14245,6 +14313,7 @@ var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 var REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES", 12);
 var REUSE_READY_DELAY_MS = 250;
+var HEALTH_FETCH_TIMEOUT_MS = 500;
 
 class DaemonLifecycle {
   stateDir;
@@ -14269,7 +14338,7 @@ class DaemonLifecycle {
   }
   async fetchStatus() {
     try {
-      const response = await fetch(this.healthUrl);
+      const response = await fetchWithTimeout(this.healthUrl);
       if (!response.ok)
         return null;
       return await response.json();
@@ -14288,11 +14357,24 @@ class DaemonLifecycle {
       return true;
     return reported !== expected;
   }
+  isBuildDrifted(status) {
+    if (process.env.AGENTBRIDGE_ALLOW_BUILD_DRIFT === "1")
+      return false;
+    const runtime = status?.build;
+    if (!runtime)
+      return true;
+    return !sameRuntimeContract(runtime, BUILD_INFO);
+  }
   async ensureRunning() {
     if (await this.isHealthy()) {
       const status = await this.fetchStatus();
       if (this.isForeignDaemon(status)) {
         this.log(`Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` + `but this pair is ${this.expectedPairId} \u2014 replacing foreign daemon`);
+        await this.replaceUnhealthyDaemon(status?.pid);
+        return;
+      }
+      if (this.isBuildDrifted(status)) {
+        this.log(`Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` + `but launcher is ${formatBuildInfo(BUILD_INFO)} \u2014 replacing drifted daemon`);
         await this.replaceUnhealthyDaemon(status?.pid);
         return;
       }
@@ -14328,11 +14410,20 @@ class DaemonLifecycle {
         await this.waitForReadyAndOurs();
         return;
       }
-      if (await this.isHealthy() && !this.isForeignDaemon(await this.fetchStatus())) {
-        try {
-          await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
-          return;
-        } catch {}
+      if (await this.isHealthy()) {
+        const status = await this.fetchStatus();
+        if (this.isForeignDaemon(status) || this.isBuildDrifted(status)) {
+          this.log(`Daemon on control port ${this.controlPort} is not reusable under startup lock ` + `(pair=${status?.pairId ?? "<none>"}, build=${formatBuildInfo(status?.build)}) \u2014 replacing`);
+          await this.kill(3000, status?.pid);
+        } else {
+          try {
+            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            return;
+          } catch {
+            this.log(`Daemon on control port ${this.controlPort} is healthy but not ready under startup lock \u2014 replacing`);
+            await this.kill(3000, status?.pid);
+          }
+        }
       }
       this.launch();
       await this.waitForReady();
@@ -14340,7 +14431,7 @@ class DaemonLifecycle {
   }
   async isHealthy() {
     try {
-      const response = await fetch(this.healthUrl);
+      const response = await fetchWithTimeout(this.healthUrl);
       return response.ok;
     } catch {
       return false;
@@ -14356,7 +14447,7 @@ class DaemonLifecycle {
   }
   async isReady() {
     try {
-      const response = await fetch(this.readyUrl);
+      const response = await fetchWithTimeout(this.readyUrl);
       return response.ok;
     } catch {
       return false;
@@ -14374,7 +14465,7 @@ class DaemonLifecycle {
     for (let attempt = 0;attempt < maxRetries; attempt++) {
       if (await this.isReady()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status))
+        if (!this.isForeignDaemon(status) && !this.isBuildDrifted(status))
           return;
       }
       await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -14412,12 +14503,12 @@ class DaemonLifecycle {
   }
   removePidFile() {
     try {
-      unlinkSync(this.stateDir.pidFile);
+      unlinkSync2(this.stateDir.pidFile);
     } catch {}
   }
   removeStatusFile() {
     try {
-      unlinkSync(this.stateDir.statusFile);
+      unlinkSync2(this.stateDir.statusFile);
     } catch {}
   }
   markKilled() {
@@ -14427,11 +14518,11 @@ class DaemonLifecycle {
   }
   clearKilled() {
     try {
-      unlinkSync(this.stateDir.killedFile);
+      unlinkSync2(this.stateDir.killedFile);
     } catch {}
   }
   wasKilled() {
-    return existsSync2(this.stateDir.killedFile);
+    return existsSync3(this.stateDir.killedFile);
   }
   launch() {
     this.stateDir.ensure();
@@ -14461,7 +14552,7 @@ class DaemonLifecycle {
       }
       if (await this.isHealthy()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status)) {
+        if (!this.isForeignDaemon(status) && !this.isBuildDrifted(status)) {
           try {
             await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
@@ -14513,7 +14604,7 @@ class DaemonLifecycle {
   }
   releaseLock() {
     try {
-      unlinkSync(this.stateDir.lockFile);
+      unlinkSync2(this.stateDir.lockFile);
     } catch {}
   }
   async kill(gracefulTimeoutMs = 3000, pidOverride) {
@@ -14571,6 +14662,15 @@ class DaemonLifecycle {
     this.removeStatusFile();
   }
 }
+async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
+  const controller = new AbortController;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 function isProcessAlive(pid) {
   try {
     process.kill(pid, 0);
@@ -14581,7 +14681,7 @@ function isProcessAlive(pid) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, existsSync as existsSync3 } from "fs";
+import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, existsSync as existsSync4 } from "fs";
 import { join as join2 } from "path";
 var DEFAULT_CONFIG = {
   version: "1.0",
@@ -14638,7 +14738,7 @@ class ConfigService {
     this.configPath = join2(this.configDir, CONFIG_FILE);
   }
   hasConfig() {
-    return existsSync3(this.configPath);
+    return existsSync4(this.configPath);
   }
   load() {
     try {
@@ -14659,7 +14759,7 @@ class ConfigService {
   initDefaults() {
     this.ensureConfigDir();
     const created = [];
-    if (!existsSync3(this.configPath)) {
+    if (!existsSync4(this.configPath)) {
       this.save(DEFAULT_CONFIG);
       created.push(this.configPath);
     }
@@ -14669,8 +14769,8 @@ class ConfigService {
     return this.configPath;
   }
   ensureConfigDir() {
-    if (!existsSync3(this.configDir)) {
-      mkdirSync2(this.configDir, { recursive: true });
+    if (!existsSync4(this.configDir)) {
+      mkdirSync3(this.configDir, { recursive: true });
     }
   }
 }
@@ -14678,18 +14778,19 @@ class ConfigService {
 // src/pair-registry.ts
 import {
   closeSync as closeSync2,
-  existsSync as existsSync4,
+  existsSync as existsSync5,
   fsyncSync,
   linkSync,
-  mkdirSync as mkdirSync3,
+  mkdirSync as mkdirSync4,
   openSync as openSync2,
   readFileSync as readFileSync3,
   realpathSync,
-  renameSync,
-  statSync,
-  unlinkSync as unlinkSync2,
+  renameSync as renameSync2,
+  statSync as statSync2,
+  unlinkSync as unlinkSync3,
   writeFileSync as writeFileSync3
 } from "fs";
+import { createHash, randomUUID as randomUUID2 } from "crypto";
 import { basename, join as join3 } from "path";
 var PAIR_BASE_PORT = 4500;
 var PAIR_SLOT_STRIDE = 10;
@@ -14706,6 +14807,17 @@ class PairError extends Error {
   }
 }
 var MAX_PAIR_SLOT = Math.floor((65535 - 2 - PAIR_BASE_PORT) / PAIR_SLOT_STRIDE);
+function derivePairId(cwd, name) {
+  let real;
+  try {
+    real = realpathSync(cwd);
+  } catch {
+    real = cwd;
+  }
+  const hash = createHash("sha256").update(real).update("\x00").update(name.toLowerCase()).digest("hex").slice(0, 8);
+  const slug = name.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 32) || "pair";
+  return `${slug}-${hash}`;
+}
 function pairsDir(base) {
   return join3(base, "pairs");
 }
@@ -14714,7 +14826,7 @@ function registryPath(base) {
 }
 function readRegistry(base) {
   const path = registryPath(base);
-  if (!existsSync4(path))
+  if (!existsSync5(path))
     return { version: 1, pairs: [] };
   let parsed;
   try {
@@ -14791,7 +14903,176 @@ function disabledReplyError(reason) {
   }
 }
 
+// src/env-guard.ts
+var GENERATED_ENV_KEYS = [
+  "AGENTBRIDGE_BASE_DIR",
+  "AGENTBRIDGE_PAIR_ID",
+  "AGENTBRIDGE_PAIR_NAME",
+  "AGENTBRIDGE_STATE_DIR",
+  "AGENTBRIDGE_CONTROL_PORT",
+  "AGENTBRIDGE_MODE",
+  "AGENTBRIDGE_FILTER_MODE",
+  "AGENTBRIDGE_MAX_BUFFERED_MESSAGES",
+  "AGENTBRIDGE_CODEX_TRANSPORT",
+  "CODEX_WS_PORT",
+  "CODEX_PROXY_PORT"
+];
+function normalizeEnvGuardMode(raw, fallback = "fix") {
+  if (raw === "off" || raw === "warn" || raw === "fix" || raw === "strict")
+    return raw;
+  return fallback;
+}
+function inspectAgentBridgeEnv(opts) {
+  const env = opts.env ?? process.env;
+  const actualPairId = nonEmpty(env.AGENTBRIDGE_PAIR_ID);
+  const pairName = nonEmpty(env.AGENTBRIDGE_PAIR_NAME) ?? "main";
+  const stateDir = nonEmpty(env.AGENTBRIDGE_STATE_DIR);
+  const baseDir = nonEmpty(env.AGENTBRIDGE_BASE_DIR);
+  const manualOptIn = env.AGENTBRIDGE_MANUAL === "1";
+  const manualRuntimeEnv = !!stateDir || !!nonEmpty(env.AGENTBRIDGE_CONTROL_PORT) || !!nonEmpty(env.CODEX_WS_PORT) || !!nonEmpty(env.CODEX_PROXY_PORT);
+  const expectedPairId = actualPairId ? derivePairId(opts.cwd, pairName) : null;
+  const reasons = [];
+  if (!actualPairId && manualRuntimeEnv && !manualOptIn) {
+    reasons.push("AgentBridge runtime env is set without AGENTBRIDGE_PAIR_ID or AGENTBRIDGE_MANUAL=1");
+  }
+  if (actualPairId && expectedPairId && actualPairId !== expectedPairId) {
+    reasons.push(`AGENTBRIDGE_PAIR_ID=${actualPairId} does not match cwd-derived ${expectedPairId}`);
+  }
+  if (actualPairId && stateDir && !stateDir.endsWith(`/pairs/${actualPairId}`)) {
+    reasons.push(`AGENTBRIDGE_STATE_DIR does not end with /pairs/${actualPairId}`);
+  }
+  if (actualPairId && baseDir && stateDir && !stateDir.startsWith(`${baseDir}/`)) {
+    reasons.push("AGENTBRIDGE_BASE_DIR and AGENTBRIDGE_STATE_DIR disagree");
+  }
+  return {
+    ok: reasons.length === 0,
+    expectedPairId,
+    actualPairId,
+    pairName,
+    reasons
+  };
+}
+function guardAgentBridgeEnv(opts) {
+  const env = opts.env ?? process.env;
+  const mode = normalizeEnvGuardMode(opts.mode, "fix");
+  const effectiveMode = mode === "strict" && opts.allowStrict === false ? "fix" : mode;
+  const inspection = inspectAgentBridgeEnv({ cwd: opts.cwd, env });
+  if (effectiveMode === "off" || inspection.ok) {
+    return { ...inspection, action: "none" };
+  }
+  const message = `stale AgentBridge environment detected for ${opts.cwd}: ${inspection.reasons.join("; ")}`;
+  if (effectiveMode === "strict") {
+    throw new Error(message);
+  }
+  opts.log?.(`[agentbridge] ${message}`);
+  if (effectiveMode === "warn") {
+    return { ...inspection, action: "warned" };
+  }
+  for (const key of GENERATED_ENV_KEYS) {
+    delete env[key];
+  }
+  opts.log?.("[agentbridge] cleared stale AgentBridge environment variables");
+  return { ...inspection, action: "fixed" };
+}
+function nonEmpty(value) {
+  return value && value.length > 0 ? value : null;
+}
+
+// src/trace-log.ts
+import { appendFileSync as appendFileSync2, mkdirSync as mkdirSync5 } from "fs";
+import { join as join4 } from "path";
+var SECRET_KEY_RE = /(token|secret|password|passwd|api[_-]?key|auth|cookie|session)/i;
+var SECRET_ARG_RE = /^--?(?:token|secret|password|passwd|apikey|api-key|api_key|auth|cookie|session)(?:=.*)?$/i;
+var RELEVANT_ENV_RE = /^(AGENTBRIDGE_|CODEX_)/;
+function pickRelevantEnv(env) {
+  const picked = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (!RELEVANT_ENV_RE.test(key))
+      continue;
+    picked[key] = SECRET_KEY_RE.test(key) && value !== undefined ? "<redacted>" : value;
+  }
+  return picked;
+}
+function redactArgv(argv) {
+  const redacted = [];
+  let redactNext = false;
+  for (const arg of argv) {
+    if (redactNext) {
+      redacted.push("<redacted>");
+      redactNext = false;
+      continue;
+    }
+    if (SECRET_ARG_RE.test(arg)) {
+      if (arg.includes("=")) {
+        const [key] = arg.split("=", 1);
+        redacted.push(`${key}=<redacted>`);
+      } else {
+        redacted.push(arg);
+        redactNext = true;
+      }
+      continue;
+    }
+    redacted.push(arg);
+  }
+  return redacted;
+}
+function traceLogPath(cwd, timestamp) {
+  const day = timestamp.slice(0, 10);
+  return join4(cwd, ".agentbridge", "logs", `trace-${day}.jsonl`);
+}
+function appendTraceEvent(input) {
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const path = traceLogPath(input.cwd, timestamp);
+  const event = {
+    timestamp,
+    event: input.event,
+    cwd: input.cwd,
+    pid: input.pid ?? process.pid,
+    ...input.argv ? { argv: redactArgv(input.argv) } : {},
+    ...input.env ? { env: pickRelevantEnv(input.env) } : {},
+    ...input.data ? { data: redactData(input.data) } : {}
+  };
+  mkdirSync5(join4(input.cwd, ".agentbridge", "logs"), { recursive: true });
+  appendFileSync2(path, JSON.stringify(event) + `
+`, "utf-8");
+  return path;
+}
+function isEnvSnapshot(key, value) {
+  return /env$/i.test(key) && !!value && typeof value === "object" && !Array.isArray(value);
+}
+function redactData(value, key = "") {
+  if (typeof value === "string") {
+    return SECRET_KEY_RE.test(key) ? "<redacted>" : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactData(item, key));
+  }
+  if (value && typeof value === "object") {
+    const redacted = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      if (SECRET_KEY_RE.test(childKey)) {
+        redacted[childKey] = "<redacted>";
+      } else if (isEnvSnapshot(childKey, childValue)) {
+        redacted[childKey] = pickRelevantEnv(childValue);
+      } else {
+        redacted[childKey] = redactData(childValue, childKey);
+      }
+    }
+    return redacted;
+  }
+  return value;
+}
+
 // src/bridge.ts
+var originalEnv = { ...process.env };
+var envGuardResult = guardAgentBridgeEnv({
+  cwd: process.cwd(),
+  env: process.env,
+  mode: normalizeEnvGuardMode(process.env.AGENTBRIDGE_ENV_GUARD),
+  allowStrict: false,
+  log: (msg) => process.stderr.write(`${msg}
+`)
+});
 var stateDir = new StateDirResolver;
 stateDir.ensure();
 var configService = new ConfigService;
@@ -14800,7 +15081,7 @@ var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 var claude = new ClaudeAdapter(stateDir.logFile);
-var daemonClient = new DaemonClient(CONTROL_WS_URL);
+var daemonClient = new DaemonClient(CONTROL_WS_URL, { identity: currentClientIdentity() });
 var shuttingDown = false;
 var daemonDisabled = false;
 var daemonDisabledReason = null;
@@ -14815,6 +15096,27 @@ var disabledRecoveryInFlight = false;
 var disabledRecoveryAttempts = 0;
 var DISABLED_RECOVERY_MAX_ATTEMPTS = 6;
 var DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS = 1000;
+if (process.env.AGENTBRIDGE_TRACE === "1") {
+  try {
+    appendTraceEvent({
+      cwd: process.cwd(),
+      event: "bridge.start",
+      pid: process.pid,
+      argv: process.argv,
+      env: process.env,
+      data: {
+        originalEnv: pickRelevantEnv(originalEnv),
+        effectiveEnv: pickRelevantEnv(process.env),
+        envGuardAction: envGuardResult.action,
+        pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+        pairName: process.env.AGENTBRIDGE_PAIR_NAME ?? null,
+        stateDir: stateDir.dir,
+        controlPort: CONTROL_PORT,
+        build: BUILD_INFO
+      }
+    });
+  } catch {}
+}
 claude.setReplySender(async (msg, requireReply) => {
   if (msg.source !== "claude") {
     return { success: false, error: "Invalid message source" };
@@ -14908,16 +15210,35 @@ async function connectToDaemon(isReconnect = false) {
   try {
     await daemonLifecycle.ensureRunning();
     await daemonClient.connect();
-    daemonClient.attachClaude();
+    const status = await daemonClient.attachClaudeAndWaitForStatus(1500);
+    if (!status) {
+      throw new Error("Daemon did not confirm Claude attach.");
+    }
+    assertAttachedToExpectedDaemon(status);
     daemonDisabledReason = null;
     if (!isReconnect) {
-      claude.pushNotification(systemMessage("system_bridge_ready", `\u2705 AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: ${pairScopedCommand("codex")}`));
+      claude.pushNotification(systemMessage(status.bridgeReady ? "system_bridge_ready" : "system_bridge_waiting", initialAttachMessage(status)));
     }
   } catch (err) {
     log(`Failed to connect to daemon: ${err.message}`);
     await claude.pushNotification(systemMessage("system_daemon_connect_failed", `\u274C AgentBridge daemon failed to start or is unreachable: ${err.message}`));
     throw err;
   }
+}
+function assertAttachedToExpectedDaemon(status) {
+  const expectedPairId = process.env.AGENTBRIDGE_PAIR_ID || null;
+  if (expectedPairId && status.pairId !== expectedPairId) {
+    throw new Error(`Daemon identity mismatch after attach: expected pair ${expectedPairId}, got ${status.pairId ?? "<none>"}.`);
+  }
+}
+function initialAttachMessage(status) {
+  if (status.bridgeReady) {
+    return "\u2705 AgentBridge bridge is ready. Codex TUI is connected.";
+  }
+  if (status.tuiConnected) {
+    return "\u23F3 AgentBridge attached to daemon. Waiting for Codex to finish creating a thread.";
+  }
+  return `\u23F3 AgentBridge attached to daemon. Waiting for Codex TUI. Start Codex in another terminal with: ${pairScopedCommand("codex")}`;
 }
 async function enterDisabledState(logMessage, notificationContent) {
   if (daemonDisabled)
@@ -15086,6 +15407,17 @@ function systemMessage(idPrefix, content) {
     timestamp: Date.now()
   };
 }
+function currentClientIdentity() {
+  return {
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    pairName: process.env.AGENTBRIDGE_PAIR_NAME ?? null,
+    cwd: process.cwd(),
+    baseDir: process.env.AGENTBRIDGE_BASE_DIR ?? null,
+    stateDir: stateDir.dir,
+    clientPid: process.pid,
+    contractVersion: BUILD_INFO.contractVersion
+  };
+}
 function shutdown(reason) {
   if (shuttingDown)
     return;
@@ -15121,7 +15453,7 @@ function log(msg) {
 `;
   process.stderr.write(line);
   try {
-    appendFileSync2(stateDir.logFile, line);
+    appendRotatingLog(stateDir.logFile, line);
   } catch {}
 }
 log(`Starting AgentBridge frontend (daemon ws ${CONTROL_WS_URL})`);

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14225,9 +14225,26 @@ class DaemonClient extends EventEmitter2 {
 import { spawn, execFileSync } from "child_process";
 import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
+
+// src/env-utils.ts
+function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) {
+  const raw = env[name];
+  if (raw == null || raw === "")
+    return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > Number.MAX_SAFE_INTEGER) {
+    log(`Invalid ${name}=${JSON.stringify(raw)} (must be a positive integer within ` + `Number.MAX_SAFE_INTEGER); falling back to ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
+// src/daemon-lifecycle.ts
 var DEFAULT_DAEMON_ENTRY = import.meta.url.endsWith(".ts") ? "./daemon.ts" : "./daemon.js";
 var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
+var REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES", 12);
+var REUSE_READY_DELAY_MS = 250;
 
 class DaemonLifecycle {
   stateDir;
@@ -14247,38 +14264,79 @@ class DaemonLifecycle {
   get controlWsUrl() {
     return `ws://127.0.0.1:${this.controlPort}/ws`;
   }
+  get expectedPairId() {
+    return process.env.AGENTBRIDGE_PAIR_ID || null;
+  }
+  async fetchStatus() {
+    try {
+      const response = await fetch(this.healthUrl);
+      if (!response.ok)
+        return null;
+      return await response.json();
+    } catch {
+      return null;
+    }
+  }
+  isForeignDaemon(status) {
+    const expected = this.expectedPairId;
+    if (!expected)
+      return false;
+    if (!status)
+      return false;
+    const reported = status.pairId;
+    if (reported == null)
+      return true;
+    return reported !== expected;
+  }
   async ensureRunning() {
     if (await this.isHealthy()) {
-      await this.waitForReady();
-      return;
+      const status = await this.fetchStatus();
+      if (this.isForeignDaemon(status)) {
+        this.log(`Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` + `but this pair is ${this.expectedPairId} \u2014 replacing foreign daemon`);
+        await this.replaceUnhealthyDaemon(status?.pid);
+        return;
+      }
+      try {
+        await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+        return;
+      } catch {
+        this.log(`Daemon on control port ${this.controlPort} is healthy but not ready within reuse window \u2014 replacing`);
+        await this.replaceUnhealthyDaemon(status?.pid);
+        return;
+      }
     }
     const existingPid = this.readPid();
     if (existingPid) {
       if (isProcessAlive(existingPid)) {
         if (this.isDaemonProcess(existingPid)) {
           try {
-            await this.waitForReady(12, 250);
+            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
           } catch {
-            throw new Error(`Found existing daemon process ${existingPid}, but control port ${this.controlPort} never became ready.`);
+            this.log(`Existing daemon process ${existingPid} never became ready \u2014 replacing`);
+            await this.replaceUnhealthyDaemon(existingPid);
+            return;
           }
         }
         this.log(`Pid ${existingPid} is alive but not an AgentBridge daemon, removing stale pid file`);
       }
       this.removeStalePidFile();
     }
-    const lockAcquired = this.acquireLock();
-    if (!lockAcquired) {
-      this.log("Another process is starting the daemon, waiting for readiness...");
-      await this.waitForReady();
-      return;
-    }
-    try {
+    await this.withStartupLockStrict(async (locked) => {
+      if (!locked) {
+        this.log("Another process holds the startup lock, waiting for readiness+identity...");
+        await this.waitForReadyAndOurs();
+        return;
+      }
+      if (await this.isHealthy() && !this.isForeignDaemon(await this.fetchStatus())) {
+        try {
+          await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+          return;
+        } catch {}
+      }
       this.launch();
       await this.waitForReady();
-    } finally {
-      this.releaseLock();
-    }
+    });
   }
   async isHealthy() {
     try {
@@ -14311,6 +14369,17 @@ class DaemonLifecycle {
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
     throw new Error(`Timed out waiting for AgentBridge daemon readiness on ${this.readyUrl}`);
+  }
+  async waitForReadyAndOurs(maxRetries = 40, delayMs = 250) {
+    for (let attempt = 0;attempt < maxRetries; attempt++) {
+      if (await this.isReady()) {
+        const status = await this.fetchStatus();
+        if (!this.isForeignDaemon(status))
+          return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    throw new Error(`Timed out waiting for AgentBridge daemon readiness+identity on ${this.readyUrl} (control port ${this.controlPort})`);
   }
   readStatus() {
     try {
@@ -14383,11 +14452,38 @@ class DaemonLifecycle {
     this.log("Removing stale pid file");
     this.removePidFile();
   }
-  acquireLock(depth = 0) {
-    if (depth > 1) {
-      this.log("Lock acquisition failed after retry, proceeding without lock");
-      return true;
+  async replaceUnhealthyDaemon(statusPid) {
+    await this.withStartupLockStrict(async (locked) => {
+      if (!locked) {
+        this.log("Another process holds the startup lock, waiting for readiness+identity...");
+        await this.waitForReadyAndOurs();
+        return;
+      }
+      if (await this.isHealthy()) {
+        const status = await this.fetchStatus();
+        if (!this.isForeignDaemon(status)) {
+          try {
+            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            return;
+          } catch {}
+        }
+      }
+      this.log(`Killing unhealthy daemon on control port ${this.controlPort} and relaunching`);
+      await this.kill(3000, statusPid);
+      this.launch();
+      await this.waitForReady();
+    });
+  }
+  async withStartupLockStrict(fn) {
+    const locked = this.acquireLockStrict();
+    try {
+      return await fn(locked);
+    } finally {
+      if (locked)
+        this.releaseLock();
     }
+  }
+  acquireLockStrict(reclaimed = false) {
     this.stateDir.ensure();
     try {
       const fd = openSync(this.stateDir.lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
@@ -14397,22 +14493,22 @@ class DaemonLifecycle {
       return true;
     } catch (err) {
       if (err.code === "EEXIST") {
+        if (reclaimed)
+          return false;
         try {
           const holderPid = Number.parseInt(readFileSync(this.stateDir.lockFile, "utf-8").trim(), 10);
           if (Number.isFinite(holderPid) && !isProcessAlive(holderPid)) {
-            this.log(`Stale lock file from dead process ${holderPid}, removing`);
+            this.log(`Stale startup lock from dead process ${holderPid}, reclaiming`);
             this.releaseLock();
-            return this.acquireLock(depth + 1);
+            return this.acquireLockStrict(true);
           }
         } catch {
-          this.log("Cannot read lock file, removing stale lock");
-          this.releaseLock();
-          return this.acquireLock(depth + 1);
+          return false;
         }
         return false;
       }
-      this.log(`Warning: could not acquire startup lock: ${err.message}`);
-      return true;
+      this.log(`Could not acquire strict startup lock: ${err.message}`);
+      return false;
     }
   }
   releaseLock() {
@@ -14420,8 +14516,8 @@ class DaemonLifecycle {
       unlinkSync(this.stateDir.lockFile);
     } catch {}
   }
-  async kill(gracefulTimeoutMs = 3000) {
-    const pid = this.readPid();
+  async kill(gracefulTimeoutMs = 3000, pidOverride) {
+    const pid = pidOverride ?? this.readPid();
     if (!pid) {
       this.log("No daemon pid file found");
       this.cleanup();
@@ -14463,7 +14559,9 @@ class DaemonLifecycle {
   isDaemonProcess(pid) {
     try {
       const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-      return cmd.includes("daemon") && (cmd.includes("agentbridge") || cmd.includes("agent_bridge"));
+      const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
+      const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
+      return hasDaemonEntry && hasAgentbridge;
     } catch {
       return false;
     }
@@ -14471,7 +14569,6 @@ class DaemonLifecycle {
   cleanup() {
     this.removePidFile();
     this.removeStatusFile();
-    this.releaseLock();
   }
 }
 function isProcessAlive(pid) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2548,6 +2548,7 @@ function detachClaude(ws, reason) {
 }
 async function handleProbeIncumbent(ws) {
   const occupant = attachedClaude;
+  log(`probe_incumbent from #${ws.data.clientId}: occupant=${occupant ? "#" + occupant.data.clientId : "none"} readyState=${occupant?.readyState}`);
   if (!occupant || occupant === ws || occupant.readyState !== WebSocket.OPEN) {
     sendProtocolMessage(ws, { type: "incumbent_status", connected: false, alive: false });
     return;
@@ -2558,6 +2559,7 @@ async function handleProbeIncumbent(ws) {
   }
   const alive = await probeLiveness2(occupant, LIVENESS_PROBE_TIMEOUT_MS);
   const stillConnected = attachedClaude === occupant && occupant.readyState === WebSocket.OPEN;
+  log(`probe_incumbent reply to #${ws.data.clientId}: connected=${stillConnected} alive=${stillConnected && alive}`);
   sendProtocolMessage(ws, {
     type: "incumbent_status",
     connected: stillConnected,

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -124,6 +124,8 @@ class CodexAdapter extends EventEmitter {
   pendingRequests = new Map;
   activeTurnIds = new Set;
   turnInProgress = false;
+  turnWatchdogs = new Map;
+  threadSwitchSeq = 0;
   nextProxyId = 1e5;
   upstreamToClient = new Map;
   serverRequestToProxy = new Map;
@@ -197,6 +199,7 @@ class CodexAdapter extends EventEmitter {
     this.proxyServer?.stop();
     this.proxyServer = null;
     this.clearResponseTrackingState();
+    this.resetTurnState("adapter disconnect");
   }
   stop() {
     this.intentionalDisconnect = true;
@@ -323,8 +326,7 @@ class CodexAdapter extends EventEmitter {
       } catch {}
     }
     this.clearResponseTrackingStateForAppServerReconnect();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server reconnect for new TUI session");
     try {
       await this.connectToAppServer(false);
       this.log("App-server reconnected for new TUI session \u2014 replaying buffered messages");
@@ -378,8 +380,7 @@ class CodexAdapter extends EventEmitter {
     this.log(`App-server connection closed (intentional=${intentional}, tuiConnected=${tuiConnected}, turnInProgress=${this.turnInProgress})`);
     this.appServerWs = null;
     this.clearResponseTrackingState();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server connection closed");
     if (!intentional) {
       this.scheduleReconnect();
     }
@@ -811,6 +812,9 @@ class CodexAdapter extends EventEmitter {
   handleAppServerPayload(raw) {
     try {
       const parsed = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null) {
+        this.refreshTurnWatchdogs();
+      }
       if (typeof parsed === "object" && parsed !== null && "id" in parsed) {
         if (this.tryConsumeReplayResponse(parsed)) {
           return null;
@@ -1039,6 +1043,9 @@ class CodexAdapter extends EventEmitter {
         pending.threadId = threadId;
       }
     }
+    if (method === "thread/start" || method === "thread/resume") {
+      pending.threadSwitchSeq = ++this.threadSwitchSeq;
+    }
     if (this.pendingRequests.has(key)) {
       this.log(`WARNING: overwriting pending request for key ${key}`);
     }
@@ -1062,6 +1069,10 @@ class CodexAdapter extends EventEmitter {
     }
     switch (pending.method) {
       case "thread/start": {
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(`Ignoring stale thread/start response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`);
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/start response ${key}`);
@@ -1070,6 +1081,10 @@ class CodexAdapter extends EventEmitter {
         break;
       }
       case "thread/resume": {
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(`Ignoring stale thread/resume response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`);
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/resume response ${key}`);
@@ -1082,10 +1097,17 @@ class CodexAdapter extends EventEmitter {
       }
       case "turn/start":
         if (pending.threadId) {
-          this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          if (this.threadId === null || this.threadId === pending.threadId) {
+            this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          } else {
+            this.log(`Ignoring turn/start response ${key} threadId=${pending.threadId} (active thread is ${this.threadId})`);
+          }
         }
         break;
     }
+  }
+  isLatestThreadSwitch(pending) {
+    return pending.threadSwitchSeq === this.threadSwitchSeq;
   }
   setActiveThreadId(threadId, reason) {
     if (this.threadId === threadId)
@@ -1101,11 +1123,9 @@ class CodexAdapter extends EventEmitter {
   }
   markTurnStarted(turnId) {
     const wasInProgress = this.turnInProgress;
-    if (typeof turnId === "string" && turnId.length > 0) {
-      this.activeTurnIds.add(turnId);
-    } else {
-      this.activeTurnIds.add(`unknown:${Date.now()}`);
-    }
+    const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
+    this.activeTurnIds.add(turnKey);
+    this.scheduleTurnWatchdog(turnKey);
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
       this.emit("turnStarted");
@@ -1114,10 +1134,67 @@ class CodexAdapter extends EventEmitter {
   markTurnCompleted(turnId) {
     if (typeof turnId === "string" && turnId.length > 0) {
       this.activeTurnIds.delete(turnId);
+      this.clearTurnWatchdog(turnId);
     } else {
       this.activeTurnIds.clear();
+      this.clearAllTurnWatchdogs();
     }
     this.turnInProgress = this.activeTurnIds.size > 0;
+  }
+  turnWatchdogMs() {
+    const v = Number(process.env.AGENTBRIDGE_TURN_WATCHDOG_MS);
+    return Number.isFinite(v) && v > 0 ? v : 300000;
+  }
+  scheduleTurnWatchdog(turnKey) {
+    this.clearTurnWatchdog(turnKey);
+    const timer = setTimeout(() => {
+      if (!this.activeTurnIds.has(turnKey))
+        return;
+      this.log(`WARNING: turn ${turnKey} watchdog fired after ${this.turnWatchdogMs()}ms of inactivity \u2014 ` + `assuming a lost turn/completed; force-completing to unblock injection`);
+      this.forceCompleteTurn(turnKey);
+    }, this.turnWatchdogMs());
+    timer.unref?.();
+    this.turnWatchdogs.set(turnKey, timer);
+  }
+  clearTurnWatchdog(turnKey) {
+    const timer = this.turnWatchdogs.get(turnKey);
+    if (timer) {
+      clearTimeout(timer);
+      this.turnWatchdogs.delete(turnKey);
+    }
+  }
+  clearAllTurnWatchdogs() {
+    for (const timer of this.turnWatchdogs.values())
+      clearTimeout(timer);
+    this.turnWatchdogs.clear();
+  }
+  refreshTurnWatchdogs() {
+    if (this.turnWatchdogs.size === 0)
+      return;
+    for (const turnKey of [...this.turnWatchdogs.keys()]) {
+      this.scheduleTurnWatchdog(turnKey);
+    }
+  }
+  forceCompleteTurn(turnKey) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.delete(turnKey);
+    this.clearTurnWatchdog(turnKey);
+    this.turnInProgress = this.activeTurnIds.size > 0;
+    if (wasInProgress && !this.turnInProgress) {
+      this.emit("turnCompleted");
+    }
+  }
+  resetTurnState(reason, emitCompleted = false) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.clear();
+    this.clearAllTurnWatchdogs();
+    this.turnInProgress = false;
+    if (emitCompleted && wasInProgress) {
+      this.emit("turnCompleted");
+    }
+    if (wasInProgress) {
+      this.log(`Turn state reset (${reason})`);
+    }
   }
   requestKey(id) {
     if (typeof id === "number" || typeof id === "string")

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -17,16 +17,16 @@ import { homedir, platform } from "os";
 
 class StateDirResolver {
   stateDir;
+  static platformBaseDir() {
+    if (platform() === "darwin") {
+      return join(homedir(), "Library", "Application Support", "AgentBridge");
+    }
+    const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+    return join(xdgState, "agentbridge");
+  }
   constructor(envOverride) {
     const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
-    if (override) {
-      this.stateDir = override;
-    } else if (platform() === "darwin") {
-      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
-    } else {
-      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-      this.stateDir = join(xdgState, "agentbridge");
-    }
+    this.stateDir = override && override.length > 0 ? override : StateDirResolver.platformBaseDir();
   }
   ensure() {
     if (!existsSync(this.stateDir)) {
@@ -1487,7 +1487,8 @@ class TuiConnectionState {
 import { spawn as spawn2, execFileSync } from "child_process";
 import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
-var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
+var DEFAULT_DAEMON_ENTRY = import.meta.url.endsWith(".ts") ? "./daemon.ts" : "./daemon.js";
+var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 
 class DaemonLifecycle {
@@ -2421,7 +2422,8 @@ function writeStatusFile() {
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
     controlPort: CONTROL_PORT,
-    pid: process.pid
+    pid: process.pid,
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null
   });
 }
 function removeStatusFile() {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -105,6 +105,232 @@ function isAppServerResponseMessage(value) {
   return (typeof value.id === "number" || typeof value.id === "string") && value.method === undefined && (("result" in value) || ("error" in value));
 }
 
+// src/codex-transport.ts
+import { createServer, connect } from "net";
+import { spawnSync } from "child_process";
+import { mkdirSync as mkdirSync2, rmSync, chmodSync } from "fs";
+import { join as join2 } from "path";
+import { tmpdir } from "os";
+var CODEX_TRANSPORT_ENV = "AGENTBRIDGE_CODEX_TRANSPORT";
+var HEADER_SEP = `\r
+\r
+`;
+var EXTENSIONS_HEADER_RE = /^sec-websocket-extensions:/i;
+var MAX_UPGRADE_HEADER_BYTES = 64 * 1024;
+function parseTransportMode(raw) {
+  switch ((raw ?? "").trim().toLowerCase()) {
+    case "ws":
+      return "ws";
+    case "unix":
+      return "unix";
+    case "auto":
+    case "":
+      return "auto";
+    default:
+      return "auto";
+  }
+}
+function probeCodexWsSupport(runHelp = defaultRunCodexAppServerHelp) {
+  const help = runHelp();
+  if (help === null)
+    return true;
+  return help.includes("ws://");
+}
+function defaultRunCodexAppServerHelp() {
+  try {
+    const res = spawnSync("codex", ["app-server", "--help"], {
+      encoding: "utf-8",
+      timeout: 5000
+    });
+    if (res.error || typeof res.stdout !== "string")
+      return null;
+    return res.stdout + (res.stderr ?? "");
+  } catch {
+    return null;
+  }
+}
+function resolveCodexTransport(mode, runHelp = defaultRunCodexAppServerHelp) {
+  if (mode === "ws")
+    return "ws";
+  if (mode === "unix")
+    return "unix";
+  return probeCodexWsSupport(runHelp) ? "ws" : "unix";
+}
+function codexSocketPath(appPort, baseTmpDir = tmpdir()) {
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  const dir = join2(baseTmpDir, `agentbridge-${uid}`);
+  const path = join2(dir, `codex-${appPort}.sock`);
+  if (path.length >= 104) {
+    throw new Error(`Codex unix socket path is too long for the platform (${path.length} >= 104): ${path}. ` + `Set a shorter TMPDIR or use ${CODEX_TRANSPORT_ENV}=ws.`);
+  }
+  return path;
+}
+function ensureSocketDir(socketPath) {
+  const dir = socketPath.slice(0, socketPath.lastIndexOf("/"));
+  if (!dir)
+    return;
+  mkdirSync2(dir, { recursive: true, mode: 448 });
+  try {
+    chmodSync(dir, 448);
+  } catch (err) {
+    throw new Error(`Refusing to use Codex socket dir ${dir}: cannot enforce 0700 perms ` + `(${err.message}). Remove it or set a private TMPDIR.`);
+  }
+}
+function removeSocketFile(socketPath) {
+  try {
+    rmSync(socketPath, { force: true });
+  } catch {}
+}
+function codexListenArg(transport, appPort, socketPath) {
+  return transport === "unix" ? `unix://${socketPath}` : `ws://127.0.0.1:${appPort}`;
+}
+function stripWebSocketExtensions(headerBlock) {
+  return headerBlock.split(`\r
+`).filter((line) => !EXTENSIONS_HEADER_RE.test(line)).join(`\r
+`);
+}
+
+class TcpToUnixRelay {
+  tcpHost;
+  tcpPort;
+  unixPath;
+  log;
+  server = null;
+  pairs = new Set;
+  constructor(tcpHost, tcpPort, unixPath, log = () => {}) {
+    this.tcpHost = tcpHost;
+    this.tcpPort = tcpPort;
+    this.unixPath = unixPath;
+    this.log = log;
+  }
+  start() {
+    return new Promise((resolve, reject) => {
+      const server = createServer((tcp) => this.handleConnection(tcp));
+      const onListenError = (err) => {
+        server.removeListener("listening", onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.removeListener("error", onListenError);
+        server.on("error", (err) => this.log(`relay server error: ${err.message}`));
+        this.server = server;
+        resolve();
+      };
+      server.once("error", onListenError);
+      server.once("listening", onListening);
+      server.listen(this.tcpPort, this.tcpHost);
+    });
+  }
+  handleConnection(tcp) {
+    const unix = connect(this.unixPath);
+    const pair = { tcp, unix };
+    this.pairs.add(pair);
+    let closed = false;
+    const teardown = () => {
+      if (closed)
+        return;
+      closed = true;
+      this.pairs.delete(pair);
+      tcp.destroy();
+      unix.destroy();
+    };
+    let head = Buffer.alloc(0);
+    const onData = (chunk) => {
+      head = Buffer.concat([head, chunk]);
+      const sep = head.indexOf(HEADER_SEP);
+      if (sep === -1) {
+        if (head.length > MAX_UPGRADE_HEADER_BYTES) {
+          tcp.removeListener("data", onData);
+          unix.write(head);
+          head = Buffer.alloc(0);
+          tcp.pipe(unix);
+        }
+        return;
+      }
+      tcp.removeListener("data", onData);
+      const headers = head.subarray(0, sep).toString("utf8");
+      const rest = head.subarray(sep + HEADER_SEP.length);
+      unix.write(stripWebSocketExtensions(headers) + HEADER_SEP);
+      head = Buffer.alloc(0);
+      if (rest.length)
+        tcp.unshift(rest);
+      tcp.pipe(unix);
+    };
+    tcp.on("data", onData);
+    unix.pipe(tcp);
+    tcp.on("error", (e) => {
+      this.log(`relay tcp error: ${e.message}`);
+      teardown();
+    });
+    unix.on("error", (e) => {
+      this.log(`relay unix error: ${e.message}`);
+      teardown();
+    });
+    tcp.on("close", teardown);
+    unix.on("close", teardown);
+  }
+  get connectionCount() {
+    return this.pairs.size;
+  }
+  get port() {
+    const addr = this.server?.address();
+    return addr && typeof addr === "object" ? addr.port : this.tcpPort;
+  }
+  stop() {
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+    }
+    for (const { tcp, unix } of this.pairs) {
+      tcp.destroy();
+      unix.destroy();
+    }
+    this.pairs.clear();
+  }
+}
+async function waitForUnixWsReady(socketPath, maxRetries = 40, delayMs = 250) {
+  for (let i = 0;i < maxRetries; i++) {
+    if (await attemptUnixWsUpgrade(socketPath))
+      return;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  throw new Error(`Codex unix app-server at ${socketPath} did not become ready`);
+}
+function attemptUnixWsUpgrade(socketPath) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (ok) => {
+      if (settled)
+        return;
+      settled = true;
+      try {
+        socket.destroy();
+      } catch {}
+      resolve(ok);
+    };
+    const socket = connect(socketPath, () => {
+      socket.write(`GET / HTTP/1.1\r
+Host: localhost\r
+Upgrade: websocket\r
+Connection: Upgrade\r
+` + `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
+Sec-WebSocket-Version: 13\r
+\r
+`);
+    });
+    let buf = "";
+    socket.on("data", (d) => {
+      buf += d.toString("utf8");
+      if (buf.includes(`\r
+`))
+        done(buf.startsWith("HTTP/1.1 101"));
+    });
+    socket.on("error", () => done(false));
+    socket.on("close", () => done(false));
+    setTimeout(() => done(false), 1500);
+  });
+}
+
 // src/codex-adapter.ts
 class CodexAdapter extends EventEmitter {
   static RESPONSE_TRACKING_TTL_MS = 30000;
@@ -112,6 +338,9 @@ class CodexAdapter extends EventEmitter {
   appServerWs = null;
   tuiWs = null;
   proxyServer = null;
+  transport = "ws";
+  socketPath = null;
+  relay = null;
   threadId = null;
   nextInjectionId = -1;
   appPort;
@@ -165,8 +394,14 @@ class CodexAdapter extends EventEmitter {
   async start() {
     this.intentionalDisconnect = false;
     await this.checkPorts();
-    this.log(`Spawning codex app-server on ${this.appServerUrl}`);
-    this.proc = spawn("codex", ["app-server", "--listen", this.appServerUrl], {
+    this.resolveTransport();
+    const listen = codexListenArg(this.transport, this.appPort, this.socketPath ?? "");
+    if (this.transport === "unix" && this.socketPath) {
+      ensureSocketDir(this.socketPath);
+      removeSocketFile(this.socketPath);
+    }
+    this.log(`Spawning codex app-server (transport=${this.transport}) --listen ${listen}`);
+    this.proc = spawn("codex", ["app-server", "--listen", listen], {
       stdio: ["pipe", "pipe", "pipe"]
     });
     this.proc.on("error", (err) => this.emit("error", err));
@@ -175,10 +410,23 @@ class CodexAdapter extends EventEmitter {
     stderrRl.on("line", (l) => this.log(`[codex-server] ${l}`));
     const stdoutRl = createInterface({ input: this.proc.stdout });
     stdoutRl.on("line", (l) => this.log(`[codex-stdout] ${l}`));
-    await this.waitForHealthy();
+    if (this.transport === "unix" && this.socketPath) {
+      await waitForUnixWsReady(this.socketPath);
+      this.relay = new TcpToUnixRelay("127.0.0.1", this.appPort, this.socketPath, (m) => this.log(`[relay] ${m}`));
+      await this.relay.start();
+      this.log(`Transport relay ready: ws://127.0.0.1:${this.appPort} \u2192 unix://${this.socketPath}`);
+    } else {
+      await this.waitForHealthy();
+    }
     await this.connectToAppServer();
     this.startProxy();
     this.log(`Proxy ready on ${this.proxyUrl}`);
+  }
+  resolveTransport() {
+    const mode = parseTransportMode(process.env[CODEX_TRANSPORT_ENV]);
+    this.transport = resolveCodexTransport(mode);
+    this.socketPath = this.transport === "unix" ? codexSocketPath(this.appPort) : null;
+    this.log(`Codex transport mode=${mode} resolved=${this.transport}`);
   }
   disconnect() {
     this.intentionalDisconnect = true;
@@ -198,6 +446,12 @@ class CodexAdapter extends EventEmitter {
     }
     this.proxyServer?.stop();
     this.proxyServer = null;
+    if (this.relay) {
+      this.relay.stop();
+      this.relay = null;
+    }
+    if (this.socketPath)
+      removeSocketFile(this.socketPath);
     this.clearResponseTrackingState();
     this.resetTurnState("adapter disconnect");
   }
@@ -1822,8 +2076,8 @@ function isProcessAlive(pid) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, existsSync as existsSync3 } from "fs";
-import { join as join2 } from "path";
+import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, existsSync as existsSync3 } from "fs";
+import { join as join3 } from "path";
 var DEFAULT_CONFIG = {
   version: "1.0",
   codex: {
@@ -1875,8 +2129,8 @@ class ConfigService {
   configPath;
   constructor(projectRoot) {
     const root = projectRoot ?? process.cwd();
-    this.configDir = join2(root, CONFIG_DIR);
-    this.configPath = join2(this.configDir, CONFIG_FILE);
+    this.configDir = join3(root, CONFIG_DIR);
+    this.configPath = join3(this.configDir, CONFIG_FILE);
   }
   hasConfig() {
     return existsSync3(this.configPath);
@@ -1911,7 +2165,7 @@ class ConfigService {
   }
   ensureConfigDir() {
     if (!existsSync3(this.configDir)) {
-      mkdirSync2(this.configDir, { recursive: true });
+      mkdirSync3(this.configDir, { recursive: true });
     }
   }
 }

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -60,6 +60,9 @@ class StateDirResolver {
   get killedFile() {
     return join(this.stateDir, "killed");
   }
+  get updateCheckFile() {
+    return join(this.stateDir, "update-check.json");
+  }
 }
 
 // src/app-server-protocol.ts
@@ -1845,8 +1848,8 @@ var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 
 // src/env-utils.ts
-function parsePositiveIntEnv(name, fallback, log = () => {}) {
-  const raw = process.env[name];
+function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) {
+  const raw = env[name];
   if (raw == null || raw === "")
     return fallback;
   const parsed = Number(raw);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2203,7 +2203,7 @@ async function probeLiveness(target, options) {
   } = options;
   if (target.readyState !== OPEN)
     return false;
-  const baseline = Math.max(target.lastPongAt, now());
+  const baseline = target.pongCount;
   try {
     target.ping();
   } catch {
@@ -2211,13 +2211,13 @@ async function probeLiveness(target, options) {
   }
   const deadline = now() + timeoutMs;
   while (now() < deadline) {
-    if (target.lastPongAt > baseline)
+    if (target.pongCount > baseline)
       return true;
     if (target.readyState !== OPEN)
       return false;
     await sleep(pollMs);
   }
-  return target.lastPongAt > baseline;
+  return target.pongCount > baseline;
 }
 
 // src/daemon.ts
@@ -2372,7 +2372,7 @@ function startControlServer() {
       if (url.pathname === "/readyz") {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now() } })) {
+      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0 } })) {
         return;
       }
       return new Response("AgentBridge daemon");
@@ -2396,6 +2396,7 @@ function startControlServer() {
       },
       pong: (ws) => {
         ws.data.lastPongAt = Date.now();
+        ws.data.pongCount++;
       }
     }
   });
@@ -2571,8 +2572,8 @@ async function probeLiveness2(ws, timeoutMs) {
     get readyState() {
       return ws.readyState;
     },
-    get lastPongAt() {
-      return ws.data.lastPongAt;
+    get pongCount() {
+      return ws.data.pongCount;
     },
     ping: () => {
       ws.ping();

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -60,6 +60,9 @@ class StateDirResolver {
   get killedFile() {
     return join(this.stateDir, "killed");
   }
+  get updateCheckFile() {
+    return join(this.stateDir, "update-check.json");
+  }
 }
 
 // src/app-server-protocol.ts
@@ -2177,8 +2180,8 @@ var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 
 // src/env-utils.ts
-function parsePositiveIntEnv(name, fallback, log = () => {}) {
-  const raw = process.env[name];
+function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) {
+  const raw = env[name];
   if (raw == null || raw === "")
     return fallback;
   const parsed = Number(raw);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2087,6 +2087,11 @@ function handleControlMessage(ws, raw) {
     case "status":
       sendStatus(ws);
       return;
+    case "probe_incumbent":
+      handleProbeIncumbent(ws).catch((err) => {
+        log(`handleProbeIncumbent threw for #${ws.data.clientId}: ${err?.message ?? err}`);
+      });
+      return;
     case "claude_to_codex": {
       if (message.message.source !== "claude") {
         sendProtocolMessage(ws, {
@@ -2206,6 +2211,24 @@ function detachClaude(ws, reason) {
   log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
   scheduleClaudeDisconnectNotification(ws.data.clientId);
   scheduleIdleShutdown();
+}
+async function handleProbeIncumbent(ws) {
+  const occupant = attachedClaude;
+  if (!occupant || occupant === ws || occupant.readyState !== WebSocket.OPEN) {
+    sendProtocolMessage(ws, { type: "incumbent_status", connected: false, alive: false });
+    return;
+  }
+  if (challengeInProgress) {
+    sendProtocolMessage(ws, { type: "incumbent_status", connected: true, alive: true });
+    return;
+  }
+  const alive = await probeLiveness2(occupant, LIVENESS_PROBE_TIMEOUT_MS);
+  const stillConnected = attachedClaude === occupant && occupant.readyState === WebSocket.OPEN;
+  sendProtocolMessage(ws, {
+    type: "incumbent_status",
+    connected: stillConnected,
+    alive: stillConnected && alive
+  });
 }
 async function probeLiveness2(ws, timeoutMs) {
   return probeLiveness({

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -105,6 +105,232 @@ function isAppServerResponseMessage(value) {
   return (typeof value.id === "number" || typeof value.id === "string") && value.method === undefined && (("result" in value) || ("error" in value));
 }
 
+// src/codex-transport.ts
+import { createServer, connect } from "net";
+import { spawnSync } from "child_process";
+import { mkdirSync as mkdirSync2, rmSync, chmodSync } from "fs";
+import { join as join2 } from "path";
+import { tmpdir } from "os";
+var CODEX_TRANSPORT_ENV = "AGENTBRIDGE_CODEX_TRANSPORT";
+var HEADER_SEP = `\r
+\r
+`;
+var EXTENSIONS_HEADER_RE = /^sec-websocket-extensions:/i;
+var MAX_UPGRADE_HEADER_BYTES = 64 * 1024;
+function parseTransportMode(raw) {
+  switch ((raw ?? "").trim().toLowerCase()) {
+    case "ws":
+      return "ws";
+    case "unix":
+      return "unix";
+    case "auto":
+    case "":
+      return "auto";
+    default:
+      return "auto";
+  }
+}
+function probeCodexWsSupport(runHelp = defaultRunCodexAppServerHelp) {
+  const help = runHelp();
+  if (help === null)
+    return true;
+  return help.includes("ws://");
+}
+function defaultRunCodexAppServerHelp() {
+  try {
+    const res = spawnSync("codex", ["app-server", "--help"], {
+      encoding: "utf-8",
+      timeout: 5000
+    });
+    if (res.error || typeof res.stdout !== "string")
+      return null;
+    return res.stdout + (res.stderr ?? "");
+  } catch {
+    return null;
+  }
+}
+function resolveCodexTransport(mode, runHelp = defaultRunCodexAppServerHelp) {
+  if (mode === "ws")
+    return "ws";
+  if (mode === "unix")
+    return "unix";
+  return probeCodexWsSupport(runHelp) ? "ws" : "unix";
+}
+function codexSocketPath(appPort, baseTmpDir = tmpdir()) {
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  const dir = join2(baseTmpDir, `agentbridge-${uid}`);
+  const path = join2(dir, `codex-${appPort}.sock`);
+  if (path.length >= 104) {
+    throw new Error(`Codex unix socket path is too long for the platform (${path.length} >= 104): ${path}. ` + `Set a shorter TMPDIR or use ${CODEX_TRANSPORT_ENV}=ws.`);
+  }
+  return path;
+}
+function ensureSocketDir(socketPath) {
+  const dir = socketPath.slice(0, socketPath.lastIndexOf("/"));
+  if (!dir)
+    return;
+  mkdirSync2(dir, { recursive: true, mode: 448 });
+  try {
+    chmodSync(dir, 448);
+  } catch (err) {
+    throw new Error(`Refusing to use Codex socket dir ${dir}: cannot enforce 0700 perms ` + `(${err.message}). Remove it or set a private TMPDIR.`);
+  }
+}
+function removeSocketFile(socketPath) {
+  try {
+    rmSync(socketPath, { force: true });
+  } catch {}
+}
+function codexListenArg(transport, appPort, socketPath) {
+  return transport === "unix" ? `unix://${socketPath}` : `ws://127.0.0.1:${appPort}`;
+}
+function stripWebSocketExtensions(headerBlock) {
+  return headerBlock.split(`\r
+`).filter((line) => !EXTENSIONS_HEADER_RE.test(line)).join(`\r
+`);
+}
+
+class TcpToUnixRelay {
+  tcpHost;
+  tcpPort;
+  unixPath;
+  log;
+  server = null;
+  pairs = new Set;
+  constructor(tcpHost, tcpPort, unixPath, log = () => {}) {
+    this.tcpHost = tcpHost;
+    this.tcpPort = tcpPort;
+    this.unixPath = unixPath;
+    this.log = log;
+  }
+  start() {
+    return new Promise((resolve, reject) => {
+      const server = createServer((tcp) => this.handleConnection(tcp));
+      const onListenError = (err) => {
+        server.removeListener("listening", onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.removeListener("error", onListenError);
+        server.on("error", (err) => this.log(`relay server error: ${err.message}`));
+        this.server = server;
+        resolve();
+      };
+      server.once("error", onListenError);
+      server.once("listening", onListening);
+      server.listen(this.tcpPort, this.tcpHost);
+    });
+  }
+  handleConnection(tcp) {
+    const unix = connect(this.unixPath);
+    const pair = { tcp, unix };
+    this.pairs.add(pair);
+    let closed = false;
+    const teardown = () => {
+      if (closed)
+        return;
+      closed = true;
+      this.pairs.delete(pair);
+      tcp.destroy();
+      unix.destroy();
+    };
+    let head = Buffer.alloc(0);
+    const onData = (chunk) => {
+      head = Buffer.concat([head, chunk]);
+      const sep = head.indexOf(HEADER_SEP);
+      if (sep === -1) {
+        if (head.length > MAX_UPGRADE_HEADER_BYTES) {
+          tcp.removeListener("data", onData);
+          unix.write(head);
+          head = Buffer.alloc(0);
+          tcp.pipe(unix);
+        }
+        return;
+      }
+      tcp.removeListener("data", onData);
+      const headers = head.subarray(0, sep).toString("utf8");
+      const rest = head.subarray(sep + HEADER_SEP.length);
+      unix.write(stripWebSocketExtensions(headers) + HEADER_SEP);
+      head = Buffer.alloc(0);
+      if (rest.length)
+        tcp.unshift(rest);
+      tcp.pipe(unix);
+    };
+    tcp.on("data", onData);
+    unix.pipe(tcp);
+    tcp.on("error", (e) => {
+      this.log(`relay tcp error: ${e.message}`);
+      teardown();
+    });
+    unix.on("error", (e) => {
+      this.log(`relay unix error: ${e.message}`);
+      teardown();
+    });
+    tcp.on("close", teardown);
+    unix.on("close", teardown);
+  }
+  get connectionCount() {
+    return this.pairs.size;
+  }
+  get port() {
+    const addr = this.server?.address();
+    return addr && typeof addr === "object" ? addr.port : this.tcpPort;
+  }
+  stop() {
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+    }
+    for (const { tcp, unix } of this.pairs) {
+      tcp.destroy();
+      unix.destroy();
+    }
+    this.pairs.clear();
+  }
+}
+async function waitForUnixWsReady(socketPath, maxRetries = 40, delayMs = 250) {
+  for (let i = 0;i < maxRetries; i++) {
+    if (await attemptUnixWsUpgrade(socketPath))
+      return;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  throw new Error(`Codex unix app-server at ${socketPath} did not become ready`);
+}
+function attemptUnixWsUpgrade(socketPath) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (ok) => {
+      if (settled)
+        return;
+      settled = true;
+      try {
+        socket.destroy();
+      } catch {}
+      resolve(ok);
+    };
+    const socket = connect(socketPath, () => {
+      socket.write(`GET / HTTP/1.1\r
+Host: localhost\r
+Upgrade: websocket\r
+Connection: Upgrade\r
+` + `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
+Sec-WebSocket-Version: 13\r
+\r
+`);
+    });
+    let buf = "";
+    socket.on("data", (d) => {
+      buf += d.toString("utf8");
+      if (buf.includes(`\r
+`))
+        done(buf.startsWith("HTTP/1.1 101"));
+    });
+    socket.on("error", () => done(false));
+    socket.on("close", () => done(false));
+    setTimeout(() => done(false), 1500);
+  });
+}
+
 // src/codex-adapter.ts
 class CodexAdapter extends EventEmitter {
   static RESPONSE_TRACKING_TTL_MS = 30000;
@@ -112,6 +338,9 @@ class CodexAdapter extends EventEmitter {
   appServerWs = null;
   tuiWs = null;
   proxyServer = null;
+  transport = "ws";
+  socketPath = null;
+  relay = null;
   threadId = null;
   nextInjectionId = -1;
   appPort;
@@ -124,6 +353,8 @@ class CodexAdapter extends EventEmitter {
   pendingRequests = new Map;
   activeTurnIds = new Set;
   turnInProgress = false;
+  turnWatchdogs = new Map;
+  threadSwitchSeq = 0;
   nextProxyId = 1e5;
   upstreamToClient = new Map;
   serverRequestToProxy = new Map;
@@ -163,8 +394,14 @@ class CodexAdapter extends EventEmitter {
   async start() {
     this.intentionalDisconnect = false;
     await this.checkPorts();
-    this.log(`Spawning codex app-server on ${this.appServerUrl}`);
-    this.proc = spawn("codex", ["app-server", "--listen", this.appServerUrl], {
+    this.resolveTransport();
+    const listen = codexListenArg(this.transport, this.appPort, this.socketPath ?? "");
+    if (this.transport === "unix" && this.socketPath) {
+      ensureSocketDir(this.socketPath);
+      removeSocketFile(this.socketPath);
+    }
+    this.log(`Spawning codex app-server (transport=${this.transport}) --listen ${listen}`);
+    this.proc = spawn("codex", ["app-server", "--listen", listen], {
       stdio: ["pipe", "pipe", "pipe"]
     });
     this.proc.on("error", (err) => this.emit("error", err));
@@ -173,10 +410,23 @@ class CodexAdapter extends EventEmitter {
     stderrRl.on("line", (l) => this.log(`[codex-server] ${l}`));
     const stdoutRl = createInterface({ input: this.proc.stdout });
     stdoutRl.on("line", (l) => this.log(`[codex-stdout] ${l}`));
-    await this.waitForHealthy();
+    if (this.transport === "unix" && this.socketPath) {
+      await waitForUnixWsReady(this.socketPath);
+      this.relay = new TcpToUnixRelay("127.0.0.1", this.appPort, this.socketPath, (m) => this.log(`[relay] ${m}`));
+      await this.relay.start();
+      this.log(`Transport relay ready: ws://127.0.0.1:${this.appPort} \u2192 unix://${this.socketPath}`);
+    } else {
+      await this.waitForHealthy();
+    }
     await this.connectToAppServer();
     this.startProxy();
     this.log(`Proxy ready on ${this.proxyUrl}`);
+  }
+  resolveTransport() {
+    const mode = parseTransportMode(process.env[CODEX_TRANSPORT_ENV]);
+    this.transport = resolveCodexTransport(mode);
+    this.socketPath = this.transport === "unix" ? codexSocketPath(this.appPort) : null;
+    this.log(`Codex transport mode=${mode} resolved=${this.transport}`);
   }
   disconnect() {
     this.intentionalDisconnect = true;
@@ -196,7 +446,14 @@ class CodexAdapter extends EventEmitter {
     }
     this.proxyServer?.stop();
     this.proxyServer = null;
+    if (this.relay) {
+      this.relay.stop();
+      this.relay = null;
+    }
+    if (this.socketPath)
+      removeSocketFile(this.socketPath);
     this.clearResponseTrackingState();
+    this.resetTurnState("adapter disconnect");
   }
   stop() {
     this.intentionalDisconnect = true;
@@ -323,8 +580,7 @@ class CodexAdapter extends EventEmitter {
       } catch {}
     }
     this.clearResponseTrackingStateForAppServerReconnect();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server reconnect for new TUI session");
     try {
       await this.connectToAppServer(false);
       this.log("App-server reconnected for new TUI session \u2014 replaying buffered messages");
@@ -378,8 +634,7 @@ class CodexAdapter extends EventEmitter {
     this.log(`App-server connection closed (intentional=${intentional}, tuiConnected=${tuiConnected}, turnInProgress=${this.turnInProgress})`);
     this.appServerWs = null;
     this.clearResponseTrackingState();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server connection closed");
     if (!intentional) {
       this.scheduleReconnect();
     }
@@ -811,6 +1066,9 @@ class CodexAdapter extends EventEmitter {
   handleAppServerPayload(raw) {
     try {
       const parsed = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null) {
+        this.refreshTurnWatchdogs();
+      }
       if (typeof parsed === "object" && parsed !== null && "id" in parsed) {
         if (this.tryConsumeReplayResponse(parsed)) {
           return null;
@@ -1039,6 +1297,9 @@ class CodexAdapter extends EventEmitter {
         pending.threadId = threadId;
       }
     }
+    if (method === "thread/start" || method === "thread/resume") {
+      pending.threadSwitchSeq = ++this.threadSwitchSeq;
+    }
     if (this.pendingRequests.has(key)) {
       this.log(`WARNING: overwriting pending request for key ${key}`);
     }
@@ -1062,6 +1323,10 @@ class CodexAdapter extends EventEmitter {
     }
     switch (pending.method) {
       case "thread/start": {
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(`Ignoring stale thread/start response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`);
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/start response ${key}`);
@@ -1070,6 +1335,10 @@ class CodexAdapter extends EventEmitter {
         break;
       }
       case "thread/resume": {
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(`Ignoring stale thread/resume response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`);
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/resume response ${key}`);
@@ -1082,10 +1351,17 @@ class CodexAdapter extends EventEmitter {
       }
       case "turn/start":
         if (pending.threadId) {
-          this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          if (this.threadId === null || this.threadId === pending.threadId) {
+            this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          } else {
+            this.log(`Ignoring turn/start response ${key} threadId=${pending.threadId} (active thread is ${this.threadId})`);
+          }
         }
         break;
     }
+  }
+  isLatestThreadSwitch(pending) {
+    return pending.threadSwitchSeq === this.threadSwitchSeq;
   }
   setActiveThreadId(threadId, reason) {
     if (this.threadId === threadId)
@@ -1101,11 +1377,9 @@ class CodexAdapter extends EventEmitter {
   }
   markTurnStarted(turnId) {
     const wasInProgress = this.turnInProgress;
-    if (typeof turnId === "string" && turnId.length > 0) {
-      this.activeTurnIds.add(turnId);
-    } else {
-      this.activeTurnIds.add(`unknown:${Date.now()}`);
-    }
+    const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
+    this.activeTurnIds.add(turnKey);
+    this.scheduleTurnWatchdog(turnKey);
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
       this.emit("turnStarted");
@@ -1114,10 +1388,67 @@ class CodexAdapter extends EventEmitter {
   markTurnCompleted(turnId) {
     if (typeof turnId === "string" && turnId.length > 0) {
       this.activeTurnIds.delete(turnId);
+      this.clearTurnWatchdog(turnId);
     } else {
       this.activeTurnIds.clear();
+      this.clearAllTurnWatchdogs();
     }
     this.turnInProgress = this.activeTurnIds.size > 0;
+  }
+  turnWatchdogMs() {
+    const v = Number(process.env.AGENTBRIDGE_TURN_WATCHDOG_MS);
+    return Number.isFinite(v) && v > 0 ? v : 300000;
+  }
+  scheduleTurnWatchdog(turnKey) {
+    this.clearTurnWatchdog(turnKey);
+    const timer = setTimeout(() => {
+      if (!this.activeTurnIds.has(turnKey))
+        return;
+      this.log(`WARNING: turn ${turnKey} watchdog fired after ${this.turnWatchdogMs()}ms of inactivity \u2014 ` + `assuming a lost turn/completed; force-completing to unblock injection`);
+      this.forceCompleteTurn(turnKey);
+    }, this.turnWatchdogMs());
+    timer.unref?.();
+    this.turnWatchdogs.set(turnKey, timer);
+  }
+  clearTurnWatchdog(turnKey) {
+    const timer = this.turnWatchdogs.get(turnKey);
+    if (timer) {
+      clearTimeout(timer);
+      this.turnWatchdogs.delete(turnKey);
+    }
+  }
+  clearAllTurnWatchdogs() {
+    for (const timer of this.turnWatchdogs.values())
+      clearTimeout(timer);
+    this.turnWatchdogs.clear();
+  }
+  refreshTurnWatchdogs() {
+    if (this.turnWatchdogs.size === 0)
+      return;
+    for (const turnKey of [...this.turnWatchdogs.keys()]) {
+      this.scheduleTurnWatchdog(turnKey);
+    }
+  }
+  forceCompleteTurn(turnKey) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.delete(turnKey);
+    this.clearTurnWatchdog(turnKey);
+    this.turnInProgress = this.activeTurnIds.size > 0;
+    if (wasInProgress && !this.turnInProgress) {
+      this.emit("turnCompleted");
+    }
+  }
+  resetTurnState(reason, emitCompleted = false) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.clear();
+    this.clearAllTurnWatchdogs();
+    this.turnInProgress = false;
+    if (emitCompleted && wasInProgress) {
+      this.emit("turnCompleted");
+    }
+    if (wasInProgress) {
+      this.log(`Turn state reset (${reason})`);
+    }
   }
   requestKey(id) {
     if (typeof id === "number" || typeof id === "string")
@@ -1746,8 +2077,8 @@ function isProcessAlive(pid) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, existsSync as existsSync3 } from "fs";
-import { join as join2 } from "path";
+import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, existsSync as existsSync3 } from "fs";
+import { join as join3 } from "path";
 var DEFAULT_CONFIG = {
   version: "1.0",
   codex: {
@@ -1799,8 +2130,8 @@ class ConfigService {
   configPath;
   constructor(projectRoot) {
     const root = projectRoot ?? process.cwd();
-    this.configDir = join2(root, CONFIG_DIR);
-    this.configPath = join2(this.configDir, CONFIG_FILE);
+    this.configDir = join3(root, CONFIG_DIR);
+    this.configPath = join3(this.configDir, CONFIG_FILE);
   }
   hasConfig() {
     return existsSync3(this.configPath);
@@ -1835,7 +2166,7 @@ class ConfigService {
   }
   ensureConfigDir() {
     if (!existsSync3(this.configDir)) {
-      mkdirSync2(this.configDir, { recursive: true });
+      mkdirSync3(this.configDir, { recursive: true });
     }
   }
 }

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -2421,6 +2421,11 @@ function handleControlMessage(ws, raw) {
     case "status":
       sendStatus(ws);
       return;
+    case "probe_incumbent":
+      handleProbeIncumbent(ws).catch((err) => {
+        log(`handleProbeIncumbent threw for #${ws.data.clientId}: ${err?.message ?? err}`);
+      });
+      return;
     case "claude_to_codex": {
       if (message.message.source !== "claude") {
         sendProtocolMessage(ws, {
@@ -2540,6 +2545,24 @@ function detachClaude(ws, reason) {
   log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
   scheduleClaudeDisconnectNotification(ws.data.clientId);
   scheduleIdleShutdown();
+}
+async function handleProbeIncumbent(ws) {
+  const occupant = attachedClaude;
+  if (!occupant || occupant === ws || occupant.readyState !== WebSocket.OPEN) {
+    sendProtocolMessage(ws, { type: "incumbent_status", connected: false, alive: false });
+    return;
+  }
+  if (challengeInProgress) {
+    sendProtocolMessage(ws, { type: "incumbent_status", connected: true, alive: true });
+    return;
+  }
+  const alive = await probeLiveness2(occupant, LIVENESS_PROBE_TIMEOUT_MS);
+  const stillConnected = attachedClaude === occupant && occupant.readyState === WebSocket.OPEN;
+  sendProtocolMessage(ws, {
+    type: "incumbent_status",
+    connected: stillConnected,
+    alive: stillConnected && alive
+  });
 }
 async function probeLiveness2(ws, timeoutMs) {
   return probeLiveness({

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1800,9 +1800,26 @@ class TuiConnectionState {
 import { spawn as spawn2, execFileSync } from "child_process";
 import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
+
+// src/env-utils.ts
+function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) {
+  const raw = env[name];
+  if (raw == null || raw === "")
+    return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > Number.MAX_SAFE_INTEGER) {
+    log(`Invalid ${name}=${JSON.stringify(raw)} (must be a positive integer within ` + `Number.MAX_SAFE_INTEGER); falling back to ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
+// src/daemon-lifecycle.ts
 var DEFAULT_DAEMON_ENTRY = import.meta.url.endsWith(".ts") ? "./daemon.ts" : "./daemon.js";
 var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
+var REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES", 12);
+var REUSE_READY_DELAY_MS = 250;
 
 class DaemonLifecycle {
   stateDir;
@@ -1822,38 +1839,79 @@ class DaemonLifecycle {
   get controlWsUrl() {
     return `ws://127.0.0.1:${this.controlPort}/ws`;
   }
+  get expectedPairId() {
+    return process.env.AGENTBRIDGE_PAIR_ID || null;
+  }
+  async fetchStatus() {
+    try {
+      const response = await fetch(this.healthUrl);
+      if (!response.ok)
+        return null;
+      return await response.json();
+    } catch {
+      return null;
+    }
+  }
+  isForeignDaemon(status) {
+    const expected = this.expectedPairId;
+    if (!expected)
+      return false;
+    if (!status)
+      return false;
+    const reported = status.pairId;
+    if (reported == null)
+      return true;
+    return reported !== expected;
+  }
   async ensureRunning() {
     if (await this.isHealthy()) {
-      await this.waitForReady();
-      return;
+      const status = await this.fetchStatus();
+      if (this.isForeignDaemon(status)) {
+        this.log(`Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` + `but this pair is ${this.expectedPairId} \u2014 replacing foreign daemon`);
+        await this.replaceUnhealthyDaemon(status?.pid);
+        return;
+      }
+      try {
+        await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+        return;
+      } catch {
+        this.log(`Daemon on control port ${this.controlPort} is healthy but not ready within reuse window \u2014 replacing`);
+        await this.replaceUnhealthyDaemon(status?.pid);
+        return;
+      }
     }
     const existingPid = this.readPid();
     if (existingPid) {
       if (isProcessAlive(existingPid)) {
         if (this.isDaemonProcess(existingPid)) {
           try {
-            await this.waitForReady(12, 250);
+            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
           } catch {
-            throw new Error(`Found existing daemon process ${existingPid}, but control port ${this.controlPort} never became ready.`);
+            this.log(`Existing daemon process ${existingPid} never became ready \u2014 replacing`);
+            await this.replaceUnhealthyDaemon(existingPid);
+            return;
           }
         }
         this.log(`Pid ${existingPid} is alive but not an AgentBridge daemon, removing stale pid file`);
       }
       this.removeStalePidFile();
     }
-    const lockAcquired = this.acquireLock();
-    if (!lockAcquired) {
-      this.log("Another process is starting the daemon, waiting for readiness...");
-      await this.waitForReady();
-      return;
-    }
-    try {
+    await this.withStartupLockStrict(async (locked) => {
+      if (!locked) {
+        this.log("Another process holds the startup lock, waiting for readiness+identity...");
+        await this.waitForReadyAndOurs();
+        return;
+      }
+      if (await this.isHealthy() && !this.isForeignDaemon(await this.fetchStatus())) {
+        try {
+          await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+          return;
+        } catch {}
+      }
       this.launch();
       await this.waitForReady();
-    } finally {
-      this.releaseLock();
-    }
+    });
   }
   async isHealthy() {
     try {
@@ -1886,6 +1944,17 @@ class DaemonLifecycle {
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
     throw new Error(`Timed out waiting for AgentBridge daemon readiness on ${this.readyUrl}`);
+  }
+  async waitForReadyAndOurs(maxRetries = 40, delayMs = 250) {
+    for (let attempt = 0;attempt < maxRetries; attempt++) {
+      if (await this.isReady()) {
+        const status = await this.fetchStatus();
+        if (!this.isForeignDaemon(status))
+          return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    throw new Error(`Timed out waiting for AgentBridge daemon readiness+identity on ${this.readyUrl} (control port ${this.controlPort})`);
   }
   readStatus() {
     try {
@@ -1958,11 +2027,38 @@ class DaemonLifecycle {
     this.log("Removing stale pid file");
     this.removePidFile();
   }
-  acquireLock(depth = 0) {
-    if (depth > 1) {
-      this.log("Lock acquisition failed after retry, proceeding without lock");
-      return true;
+  async replaceUnhealthyDaemon(statusPid) {
+    await this.withStartupLockStrict(async (locked) => {
+      if (!locked) {
+        this.log("Another process holds the startup lock, waiting for readiness+identity...");
+        await this.waitForReadyAndOurs();
+        return;
+      }
+      if (await this.isHealthy()) {
+        const status = await this.fetchStatus();
+        if (!this.isForeignDaemon(status)) {
+          try {
+            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            return;
+          } catch {}
+        }
+      }
+      this.log(`Killing unhealthy daemon on control port ${this.controlPort} and relaunching`);
+      await this.kill(3000, statusPid);
+      this.launch();
+      await this.waitForReady();
+    });
+  }
+  async withStartupLockStrict(fn) {
+    const locked = this.acquireLockStrict();
+    try {
+      return await fn(locked);
+    } finally {
+      if (locked)
+        this.releaseLock();
     }
+  }
+  acquireLockStrict(reclaimed = false) {
     this.stateDir.ensure();
     try {
       const fd = openSync(this.stateDir.lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
@@ -1972,22 +2068,22 @@ class DaemonLifecycle {
       return true;
     } catch (err) {
       if (err.code === "EEXIST") {
+        if (reclaimed)
+          return false;
         try {
           const holderPid = Number.parseInt(readFileSync(this.stateDir.lockFile, "utf-8").trim(), 10);
           if (Number.isFinite(holderPid) && !isProcessAlive(holderPid)) {
-            this.log(`Stale lock file from dead process ${holderPid}, removing`);
+            this.log(`Stale startup lock from dead process ${holderPid}, reclaiming`);
             this.releaseLock();
-            return this.acquireLock(depth + 1);
+            return this.acquireLockStrict(true);
           }
         } catch {
-          this.log("Cannot read lock file, removing stale lock");
-          this.releaseLock();
-          return this.acquireLock(depth + 1);
+          return false;
         }
         return false;
       }
-      this.log(`Warning: could not acquire startup lock: ${err.message}`);
-      return true;
+      this.log(`Could not acquire strict startup lock: ${err.message}`);
+      return false;
     }
   }
   releaseLock() {
@@ -1995,8 +2091,8 @@ class DaemonLifecycle {
       unlinkSync(this.stateDir.lockFile);
     } catch {}
   }
-  async kill(gracefulTimeoutMs = 3000) {
-    const pid = this.readPid();
+  async kill(gracefulTimeoutMs = 3000, pidOverride) {
+    const pid = pidOverride ?? this.readPid();
     if (!pid) {
       this.log("No daemon pid file found");
       this.cleanup();
@@ -2038,7 +2134,9 @@ class DaemonLifecycle {
   isDaemonProcess(pid) {
     try {
       const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-      return cmd.includes("daemon") && (cmd.includes("agentbridge") || cmd.includes("agent_bridge"));
+      const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
+      const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
+      return hasDaemonEntry && hasAgentbridge;
     } catch {
       return false;
     }
@@ -2046,7 +2144,6 @@ class DaemonLifecycle {
   cleanup() {
     this.removePidFile();
     this.removeStatusFile();
-    this.releaseLock();
   }
 }
 function isProcessAlive(pid) {
@@ -2158,19 +2255,6 @@ var CLOSE_CODE_REPLACED = 4001;
 var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 
-// src/env-utils.ts
-function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) {
-  const raw = env[name];
-  if (raw == null || raw === "")
-    return fallback;
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > Number.MAX_SAFE_INTEGER) {
-    log(`Invalid ${name}=${JSON.stringify(raw)} (must be a positive integer within ` + `Number.MAX_SAFE_INTEGER); falling back to ${fallback}`);
-    return fallback;
-  }
-  return parsed;
-}
-
 // src/liveness-probe.ts
 var OPEN = 1;
 async function probeLiveness(target, options) {
@@ -2213,6 +2297,8 @@ var MAX_BUFFERED_MESSAGES = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAG
 var FILTER_MODE = process.env.AGENTBRIDGE_FILTER_MODE === "full" ? "full" : "filtered";
 var IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
 var ATTENTION_WINDOW_MS = parseInt(process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS ?? String(config.turnCoordination.attentionWindowSeconds * 1000), 10);
+var BOOTSTRAP_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_BOOTSTRAP_TIMEOUT_MS", 45000);
+var CODEX_BOOT_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_CODEX_BOOT_RETRIES", 2);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
 var attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
@@ -2226,6 +2312,7 @@ var inAttentionWindow = false;
 var replyRequired = false;
 var replyReceivedDuringTurn = false;
 var shuttingDown = false;
+var bootDeadlineTimer = null;
 var idleShutdownTimer = null;
 var claudeDisconnectTimer = null;
 var lastAttachStatusSentTs = 0;
@@ -2326,6 +2413,7 @@ codex.on("exit", (code) => {
   clearPendingClaudeDisconnect("Codex process exited");
   emitToClaude(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running, but the Codex side needs to be restarted.`));
   broadcastStatus();
+  armBootDeadline();
 });
 function startControlServer() {
   controlServer = Bun.serve({
@@ -2682,7 +2770,8 @@ function currentStatus() {
     queuedMessageCount: bufferedMessages.length + statusBuffer.size,
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
-    pid: process.pid
+    pid: process.pid,
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null
   };
 }
 function currentWaitingMessage() {
@@ -2718,28 +2807,64 @@ function writeStatusFile() {
 function removeStatusFile() {
   daemonLifecycle.removeStatusFile();
 }
+function armBootDeadline() {
+  if (bootDeadlineTimer)
+    return;
+  bootDeadlineTimer = setTimeout(() => {
+    bootDeadlineTimer = null;
+    if (codexBootstrapped)
+      return;
+    if (tuiConnectionState.snapshot().tuiConnected)
+      return;
+    log(`Codex not ready within bootstrap deadline (${BOOTSTRAP_TIMEOUT_MS}ms) \u2014 self-exiting to release control port`);
+    shutdown("codex not ready within bootstrap deadline", 1);
+  }, BOOTSTRAP_TIMEOUT_MS);
+  bootDeadlineTimer.unref?.();
+}
+function clearBootDeadline() {
+  if (bootDeadlineTimer) {
+    clearTimeout(bootDeadlineTimer);
+    bootDeadlineTimer = null;
+  }
+}
 async function bootCodex() {
   log("Starting AgentBridge daemon...");
   log(`Codex app-server: ${codex.appServerUrl}`);
   log(`Codex proxy: ${codex.proxyUrl}`);
   log(`Control server: ws://127.0.0.1:${CONTROL_PORT}/ws`);
-  try {
-    await codex.start();
-    codexBootstrapped = true;
-    writeStatusFile();
-    emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));
-    broadcastStatus();
-  } catch (err) {
-    log(`Failed to start Codex: ${err.message}`);
-    emitToClaude(systemMessage("system_codex_start_failed", `\u274C AgentBridge failed to start Codex app-server: ${err.message}`));
-    broadcastStatus();
+  for (let attempt = 0;attempt <= CODEX_BOOT_RETRIES; attempt++) {
+    try {
+      await codex.start();
+      codexBootstrapped = true;
+      clearBootDeadline();
+      writeStatusFile();
+      emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));
+      broadcastStatus();
+      return;
+    } catch (err) {
+      const attemptsLeft = CODEX_BOOT_RETRIES - attempt;
+      log(`Failed to start Codex (attempt ${attempt + 1}/${CODEX_BOOT_RETRIES + 1}): ${err.message}`);
+      if (attemptsLeft > 0) {
+        const backoffMs = 1000 * (attempt + 1);
+        log(`Retrying Codex bootstrap in ${backoffMs}ms (${attemptsLeft} attempt(s) left)...`);
+        await new Promise((r) => setTimeout(r, backoffMs));
+        if (shuttingDown)
+          return;
+        continue;
+      }
+      emitToClaude(systemMessage("system_codex_start_failed", `\u274C AgentBridge failed to start Codex app-server after ${CODEX_BOOT_RETRIES + 1} attempts: ${err.message}`));
+      broadcastStatus();
+      shutdown("codex bootstrap failed", 1);
+      return;
+    }
   }
 }
-function shutdown(reason) {
+function shutdown(reason, exitCode = 0) {
   if (shuttingDown)
     return;
   shuttingDown = true;
   log(`Shutting down daemon (${reason})...`);
+  clearBootDeadline();
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);
   clearPendingClaudeDisconnect(`daemon shutdown (${reason})`);
   controlServer?.stop();
@@ -2747,7 +2872,7 @@ function shutdown(reason) {
   codex.stop();
   removePidFile();
   removeStatusFile();
-  process.exit(0);
+  process.exit(exitCode);
 }
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
@@ -2775,4 +2900,5 @@ if (daemonLifecycle.wasKilled()) {
 }
 writePidFile();
 startControlServer();
+armBootDeadline();
 bootCodex();

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1,14 +1,42 @@
 #!/usr/bin/env bun
 // @bun
 
-// src/daemon.ts
-import { appendFileSync as appendFileSync2 } from "fs";
+// src/build-info.ts
+function defineString(value, fallback) {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+function defineBundle(value) {
+  if (value === "source" || value === "dist" || value === "plugin")
+    return value;
+  return import.meta.url.endsWith(".ts") ? "source" : "dist";
+}
+function defineNumber(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+var BUILD_INFO = Object.freeze({
+  version: defineString("0.1.6", "0.0.0-source"),
+  commit: defineString("6c24127", "source"),
+  bundle: defineBundle("plugin"),
+  contractVersion: defineNumber(1, 1)
+});
+function daemonStatusBuildInfo() {
+  return { ...BUILD_INFO };
+}
+function sameRuntimeContract(a, b) {
+  if (!a || !b)
+    return false;
+  return a.version === b.version && a.commit === b.commit && a.contractVersion === b.contractVersion;
+}
+function formatBuildInfo(build) {
+  if (!build)
+    return "<unknown>";
+  return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}`;
+}
 
 // src/codex-adapter.ts
 import { spawn, execSync } from "child_process";
 import { createInterface } from "readline";
 import { EventEmitter } from "events";
-import { appendFileSync } from "fs";
 
 // src/state-dir.ts
 import { mkdirSync, existsSync } from "fs";
@@ -51,6 +79,9 @@ class StateDirResolver {
   get portsFile() {
     return join(this.stateDir, "ports.json");
   }
+  get currentThreadFile() {
+    return join(this.stateDir, "current-thread.json");
+  }
   get logFile() {
     return join(this.stateDir, "agentbridge.log");
   }
@@ -63,6 +94,40 @@ class StateDirResolver {
   get updateCheckFile() {
     return join(this.stateDir, "update-check.json");
   }
+}
+
+// src/rotating-log.ts
+import { appendFileSync, existsSync as existsSync2, mkdirSync as mkdirSync2, renameSync, statSync, unlinkSync } from "fs";
+import { dirname } from "path";
+var DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+var DEFAULT_KEEP = 3;
+function appendRotatingLog(path, content, options = {}) {
+  const maxBytes = options.maxBytes ?? Number(process.env.AGENTBRIDGE_LOG_MAX_BYTES || DEFAULT_MAX_BYTES);
+  const keep = options.keep ?? Number(process.env.AGENTBRIDGE_LOG_ROTATE_KEEP || DEFAULT_KEEP);
+  mkdirSync2(dirname(path), { recursive: true });
+  rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep);
+  appendFileSync(path, content, "utf-8");
+}
+function rotateIfNeeded(path, incomingBytes, maxBytes, keep) {
+  if (!Number.isFinite(maxBytes) || maxBytes <= 0 || keep <= 0)
+    return;
+  if (!existsSync2(path))
+    return;
+  const size = statSync(path).size;
+  if (size + incomingBytes <= maxBytes)
+    return;
+  for (let index = keep;index >= 1; index--) {
+    const current = `${path}.${index}`;
+    const next = `${path}.${index + 1}`;
+    if (!existsSync2(current))
+      continue;
+    if (index === keep) {
+      unlinkSync(current);
+    } else {
+      renameSync(current, next);
+    }
+  }
+  renameSync(path, `${path}.1`);
 }
 
 // src/app-server-protocol.ts
@@ -111,7 +176,7 @@ function isAppServerResponseMessage(value) {
 // src/codex-transport.ts
 import { createServer, connect } from "net";
 import { spawnSync } from "child_process";
-import { mkdirSync as mkdirSync2, rmSync, chmodSync } from "fs";
+import { mkdirSync as mkdirSync3, rmSync, chmodSync } from "fs";
 import { join as join2 } from "path";
 import { tmpdir } from "os";
 var CODEX_TRANSPORT_ENV = "AGENTBRIDGE_CODEX_TRANSPORT";
@@ -172,7 +237,7 @@ function ensureSocketDir(socketPath) {
   const dir = socketPath.slice(0, socketPath.lastIndexOf("/"));
   if (!dir)
     return;
-  mkdirSync2(dir, { recursive: true, mode: 448 });
+  mkdirSync3(dir, { recursive: true, mode: 448 });
   try {
     chmodSync(dir, 448);
   } catch (err) {
@@ -357,6 +422,7 @@ class CodexAdapter extends EventEmitter {
   activeTurnIds = new Set;
   turnInProgress = false;
   turnWatchdogs = new Map;
+  stalledTurnIds = new Set;
   threadSwitchSeq = 0;
   nextProxyId = 1e5;
   upstreamToClient = new Map;
@@ -847,7 +913,13 @@ class CodexAdapter extends EventEmitter {
   }
   setupSecondaryConnection(ws, connId) {
     const appWs = new WebSocket(this.appServerUrl);
-    const entry = { tuiWs: ws, appServerWs: appWs, buffer: [] };
+    const entry = {
+      tuiWs: ws,
+      appServerWs: appWs,
+      buffer: [],
+      initialized: false,
+      initializationReplayed: false
+    };
     this.secondaryConnections.set(connId, entry);
     appWs.onopen = () => {
       if (!this.secondaryConnections.has(connId)) {
@@ -969,13 +1041,13 @@ class CodexAdapter extends EventEmitter {
     const connId = ws.data.connId;
     const secondary = this.secondaryConnections.get(connId);
     if (secondary) {
-      if (secondary.appServerWs && secondary.appServerWs.readyState === WebSocket.OPEN) {
-        try {
-          secondary.appServerWs.send(data);
-        } catch {}
-      } else {
-        secondary.buffer.push(data);
+      const method = this.detectJsonMethod(data);
+      if (method === "initialize" || method === "initialized") {
+        secondary.initialized = true;
+      } else if (!secondary.initialized) {
+        this.ensureSecondaryInitialized(secondary, connId);
       }
+      this.sendOrBufferSecondary(secondary, data);
       return;
     }
     if (connId !== this.tuiConnId) {
@@ -1064,6 +1136,38 @@ class CodexAdapter extends EventEmitter {
       this.appServerWs.send(forwarded);
     } else {
       this.log(`WARNING: app-server closed between OPEN check and send \u2014 message lost (connId=${ws.data.connId})`);
+    }
+  }
+  detectJsonMethod(raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      return typeof parsed?.method === "string" ? parsed.method : undefined;
+    } catch {
+      return;
+    }
+  }
+  ensureSecondaryInitialized(secondary, connId) {
+    if (secondary.initializationReplayed)
+      return;
+    secondary.initializationReplayed = true;
+    if (!this.lastInitializeRaw) {
+      this.log(`Secondary conn #${connId}: no cached initialize available before first non-initialize request`);
+      return;
+    }
+    this.log(`Secondary conn #${connId}: replaying cached initialize before picker request`);
+    this.sendOrBufferSecondary(secondary, this.lastInitializeRaw);
+    if (this.lastInitializedRaw) {
+      this.sendOrBufferSecondary(secondary, this.lastInitializedRaw);
+    }
+    secondary.initialized = true;
+  }
+  sendOrBufferSecondary(secondary, raw) {
+    if (secondary.appServerWs && secondary.appServerWs.readyState === WebSocket.OPEN) {
+      try {
+        secondary.appServerWs.send(raw);
+      } catch {}
+    } else {
+      secondary.buffer.push(raw);
     }
   }
   handleAppServerPayload(raw) {
@@ -1185,6 +1289,7 @@ class CodexAdapter extends EventEmitter {
     if (!isNaN(numericId) && this.consumeBridgeRequestId(numericId)) {
       if (parsed.error) {
         this.log(`Bridge-originated request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
+        this.emit("turnAborted", `injected turn/start rejected: ${parsed.error.message ?? "unknown error"}`);
       } else {
         this.log(`Bridge-originated request completed (id ${responseId})`);
       }
@@ -1371,6 +1476,7 @@ class CodexAdapter extends EventEmitter {
       return;
     const previousThreadId = this.threadId;
     this.threadId = threadId;
+    this.emit("threadChanged", { threadId, previousThreadId, reason });
     if (previousThreadId) {
       this.log(`Active thread changed: ${previousThreadId} \u2192 ${threadId} (${reason})`);
       return;
@@ -1382,6 +1488,7 @@ class CodexAdapter extends EventEmitter {
     const wasInProgress = this.turnInProgress;
     const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
     this.activeTurnIds.add(turnKey);
+    this.stalledTurnIds.delete(turnKey);
     this.scheduleTurnWatchdog(turnKey);
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
@@ -1392,9 +1499,11 @@ class CodexAdapter extends EventEmitter {
     if (typeof turnId === "string" && turnId.length > 0) {
       this.activeTurnIds.delete(turnId);
       this.clearTurnWatchdog(turnId);
+      this.stalledTurnIds.delete(turnId);
     } else {
       this.activeTurnIds.clear();
       this.clearAllTurnWatchdogs();
+      this.stalledTurnIds.clear();
     }
     this.turnInProgress = this.activeTurnIds.size > 0;
   }
@@ -1407,8 +1516,8 @@ class CodexAdapter extends EventEmitter {
     const timer = setTimeout(() => {
       if (!this.activeTurnIds.has(turnKey))
         return;
-      this.log(`WARNING: turn ${turnKey} watchdog fired after ${this.turnWatchdogMs()}ms of inactivity \u2014 ` + `assuming a lost turn/completed; force-completing to unblock injection`);
-      this.forceCompleteTurn(turnKey);
+      this.log(`WARNING: turn ${turnKey} watchdog fired after ${this.turnWatchdogMs()}ms of inactivity \u2014 ` + `marking stalled but keeping Codex busy until a real completion or reconnect`);
+      this.markTurnStalled(turnKey);
     }, this.turnWatchdogMs());
     timer.unref?.();
     this.turnWatchdogs.set(turnKey, timer);
@@ -1432,24 +1541,30 @@ class CodexAdapter extends EventEmitter {
       this.scheduleTurnWatchdog(turnKey);
     }
   }
-  forceCompleteTurn(turnKey) {
-    const wasInProgress = this.turnInProgress;
-    this.activeTurnIds.delete(turnKey);
-    this.clearTurnWatchdog(turnKey);
-    this.turnInProgress = this.activeTurnIds.size > 0;
-    if (wasInProgress && !this.turnInProgress) {
-      this.emit("turnCompleted");
-    }
+  markTurnStalled(turnKey) {
+    if (!this.activeTurnIds.has(turnKey))
+      return;
+    this.turnInProgress = true;
+    if (this.stalledTurnIds.has(turnKey))
+      return;
+    this.stalledTurnIds.add(turnKey);
+    this.emit("turnStalled", {
+      turnId: turnKey,
+      inactivityMs: this.turnWatchdogMs()
+    });
   }
   resetTurnState(reason, emitCompleted = false) {
     const wasInProgress = this.turnInProgress;
     this.activeTurnIds.clear();
     this.clearAllTurnWatchdogs();
+    this.stalledTurnIds.clear();
     this.turnInProgress = false;
-    if (emitCompleted && wasInProgress) {
-      this.emit("turnCompleted");
-    }
     if (wasInProgress) {
+      if (emitCompleted) {
+        this.emit("turnCompleted");
+      } else {
+        this.emit("turnAborted", reason);
+      }
       this.log(`Turn state reset (${reason})`);
     }
   }
@@ -1611,9 +1726,39 @@ class CodexAdapter extends EventEmitter {
 `;
     process.stderr.write(line);
     try {
-      appendFileSync(this.logFile, line);
+      appendRotatingLog(this.logFile, line);
     } catch {}
   }
+}
+
+// src/control-protocol.ts
+var CLOSE_CODE_REPLACED = 4001;
+var CLOSE_CODE_EVICTED_STALE = 4002;
+var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
+var CLOSE_CODE_PAIR_MISMATCH = 4004;
+
+// src/daemon-identity.ts
+function validateClaudeClientIdentity(input) {
+  if (!input.expectedPairId)
+    return { ok: true };
+  if (!input.identity) {
+    return input.allowIdentityless ? { ok: true } : { ok: false, closeCode: CLOSE_CODE_PAIR_MISMATCH, reason: "missing client identity" };
+  }
+  if (input.identity.pairId !== input.expectedPairId) {
+    return {
+      ok: false,
+      closeCode: CLOSE_CODE_PAIR_MISMATCH,
+      reason: `pair mismatch: expected ${input.expectedPairId}, got ${input.identity.pairId ?? "<none>"}`
+    };
+  }
+  if (!input.identity.cwd || input.identity.cwd !== input.daemonCwd) {
+    return {
+      ok: false,
+      closeCode: CLOSE_CODE_PAIR_MISMATCH,
+      reason: `cwd mismatch: expected ${input.daemonCwd}, got ${input.identity.cwd ?? "<none>"}`
+    };
+  }
+  return { ok: true };
 }
 
 // src/message-filter.ts
@@ -1798,7 +1943,7 @@ class TuiConnectionState {
 
 // src/daemon-lifecycle.ts
 import { spawn as spawn2, execFileSync } from "child_process";
-import { existsSync as existsSync2, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "fs";
+import { existsSync as existsSync3, readFileSync, unlinkSync as unlinkSync2, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 
 // src/env-utils.ts
@@ -1820,6 +1965,7 @@ var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 var REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES", 12);
 var REUSE_READY_DELAY_MS = 250;
+var HEALTH_FETCH_TIMEOUT_MS = 500;
 
 class DaemonLifecycle {
   stateDir;
@@ -1844,7 +1990,7 @@ class DaemonLifecycle {
   }
   async fetchStatus() {
     try {
-      const response = await fetch(this.healthUrl);
+      const response = await fetchWithTimeout(this.healthUrl);
       if (!response.ok)
         return null;
       return await response.json();
@@ -1863,11 +2009,24 @@ class DaemonLifecycle {
       return true;
     return reported !== expected;
   }
+  isBuildDrifted(status) {
+    if (process.env.AGENTBRIDGE_ALLOW_BUILD_DRIFT === "1")
+      return false;
+    const runtime = status?.build;
+    if (!runtime)
+      return true;
+    return !sameRuntimeContract(runtime, BUILD_INFO);
+  }
   async ensureRunning() {
     if (await this.isHealthy()) {
       const status = await this.fetchStatus();
       if (this.isForeignDaemon(status)) {
         this.log(`Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` + `but this pair is ${this.expectedPairId} \u2014 replacing foreign daemon`);
+        await this.replaceUnhealthyDaemon(status?.pid);
+        return;
+      }
+      if (this.isBuildDrifted(status)) {
+        this.log(`Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` + `but launcher is ${formatBuildInfo(BUILD_INFO)} \u2014 replacing drifted daemon`);
         await this.replaceUnhealthyDaemon(status?.pid);
         return;
       }
@@ -1903,11 +2062,20 @@ class DaemonLifecycle {
         await this.waitForReadyAndOurs();
         return;
       }
-      if (await this.isHealthy() && !this.isForeignDaemon(await this.fetchStatus())) {
-        try {
-          await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
-          return;
-        } catch {}
+      if (await this.isHealthy()) {
+        const status = await this.fetchStatus();
+        if (this.isForeignDaemon(status) || this.isBuildDrifted(status)) {
+          this.log(`Daemon on control port ${this.controlPort} is not reusable under startup lock ` + `(pair=${status?.pairId ?? "<none>"}, build=${formatBuildInfo(status?.build)}) \u2014 replacing`);
+          await this.kill(3000, status?.pid);
+        } else {
+          try {
+            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            return;
+          } catch {
+            this.log(`Daemon on control port ${this.controlPort} is healthy but not ready under startup lock \u2014 replacing`);
+            await this.kill(3000, status?.pid);
+          }
+        }
       }
       this.launch();
       await this.waitForReady();
@@ -1915,7 +2083,7 @@ class DaemonLifecycle {
   }
   async isHealthy() {
     try {
-      const response = await fetch(this.healthUrl);
+      const response = await fetchWithTimeout(this.healthUrl);
       return response.ok;
     } catch {
       return false;
@@ -1931,7 +2099,7 @@ class DaemonLifecycle {
   }
   async isReady() {
     try {
-      const response = await fetch(this.readyUrl);
+      const response = await fetchWithTimeout(this.readyUrl);
       return response.ok;
     } catch {
       return false;
@@ -1949,7 +2117,7 @@ class DaemonLifecycle {
     for (let attempt = 0;attempt < maxRetries; attempt++) {
       if (await this.isReady()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status))
+        if (!this.isForeignDaemon(status) && !this.isBuildDrifted(status))
           return;
       }
       await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -1987,12 +2155,12 @@ class DaemonLifecycle {
   }
   removePidFile() {
     try {
-      unlinkSync(this.stateDir.pidFile);
+      unlinkSync2(this.stateDir.pidFile);
     } catch {}
   }
   removeStatusFile() {
     try {
-      unlinkSync(this.stateDir.statusFile);
+      unlinkSync2(this.stateDir.statusFile);
     } catch {}
   }
   markKilled() {
@@ -2002,11 +2170,11 @@ class DaemonLifecycle {
   }
   clearKilled() {
     try {
-      unlinkSync(this.stateDir.killedFile);
+      unlinkSync2(this.stateDir.killedFile);
     } catch {}
   }
   wasKilled() {
-    return existsSync2(this.stateDir.killedFile);
+    return existsSync3(this.stateDir.killedFile);
   }
   launch() {
     this.stateDir.ensure();
@@ -2036,7 +2204,7 @@ class DaemonLifecycle {
       }
       if (await this.isHealthy()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status)) {
+        if (!this.isForeignDaemon(status) && !this.isBuildDrifted(status)) {
           try {
             await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
@@ -2088,7 +2256,7 @@ class DaemonLifecycle {
   }
   releaseLock() {
     try {
-      unlinkSync(this.stateDir.lockFile);
+      unlinkSync2(this.stateDir.lockFile);
     } catch {}
   }
   async kill(gracefulTimeoutMs = 3000, pidOverride) {
@@ -2146,6 +2314,15 @@ class DaemonLifecycle {
     this.removeStatusFile();
   }
 }
+async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
+  const controller = new AbortController;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 function isProcessAlive(pid) {
   try {
     process.kill(pid, 0);
@@ -2156,7 +2333,7 @@ function isProcessAlive(pid) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, existsSync as existsSync3 } from "fs";
+import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync4, existsSync as existsSync4 } from "fs";
 import { join as join3 } from "path";
 var DEFAULT_CONFIG = {
   version: "1.0",
@@ -2213,7 +2390,7 @@ class ConfigService {
     this.configPath = join3(this.configDir, CONFIG_FILE);
   }
   hasConfig() {
-    return existsSync3(this.configPath);
+    return existsSync4(this.configPath);
   }
   load() {
     try {
@@ -2234,7 +2411,7 @@ class ConfigService {
   initDefaults() {
     this.ensureConfigDir();
     const created = [];
-    if (!existsSync3(this.configPath)) {
+    if (!existsSync4(this.configPath)) {
       this.save(DEFAULT_CONFIG);
       created.push(this.configPath);
     }
@@ -2244,16 +2421,166 @@ class ConfigService {
     return this.configPath;
   }
   ensureConfigDir() {
-    if (!existsSync3(this.configDir)) {
-      mkdirSync3(this.configDir, { recursive: true });
+    if (!existsSync4(this.configDir)) {
+      mkdirSync4(this.configDir, { recursive: true });
     }
   }
 }
 
-// src/control-protocol.ts
-var CLOSE_CODE_REPLACED = 4001;
-var CLOSE_CODE_EVICTED_STALE = 4002;
-var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
+// src/reply-required-tracker.ts
+class ReplyRequiredTracker {
+  armed = false;
+  forwardedDuringTurn = false;
+  get isArmed() {
+    return this.armed;
+  }
+  arm() {
+    this.armed = true;
+    this.forwardedDuringTurn = false;
+  }
+  noteForwarded() {
+    if (this.armed)
+      this.forwardedDuringTurn = true;
+  }
+  consumeOnTurnComplete() {
+    const warnReplyMissing = this.armed && !this.forwardedDuringTurn;
+    this.reset();
+    return { warnReplyMissing };
+  }
+  reset() {
+    this.armed = false;
+    this.forwardedDuringTurn = false;
+  }
+}
+
+// src/thread-state.ts
+import {
+  existsSync as existsSync5,
+  mkdirSync as mkdirSync5,
+  readdirSync,
+  readFileSync as readFileSync3,
+  renameSync as renameSync2,
+  writeFileSync as writeFileSync3
+} from "fs";
+import { homedir as homedir2 } from "os";
+import { basename, dirname as dirname2, join as join4 } from "path";
+function nowIso() {
+  return new Date().toISOString();
+}
+function threadTag(identity) {
+  const name = identity.pairName ?? identity.pairId ?? "manual";
+  return `abg:${name}:${identity.cwd}`;
+}
+function codexHome(env = process.env) {
+  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join4(homedir2(), ".codex");
+}
+function atomicWriteJson(path, value) {
+  mkdirSync5(dirname2(path), { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync3(tmp, JSON.stringify(value, null, 2) + `
+`, "utf-8");
+  renameSync2(tmp, path);
+}
+function readRawCurrentThread(stateDir) {
+  try {
+    const parsed = JSON.parse(readFileSync3(stateDir.currentThreadFile, "utf-8"));
+    if (parsed?.version === 1 && typeof parsed.threadId === "string" && parsed.threadId.length > 0 && (parsed.status === "pending" || parsed.status === "current") && typeof parsed.cwd === "string") {
+      return parsed;
+    }
+  } catch {}
+  return null;
+}
+function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
+  const sessionsDir = join4(codexHome(env), "sessions");
+  if (!threadId || !existsSync5(sessionsDir))
+    return null;
+  const exactName = `rollout-${threadId}.jsonl`;
+  const stack = [sessionsDir];
+  let visited = 0;
+  while (stack.length > 0 && visited < maxEntries) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      visited++;
+      const path = join4(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(path);
+        continue;
+      }
+      if (!entry.isFile())
+        continue;
+      const name = basename(entry.name);
+      if (name === exactName || name.startsWith("rollout-") && name.endsWith(".jsonl") && name.includes(threadId)) {
+        return path;
+      }
+    }
+  }
+  return null;
+}
+function writePendingCurrentThread(identity, threadId, reason) {
+  const state = {
+    version: 1,
+    status: "pending",
+    pairId: identity.pairId,
+    pairName: identity.pairName,
+    cwd: identity.cwd,
+    threadId,
+    updatedAt: nowIso(),
+    reason,
+    tag: threadTag(identity)
+  };
+  atomicWriteJson(identity.stateDir.currentThreadFile, state);
+  return state;
+}
+function promoteCurrentThreadIfRolloutExists(identity, threadId, reason, env = process.env) {
+  const rolloutPath = findCodexRolloutFile(threadId, env);
+  const state = {
+    version: 1,
+    status: rolloutPath ? "current" : "pending",
+    pairId: identity.pairId,
+    pairName: identity.pairName,
+    cwd: identity.cwd,
+    threadId,
+    updatedAt: nowIso(),
+    reason,
+    tag: threadTag(identity),
+    ...rolloutPath ? { rolloutPath, rolloutVerifiedAt: nowIso() } : {}
+  };
+  atomicWriteJson(identity.stateDir.currentThreadFile, state);
+  return state;
+}
+async function persistCurrentThreadWithRolloutRetry(identity, threadId, reason, options = {}) {
+  const env = options.env ?? process.env;
+  const attempts = options.attempts ?? 20;
+  const delayMs = options.delayMs ?? 250;
+  const shouldContinue = options.shouldContinue ?? (() => true);
+  if (!shouldContinue())
+    return null;
+  writePendingCurrentThread(identity, threadId, reason);
+  for (let attempt = 1;attempt <= attempts; attempt++) {
+    if (!shouldContinue()) {
+      options.log?.(`Abandoned current-thread persistence for ${threadId}: a newer thread became active`);
+      return null;
+    }
+    const state = promoteCurrentThreadIfRolloutExists(identity, threadId, reason, env);
+    if (state.status === "current") {
+      options.log?.(`Current Codex thread persisted: ${threadId} (${state.rolloutPath})`);
+      return state;
+    }
+    if (attempt < attempts) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  if (!shouldContinue())
+    return null;
+  options.log?.(`Current Codex thread left pending because no rollout file was found: ${threadId}`);
+  return readRawCurrentThread(identity.stateDir) ?? writePendingCurrentThread(identity, threadId, reason);
+}
 
 // src/liveness-probe.ts
 var OPEN = 1;
@@ -2299,6 +2626,7 @@ var IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? Stri
 var ATTENTION_WINDOW_MS = parseInt(process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS ?? String(config.turnCoordination.attentionWindowSeconds * 1000), 10);
 var BOOTSTRAP_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_BOOTSTRAP_TIMEOUT_MS", 45000);
 var CODEX_BOOT_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_CODEX_BOOT_RETRIES", 2);
+var ALLOW_IDENTITYLESS_CLIENT = process.env.AGENTBRIDGE_COMPAT_IDENTITYLESS === "1";
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
 var attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
@@ -2309,8 +2637,7 @@ var nextSystemMessageId = 0;
 var codexBootstrapped = false;
 var attentionWindowTimer = null;
 var inAttentionWindow = false;
-var replyRequired = false;
-var replyReceivedDuringTurn = false;
+var replyTracker = new ReplyRequiredTracker;
 var shuttingDown = false;
 var bootDeadlineTimer = null;
 var idleShutdownTimer = null;
@@ -2340,9 +2667,9 @@ codex.on("agentMessage", (msg) => {
   if (msg.source !== "codex")
     return;
   const result = classifyMessage(msg.content, FILTER_MODE);
-  if (replyRequired) {
+  if (replyTracker.isArmed) {
     log(`Codex \u2192 Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
-    replyReceivedDuringTurn = true;
+    replyTracker.noteForwarded();
     if (statusBuffer.size > 0) {
       statusBuffer.flush("reply-required message arrived");
     }
@@ -2375,20 +2702,41 @@ codex.on("agentMessage", (msg) => {
 codex.on("turnCompleted", () => {
   log("Codex turn completed");
   statusBuffer.flush("turn completed");
-  if (replyRequired && !replyReceivedDuringTurn) {
+  const { warnReplyMissing } = replyTracker.consumeOnTurnComplete();
+  if (warnReplyMissing) {
     log("\u26A0\uFE0F Reply was required but Codex did not send any agentMessage");
     emitToClaude(systemMessage("system_reply_missing", "\u26A0\uFE0F Codex completed the turn without sending a reply (require_reply was set). Codex may not have generated an agentMessage. You may want to retry or rephrase."));
   }
-  replyRequired = false;
-  replyReceivedDuringTurn = false;
   emitToClaude(systemMessage("system_turn_completed", "\u2705 Codex finished the current turn. You can reply now if needed."));
   startAttentionWindow();
+});
+codex.on("turnAborted", (reason) => {
+  log(`Codex turn aborted (${reason}) \u2014 clearing reply-required state`);
+  replyTracker.reset();
+});
+codex.on("turnStalled", (event) => {
+  log(`Codex turn stalled (${event.turnId}, inactivity ${event.inactivityMs}ms)`);
+  emitToClaude(systemMessage("system_turn_stalled", `\u26A0\uFE0F Codex has been silent for ${event.inactivityMs}ms while a turn is still in progress. AgentBridge is keeping the turn busy and will not send a fake completion; wait for Codex to finish or reconnect the TUI if it is stuck.`));
 });
 codex.on("ready", (threadId) => {
   tuiConnectionState.markBridgeReady();
   log(`Codex ready \u2014 thread ${threadId}`);
   log("Bridge fully operational");
   emitToClaude(systemMessage("system_ready", currentReadyMessage()));
+});
+codex.on("threadChanged", (event) => {
+  broadcastStatus();
+  persistCurrentThreadWithRolloutRetry({
+    stateDir,
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    pairName: process.env.AGENTBRIDGE_PAIR_NAME,
+    cwd: process.cwd()
+  }, event.threadId, event.reason, {
+    log,
+    shouldContinue: () => codex.activeThreadId === event.threadId
+  }).catch((err) => {
+    log(`Failed to persist current thread ${event.threadId}: ${err?.message ?? err}`);
+  });
 });
 codex.on("tuiConnected", (connId) => {
   tuiConnectionState.handleTuiConnected(connId);
@@ -2408,6 +2756,7 @@ codex.on("error", (err) => {
 codex.on("exit", (code) => {
   log(`Codex process exited (code ${code})`);
   codexBootstrapped = false;
+  replyTracker.reset();
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
@@ -2467,7 +2816,18 @@ function handleControlMessage(ws, raw) {
   }
   switch (message.type) {
     case "claude_connect":
-      attachClaude(ws).catch((err) => {
+      const admission = validateClaudeClientIdentity({
+        expectedPairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+        daemonCwd: process.cwd(),
+        identity: message.identity,
+        allowIdentityless: ALLOW_IDENTITYLESS_CLIENT
+      });
+      if (!admission.ok) {
+        log(`Rejecting Claude frontend #${ws.data.clientId}: ${admission.reason}`);
+        ws.close(admission.closeCode, admission.reason);
+        return;
+      }
+      attachClaude(ws, message.identity).catch((err) => {
         log(`attachClaude threw for #${ws.data.clientId}: ${err?.message ?? err}`);
       });
       return;
@@ -2505,9 +2865,6 @@ function handleControlMessage(ws, raw) {
       let contentToSend = message.message.content;
       if (requireReply) {
         contentToSend += REPLY_REQUIRED_INSTRUCTION;
-        replyRequired = true;
-        replyReceivedDuringTurn = false;
-        log(`Reply required flag set for this message`);
       }
       log(`Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
       const injected = codex.injectMessage(contentToSend);
@@ -2522,6 +2879,10 @@ function handleControlMessage(ws, raw) {
         });
         return;
       }
+      if (requireReply) {
+        replyTracker.arm();
+        log(`Reply required flag set for this message`);
+      }
       clearAttentionWindow();
       sendProtocolMessage(ws, {
         type: "claude_to_codex_result",
@@ -2532,7 +2893,7 @@ function handleControlMessage(ws, raw) {
     }
   }
 }
-async function attachClaude(ws) {
+async function attachClaude(ws, identity) {
   const occupant = attachedClaude;
   if (occupant && occupant !== ws && occupant.readyState !== WebSocket.CLOSED) {
     const msSincePong = Date.now() - occupant.data.lastPongAt;
@@ -2569,10 +2930,11 @@ async function attachClaude(ws) {
     return;
   }
   clearPendingClaudeDisconnect("Claude frontend attached");
+  ws.data.identity = identity;
   attachedClaude = ws;
   ws.data.attached = true;
   cancelIdleShutdown();
-  log(`Claude frontend attached (#${ws.data.clientId})`);
+  log(`Claude frontend attached (#${ws.data.clientId}, pair=${identity?.pairId ?? "<none>"}, cwd=${identity?.cwd ?? "<unknown>"})`);
   statusBuffer.flush("claude reconnected");
   sendStatus(ws);
   const now = Date.now();
@@ -2771,7 +3133,10 @@ function currentStatus() {
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
     pid: process.pid,
-    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    cwd: process.cwd(),
+    stateDir: stateDir.dir,
+    build: daemonStatusBuildInfo()
   };
 }
 function currentWaitingMessage() {
@@ -2801,7 +3166,10 @@ function writeStatusFile() {
     appServerUrl: codex.appServerUrl,
     controlPort: CONTROL_PORT,
     pid: process.pid,
-    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    cwd: process.cwd(),
+    stateDir: stateDir.dir,
+    build: daemonStatusBuildInfo()
   });
 }
 function removeStatusFile() {
@@ -2891,7 +3259,7 @@ function log(msg) {
 `;
   process.stderr.write(line);
   try {
-    appendFileSync2(stateDir.logFile, line);
+    appendRotatingLog(stateDir.logFile, line);
   } catch {}
 }
 if (daemonLifecycle.wasKilled()) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1642,27 +1642,6 @@ function classifyMessage(content, mode) {
       return { action: "forward", marker };
   }
 }
-var BRIDGE_CONTRACT_REMINDER = `[Bridge Contract] When sending agentMessage, put the marker at the very start of the message:
-- [IMPORTANT] for decisions, reviews, completions, blockers
-- [STATUS] for progress updates
-- [FYI] for background context
-The marker MUST be the first text in the message (e.g. "[IMPORTANT] Task done", not "Task done [IMPORTANT]").
-Keep agentMessage for high-value communication only.
-
-[Git Operations \u2014 FORBIDDEN]
-You MUST NOT execute any git write commands. This includes but is not limited to:
-git commit, git push, git pull, git fetch, git checkout -b, git branch, git merge, git rebase, git cherry-pick, git tag, git stash.
-These commands write to the .git directory, which is blocked by your sandbox. Attempting them will cause your session to hang indefinitely.
-Read-only git commands (git status, git log, git diff, git show, git rev-parse) are allowed.
-All git write operations must be delegated to Claude Code via agentMessage. Report what you changed and let Claude handle branching, committing, and pushing.
-
-[Role Guidance for Codex]
-- Your default role: Implementer, Executor, Verifier
-- Analytical/review tasks: Independent Analysis & Convergence
-- Implementation tasks: Architect -> Builder -> Critic
-- Debugging tasks: Hypothesis -> Experiment -> Interpretation
-- Do not blindly follow Claude - challenge with evidence when you disagree
-- Use explicit collaboration phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:"`;
 var REPLY_REQUIRED_INSTRUCTION = `
 
 [\u26A0\uFE0F REPLY REQUIRED] Claude has explicitly requested a reply. You MUST send an agentMessage with [IMPORTANT] marker containing your response. This is a mandatory requirement \u2014 do not skip or use [STATUS]/[FYI] markers for this reply.`;
@@ -2249,9 +2228,6 @@ var replyReceivedDuringTurn = false;
 var shuttingDown = false;
 var idleShutdownTimer = null;
 var claudeDisconnectTimer = null;
-var claudeOnlineNoticeSent = false;
-var claudeOfflineNoticeShown = false;
-var codexCollaborationKickoffSent = false;
 var lastAttachStatusSentTs = 0;
 var ATTACH_STATUS_COOLDOWN_MS = 30000;
 var LIVENESS_PROBE_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS", 3000, log);
@@ -2266,7 +2242,6 @@ var tuiConnectionState = new TuiConnectionState({
   },
   onReconnectAfterNotice: (connId) => {
     emitToClaude(systemMessage("system_tui_reconnected", `\u2705 Codex TUI reconnected (conn #${connId}). Bridge restored, communication can continue.`));
-    codex.injectMessage("\u2705 Claude Code is still online, bridge restored. Bidirectional communication can continue.");
   }
 });
 var statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
@@ -2321,18 +2296,12 @@ codex.on("turnCompleted", () => {
   replyReceivedDuringTurn = false;
   emitToClaude(systemMessage("system_turn_completed", "\u2705 Codex finished the current turn. You can reply now if needed."));
   startAttentionWindow();
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
 });
 codex.on("ready", (threadId) => {
   tuiConnectionState.markBridgeReady();
   log(`Codex ready \u2014 thread ${threadId}`);
   log("Bridge fully operational");
   emitToClaude(systemMessage("system_ready", currentReadyMessage()));
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
 });
 codex.on("tuiConnected", (connId) => {
   tuiConnectionState.handleTuiConnected(connId);
@@ -2355,8 +2324,6 @@ codex.on("exit", (code) => {
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
-  claudeOnlineNoticeSent = false;
-  claudeOfflineNoticeShown = false;
   emitToClaude(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running, but the Codex side needs to be restarted.`));
   broadcastStatus();
 });
@@ -2447,17 +2414,15 @@ function handleControlMessage(ws, raw) {
         return;
       }
       const requireReply = !!message.requireReply;
-      let contentWithReminder = message.message.content + `
-
-` + BRIDGE_CONTRACT_REMINDER;
+      let contentToSend = message.message.content;
       if (requireReply) {
-        contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
+        contentToSend += REPLY_REQUIRED_INSTRUCTION;
         replyRequired = true;
         replyReceivedDuringTurn = false;
         log(`Reply required flag set for this message`);
       }
       log(`Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-      const injected = codex.injectMessage(contentWithReminder);
+      const injected = codex.injectMessage(contentToSend);
       if (!injected) {
         const reason = codex.turnInProgress ? "Codex is busy executing a turn. Wait for it to finish before sending another message." : "Injection failed: no active thread or WebSocket not connected.";
         log(`Injection rejected: ${reason}`);
@@ -2534,9 +2499,6 @@ async function attachClaude(ws) {
     }
   }
   lastAttachStatusSentTs = now;
-  if (tuiConnectionState.canReply() && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
 }
 function detachClaude(ws, reason) {
   if (attachedClaude !== ws)
@@ -2652,17 +2614,6 @@ function scheduleClaudeDisconnectNotification(clientId) {
       log(`Skipping Claude disconnect notification for client #${clientId} because Claude already reconnected`);
       return;
     }
-    if (!tuiConnectionState.canReply()) {
-      log(`Suppressing Claude disconnect notification for client #${clientId} because Codex cannot reply`);
-      return;
-    }
-    if (!claudeOnlineNoticeSent) {
-      log(`Suppressing Claude disconnect notification for client #${clientId} because Claude was never announced online`);
-      return;
-    }
-    codex.injectMessage("\u26A0\uFE0F Claude Code went offline. AgentBridge is still running in the background; it will reconnect automatically when Claude reopens.");
-    claudeOnlineNoticeSent = false;
-    claudeOfflineNoticeShown = true;
     log(`Claude disconnect persisted past grace window (client #${clientId})`);
   }, CLAUDE_DISCONNECT_GRACE_MS);
 }
@@ -2740,28 +2691,6 @@ ${attachCmd}`;
 }
 function currentReadyMessage() {
   return `\u2705 Codex TUI connected (${codex.activeThreadId}). Bridge ready.`;
-}
-function notifyCodexClaudeOnline() {
-  const message = !codexCollaborationKickoffSent ? [
-    "\uD83E\uDD1D Claude Code has connected via AgentBridge.",
-    "You are now in a multi-agent collaboration session.",
-    "When you receive a complex task, propose a division of labor to Claude.",
-    "Claude can send you messages \u2014 they will appear as injected user messages.",
-    "Respond naturally and Claude will receive your output via AgentBridge."
-  ].join(`
-`) : "\u2705 AgentBridge connected to Claude Code.";
-  const delivered = codex.injectMessage(message);
-  if (!delivered) {
-    log("Deferred Claude-online notice to Codex \u2014 will retry after current turn completes");
-    return false;
-  }
-  claudeOnlineNoticeSent = true;
-  claudeOfflineNoticeShown = false;
-  codexCollaborationKickoffSent = true;
-  return true;
-}
-function shouldNotifyCodexClaudeOnline() {
-  return !claudeOnlineNoticeSent || claudeOfflineNoticeShown;
 }
 function systemMessage(idPrefix, content) {
   return {

--- a/scripts/build-bundles.mjs
+++ b/scripts/build-bundles.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(new URL("..", import.meta.url).pathname);
+const pkg = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf-8"));
+const CONTRACT_VERSION = 1;
+
+const TARGETS = {
+  cli: { source: "src/cli.ts", output: "dist/cli.js", bundle: "dist", executable: true },
+  daemon: { source: "src/daemon.ts", output: "dist/daemon.js", bundle: "dist" },
+  "bridge-plugin": { source: "src/bridge.ts", output: "plugins/agentbridge/server/bridge-server.js", bundle: "plugin" },
+  "daemon-plugin": { source: "src/daemon.ts", output: "plugins/agentbridge/server/daemon.js", bundle: "plugin" },
+};
+
+function usage() {
+  console.error(`Usage:
+  node scripts/build-bundles.mjs <target...>
+  node scripts/build-bundles.mjs <target> --outfile <path>
+
+Targets: ${Object.keys(TARGETS).join(", ")}
+`);
+}
+
+function gitCommit() {
+  try {
+    return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function defineArgs(bundle) {
+  const defines = {
+    __AGENTBRIDGE_BUILD_VERSION__: pkg.version,
+    __AGENTBRIDGE_BUILD_COMMIT__: gitCommit(),
+    __AGENTBRIDGE_BUILD_BUNDLE__: bundle,
+    __AGENTBRIDGE_CONTRACT_VERSION__: CONTRACT_VERSION,
+  };
+  return Object.entries(defines).flatMap(([key, value]) => [
+    "--define",
+    `${key}=${JSON.stringify(value)}`,
+  ]);
+}
+
+function runBuild(targetName, outfileOverride) {
+  const target = TARGETS[targetName];
+  if (!target) {
+    console.error(`Unknown build target: ${targetName}`);
+    usage();
+    process.exit(1);
+  }
+
+  const output = outfileOverride ?? target.output;
+  const args = [
+    "build",
+    target.source,
+    "--outfile",
+    output,
+    "--target",
+    "bun",
+    ...defineArgs(target.bundle),
+  ];
+
+  const res = spawnSync("bun", args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+  if (res.error) {
+    console.error(`build-bundles: failed to start bun: ${res.error.message}`);
+    process.exit(1);
+  }
+  if (res.status !== 0) {
+    process.exit(res.status ?? 1);
+  }
+
+  if (!outfileOverride && target.executable) {
+    chmodSync(resolve(repoRoot, output), 0o755);
+  }
+}
+
+const args = process.argv.slice(2);
+const outfileIndex = args.indexOf("--outfile");
+let outfile;
+if (outfileIndex !== -1) {
+  outfile = args[outfileIndex + 1];
+  args.splice(outfileIndex, 2);
+  if (!outfile || args.length !== 1) {
+    usage();
+    process.exit(1);
+  }
+}
+
+if (args.length === 0) {
+  usage();
+  process.exit(1);
+}
+
+for (const target of args) {
+  runBuild(target, outfile);
+}

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Bump the AgentBridge version in lock-step across all three manifests that
+ * `scripts/check-plugin-versions.js` enforces equal:
+ *   - package.json                                  .version
+ *   - plugins/agentbridge/.claude-plugin/plugin.json .version
+ *   - .claude-plugin/marketplace.json                .plugins[name===plugin.name].version
+ *
+ * Usage:  node scripts/bump-version.mjs [patch|minor|major]   (default: patch)
+ * Prints a human line to STDERR and the new version (only) to STDOUT, so CI can
+ * capture it with `NEW=$(node scripts/bump-version.mjs patch)`.
+ *
+ * Refuses to run if the current version is not a clean stable `X.Y.Z` (so we
+ * never publish a prerelease/garbage version automatically).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkgPath = join(root, "package.json");
+const pluginPath = join(root, "plugins/agentbridge/.claude-plugin/plugin.json");
+const marketplacePath = join(root, ".claude-plugin/marketplace.json");
+
+const STABLE_RE = /^\d+\.\d+\.\d+$/;
+const LEVELS = ["patch", "minor", "major"];
+
+function readJson(p) {
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+function writeJson(p, obj) {
+  writeFileSync(p, JSON.stringify(obj, null, 2) + "\n", "utf-8");
+}
+function die(msg) {
+  process.stderr.write(`bump-version: ${msg}\n`);
+  process.exit(1);
+}
+
+const level = (process.argv[2] ?? "patch").toLowerCase();
+if (!LEVELS.includes(level)) die(`unknown bump level "${level}" (expected ${LEVELS.join("|")})`);
+
+const pkg = readJson(pkgPath);
+const current = pkg.version;
+if (typeof current !== "string" || !STABLE_RE.test(current)) {
+  die(`package.json version ${JSON.stringify(current)} is not a clean X.Y.Z stable version`);
+}
+
+const [major, minor, patch] = current.split(".").map(Number);
+const next =
+  level === "major" ? `${major + 1}.0.0`
+  : level === "minor" ? `${major}.${minor + 1}.0`
+  : `${major}.${minor}.${patch + 1}`;
+
+// package.json
+pkg.version = next;
+writeJson(pkgPath, pkg);
+
+// plugin.json
+const plugin = readJson(pluginPath);
+plugin.version = next;
+writeJson(pluginPath, plugin);
+
+// marketplace.json — the entry whose name matches the plugin's name
+const marketplace = readJson(marketplacePath);
+const entry = Array.isArray(marketplace.plugins)
+  ? marketplace.plugins.find((p) => p.name === plugin.name)
+  : null;
+if (!entry) die(`.claude-plugin/marketplace.json is missing the "${plugin.name}" plugin entry`);
+entry.version = next;
+writeJson(marketplacePath, marketplace);
+
+process.stderr.write(`bump-version: ${current} -> ${next} (package.json, plugin.json, marketplace.json)\n`);
+process.stdout.write(`${next}\n`);

--- a/scripts/e2e-codex-transport.mjs
+++ b/scripts/e2e-codex-transport.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+// Real-codex integration E2E for #85: drive the actual CodexAdapter in unix
+// transport mode against a real `codex app-server`, and prove a client can do a
+// full initialize round-trip through proxy → adapter → relay → codex(unix).
+// Uses isolated ports so it never touches the running daemon (4500/4501).
+import { CodexAdapter } from "../src/codex-adapter.ts";
+import { codexSocketPath, removeSocketFile } from "../src/codex-transport.ts";
+
+const APP_PORT = 4560;
+const PROXY_PORT = 4561;
+const log = (...a) => console.log("[e2e-tp]", ...a);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+process.env.AGENTBRIDGE_CODEX_TRANSPORT = "unix";
+const logFile = "/tmp/agentbridge-probe/e2e-transport.log";
+
+const adapter = new CodexAdapter(APP_PORT, PROXY_PORT, logFile);
+let failed = false;
+
+async function proxyInitialize() {
+  return new Promise((resolve) => {
+    let done = false;
+    const fin = (ok, msg) => { if (done) return; done = true; log(ok ? "PASS" : "FAIL", msg); if (!ok) failed = true; resolve(); };
+    const ws = new WebSocket(`ws://127.0.0.1:${PROXY_PORT}`);
+    ws.onopen = () => { log("proxy WS open; sending initialize"); ws.send(JSON.stringify({ id: 1, method: "initialize", params: { clientInfo: { name: "e2e", title: "e2e", version: "0" } } })); };
+    ws.onmessage = (ev) => {
+      const txt = String(ev.data);
+      if (txt.includes('"id":1') && txt.includes("result")) { fin(true, "initialize round-trip through proxy→relay→codex(unix): " + txt.slice(0, 100)); try { ws.close(); } catch {} }
+    };
+    ws.onerror = (e) => fin(false, "proxy WS error: " + (e?.message ?? "?"));
+    setTimeout(() => fin(false, "proxy initialize timeout"), 5000);
+  });
+}
+
+async function main() {
+  removeSocketFile(codexSocketPath(APP_PORT));
+  log("starting adapter in unix transport mode (appPort=" + APP_PORT + ")");
+  await adapter.start();
+  log("adapter.start() completed; transport=" + adapter.transport + " socket=" + adapter.socketPath);
+  if (adapter.transport !== "unix") { log("FAIL: expected unix transport"); failed = true; }
+
+  // 1) Adapter's own primary WS is connected to codex via the relay.
+  await sleep(300);
+  log("relay connectionCount:", adapter.relay?.connectionCount);
+
+  // 2) Full client round-trip through the proxy.
+  await proxyInitialize();
+
+  // 3) Socket file exists during run, removed on stop.
+  const sock = adapter.socketPath;
+  adapter.stop();
+  await sleep(500);
+  const { existsSync } = await import("node:fs");
+  if (sock && existsSync(sock)) { log("FAIL: socket not cleaned up on stop:", sock); failed = true; }
+  else log("PASS: socket cleaned up on stop");
+
+  log(failed ? "=== E2E FAILED ===" : "=== E2E PASSED ===");
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((e) => { log("FATAL", e); try { adapter.stop(); } catch {} process.exit(1); });

--- a/scripts/install-global.mjs
+++ b/scripts/install-global.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Install AgentBridge globally in a way that is convenient for local testing.
+ *
+ * Modes:
+ *   local  build this checkout, pack it, uninstall the global package, install the tarball
+ *   npm    verify npm latest exists, uninstall the global package, install latest
+ *
+ * The uninstall step is intentionally ignored when the package is not installed:
+ * the goal is a clean replacement, not a brittle precondition.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"));
+const packageName = pkg.name;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const mode = args.find((arg) => !arg.startsWith("-"));
+
+function usage() {
+  process.stderr.write(`Usage: node scripts/install-global.mjs <local|npm> [--dry-run]
+
+Examples:
+  bun run install:global:local   # build this checkout, then fully replace the global install
+  bun run install:global:npm     # fully replace the global install with npm latest
+`);
+}
+
+function quote(arg) {
+  return /^[A-Za-z0-9_@%+=:,./<>-]+$/.test(arg) ? arg : JSON.stringify(arg);
+}
+
+function commandLine(cmd, commandArgs) {
+  return [cmd, ...commandArgs].map(quote).join(" ");
+}
+
+function printDry(cmd, commandArgs, suffix = "") {
+  process.stdout.write(`$ ${commandLine(cmd, commandArgs)}${suffix}\n`);
+}
+
+function run(cmd, commandArgs, options = {}) {
+  const { allowFailure = false, cwd = root, captureStdout = false } = options;
+  process.stdout.write(`$ ${commandLine(cmd, commandArgs)}\n`);
+  const res = spawnSync(cmd, commandArgs, {
+    cwd,
+    encoding: "utf-8",
+    stdio: captureStdout ? ["ignore", "pipe", "inherit"] : "inherit",
+  });
+
+  if (res.error) {
+    process.stderr.write(`install-global: failed to start ${cmd}: ${res.error.message}\n`);
+    if (!allowFailure) process.exit(1);
+  }
+  if (res.status !== 0 && !allowFailure) {
+    process.stderr.write(`install-global: command failed with exit code ${res.status}: ${commandLine(cmd, commandArgs)}\n`);
+    process.exit(res.status ?? 1);
+  }
+  return res;
+}
+
+function packedTarballFrom(stdout, destination) {
+  const file = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .pop();
+  if (!file) {
+    process.stderr.write("install-global: npm pack did not report a tarball name\n");
+    process.exit(1);
+  }
+  return isAbsolute(file) ? file : join(destination, file);
+}
+
+function installLocal() {
+  if (dryRun) {
+    printDry("bun", ["run", "prepublishOnly"]);
+    printDry("npm", ["pack", "--pack-destination", "<temp>"]);
+    printDry("npm", ["uninstall", "-g", packageName], "  # ignored if not installed");
+    printDry("npm", ["install", "-g", "--force", "<packed-tarball>"]);
+    return;
+  }
+
+  let packDir = "";
+  try {
+    run("bun", ["run", "prepublishOnly"]);
+    packDir = mkdtempSync(join(tmpdir(), "agentbridge-pack-"));
+    const packed = run("npm", ["pack", "--pack-destination", packDir], { captureStdout: true });
+    const tarball = packedTarballFrom(packed.stdout ?? "", packDir);
+    run("npm", ["uninstall", "-g", packageName], { allowFailure: true });
+    run("npm", ["install", "-g", "--force", tarball]);
+    process.stdout.write(`install-global: installed ${packageName} globally from local source\n`);
+  } finally {
+    if (packDir) rmSync(packDir, { recursive: true, force: true });
+  }
+}
+
+function installNpm() {
+  const spec = `${packageName}@latest`;
+  if (dryRun) {
+    printDry("npm", ["view", spec, "version"]);
+    printDry("npm", ["uninstall", "-g", packageName], "  # ignored if not installed");
+    printDry("npm", ["install", "-g", "--force", spec]);
+    return;
+  }
+
+  run("npm", ["view", spec, "version"]);
+  run("npm", ["uninstall", "-g", packageName], { allowFailure: true });
+  run("npm", ["install", "-g", "--force", spec]);
+  process.stdout.write(`install-global: installed ${packageName} globally from npm latest\n`);
+}
+
+if (mode === "local" || mode === "source") {
+  installLocal();
+} else if (mode === "npm" || mode === "registry") {
+  installNpm();
+} else {
+  usage();
+  process.exit(1);
+}

--- a/scripts/install-global.mjs
+++ b/scripts/install-global.mjs
@@ -13,9 +13,12 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(import.meta.url);
+const { agentBridgeInstallEnv } = require("./install-safety.cjs");
 const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"));
 const packageName = pkg.name;
 
@@ -50,6 +53,7 @@ function run(cmd, commandArgs, options = {}) {
   const res = spawnSync(cmd, commandArgs, {
     cwd,
     encoding: "utf-8",
+    env: agentBridgeInstallEnv(process.env),
     stdio: captureStdout ? ["ignore", "pipe", "inherit"] : "inherit",
   });
 
@@ -79,8 +83,11 @@ function packedTarballFrom(stdout, destination) {
 
 function installLocal() {
   if (dryRun) {
+    printDry("node", ["scripts/install-safety.cjs", "stop-running", "--dry-run"]);
     printDry("bun", ["run", "prepublishOnly"]);
+    printDry("node", ["scripts/install-safety.cjs", "verify-built"]);
     printDry("npm", ["pack", "--pack-destination", "<temp>"]);
+    printDry("node", ["scripts/install-safety.cjs", "verify-tarball", "<packed-tarball>"]);
     printDry("npm", ["uninstall", "-g", packageName], "  # ignored if not installed");
     printDry("npm", ["install", "-g", "--force", "<packed-tarball>"]);
     return;
@@ -88,10 +95,13 @@ function installLocal() {
 
   let packDir = "";
   try {
+    run("node", ["scripts/install-safety.cjs", "stop-running"]);
     run("bun", ["run", "prepublishOnly"]);
+    run("node", ["scripts/install-safety.cjs", "verify-built"]);
     packDir = mkdtempSync(join(tmpdir(), "agentbridge-pack-"));
     const packed = run("npm", ["pack", "--pack-destination", packDir], { captureStdout: true });
     const tarball = packedTarballFrom(packed.stdout ?? "", packDir);
+    run("node", ["scripts/install-safety.cjs", "verify-tarball", tarball]);
     run("npm", ["uninstall", "-g", packageName], { allowFailure: true });
     run("npm", ["install", "-g", "--force", tarball]);
     process.stdout.write(`install-global: installed ${packageName} globally from local source\n`);
@@ -103,12 +113,14 @@ function installLocal() {
 function installNpm() {
   const spec = `${packageName}@latest`;
   if (dryRun) {
+    printDry("node", ["scripts/install-safety.cjs", "stop-running", "--dry-run"]);
     printDry("npm", ["view", spec, "version"]);
     printDry("npm", ["uninstall", "-g", packageName], "  # ignored if not installed");
     printDry("npm", ["install", "-g", "--force", spec]);
     return;
   }
 
+  run("node", ["scripts/install-safety.cjs", "stop-running"]);
   run("npm", ["view", spec, "version"]);
   run("npm", ["uninstall", "-g", packageName], { allowFailure: true });
   run("npm", ["install", "-g", "--force", spec]);

--- a/scripts/install-safety.cjs
+++ b/scripts/install-safety.cjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+/**
+ * Shared install-time safety checks.
+ *
+ * This intentionally stays CommonJS so both the ESM local installer and npm's
+ * CommonJS postinstall hook can use the same stop/verify behavior.
+ */
+
+const { spawnSync } = require("node:child_process");
+const { existsSync, readFileSync, statSync } = require("node:fs");
+const path = require("node:path");
+
+const PACKAGE_ROOT = path.resolve(__dirname, "..");
+
+const REQUIRED_ARTIFACTS = Object.freeze([
+  "dist/cli.js",
+  "dist/daemon.js",
+  ".claude-plugin/marketplace.json",
+  "plugins/agentbridge/.claude-plugin/plugin.json",
+  "plugins/agentbridge/.mcp.json",
+  "plugins/agentbridge/README.md",
+  "plugins/agentbridge/commands/init.md",
+  "plugins/agentbridge/hooks/hooks.json",
+  "plugins/agentbridge/scripts/health-check.sh",
+  "plugins/agentbridge/scripts/plugin-update-notice.mjs",
+  "plugins/agentbridge/server/bridge-server.js",
+  "plugins/agentbridge/server/daemon.js",
+  "package.json",
+  "README.md",
+  "scripts/install-safety.cjs",
+  "scripts/postinstall.cjs",
+]);
+
+function quote(arg) {
+  return /^[A-Za-z0-9_@%+=:,./<>-]+$/.test(arg) ? arg : JSON.stringify(arg);
+}
+
+function commandLine(cmd, args) {
+  return [cmd, ...args].map(quote).join(" ");
+}
+
+function fail(message, details = []) {
+  process.stderr.write(`install-safety: ${message}\n`);
+  for (const detail of details) {
+    process.stderr.write(`  - ${detail}\n`);
+  }
+  process.exit(1);
+}
+
+function readPackageJson() {
+  return JSON.parse(readFileSync(path.join(PACKAGE_ROOT, "package.json"), "utf-8"));
+}
+
+function requiredPackagePaths() {
+  const pkg = readPackageJson();
+  const binTargets = Object.values(pkg.bin ?? {});
+  return [...new Set([...REQUIRED_ARTIFACTS, ...binTargets])];
+}
+
+function buildStopCommand() {
+  const sourceCli = path.join(PACKAGE_ROOT, "src", "cli.ts");
+  const bundledCli = path.join(PACKAGE_ROOT, "dist", "cli.js");
+  if (existsSync(sourceCli)) return ["bun", ["run", "src/cli.ts", "kill", "--all"]];
+  return ["bun", ["run", bundledCli, "kill", "--all"]];
+}
+
+function agentBridgeInstallEnv(baseEnv = process.env) {
+  const env = { ...baseEnv };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("AGENTBRIDGE_")) delete env[key];
+  }
+  delete env.CODEX_WS_PORT;
+  delete env.CODEX_PROXY_PORT;
+  return env;
+}
+
+function stopRunningAgentBridge(options = {}) {
+  const { dryRun = false, bestEffort = false } = options;
+  const [cmd, args] = buildStopCommand();
+  if (dryRun) {
+    process.stdout.write(`$ ${commandLine(cmd, args)}  # stop running AgentBridge daemons/TUIs\n`);
+    return { status: 0 };
+  }
+
+  process.stdout.write(`$ ${commandLine(cmd, args)}\n`);
+  const res = spawnSync(cmd, args, {
+    cwd: PACKAGE_ROOT,
+    env: agentBridgeInstallEnv(),
+    stdio: "inherit",
+  });
+
+  if (res.error || res.status !== 0) {
+    const message = res.error
+      ? `failed to start stop command: ${res.error.message}`
+      : `stop command exited with ${res.status}`;
+    if (bestEffort) {
+      process.stdout.write(`install-safety: ${message}; continuing because this hook is best-effort\n`);
+      return res;
+    }
+    fail(message);
+  }
+  return res;
+}
+
+function verifyBuiltArtifacts() {
+  const missing = [];
+  const empty = [];
+  const notExecutable = [];
+  const pkg = readPackageJson();
+  const required = requiredPackagePaths();
+  const binTargets = new Set(Object.values(pkg.bin ?? {}));
+
+  for (const rel of required) {
+    const absolute = path.join(PACKAGE_ROOT, rel);
+    if (!existsSync(absolute)) {
+      missing.push(rel);
+      continue;
+    }
+    const stat = statSync(absolute);
+    if (stat.size <= 0) empty.push(rel);
+    if (binTargets.has(rel) && (stat.mode & 0o111) === 0) {
+      notExecutable.push(rel);
+    }
+  }
+
+  const problems = [
+    ...missing.map((rel) => `missing: ${rel}`),
+    ...empty.map((rel) => `empty: ${rel}`),
+    ...notExecutable.map((rel) => `not executable: ${rel}`),
+  ];
+  if (problems.length > 0) {
+    fail("built artifact verification failed", problems);
+  }
+
+  process.stdout.write(`install-safety: verified ${required.length} built artifact(s)\n`);
+}
+
+function verifyTarball(tarballPath) {
+  if (!tarballPath) fail("verify-tarball requires a tarball path");
+  if (!existsSync(tarballPath)) fail(`tarball does not exist: ${tarballPath}`);
+
+  const res = spawnSync("tar", ["-tf", tarballPath], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.error) fail(`failed to inspect tarball: ${res.error.message}`);
+  if (res.status !== 0) {
+    fail(`tar -tf failed with ${res.status}`, [res.stderr?.trim()].filter(Boolean));
+  }
+
+  const packed = new Set(
+    res.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => line.replace(/^package\//, "")),
+  );
+  const required = requiredPackagePaths();
+  const missing = required.filter((rel) => !packed.has(rel));
+  if (missing.length > 0) {
+    fail("packed tarball is missing required artifact(s)", missing);
+  }
+
+  process.stdout.write(`install-safety: verified ${required.length} artifact(s) in ${tarballPath}\n`);
+}
+
+function usage() {
+  process.stderr.write(`Usage:
+  node scripts/install-safety.cjs stop-running [--dry-run] [--best-effort]
+  node scripts/install-safety.cjs verify-built
+  node scripts/install-safety.cjs verify-tarball <tarball>
+`);
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === "stop-running") {
+    stopRunningAgentBridge({
+      dryRun: args.includes("--dry-run"),
+      bestEffort: args.includes("--best-effort"),
+    });
+    return;
+  }
+  if (command === "verify-built") {
+    verifyBuiltArtifacts();
+    return;
+  }
+  if (command === "verify-tarball") {
+    verifyTarball(args[0]);
+    return;
+  }
+  usage();
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  REQUIRED_ARTIFACTS,
+  agentBridgeInstallEnv,
+  commandLine,
+  requiredPackagePaths,
+  stopRunningAgentBridge,
+  verifyBuiltArtifacts,
+  verifyTarball,
+};

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -9,20 +9,59 @@
  */
 
 const { execFileSync } = require("child_process");
+const { existsSync } = require("fs");
 const path = require("path");
+const { stopRunningAgentBridge } = require("./install-safety.cjs");
 
 const PACKAGE_ROOT = path.resolve(__dirname, "..");
 const MARKETPLACE_NAME = "agentbridge";
 const PLUGIN_NAME = "agentbridge";
+/**
+ * Decide whether postinstall should stop ALL running AgentBridge pairs.
+ *
+ * Stop-the-world is destructive (it kills every running daemon/TUI), so it is
+ * gated to INTENTIONAL global self-installs only. The intentional installer
+ * (scripts/install-global.mjs) already calls install-safety stop-running
+ * directly, so postinstall only needs to react to an explicit global signal.
+ *
+ * Pure + injectable for unit testing.
+ *
+ * @param {{ env?: NodeJS.ProcessEnv, hasSourceCli?: boolean }} [opts]
+ * @returns {boolean}
+ */
+function shouldStopRunningDaemons({
+  env = process.env,
+  hasSourceCli = existsSync(path.join(PACKAGE_ROOT, "src", "cli.ts")),
+} = {}) {
+  // hasSourceCli is accepted for symmetry/future use; intentionally unused so
+  // that a packed (no-src) install no longer triggers stop-the-world on its own.
+  void hasSourceCli;
+  if (env.AGENTBRIDGE_POSTINSTALL_STOP === "0") return false;
+  if (env.AGENTBRIDGE_POSTINSTALL_STOP === "1") return true;
+  if (env.npm_config_global === "true") return true;
+  if (env.npm_config_location === "global") return true;
+  return false;
+}
 
-// Step 1: Check Bun
-let bunOk = false;
-try {
-  const version = execFileSync("bun", ["--version"], { encoding: "utf-8" }).trim();
-  console.log(`\x1b[32m✔\x1b[0m AgentBridge: Bun ${version} detected.`);
-  bunOk = true;
-} catch {
-  console.warn(`
+function runPostinstall() {
+  const dryRun = process.argv.includes("--dry-run");
+
+  if (dryRun) {
+    stopRunningAgentBridge({ dryRun: true });
+    console.log("$ claude --version");
+    console.log(`$ claude plugin marketplace add ${PACKAGE_ROOT}`);
+    console.log(`$ claude plugin install ${PLUGIN_NAME}@${MARKETPLACE_NAME}`);
+    process.exit(0);
+  }
+
+  // Step 1: Check Bun
+  let bunOk = false;
+  try {
+    const version = execFileSync("bun", ["--version"], { encoding: "utf-8" }).trim();
+    console.log(`\x1b[32m✔\x1b[0m AgentBridge: Bun ${version} detected.`);
+    bunOk = true;
+  } catch {
+    console.warn(`
 \x1b[33m⚠ AgentBridge requires Bun (v1.0+) as its runtime.\x1b[0m
 
 The CLI was installed, but it won't work without Bun.
@@ -34,34 +73,53 @@ Then restart your terminal and run:
 
   abg init
 `);
+  }
+
+  // Step 2: Register marketplace + install plugin (requires Claude Code)
+  if (bunOk) {
+    if (shouldStopRunningDaemons()) {
+      try {
+        stopRunningAgentBridge({ bestEffort: true });
+      } catch {
+        console.log(`\x1b[33m⚠\x1b[0m AgentBridge: could not stop running daemons — run \`abg kill --all\` before relying on this install.`);
+      }
+    } else {
+      console.log(`\x1b[33m⚠\x1b[0m AgentBridge: not an explicit global self-install — leaving running daemons untouched (use \`abg kill --all\` or install-global to stop).`);
+    }
+
+    try {
+      execFileSync("claude", ["--version"], { encoding: "utf-8" });
+    } catch {
+      console.log(`\x1b[33m⚠\x1b[0m AgentBridge: Claude Code not found — skipping plugin install.`);
+      console.log(`  After installing Claude Code, run: abg init`);
+      process.exit(0);
+    }
+
+    try {
+      execFileSync("claude", ["plugin", "marketplace", "add", PACKAGE_ROOT], {
+        stdio: "pipe",
+      });
+      console.log(`\x1b[32m✔\x1b[0m AgentBridge: Marketplace registered.`);
+    } catch (e) {
+      console.log(`\x1b[33m⚠\x1b[0m AgentBridge: Marketplace registration failed — run \`abg init\` to retry.`);
+      process.exit(0);
+    }
+
+    try {
+      execFileSync("claude", ["plugin", "install", `${PLUGIN_NAME}@${MARKETPLACE_NAME}`], {
+        stdio: "pipe",
+      });
+      console.log(`\x1b[32m✔\x1b[0m AgentBridge: Plugin installed. Run \`abg claude\` to start.`);
+    } catch (e) {
+      console.log(`\x1b[33m⚠\x1b[0m AgentBridge: Plugin install failed — run \`abg init\` to retry.`);
+    }
+  }
 }
 
-// Step 2: Register marketplace + install plugin (requires Claude Code)
-if (bunOk) {
-  try {
-    execFileSync("claude", ["--version"], { encoding: "utf-8" });
-  } catch {
-    console.log(`\x1b[33m⚠\x1b[0m AgentBridge: Claude Code not found — skipping plugin install.`);
-    console.log(`  After installing Claude Code, run: abg init`);
-    process.exit(0);
-  }
+module.exports = { shouldStopRunningDaemons };
 
-  try {
-    execFileSync("claude", ["plugin", "marketplace", "add", PACKAGE_ROOT], {
-      stdio: "pipe",
-    });
-    console.log(`\x1b[32m✔\x1b[0m AgentBridge: Marketplace registered.`);
-  } catch (e) {
-    console.log(`\x1b[33m⚠\x1b[0m AgentBridge: Marketplace registration failed — run \`abg init\` to retry.`);
-    process.exit(0);
-  }
-
-  try {
-    execFileSync("claude", ["plugin", "install", `${PLUGIN_NAME}@${MARKETPLACE_NAME}`], {
-      stdio: "pipe",
-    });
-    console.log(`\x1b[32m✔\x1b[0m AgentBridge: Plugin installed. Run \`abg claude\` to start.`);
-  } catch (e) {
-    console.log(`\x1b[33m⚠\x1b[0m AgentBridge: Plugin install failed — run \`abg init\` to retry.`);
-  }
+// Only run install side effects when invoked directly (not when require()'d
+// from a unit test).
+if (require.main === module) {
+  runPostinstall();
 }

--- a/scripts/runtime-dual-pair-e2e.py
+++ b/scripts/runtime-dual-pair-e2e.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+Manual runtime E2E harness for AgentBridge route-A multi-pair.
+
+This is intentionally outside `bun test src`: it launches real Claude Code and
+Codex TUIs and therefore depends on local auth, terminal behavior, and plugin
+setup. It is a repeatable operator harness for the final validation pass.
+
+Example:
+  python3 scripts/runtime-dual-pair-e2e.py --pairs a b --mode pull
+  python3 scripts/runtime-dual-pair-e2e.py --state-base /tmp/abg-e2e --reserve-slots 2
+
+Notes:
+  - Requires the multi-pair branch where `abg claude/codex/kill --pair` and
+    `abg pairs --json` exist.
+  - Uses Python's stdlib pty module; no npm dependency is required.
+  - If `--state-base` is supplied, the harness exports both AGENTBRIDGE_BASE_DIR
+    (registry base) and AGENTBRIDGE_STATE_DIR (legacy/base compatibility).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import selectors
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import pty
+
+
+BASE_PORT = 4500
+STRIDE = 10
+
+
+def now_stamp() -> str:
+    return time.strftime("%Y%m%d-%H%M%S")
+
+
+def strip_ansi(text: str) -> str:
+    # Small, sufficient ANSI stripper for transcript searches.
+    import re
+
+    return re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)", "", text)
+
+
+def run(
+    args: list[str],
+    env: dict[str, str] | None = None,
+    timeout: float = 10,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def command_exists(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def lsof_listen_pid(port: int) -> str | None:
+    if not command_exists("lsof"):
+        return None
+    proc = run(["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"], timeout=3)
+    out = proc.stdout.strip().splitlines()
+    return out[0].strip() if out else None
+
+
+def curl_ok(port: int, path: str = "/healthz") -> bool:
+    try:
+        proc = run(
+            ["curl", "-fsS", "--max-time", "1", f"http://127.0.0.1:{port}{path}"],
+            timeout=2,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+def ports_for_slot(slot: int) -> tuple[int, int, int]:
+    app = BASE_PORT + slot * STRIDE
+    return app, app + 1, app + 2
+
+
+@dataclass
+class PtyProcess:
+    name: str
+    argv: list[str]
+    env: dict[str, str]
+    log_path: Path
+    pid: int | None = None
+    fd: int | None = None
+    _buffer: str = ""
+
+    def start(self) -> None:
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.execvpe(self.argv[0], self.argv, self.env)
+        self.pid = pid
+        self.fd = fd
+        os.set_blocking(fd, False)
+
+    def pump(self, duration: float = 0.5) -> str:
+        if self.fd is None:
+            return ""
+        sel = selectors.DefaultSelector()
+        sel.register(self.fd, selectors.EVENT_READ)
+        deadline = time.time() + duration
+        chunks: list[str] = []
+        with self.log_path.open("ab") as out:
+            while time.time() < deadline:
+                timeout = max(0, min(0.1, deadline - time.time()))
+                events = sel.select(timeout)
+                if not events:
+                    continue
+                try:
+                    data = os.read(self.fd, 8192)
+                except BlockingIOError:
+                    continue
+                except OSError:
+                    break
+                if not data:
+                    break
+                out.write(data)
+                out.flush()
+                text = data.decode("utf-8", errors="replace")
+                chunks.append(text)
+                self._buffer += text
+        return "".join(chunks)
+
+    def send(self, text: str) -> None:
+        if self.fd is not None:
+            os.write(self.fd, text.encode("utf-8"))
+
+    def wait_for(self, patterns: Iterable[str], timeout: float = 30) -> bool:
+        wanted = list(patterns)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            self.pump(0.3)
+            clean = strip_ansi(self._buffer)
+            if any(p in clean for p in wanted):
+                return True
+        return False
+
+    def terminate(self) -> None:
+        if self.pid is None:
+            return
+        try:
+            self.send("/exit\r")
+            time.sleep(0.5)
+            self.pump(0.5)
+        except Exception:
+            pass
+        try:
+            os.kill(self.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        except Exception:
+            pass
+        deadline = time.time() + 3
+        while time.time() < deadline:
+            try:
+                pid, _ = os.waitpid(self.pid, os.WNOHANG)
+                if pid == self.pid:
+                    return
+            except ChildProcessError:
+                return
+            time.sleep(0.1)
+        try:
+            os.kill(self.pid, signal.SIGKILL)
+        except Exception:
+            pass
+
+
+def default_state_base() -> Path:
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "AgentBridge"
+    xdg = os.environ.get("XDG_STATE_HOME")
+    return Path(xdg) / "agentbridge" if xdg else Path.home() / ".local" / "state" / "agentbridge"
+
+
+def build_env(args: argparse.Namespace) -> dict[str, str]:
+    env = os.environ.copy()
+    env["AGENTBRIDGE_MODE"] = args.mode
+    if args.state_base:
+        base = str(Path(args.state_base).expanduser().resolve())
+        env["AGENTBRIDGE_BASE_DIR"] = base
+        env["AGENTBRIDGE_STATE_DIR"] = base
+    return env
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def seed_reserved_slots(state_base: Path, count: int) -> None:
+    if count <= 0:
+        return
+    registry_path = state_base / "pairs" / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    if registry_path.exists():
+        registry = read_json(registry_path)
+    else:
+        registry = {"version": 1, "pairs": []}
+    require(registry.get("version") == 1 and isinstance(registry.get("pairs"), list), "registry shape is invalid")
+
+    pairs = registry["pairs"]
+    used_slots = {entry.get("slot") for entry in pairs if isinstance(entry, dict)}
+    used_ids = {str(entry.get("pairId", "")).lower() for entry in pairs if isinstance(entry, dict)}
+    created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    for slot in range(count):
+        pair_id = f"_reserved-slot-{slot}"
+        if slot in used_slots:
+            continue
+        require(pair_id.lower() not in used_ids, f"reserved pair id already exists: {pair_id}")
+        pairs.append(
+            {
+                "pairId": pair_id,
+                "slot": slot,
+                "cwd": str(state_base),
+                "source": "flag",
+                "createdAt": created_at,
+            }
+        )
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+
+
+def assert_no_initial_port_conflicts(pairs: list[str], start_slot: int, allow_busy: bool) -> None:
+    busy: list[str] = []
+    for index, _pair in enumerate(pairs):
+        slot = start_slot + index
+        for port in ports_for_slot(slot):
+            pid = lsof_listen_pid(port)
+            if pid:
+                busy.append(f"{port} pid={pid}")
+    if busy and not allow_busy:
+        raise RuntimeError(
+            "Target ports are already busy; aborting before launch: " + ", ".join(busy)
+        )
+
+
+def dump_diagnostics(artifact: Path, state_base: Path, pairs: list[str], start_slot: int, env: dict[str, str], abg: str) -> None:
+    diag = artifact / "diagnostics.txt"
+    with diag.open("w", encoding="utf-8") as f:
+        f.write("== ports ==\n")
+        for index, pair in enumerate(pairs):
+            slot = start_slot + index
+            f.write(f"# pair {pair} slot {slot}\n")
+            for port in ports_for_slot(slot):
+                proc = run(["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN"], timeout=3)
+                f.write(proc.stdout or proc.stderr or f"(no listener on {port})\n")
+        f.write("\n== abg pairs --json ==\n")
+        proc = run([abg, "pairs", "--json"], env=env, timeout=10)
+        f.write(proc.stdout)
+        f.write(proc.stderr)
+        f.write("\n== state files ==\n")
+        for pair in pairs:
+            state = state_base / "pairs" / pair
+            f.write(f"\n# {state}\n")
+            for rel in ["status.json", "daemon.pid", "codex-tui.pid", "agentbridge.log", "codex-wrapper.log"]:
+                path = state / rel
+                f.write(f"--- {path} ---\n")
+                if path.exists():
+                    content = path.read_text(errors="replace")
+                    f.write(content[-20000:])
+                else:
+                    f.write("(missing)\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pairs", nargs=2, default=["a", "b"], metavar=("PAIR_A", "PAIR_B"))
+    parser.add_argument("--mode", choices=["pull", "push"], default="pull")
+    parser.add_argument("--abg", default="abg", help="agentbridge/abg command")
+    parser.add_argument("--artifact-dir", default=f"artifacts/runtime-dual-pair/{now_stamp()}")
+    parser.add_argument("--state-base", help="optional multi-pair registry base override")
+    parser.add_argument(
+        "--reserve-slots",
+        type=int,
+        default=0,
+        help="pre-seed registry placeholders for slots 0..N-1 so test pairs start at slot N",
+    )
+    parser.add_argument("--allow-busy-ports", action="store_true")
+    parser.add_argument("--skip-launch", action="store_true", help="only run state/port assertions")
+    parser.add_argument("--no-cleanup", action="store_true")
+    args = parser.parse_args()
+
+    artifact = Path(args.artifact_dir).resolve()
+    artifact.mkdir(parents=True, exist_ok=True)
+    env = build_env(args)
+    state_base = Path(args.state_base).expanduser().resolve() if args.state_base else default_state_base()
+    pairs = list(args.pairs)
+
+    require(command_exists(args.abg), f"{args.abg} not found")
+    require(command_exists("lsof"), "lsof not found")
+    require(command_exists("curl"), "curl not found")
+
+    processes: list[PtyProcess] = []
+    try:
+        require(args.reserve_slots >= 0, "--reserve-slots must be >= 0")
+        require(args.reserve_slots == 0 or args.state_base, "--reserve-slots requires an isolated --state-base")
+        if args.reserve_slots > 0:
+            seed_reserved_slots(state_base, args.reserve_slots)
+        assert_no_initial_port_conflicts(pairs, args.reserve_slots, args.allow_busy_ports)
+
+        if not args.skip_launch:
+            for pair in pairs:
+                claude = PtyProcess(
+                    name=f"claude-{pair}",
+                    argv=[args.abg, "claude", "--pair", pair],
+                    env=env,
+                    log_path=artifact / "pty" / f"claude-{pair}.log",
+                )
+                codex = PtyProcess(
+                    name=f"codex-{pair}",
+                    argv=[args.abg, "codex", "--pair", pair],
+                    env=env,
+                    log_path=artifact / "pty" / f"codex-{pair}.log",
+                )
+                print(f"starting {claude.name}: {' '.join(claude.argv)}")
+                claude.start()
+                processes.append(claude)
+                time.sleep(1)
+                claude.pump(1)
+                clean_prompt = strip_ansi(claude._buffer)
+                if "Enter" in clean_prompt and "confirm" in clean_prompt:
+                    claude.send("\r")
+                print(f"starting {codex.name}: {' '.join(codex.argv)}")
+                codex.start()
+                processes.append(codex)
+                time.sleep(2)
+                codex.pump(1)
+
+        # Let daemons and TUIs settle.
+        deadline = time.time() + 90
+        while time.time() < deadline:
+            for proc in processes:
+                proc.pump(0.05)
+            if all(curl_ok(ports_for_slot(args.reserve_slots + i)[2]) for i in range(len(pairs))):
+                break
+            time.sleep(0.5)
+
+        # Port/status assertions.
+        for index, pair in enumerate(pairs):
+            slot = args.reserve_slots + index
+            app, proxy, control = ports_for_slot(slot)
+            state = state_base / "pairs" / pair
+            status_path = state / "status.json"
+            require(status_path.exists(), f"missing status for {pair}: {status_path}")
+            status = read_json(status_path)
+            require(status.get("controlPort") == control, f"{pair} wrong controlPort: {status}")
+            require(status.get("appServerUrl") == f"ws://127.0.0.1:{app}", f"{pair} wrong appServerUrl: {status}")
+            require(status.get("proxyUrl") == f"ws://127.0.0.1:{proxy}", f"{pair} wrong proxyUrl: {status}")
+            require(curl_ok(control), f"{pair} control healthz failed on {control}")
+            require(lsof_listen_pid(control) is not None, f"{pair} no LISTEN on control {control}")
+            require(lsof_listen_pid(proxy) is not None, f"{pair} no LISTEN on proxy {proxy}")
+            require(lsof_listen_pid(app) is not None, f"{pair} no LISTEN on app {app}")
+
+            log = (state / "agentbridge.log").read_text(errors="replace")
+            require(f"Control server: ws://127.0.0.1:{control}/ws" in log, f"{pair} daemon log missing control port")
+            require(f"Codex app-server: ws://127.0.0.1:{app}" in log, f"{pair} daemon log missing app port")
+            require(f"Codex proxy: ws://127.0.0.1:{proxy}" in log, f"{pair} daemon log missing proxy port")
+            require(
+                f"Starting AgentBridge frontend (daemon ws ws://127.0.0.1:{control}/ws)" in log,
+                f"{pair} frontend log missing control port",
+            )
+
+        # Cross-negative checks.
+        state_a = state_base / "pairs" / pairs[0] / "agentbridge.log"
+        state_b = state_base / "pairs" / pairs[1] / "agentbridge.log"
+        if state_a.exists() and state_b.exists():
+            a_log = state_a.read_text(errors="replace")
+            b_log = state_b.read_text(errors="replace")
+            pair_a_control = ports_for_slot(args.reserve_slots)[2]
+            pair_b_control = ports_for_slot(args.reserve_slots + 1)[2]
+            require(f"ws://127.0.0.1:{pair_b_control}/ws" not in a_log, "pair a log mentions pair b control port")
+            require(f"ws://127.0.0.1:{pair_a_control}/ws" not in b_log, "pair b log mentions pair a control port")
+
+        print("PASS: dual-pair port/state/log assertions passed")
+        print(f"artifacts: {artifact}")
+        return 0
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        dump_diagnostics(artifact, state_base, pairs, args.reserve_slots, env, args.abg)
+        print(f"diagnostics: {artifact / 'diagnostics.txt'}", file=sys.stderr)
+        return 1
+    finally:
+        if not args.no_cleanup:
+            for pair in pairs:
+                run([args.abg, "kill", "--pair", pair], env=env, timeout=20)
+            for proc in reversed(processes):
+                proc.terminate()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke-built-cli.mjs
+++ b/scripts/smoke-built-cli.mjs
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, statSync, readFileSync } from "node:fs";
+import { chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import net from "node:net";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distCli = join(repoRoot, "dist", "cli.js");
+const distDaemon = join(repoRoot, "dist", "daemon.js");
+const skipBuild = process.argv.includes("--skip-build");
+const keepTmp = process.env.AGENTBRIDGE_SMOKE_KEEP_TMP === "1";
+const fakeCodexHealthStatus = Number.parseInt(process.env.AGENTBRIDGE_SMOKE_FAKE_CODEX_HEALTH_STATUS ?? "200", 10);
+
+const SMOKE_TIMEOUT_MS = 20_000;
+
+function log(message) {
+  process.stderr.write(`[smoke-built-cli] ${message}\n`);
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assert(condition, message) {
+  if (!condition) fail(message);
+}
+
+async function run(command, args, options = {}) {
+  const {
+    cwd = repoRoot,
+    env = process.env,
+    timeoutMs = SMOKE_TIMEOUT_MS,
+  } = options;
+
+  return await new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (child.exitCode === null) child.kill("SIGKILL");
+      }, 1000).unref();
+      reject(new Error(`${command} ${args.join(" ")} timed out after ${timeoutMs}ms\n${stderr}`));
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolvePromise({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+async function runChecked(command, args, options = {}) {
+  const result = await run(command, args, options);
+  if (result.code !== 0) {
+    fail(
+      `${command} ${args.join(" ")} failed with code ${result.code ?? `signal ${result.signal}`}\n` +
+        `--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+    );
+  }
+  return result;
+}
+
+function assertRunnableArtifact(path, label) {
+  assert(existsSync(path), `${label} is missing: ${path}`);
+  const mode = statSync(path).mode;
+  assert((mode & 0o111) !== 0, `${label} is not executable: ${path}`);
+}
+
+async function getFreePort() {
+  return await new Promise((resolvePort, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("failed to allocate a TCP port")));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolvePort(port));
+    });
+  });
+}
+
+async function assertPortFree(port, label) {
+  const deadline = Date.now() + 3000;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    const free = await new Promise((resolveProbe) => {
+      const server = net.createServer();
+      server.unref();
+      server.on("error", (err) => {
+        lastError = err;
+        resolveProbe(false);
+      });
+      server.listen(port, "127.0.0.1", () => {
+        server.close(() => resolveProbe(true));
+      });
+    });
+
+    if (free) return;
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 100));
+  }
+
+  throw new Error(`${label} port ${port} was not released: ${lastError?.message ?? "still busy"}`);
+}
+
+function readPidFile(path) {
+  try {
+    const raw = readFileSync(path, "utf-8").trim();
+    if (!raw) return null;
+    const pid = Number.parseInt(raw, 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function pidFromStatus(path) {
+  try {
+    const status = JSON.parse(readFileSync(path, "utf-8"));
+    return Number.isInteger(status.pid) && status.pid > 0 ? status.pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function waitForHttpOk(url, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response;
+      lastError = new Error(`${url} returned ${response.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 100));
+  }
+  throw lastError ?? new Error(`${url} did not become ready`);
+}
+
+async function waitForProcessExit(pid, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 100));
+  }
+  fail(`daemon pid ${pid} did not exit within ${timeoutMs}ms`);
+}
+
+function writeFakeCodex(binDir) {
+  const fakeCodexPath = join(binDir, "codex");
+  const fakeCodex = `#!${process.execPath}
+const args = process.argv.slice(2);
+
+if (args[0] === "app-server") {
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: codex app-server [OPTIONS]");
+    console.log("      --listen <URL>");
+    console.log("          Transport endpoint URL. Supported values: stdio://, unix://, unix://PATH, ws://IP:PORT, off");
+    process.exit(0);
+  }
+
+  const listenIndex = args.indexOf("--listen");
+  const listenUrl = listenIndex >= 0 ? args[listenIndex + 1] : "stdio://";
+  if (!listenUrl || !listenUrl.startsWith("ws://")) {
+    console.error("fake codex only supports app-server --listen ws://HOST:PORT");
+    process.exit(2);
+  }
+
+  const url = new URL(listenUrl);
+  const port = Number.parseInt(url.port, 10);
+  const hostname = url.hostname || "127.0.0.1";
+  const healthStatus = () => Number.parseInt(process.env.AGENTBRIDGE_SMOKE_FAKE_CODEX_HEALTH_STATUS || "200", 10);
+
+  if (typeof Bun !== "undefined" && typeof Bun.serve === "function") {
+    const server = Bun.serve({
+      port,
+      hostname,
+      fetch(req, server) {
+        const url = new URL(req.url);
+        if (url.pathname === "/healthz" || url.pathname === "/readyz") {
+          const status = healthStatus();
+          return Response.json({ ok: status >= 200 && status < 300 }, { status });
+        }
+        if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+          if (server.upgrade(req)) return undefined;
+          return new Response("websocket upgrade failed", { status: 400 });
+        }
+        return new Response("fake codex app-server\\n");
+      },
+      websocket: {
+        open() {},
+        message() {},
+        close() {},
+      },
+    });
+
+    console.error("fake codex app-server listening " + listenUrl);
+
+    function shutdown() {
+      server.stop(true);
+      process.exit(0);
+    }
+    process.on("SIGTERM", shutdown);
+    process.on("SIGINT", shutdown);
+    setInterval(() => {}, 1000);
+    return;
+  }
+
+  const http = require("node:http");
+  const crypto = require("node:crypto");
+
+  function websocketAccept(key) {
+    return crypto
+      .createHash("sha1")
+      .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+      .digest("base64");
+  }
+
+  const server = http.createServer((req, res) => {
+    if (req.url === "/healthz" || req.url === "/readyz") {
+      const status = healthStatus();
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: status >= 200 && status < 300 }) + "\\n");
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("fake codex app-server\\n");
+  });
+
+  server.on("upgrade", (req, socket) => {
+    const key = req.headers["sec-websocket-key"];
+    if (!key) {
+      socket.destroy();
+      return;
+    }
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\\r\\n" +
+        "Upgrade: websocket\\r\\n" +
+        "Connection: Upgrade\\r\\n" +
+        "Sec-WebSocket-Accept: " + websocketAccept(key) + "\\r\\n" +
+        "\\r\\n",
+    );
+    socket.on("data", () => {});
+    socket.on("error", () => {});
+  });
+
+  server.listen(port, hostname, () => {
+    console.error("fake codex app-server listening " + listenUrl);
+  });
+
+  function shutdown() {
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(0), 500).unref();
+  }
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+  setInterval(() => {}, 1000).unref();
+  return;
+}
+
+if (args.includes("--version")) {
+  console.log("fake-codex 0.0.0");
+  process.exit(0);
+}
+
+console.log("fake codex " + args.join(" "));
+process.exit(0);
+`;
+
+  writeFileSync(fakeCodexPath, fakeCodex, "utf-8");
+  return fakeCodexPath;
+}
+
+async function main() {
+  if (!skipBuild) {
+    log("building CLI artifacts");
+    await runChecked("bun", ["run", "build:cli"], { timeoutMs: 60_000 });
+  } else {
+    log("skipping build (--skip-build)");
+  }
+
+  assertRunnableArtifact(distCli, "dist/cli.js");
+  assertRunnableArtifact(distDaemon, "dist/daemon.js");
+
+  const tempRoot = mkdtempSync(join(tmpdir(), "agentbridge-built-smoke-"));
+  const stateDir = join(tempRoot, "state");
+  const binDir = join(tempRoot, "bin");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeCodexPath = writeFakeCodex(binDir);
+  await chmod(fakeCodexPath, 0o755);
+
+  const appPort = await getFreePort();
+  const proxyPort = await getFreePort();
+  const controlPort = await getFreePort();
+  let daemonPid = null;
+  const statusPath = join(stateDir, "status.json");
+
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    AGENTBRIDGE_STATE_DIR: stateDir,
+    AGENTBRIDGE_CONTROL_PORT: String(controlPort),
+    CODEX_WS_PORT: String(appPort),
+    CODEX_PROXY_PORT: String(proxyPort),
+    AGENTBRIDGE_SMOKE_FAKE_CODEX_HEALTH_STATUS: String(fakeCodexHealthStatus),
+  };
+
+  try {
+    log(`starting built CLI smoke on app:${appPort} proxy:${proxyPort} control:${controlPort}`);
+    const cliResult = await run(distCli, ["codex", "help"], {
+      env,
+      timeoutMs: SMOKE_TIMEOUT_MS,
+    });
+
+    if (cliResult.code !== 0) {
+      fail(
+        `built CLI smoke command failed with code ${cliResult.code ?? `signal ${cliResult.signal}`}\n` +
+          `--- stdout ---\n${cliResult.stdout}\n--- stderr ---\n${cliResult.stderr}`,
+      );
+    }
+
+    await waitForHttpOk(`http://127.0.0.1:${controlPort}/healthz`);
+    await waitForHttpOk(`http://127.0.0.1:${controlPort}/readyz`);
+
+    assert(existsSync(statusPath), `status.json was not written: ${statusPath}`);
+    const status = JSON.parse(readFileSync(statusPath, "utf-8"));
+    assert(Number.isInteger(status.pid) && status.pid > 0, "status.json missing numeric pid");
+    assert(status.controlPort === controlPort, `status.json controlPort mismatch: ${status.controlPort}`);
+    assert(status.proxyUrl === `ws://127.0.0.1:${proxyPort}`, `status.json proxyUrl mismatch: ${status.proxyUrl}`);
+    assert(status.appServerUrl === `ws://127.0.0.1:${appPort}`, `status.json appServerUrl mismatch: ${status.appServerUrl}`);
+
+    daemonPid = status.pid;
+    try {
+      process.kill(daemonPid, 0);
+    } catch {
+      fail(`daemon pid from status.json is not alive: ${daemonPid}`);
+    }
+
+    log(`daemon healthy pid=${daemonPid}`);
+  } finally {
+    const pidPath = join(stateDir, "daemon.pid");
+    daemonPid ??= pidFromStatus(statusPath);
+    daemonPid ??= readPidFile(pidPath);
+
+    let cleanupError = null;
+    if (daemonPid) {
+      try {
+        process.kill(daemonPid, "SIGTERM");
+        await waitForProcessExit(daemonPid);
+      } catch (err) {
+        log(`cleanup warning: ${err.message}`);
+        try { process.kill(daemonPid, "SIGKILL"); } catch {}
+      }
+    }
+
+    for (const [port, label] of [
+      [appPort, "app"],
+      [proxyPort, "proxy"],
+      [controlPort, "control"],
+    ]) {
+      try {
+        await assertPortFree(port, label);
+      } catch (err) {
+        cleanupError ??= new Error(
+          `${err.message}. This often means daemon bootstrap failed before status.json was written; ` +
+            `cleanup attempted pid from ${statusPath} and ${pidPath}.`,
+        );
+      }
+    }
+
+    if (keepTmp) {
+      log(`kept temp dir: ${tempRoot}`);
+    } else {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+
+    if (cleanupError) throw cleanupError;
+  }
+
+  log("PASS");
+}
+
+main().catch((err) => {
+  console.error(`[smoke-built-cli] FAIL: ${err.stack ?? err.message}`);
+  process.exit(1);
+});

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env bun
+
+// Packaged-artifact smoke test: verifies that `npm pack` would ship every file
+// the CLI + daemon + plugin need at runtime.
+//
+// Background: a recent release shipped a broken package because `build:cli` did
+// not emit `dist/daemon.js` and nothing verified the packed output. This script
+// is the packaging-completeness guard (sibling to scripts/smoke-built-cli.mjs).
+//
+// It is deterministic, fast, offline, and side-effect-free on the repo:
+//   1. builds dist/ + plugin bundles,
+//   2. asks `npm pack --dry-run --json` what would be packed (no publish, no
+//      install, no postinstall),
+//   3. asserts every required artifact (incl. dist/daemon.js and the bin
+//      targets) is present and that bin targets exist + are executable on disk.
+//
+// Manual regression check (confirm it catches the original bug class — a
+// build:cli that FAILS to emit dist/daemon.js): temporarily delete the
+// `bun build src/daemon.ts ...` step from the build:cli script, then run
+// `bun scripts/smoke-pack.mjs` — it must exit non-zero (MISSING: dist/daemon.js).
+// Restore build:cli afterward. (Deleting dist/daemon.js on disk does NOT
+// reproduce it — this script rebuilds dist/ before packing.)
+// `npm pack --dry-run` writes no tarball, so this script touches nothing on disk.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+function fail(message, details = []) {
+  console.error(`\nsmoke-pack FAILED: ${message}`);
+  for (const line of details) {
+    console.error(`  - ${line}`);
+  }
+  process.exit(1);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function build() {
+  console.log("smoke-pack: building dist/ + plugin bundles ...");
+  for (const script of ["build:cli", "build:plugin"]) {
+    execFileSync("bun", ["run", script], {
+      cwd: repoRoot,
+      stdio: "inherit",
+    });
+  }
+}
+
+function packedPaths() {
+  // `npm pack --dry-run --json` reports exactly what would ship, without
+  // publishing or creating a tarball on disk. Output is a JSON array whose
+  // single entry has a `files: [{ path }]` list.
+  const raw = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    fail(`could not parse \`npm pack --dry-run --json\` output: ${error.message}`);
+  }
+  const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!entry || !Array.isArray(entry.files)) {
+    fail("`npm pack --dry-run --json` did not return a files list");
+  }
+  return new Set(entry.files.map((f) => f.path));
+}
+
+function main() {
+  build();
+
+  const pkg = readJson(join(repoRoot, "package.json"));
+  const binTargets = [...new Set(Object.values(pkg.bin ?? {}))];
+  if (binTargets.length === 0) {
+    fail("package.json has no bin targets to verify");
+  }
+
+  // Required artifacts the published package must contain for CLI + daemon +
+  // plugin to work. Bin targets are unioned in so package.json drift is caught.
+  const required = new Set([
+    "dist/cli.js",
+    "dist/daemon.js", // ← the omission that shipped the original broken package
+    "plugins/agentbridge/server/bridge-server.js",
+    "plugins/agentbridge/server/daemon.js",
+    "package.json",
+    "README.md",
+    ...binTargets,
+  ]);
+
+  const packed = packedPaths();
+  const missing = [...required].filter((path) => !packed.has(path)).sort();
+  if (missing.length > 0) {
+    const present = [...packed].sort();
+    fail(
+      `${missing.length} required artifact(s) missing from the packed set`,
+      [
+        ...missing.map((path) => `MISSING: ${path}`),
+        `--- ${present.length} packed paths ---`,
+        ...present.map((path) => `present: ${path}`),
+      ],
+    );
+  }
+
+  // Bin targets must also exist on disk and be executable (chmod +x), since the
+  // packed `mode` only matters if the source file is actually executable.
+  const binProblems = [];
+  for (const target of binTargets) {
+    const absolute = join(repoRoot, target);
+    if (!existsSync(absolute)) {
+      binProblems.push(`bin target does not exist on disk: ${target}`);
+      continue;
+    }
+    const mode = statSync(absolute).mode;
+    const isExecutable = (mode & 0o111) !== 0;
+    if (!isExecutable) {
+      binProblems.push(`bin target is not executable (missing +x): ${target}`);
+    }
+  }
+  if (binProblems.length > 0) {
+    fail("bin target on-disk checks failed", binProblems);
+  }
+
+  console.log(
+    `\nsmoke-pack OK: ${packed.size} files packed, all ${required.size} required artifacts present; ` +
+      `bin targets [${binTargets.join(", ")}] exist + are executable.`,
+  );
+  process.exit(0);
+}
+
+// `npm pack --dry-run` writes no tarball, so the script touches nothing on disk
+// (and never the repo) — no temp dir to manage.
+main();

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -87,10 +87,20 @@ function main() {
   const required = new Set([
     "dist/cli.js",
     "dist/daemon.js", // ← the omission that shipped the original broken package
+    ".claude-plugin/marketplace.json",
+    "plugins/agentbridge/.claude-plugin/plugin.json",
+    "plugins/agentbridge/.mcp.json",
+    "plugins/agentbridge/README.md",
+    "plugins/agentbridge/commands/init.md",
+    "plugins/agentbridge/hooks/hooks.json",
+    "plugins/agentbridge/scripts/health-check.sh",
+    "plugins/agentbridge/scripts/plugin-update-notice.mjs",
     "plugins/agentbridge/server/bridge-server.js",
     "plugins/agentbridge/server/daemon.js",
     "package.json",
     "README.md",
+    "scripts/install-safety.cjs",
+    "scripts/postinstall.cjs",
     ...binTargets,
   ]);
 

--- a/scripts/verify-plugin-sync.cjs
+++ b/scripts/verify-plugin-sync.cjs
@@ -9,13 +9,13 @@ const repoRoot = resolve(__dirname, "..");
 const pluginBundles = [
   {
     label: "plugins/agentbridge/server/bridge-server.js",
-    source: "src/bridge.ts",
+    target: "bridge-plugin",
     output: resolve(repoRoot, "plugins/agentbridge/server/bridge-server.js"),
     outfileName: "bridge-server.js",
   },
   {
     label: "plugins/agentbridge/server/daemon.js",
-    source: "src/daemon.ts",
+    target: "daemon-plugin",
     output: resolve(repoRoot, "plugins/agentbridge/server/daemon.js"),
     outfileName: "daemon.js",
   },
@@ -46,7 +46,7 @@ const tempDir = mkdtempSync(join(tmpdir(), "agentbridge-plugin-sync-"));
 try {
   for (const bundle of pluginBundles) {
     const tempOutput = join(tempDir, bundle.outfileName);
-    run("bun", ["build", bundle.source, "--outfile", tempOutput, "--target", "bun"]);
+    run("node", ["scripts/build-bundles.mjs", bundle.target, "--outfile", tempOutput]);
     bundle.generated = tempOutput;
   }
 

--- a/src/agents-contract.ts
+++ b/src/agents-contract.ts
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { MARKER_ID } from "./collaboration-content";
+
+export interface AgentsContractCheck {
+  /** Whether the AgentBridge contract block in AGENTS.md is present and current. */
+  fresh: boolean;
+  /** Whether an AGENTS.md file exists at all. */
+  exists: boolean;
+  /** Human-readable summary suitable for a single stderr nudge line. */
+  message: string;
+}
+
+/**
+ * Read-only check of the AgentBridge contract in AGENTS.md.
+ *
+ * NEVER writes and NEVER throws/exits. AGENTS.md is managed exclusively by
+ * `abg init`; `abg codex` startup must not create, rewrite, or block on it.
+ * The caller may use the result to print a single nudge suggesting `abg init`.
+ */
+export function checkAgentsMdContract(cwd: string): AgentsContractCheck {
+  const path = join(cwd, "AGENTS.md");
+  const exists = existsSync(path);
+
+  let content = "";
+  if (exists) {
+    try {
+      content = readFileSync(path, "utf-8");
+    } catch {
+      // Unreadable file → treat as stale, but never throw from a startup check.
+      return {
+        fresh: false,
+        exists,
+        message: "AGENTS.md could not be read; re-run `abg init` to refresh the AgentBridge contract.",
+      };
+    }
+  }
+
+  const fresh = isFreshAgentsMdContract(content);
+  if (fresh) {
+    return { fresh: true, exists, message: "AGENTS.md AgentBridge contract is up to date" };
+  }
+
+  return {
+    fresh: false,
+    exists,
+    message: exists
+      ? "AGENTS.md is missing the current AgentBridge contract; re-run `abg init` to refresh it."
+      : "AGENTS.md not found; re-run `abg init` to write the AgentBridge contract.",
+  };
+}
+
+export function isFreshAgentsMdContract(content: string): boolean {
+  if (!content.includes(`<!-- ${MARKER_ID}:start -->`)) return false;
+  return (
+    content.includes("transparent proxy") &&
+    content.includes("Do not") &&
+    content.includes("sendToClaude") &&
+    content.includes("Git operations") &&
+    content.includes("Implementer, Executor, Verifier")
+  );
+}

--- a/src/bridge-disabled-state.ts
+++ b/src/bridge-disabled-state.ts
@@ -5,17 +5,23 @@ export type BridgeDisabledReason =
   | "probe_in_progress"
   | "auto_recovery_exhausted";
 
+import { pairScopedCommand } from "./pair-command";
+
 export function disabledReplyError(reason: BridgeDisabledReason): string {
+  // These render in the bridge (MCP server) process, which inherits
+  // AGENTBRIDGE_PAIR_ID in multi-pair mode — so the suggested commands carry
+  // `--pair <id>` and don't send the user to a different pair / kill all pairs.
+  const claudeCmd = pairScopedCommand("claude");
   switch (reason) {
     case "rejected":
-      return "AgentBridge rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset.";
+      return `AgentBridge rejected this session — another Claude Code session is already connected. Close the other session first, or run \`${pairScopedCommand("kill")}\` to reset.`;
     case "evicted":
-      return "AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude`.";
+      return `AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with \`${claudeCmd}\`.`;
     case "probe_in_progress":
-      return "AgentBridge rejected this session — a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with `agentbridge claude`.";
+      return `AgentBridge rejected this session — a liveness probe is currently checking the incumbent Claude session. Retry in a few seconds with \`${claudeCmd}\`.`;
     case "auto_recovery_exhausted":
-      return "AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`.";
+      return `AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${claudeCmd}\`.`;
     case "killed":
-      return "AgentBridge is disabled by `agentbridge kill`. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.";
+      return `AgentBridge is disabled by \`agentbridge kill\`. Restart Claude Code (\`${claudeCmd}\`), switch to a new conversation, or run \`/resume\` to reconnect.`;
   }
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,6 +7,7 @@ import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
 import { ConfigService } from "./config-service";
 import { disabledReplyError, type BridgeDisabledReason } from "./bridge-disabled-state";
+import { pairScopedCommand } from "./pair-command";
 import {
   CLOSE_CODE_EVICTED_STALE,
   CLOSE_CODE_PROBE_IN_PROGRESS,
@@ -115,17 +116,17 @@ daemonClient.on("rejected", async (code: number) => {
     case CLOSE_CODE_EVICTED_STALE:
       reason = "evicted";
       notificationId = "system_bridge_evicted";
-      notificationContent = "⚠️ AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with `agentbridge claude` if you want to reconnect. AgentBridge 因此会话未响应存活探测而将其驱逐——更新的 Claude Code 会话已接管。如需重连，请关闭此会话并运行 `agentbridge claude` 启动新会话。";
+      notificationContent = `⚠️ AgentBridge evicted this session because it stopped responding to liveness probes — a newer Claude Code session has taken over. Close this session and start a new one with \`${pairScopedCommand("claude")}\` if you want to reconnect. AgentBridge 因此会话未响应存活探测而将其驱逐——更新的 Claude Code 会话已接管。如需重连，请关闭此会话并运行 \`${pairScopedCommand("claude")}\` 启动新会话。`;
       break;
     case CLOSE_CODE_PROBE_IN_PROGRESS:
       reason = "probe_in_progress";
       notificationId = "system_bridge_probe_in_progress";
-      notificationContent = "⚠️ AgentBridge rejected this session — a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with `agentbridge claude`. AgentBridge 拒绝了此会话——正在通过存活探测检查现有 Claude 会话是否仍然在线。请稍后用 `agentbridge claude` 重试。";
+      notificationContent = `⚠️ AgentBridge rejected this session — a liveness probe is currently checking whether the incumbent Claude session is still alive. Retry in a few seconds with \`${pairScopedCommand("claude")}\`. AgentBridge 拒绝了此会话——正在通过存活探测检查现有 Claude 会话是否仍然在线。请稍后用 \`${pairScopedCommand("claude")}\` 重试。`;
       break;
     default:
       reason = "rejected";
       notificationId = "system_bridge_replaced";
-      notificationContent = "⚠️ AgentBridge daemon rejected this session — another Claude Code session is already connected. Close the other session first, or run `agentbridge kill` to reset. AgentBridge 守护进程拒绝了此会话——另一个 Claude Code 会话已在连接中。请先关闭另一个会话，或运行 `agentbridge kill` 重置。";
+      notificationContent = `⚠️ AgentBridge daemon rejected this session — another Claude Code session is already connected. Close the other session first, or run \`${pairScopedCommand("kill")}\` to reset. AgentBridge 守护进程拒绝了此会话——另一个 Claude Code 会话已在连接中。请先关闭另一个会话，或运行 \`${pairScopedCommand("kill")}\` 重置。`;
       break;
   }
   log(`Daemon rejected this session (close code ${code}, reason=${reason})`);
@@ -150,7 +151,7 @@ claude.on("ready", async () => {
   if (daemonLifecycle.wasKilled()) {
     await enterDisabledState(
       "Killed sentinel found — bridge staying idle",
-      "⛔ AgentBridge was stopped by `agentbridge kill`. Bridge is staying idle. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.",
+      `⛔ AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`,
     );
     return;
   }
@@ -171,7 +172,7 @@ async function connectToDaemon(isReconnect = false) {
     if (!isReconnect) {
       void claude.pushNotification(systemMessage(
         "system_bridge_ready",
-        "✅ AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: agentbridge codex",
+        `✅ AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: ${pairScopedCommand("codex")}`,
       ));
     }
   } catch (err: any) {
@@ -205,7 +206,7 @@ async function notifyIfDaemonKilled(logMessage: string) {
 
   await enterDisabledState(
     logMessage,
-    "⛔ AgentBridge was stopped by `agentbridge kill`. Bridge is staying idle. Restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to reconnect.",
+    `⛔ AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`,
   );
   return true;
 }
@@ -311,7 +312,7 @@ async function pollDisabledRecovery() {
           stopDisabledRecoveryPoller();
           void claude.pushNotification(systemMessage(
             "system_bridge_auto_recovery_gave_up",
-            "⚠️ AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with `agentbridge claude`. AgentBridge 自动恢复已放弃——存活探测争用的重试预算已用尽。请使用 `agentbridge claude` 手动重试。",
+            `⚠️ AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${pairScopedCommand("claude")}\`. AgentBridge 自动恢复已放弃——存活探测争用的重试预算已用尽。请使用 \`${pairScopedCommand("claude")}\` 手动重试。`,
           ));
           return;
         }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,18 +1,31 @@
 #!/usr/bin/env bun
 
-import { appendFileSync } from "node:fs";
 import { ClaudeAdapter } from "./claude-adapter";
+import { BUILD_INFO } from "./build-info";
 import { DaemonClient } from "./daemon-client";
 import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
 import { ConfigService } from "./config-service";
 import { disabledReplyError, type BridgeDisabledReason } from "./bridge-disabled-state";
+import { guardAgentBridgeEnv, normalizeEnvGuardMode } from "./env-guard";
 import { pairScopedCommand } from "./pair-command";
+import { appendTraceEvent, pickRelevantEnv } from "./trace-log";
+import { appendRotatingLog } from "./rotating-log";
 import {
   CLOSE_CODE_EVICTED_STALE,
   CLOSE_CODE_PROBE_IN_PROGRESS,
 } from "./control-protocol";
+import type { ControlClientIdentity } from "./control-protocol";
 import type { BridgeMessage } from "./types";
+
+const originalEnv = { ...process.env };
+const envGuardResult = guardAgentBridgeEnv({
+  cwd: process.cwd(),
+  env: process.env,
+  mode: normalizeEnvGuardMode(process.env.AGENTBRIDGE_ENV_GUARD),
+  allowStrict: false,
+  log: (msg) => process.stderr.write(`${msg}\n`),
+});
 
 const stateDir = new StateDirResolver();
 stateDir.ensure();
@@ -24,7 +37,7 @@ const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_POR
 const CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 
 const claude = new ClaudeAdapter(stateDir.logFile);
-const daemonClient = new DaemonClient(CONTROL_WS_URL);
+const daemonClient = new DaemonClient(CONTROL_WS_URL, { identity: currentClientIdentity() });
 
 let shuttingDown = false;
 let daemonDisabled = false;
@@ -45,6 +58,33 @@ let disabledRecoveryAttempts = 0;
 
 const DISABLED_RECOVERY_MAX_ATTEMPTS = 6;
 const DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS = 1000;
+
+// Tracing is opt-in (default off) and must never write a full env snapshot —
+// bridge.ts runs on every Claude Code session, so an ungated full-env dump would
+// leak DATABASE_URL/*_DSN-style secrets to a local trace file on every start.
+if (process.env.AGENTBRIDGE_TRACE === "1") {
+  try {
+    appendTraceEvent({
+      cwd: process.cwd(),
+      event: "bridge.start",
+      pid: process.pid,
+      argv: process.argv,
+      env: process.env,
+      data: {
+        originalEnv: pickRelevantEnv(originalEnv),
+        effectiveEnv: pickRelevantEnv(process.env),
+        envGuardAction: envGuardResult.action,
+        pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+        pairName: process.env.AGENTBRIDGE_PAIR_NAME ?? null,
+        stateDir: stateDir.dir,
+        controlPort: CONTROL_PORT,
+        build: BUILD_INFO,
+      },
+    });
+  } catch {
+    // Trace logging must never break MCP startup.
+  }
+}
 
 claude.setReplySender(async (msg: BridgeMessage, requireReply?: boolean) => {
   if (msg.source !== "claude") {
@@ -167,12 +207,16 @@ async function connectToDaemon(isReconnect = false) {
   try {
     await daemonLifecycle.ensureRunning();
     await daemonClient.connect();
-    daemonClient.attachClaude();
+    const status = await daemonClient.attachClaudeAndWaitForStatus(1500);
+    if (!status) {
+      throw new Error("Daemon did not confirm Claude attach.");
+    }
+    assertAttachedToExpectedDaemon(status);
     daemonDisabledReason = null;
     if (!isReconnect) {
       void claude.pushNotification(systemMessage(
-        "system_bridge_ready",
-        `✅ AgentBridge bridge is ready. Daemon connected. Start Codex in another terminal with: ${pairScopedCommand("codex")}`,
+        status.bridgeReady ? "system_bridge_ready" : "system_bridge_waiting",
+        initialAttachMessage(status),
       ));
     }
   } catch (err: any) {
@@ -185,6 +229,25 @@ async function connectToDaemon(isReconnect = false) {
     );
     throw err;
   }
+}
+
+function assertAttachedToExpectedDaemon(status: { pairId?: string | null }) {
+  const expectedPairId = process.env.AGENTBRIDGE_PAIR_ID || null;
+  if (expectedPairId && status.pairId !== expectedPairId) {
+    throw new Error(
+      `Daemon identity mismatch after attach: expected pair ${expectedPairId}, got ${status.pairId ?? "<none>"}.`,
+    );
+  }
+}
+
+function initialAttachMessage(status: { bridgeReady: boolean; tuiConnected: boolean }) {
+  if (status.bridgeReady) {
+    return "✅ AgentBridge bridge is ready. Codex TUI is connected.";
+  }
+  if (status.tuiConnected) {
+    return "⏳ AgentBridge attached to daemon. Waiting for Codex to finish creating a thread.";
+  }
+  return `⏳ AgentBridge attached to daemon. Waiting for Codex TUI. Start Codex in another terminal with: ${pairScopedCommand("codex")}`;
 }
 
 async function enterDisabledState(logMessage: string, notificationContent: string) {
@@ -411,6 +474,18 @@ function systemMessage(idPrefix: string, content: string): BridgeMessage {
   };
 }
 
+function currentClientIdentity(): ControlClientIdentity {
+  return {
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    pairName: process.env.AGENTBRIDGE_PAIR_NAME ?? null,
+    cwd: process.cwd(),
+    baseDir: process.env.AGENTBRIDGE_BASE_DIR ?? null,
+    stateDir: stateDir.dir,
+    clientPid: process.pid,
+    contractVersion: BUILD_INFO.contractVersion,
+  };
+}
+
 function shutdown(reason: string) {
   if (shuttingDown) return;
   shuttingDown = true;
@@ -446,7 +521,7 @@ function log(msg: string) {
   const line = `[${new Date().toISOString()}] [AgentBridgeFrontend] ${msg}\n`;
   process.stderr.write(line);
   try {
-    appendFileSync(stateDir.logFile, line);
+    appendRotatingLog(stateDir.logFile, line);
   } catch {}
 }
 

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -1,0 +1,86 @@
+declare const __AGENTBRIDGE_BUILD_VERSION__: string | undefined;
+declare const __AGENTBRIDGE_BUILD_COMMIT__: string | undefined;
+declare const __AGENTBRIDGE_BUILD_BUNDLE__: "source" | "dist" | "plugin" | undefined;
+declare const __AGENTBRIDGE_CONTRACT_VERSION__: number | undefined;
+
+export type AgentBridgeBundleKind = "source" | "dist" | "plugin";
+
+export interface AgentBridgeBuildInfo {
+  version: string;
+  commit: string;
+  bundle: AgentBridgeBundleKind;
+  contractVersion: number;
+}
+
+function defineString(value: string | undefined, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function defineBundle(value: string | undefined): AgentBridgeBundleKind {
+  if (value === "source" || value === "dist" || value === "plugin") return value;
+  return import.meta.url.endsWith(".ts") ? "source" : "dist";
+}
+
+function defineNumber(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export const BUILD_INFO: AgentBridgeBuildInfo = Object.freeze({
+  version: defineString(
+    typeof __AGENTBRIDGE_BUILD_VERSION__ === "string" ? __AGENTBRIDGE_BUILD_VERSION__ : undefined,
+    "0.0.0-source",
+  ),
+  commit: defineString(
+    typeof __AGENTBRIDGE_BUILD_COMMIT__ === "string" ? __AGENTBRIDGE_BUILD_COMMIT__ : undefined,
+    "source",
+  ),
+  bundle: defineBundle(
+    typeof __AGENTBRIDGE_BUILD_BUNDLE__ === "string" ? __AGENTBRIDGE_BUILD_BUNDLE__ : undefined,
+  ),
+  contractVersion: defineNumber(
+    typeof __AGENTBRIDGE_CONTRACT_VERSION__ === "number" ? __AGENTBRIDGE_CONTRACT_VERSION__ : undefined,
+    1,
+  ),
+});
+
+export function daemonStatusBuildInfo(): AgentBridgeBuildInfo {
+  return { ...BUILD_INFO };
+}
+
+export function sameBuildInfo(a: AgentBridgeBuildInfo | null | undefined, b: AgentBridgeBuildInfo | null | undefined): boolean {
+  if (!a || !b) return false;
+  return (
+    a.version === b.version &&
+    a.commit === b.commit &&
+    a.bundle === b.bundle &&
+    a.contractVersion === b.contractVersion
+  );
+}
+
+/**
+ * Whether two builds share the same RUNTIME CONTRACT — i.e. one daemon can be
+ * reused in place of the other. This deliberately IGNORES `bundle`: the dist CLI
+ * (`bundle: "dist"`) and the Claude Code plugin (`bundle: "plugin"`) are co-equal
+ * artifacts built from the same source for the same pair and same control port,
+ * so a daemon launched by one must NOT be treated as "drifted" by the other —
+ * otherwise the two launchers replace-war each other's daemon on every
+ * `ensureRunning` and the Codex TUI can never stay up. Drift that actually
+ * matters (a real code change) moves version/commit/contractVersion, which this
+ * still detects.
+ */
+export function sameRuntimeContract(
+  a: AgentBridgeBuildInfo | null | undefined,
+  b: AgentBridgeBuildInfo | null | undefined,
+): boolean {
+  if (!a || !b) return false;
+  return (
+    a.version === b.version &&
+    a.commit === b.commit &&
+    a.contractVersion === b.contractVersion
+  );
+}
+
+export function formatBuildInfo(build: AgentBridgeBuildInfo | null | undefined): string {
+  if (!build) return "<unknown>";
+  return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}`;
+}

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -20,7 +20,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { EventEmitter } from "node:events";
 import { randomUUID } from "node:crypto";
-import { appendFileSync } from "node:fs";
+import { appendRotatingLog } from "./rotating-log";
 import { StateDirResolver } from "./state-dir";
 import type { BridgeMessage } from "./types";
 
@@ -344,7 +344,7 @@ export class ClaudeAdapter extends EventEmitter {
     const line = `[${new Date().toISOString()}] [ClaudeAdapter] ${msg}\n`;
     process.stderr.write(line);
     try {
-      appendFileSync(this.logFile, line);
+      appendRotatingLog(this.logFile, line);
     } catch {}
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,22 @@ const restArgs = args.slice(1);
 export const MARKETPLACE_NAME = "agentbridge";
 export const PLUGIN_NAME = "agentbridge";
 
+/** Commands that print an update notice. claude/codex also trigger the daily refresh. */
+const REFRESH_COMMANDS = new Set(["claude", "codex"]);
+const NOTIFY_COMMANDS = new Set(["claude", "codex", "init", "dev"]);
+
 async function main() {
+  // Best-effort, non-blocking update notice. Fully guarded — never blocks,
+  // delays, or fails the command (see src/update-notifier.ts).
+  if (command && NOTIFY_COMMANDS.has(command)) {
+    try {
+      const { maybeNotifyUpdate } = await import("./update-notifier");
+      maybeNotifyUpdate({ refresh: REFRESH_COMMANDS.has(command) });
+    } catch {
+      // ignore — the notifier must never affect the command
+    }
+  }
+
   switch (command) {
     case "init":
       const { runInit } = await import("./cli/init");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,11 @@ async function main() {
       break;
     case "kill":
       const { runKill } = await import("./cli/kill");
-      await runKill();
+      await runKill(restArgs);
+      break;
+    case "pairs":
+      const { runPairs } = await import("./cli/pairs");
+      await runPairs(restArgs);
       break;
     case "--help":
     case "-h":
@@ -66,23 +70,33 @@ Usage:
   abg <command> [args...]
 
 Commands:
-  init              Install plugin, check dependencies, generate project config
-  dev               Register local marketplace + install plugin (for local dev)
-  claude [args...]  Start Claude Code with push channel enabled
-  codex [args...]   Start Codex TUI connected to AgentBridge daemon
-  kill              Force kill all AgentBridge processes
+  init               Install plugin, check dependencies, generate project config
+  dev                Register local marketplace + install plugin (for local dev)
+  claude [args...]   Start Claude Code with push channel enabled
+  codex [args...]    Start Codex TUI connected to AgentBridge daemon
+  pairs [rm <id>]    List running Claude+Codex pairs (or remove one)
+  kill [--pair <id>] Stop all pairs, or just one with --pair (alias: --all)
 
 Options:
-  --help, -h        Show this help message
-  --version, -v     Show version
+  --pair <name>      Run claude/codex in a named pair (multiple pairs per machine).
+                     Without it, the pair is derived from the current directory.
+  --help, -h         Show this help message
+  --version, -v      Show version
+
+Multi-pair:
+  Each pair is an isolated daemon with its own port triple. The first pair uses
+  the classic ports 4500/4501/4502; each additional pair steps +10.
 
 Examples:
   abg init                     # First-time setup
-  abg claude                   # Start Claude Code
-  abg claude --resume          # Start Claude Code and resume session
-  abg codex                    # Start Codex TUI
-  abg codex --model o3         # Start Codex with specific model
-  abg kill                     # Emergency: kill all processes
+  abg claude                   # Start Claude Code (pair derived from cwd)
+  abg claude --pair work       # Start a named pair "work"
+  abg codex  --pair work       # Connect Codex to the "work" pair
+  abg claude --pair review     # A second, parallel pair
+  abg pairs                    # List all pairs and their ports/status
+  abg pairs rm work            # Stop the "work" pair and free its slot
+  abg kill --pair work         # Stop only the "work" pair
+  abg kill                     # Stop ALL pairs
 `.trim());
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,15 +11,55 @@
  *   agentbridge kill        — Force kill all AgentBridge processes
  */
 
-const args = process.argv.slice(2);
-const command = args[0];
-const restArgs = args.slice(1);
-
 // Marketplace name constant (shared with plugin)
 export const MARKETPLACE_NAME = "agentbridge";
 export const PLUGIN_NAME = "agentbridge";
 
-async function main() {
+/** Subcommands that accept a `--pair <name>` selector. */
+const PAIR_AWARE_COMMANDS = new Set(["claude", "codex", "kill"]);
+
+/**
+ * Split argv into the subcommand and its args, allowing a leading `--pair <name>`
+ * (or `--pair=<name>`) to appear BEFORE the subcommand:
+ *
+ *   abg --pair work claude --resume   →  command="claude", restArgs=["--pair","work","--resume"]
+ *
+ * The leading pair token(s) are re-attached to the front of the subcommand's args
+ * (only for pair-aware commands), so each command's own `--pair` parser
+ * (parsePairFlag / parseKillArgs) handles BOTH the new leading position and the
+ * classic trailing `abg claude --pair work`. For non-pair-aware commands a leading
+ * `--pair` is dropped (those commands ignore it), preserving prior behaviour.
+ */
+export function parseTopLevel(args: string[]): { command: string | undefined; restArgs: string[] } {
+  const pairTokens: string[] = [];
+  let i = 0;
+  for (; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--pair") {
+      pairTokens.push(a);
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith("-")) {
+        pairTokens.push(next);
+        i++;
+      }
+      continue;
+    }
+    if (a.startsWith("--pair=")) {
+      pairTokens.push(a);
+      continue;
+    }
+    break; // first non-pair token is the subcommand
+  }
+
+  const command = args[i];
+  const tail = args.slice(i + 1);
+  if (command !== undefined && PAIR_AWARE_COMMANDS.has(command)) {
+    return { command, restArgs: [...pairTokens, ...tail] };
+  }
+  return { command, restArgs: tail };
+}
+
+async function main(command: string | undefined, restArgs: string[]) {
   switch (command) {
     case "init":
       const { runInit } = await import("./cli/init");
@@ -66,36 +106,42 @@ function printHelp() {
 AgentBridge — Multi-agent collaboration bridge
 
 Usage:
-  agentbridge <command> [args...]
-  abg <command> [args...]
+  agentbridge [--pair <name>] <command> [args...]
+  abg [--pair <name>] <command> [args...]
 
 Commands:
   init               Install plugin, check dependencies, generate project config
   dev                Register local marketplace + install plugin (for local dev)
   claude [args...]   Start Claude Code with push channel enabled
   codex [args...]    Start Codex TUI connected to AgentBridge daemon
-  pairs [rm <id>]    List running Claude+Codex pairs (or remove one)
-  kill [--pair <id>] Stop all pairs, or just one with --pair (alias: --all)
+  pairs [rm <name|id>]  List running Claude+Codex pairs (or remove one)
+  kill [--pair <name|id>]  Stop all pairs, or just one with --pair (alias: --all)
 
 Options:
-  --pair <name>      Run claude/codex in a named pair (multiple pairs per machine).
-                     Without it, the pair is derived from the current directory.
+  --pair <name>      Run claude/codex/kill in a named pair. The name is scoped to
+                     the current directory, so the same name in another directory
+                     is a separate pair. Goes BEFORE the command. Without it, the
+                     pair name defaults to "main" for the current directory.
   --help, -h         Show this help message
   --version, -v      Show version
 
 Multi-pair:
   Each pair is an isolated daemon with its own port triple. The first pair uses
-  the classic ports 4500/4501/4502; each additional pair steps +10.
+  the classic ports 4500/4501/4502; each additional pair steps +10. If "main" in
+  this directory already has a live Claude session, "abg claude" errors instead of
+  contesting it — pick another --pair name (or kill the live one first).
 
 Examples:
   abg init                     # First-time setup
-  abg claude                   # Start Claude Code (pair derived from cwd)
-  abg claude --pair work       # Start a named pair "work"
-  abg codex  --pair work       # Connect Codex to the "work" pair
-  abg claude --pair review     # A second, parallel pair
+  abg claude                   # Start the "main" pair for this directory
+  abg codex                    # Connect Codex to this directory's "main" pair
+  abg --pair work claude       # Start a named pair "work" (this directory)
+  abg --pair work codex        # Connect Codex to the "work" pair
+  abg --pair review claude     # A second, parallel pair
   abg pairs                    # List all pairs and their ports/status
-  abg pairs rm work            # Stop the "work" pair and free its slot
-  abg kill --pair work         # Stop only the "work" pair
+  abg pairs rm work            # Stop this directory's "work" pair and free its slot
+  abg pairs rm work-1a2b3c4d   # ...or by its full id (works from any directory)
+  abg --pair work kill         # Stop only this directory's "work" pair
   abg kill                     # Stop ALL pairs
 `.trim());
 }
@@ -109,7 +155,13 @@ function printVersion() {
   }
 }
 
-main().catch((err) => {
-  console.error(`Error: ${err.message}`);
-  process.exit(1);
-});
+// Only dispatch when executed as the CLI entrypoint. cli.ts is also imported as a
+// module (e.g. claude.ts/codex.ts pull MARKETPLACE_NAME, tests pull parseTopLevel);
+// in those cases import.meta.main is false and we must NOT run the command switch.
+if (import.meta.main) {
+  const { command, restArgs } = parseTopLevel(process.argv.slice(2));
+  main(command, restArgs).catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ const REFRESH_COMMANDS = new Set(["claude", "codex"]);
 const NOTIFY_COMMANDS = new Set(["claude", "codex", "init", "dev"]);
 
 /** Subcommands that accept a `--pair <name>` selector. */
-const PAIR_AWARE_COMMANDS = new Set(["claude", "codex", "kill"]);
+const PAIR_AWARE_COMMANDS = new Set(["claude", "codex", "kill", "doctor"]);
 
 /**
  * Split argv into the subcommand and its args, allowing a leading `--pair <name>`
@@ -100,6 +100,10 @@ async function main(command: string | undefined, restArgs: string[]) {
       const { runPairs } = await import("./cli/pairs");
       await runPairs(restArgs);
       break;
+    case "doctor":
+      const { runDoctor } = await import("./cli/doctor");
+      await runDoctor(restArgs);
+      break;
     case "--help":
     case "-h":
     case undefined:
@@ -130,6 +134,8 @@ Commands:
   claude [args...]   Start Claude Code with push channel enabled
   codex [args...]    Start Codex TUI connected to AgentBridge daemon
   pairs [rm <name|id>]  List running Claude+Codex pairs (or remove one)
+  doctor [--json]    Diagnose env, daemon, build drift, logs, and current thread
+  doctor resume-pollution [--apply]  Find/fix old AgentBridge kickoff metadata
   kill [--pair <name|id>]  Stop all pairs, or just one with --pair (alias: --all)
 
 Options:
@@ -154,8 +160,10 @@ Examples:
   abg --pair work codex        # Connect Codex to the "work" pair
   abg --pair review claude     # A second, parallel pair
   abg pairs                    # List all pairs and their ports/status
+  abg pairs --threads          # Include current thread mapping
+  abg doctor --json            # Emit a structured diagnostics report
   abg pairs rm work            # Stop this directory's "work" pair and free its slot
-  abg pairs rm work-1a2b3c4d   # ...or by its full id (works from any directory)
+  abg pairs rm work-1a2b3c4d   # ...or by its full id (from that pair's directory)
   abg --pair work kill         # Stop only this directory's "work" pair
   abg kill                     # Stop ALL pairs
 `.trim());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,10 +11,6 @@
  *   agentbridge kill        — Force kill all AgentBridge processes
  */
 
-const args = process.argv.slice(2);
-const command = args[0];
-const restArgs = args.slice(1);
-
 // Marketplace name constant (shared with plugin)
 export const MARKETPLACE_NAME = "agentbridge";
 export const PLUGIN_NAME = "agentbridge";
@@ -23,7 +19,51 @@ export const PLUGIN_NAME = "agentbridge";
 const REFRESH_COMMANDS = new Set(["claude", "codex"]);
 const NOTIFY_COMMANDS = new Set(["claude", "codex", "init", "dev"]);
 
-async function main() {
+/** Subcommands that accept a `--pair <name>` selector. */
+const PAIR_AWARE_COMMANDS = new Set(["claude", "codex", "kill"]);
+
+/**
+ * Split argv into the subcommand and its args, allowing a leading `--pair <name>`
+ * (or `--pair=<name>`) to appear BEFORE the subcommand:
+ *
+ *   abg --pair work claude --resume   →  command="claude", restArgs=["--pair","work","--resume"]
+ *
+ * The leading pair token(s) are re-attached to the front of the subcommand's args
+ * (only for pair-aware commands), so each command's own `--pair` parser
+ * (parsePairFlag / parseKillArgs) handles BOTH the new leading position and the
+ * classic trailing `abg claude --pair work`. For non-pair-aware commands a leading
+ * `--pair` is dropped (those commands ignore it), preserving prior behaviour.
+ */
+export function parseTopLevel(args: string[]): { command: string | undefined; restArgs: string[] } {
+  const pairTokens: string[] = [];
+  let i = 0;
+  for (; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--pair") {
+      pairTokens.push(a);
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith("-")) {
+        pairTokens.push(next);
+        i++;
+      }
+      continue;
+    }
+    if (a.startsWith("--pair=")) {
+      pairTokens.push(a);
+      continue;
+    }
+    break; // first non-pair token is the subcommand
+  }
+
+  const command = args[i];
+  const tail = args.slice(i + 1);
+  if (command !== undefined && PAIR_AWARE_COMMANDS.has(command)) {
+    return { command, restArgs: [...pairTokens, ...tail] };
+  }
+  return { command, restArgs: tail };
+}
+
+async function main(command: string | undefined, restArgs: string[]) {
   // Best-effort, non-blocking update notice. Fully guarded — never blocks,
   // delays, or fails the command (see src/update-notifier.ts).
   if (command && NOTIFY_COMMANDS.has(command)) {
@@ -81,36 +121,42 @@ function printHelp() {
 AgentBridge — Multi-agent collaboration bridge
 
 Usage:
-  agentbridge <command> [args...]
-  abg <command> [args...]
+  agentbridge [--pair <name>] <command> [args...]
+  abg [--pair <name>] <command> [args...]
 
 Commands:
   init               Install plugin, check dependencies, generate project config
   dev                Register local marketplace + install plugin (for local dev)
   claude [args...]   Start Claude Code with push channel enabled
   codex [args...]    Start Codex TUI connected to AgentBridge daemon
-  pairs [rm <id>]    List running Claude+Codex pairs (or remove one)
-  kill [--pair <id>] Stop all pairs, or just one with --pair (alias: --all)
+  pairs [rm <name|id>]  List running Claude+Codex pairs (or remove one)
+  kill [--pair <name|id>]  Stop all pairs, or just one with --pair (alias: --all)
 
 Options:
-  --pair <name>      Run claude/codex in a named pair (multiple pairs per machine).
-                     Without it, the pair is derived from the current directory.
+  --pair <name>      Run claude/codex/kill in a named pair. The name is scoped to
+                     the current directory, so the same name in another directory
+                     is a separate pair. Goes BEFORE the command. Without it, the
+                     pair name defaults to "main" for the current directory.
   --help, -h         Show this help message
   --version, -v      Show version
 
 Multi-pair:
   Each pair is an isolated daemon with its own port triple. The first pair uses
-  the classic ports 4500/4501/4502; each additional pair steps +10.
+  the classic ports 4500/4501/4502; each additional pair steps +10. If "main" in
+  this directory already has a live Claude session, "abg claude" errors instead of
+  contesting it — pick another --pair name (or kill the live one first).
 
 Examples:
   abg init                     # First-time setup
-  abg claude                   # Start Claude Code (pair derived from cwd)
-  abg claude --pair work       # Start a named pair "work"
-  abg codex  --pair work       # Connect Codex to the "work" pair
-  abg claude --pair review     # A second, parallel pair
+  abg claude                   # Start the "main" pair for this directory
+  abg codex                    # Connect Codex to this directory's "main" pair
+  abg --pair work claude       # Start a named pair "work" (this directory)
+  abg --pair work codex        # Connect Codex to the "work" pair
+  abg --pair review claude     # A second, parallel pair
   abg pairs                    # List all pairs and their ports/status
-  abg pairs rm work            # Stop the "work" pair and free its slot
-  abg kill --pair work         # Stop only the "work" pair
+  abg pairs rm work            # Stop this directory's "work" pair and free its slot
+  abg pairs rm work-1a2b3c4d   # ...or by its full id (works from any directory)
+  abg --pair work kill         # Stop only this directory's "work" pair
   abg kill                     # Stop ALL pairs
 `.trim());
 }
@@ -124,7 +170,13 @@ function printVersion() {
   }
 }
 
-main().catch((err) => {
-  console.error(`Error: ${err.message}`);
-  process.exit(1);
-});
+// Only dispatch when executed as the CLI entrypoint. cli.ts is also imported as a
+// module (e.g. claude.ts/codex.ts pull MARKETPLACE_NAME, tests pull parseTopLevel);
+// in those cases import.meta.main is false and we must NOT run the command switch.
+if (import.meta.main) {
+  const { command, restArgs } = parseTopLevel(process.argv.slice(2));
+  main(command, restArgs).catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { DaemonClient } from "../daemon-client";
 import { DaemonLifecycle } from "../daemon-lifecycle";
+import { parsePositiveIntEnv } from "../env-utils";
 import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
 
 /** Flags that AgentBridge owns and will inject automatically. */
@@ -107,7 +108,17 @@ async function assertPairNotLive(lifecycle: DaemonLifecycle, pair: PairResolutio
   let incumbent: { connected: boolean; alive: boolean };
   try {
     await client.connect();
-    incumbent = await client.probeIncumbent();
+    // The daemon answers `probe_incumbent` only AFTER running its own liveness
+    // ping against the incumbent (up to AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS).
+    // The client must therefore wait LONGER than the daemon's probe, or the two
+    // timeouts race and a live-but-slightly-delayed pong reply is missed (→ the
+    // guard wrongly fails open). Use the SAME parser the daemon uses for this env
+    // (parsePositiveIntEnv — rejects "1.5"/"10abc"/negatives) so the two never
+    // disagree on the value, then add a margin. (If the daemon was started with a
+    // larger override than this process sees, the margin may not fully cover it;
+    // the daemon's own admission probe at attach time remains the backstop.)
+    const daemonProbeMs = parsePositiveIntEnv("AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS", 3000);
+    incumbent = await client.probeIncumbent(daemonProbeMs + 2500);
   } catch {
     return; // probe failed → fail open
   } finally {

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -26,6 +26,8 @@ export async function runClaude(args: string[]) {
     process.exit(1);
   }
 
+  if (pair.warning) console.error(`[agentbridge] ⚠️  ${pair.warning}`);
+
   const stateDir = pair.stateDir;
   const controlPort = pair.ports.controlPort;
   const lifecycle = new DaemonLifecycle({

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
+import { DaemonClient } from "../daemon-client";
 import { DaemonLifecycle } from "../daemon-lifecycle";
 import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
 
@@ -39,6 +40,14 @@ export async function runClaude(args: string[]) {
     );
   }
 
+  // Conflict guard: refuse to launch a SECOND Claude frontend into a pair that
+  // already has a LIVE one (the confirmed "smart" behaviour: live → error here,
+  // stale/none → fall through and let admission take over). Skipped in manual
+  // mode (power-user single-pair). Fail-open on any probe error.
+  if (!pair.manual) {
+    await assertPairNotLive(lifecycle, pair);
+  }
+
   lifecycle.clearKilled();
 
   // Channel entry format: "server:<mcp-server-name>" for MCP-based channels,
@@ -73,6 +82,54 @@ export async function runClaude(args: string[]) {
     console.error(`Error starting Claude Code: ${err.message}`);
     process.exit(1);
   });
+}
+
+/**
+ * Refuse to start a second Claude session in a pair that already has a LIVE one.
+ *
+ * Probes the pair's running daemon (if any) WITHOUT attaching, so it never
+ * contests the incumbent. If a live frontend is found, prints a clear conflict
+ * message and exits — the user picks another `--pair` name or stops the live one.
+ * If there is no daemon, no incumbent, or only a stale (half-open dead) one, it
+ * returns so the launch proceeds; the daemon's admission logic then takes over
+ * the stale slot cleanly. Any probe error fails open (launch proceeds).
+ */
+async function assertPairNotLive(lifecycle: DaemonLifecycle, pair: PairResolution): Promise<void> {
+  let healthy = false;
+  try {
+    healthy = await lifecycle.isHealthy();
+  } catch {
+    return; // can't tell → don't block
+  }
+  if (!healthy) return; // no daemon yet → fresh start, no conflict
+
+  const client = new DaemonClient(lifecycle.controlWsUrl);
+  let incumbent: { connected: boolean; alive: boolean };
+  try {
+    await client.connect();
+    incumbent = await client.probeIncumbent();
+  } catch {
+    return; // probe failed → fail open
+  } finally {
+    try {
+      await client.disconnect();
+    } catch {}
+  }
+
+  if (incumbent.connected && incumbent.alive) {
+    const name = pair.name;
+    console.error(
+      `[agentbridge] Pair "${name}" in ${process.cwd()} already has an active Claude session.`,
+    );
+    console.error(`[agentbridge] Refusing to open a second one in the same pair.`);
+    console.error(`[agentbridge]`);
+    console.error(`[agentbridge]   • Use that existing session, or`);
+    console.error(`[agentbridge]   • Start a different pair:  abg --pair <other-name> claude`);
+    console.error(
+      `[agentbridge]   • If that session is actually dead, take it over with:  abg --pair ${name} kill`,
+    );
+    process.exit(1);
+  }
 }
 
 /**

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -1,22 +1,43 @@
 import { spawn } from "node:child_process";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { DaemonLifecycle } from "../daemon-lifecycle";
-import { StateDirResolver } from "../state-dir";
+import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
 
 /** Flags that AgentBridge owns and will inject automatically. */
 const OWNED_FLAGS = ["--channels", "--dangerously-load-development-channels"];
 
 export async function runClaude(args: string[]) {
-  // Check for owned flag conflicts
-  checkOwnedFlagConflicts(args, "agentbridge claude", OWNED_FLAGS);
+  // Strip `--pair <name>` before anything else; the rest flows through to claude.
+  const { pairFlag, rest } = parsePairFlag(args);
 
-  const stateDir = new StateDirResolver();
-  const controlPort = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
+  // Check for owned flag conflicts (on the real claude args, not the pair flag).
+  checkOwnedFlagConflicts(rest, "agentbridge claude", OWNED_FLAGS);
+
+  // Resolve the pair and inject its env (state dir + ports) BEFORE building the
+  // lifecycle or spawning claude, so the daemon, the spawned `claude`, and its
+  // plugin MCP server all target this pair's state dir + control port.
+  let pair: PairResolution;
+  try {
+    pair = await applyPairEnv({ pairFlag });
+  } catch (err: any) {
+    console.error(`[agentbridge] ${err.message}`);
+    process.exit(1);
+  }
+
+  const stateDir = pair.stateDir;
+  const controlPort = pair.ports.controlPort;
   const lifecycle = new DaemonLifecycle({
     stateDir,
     controlPort,
     log: (msg) => console.error(`[agentbridge] ${msg}`),
   });
+
+  if (!pair.manual) {
+    console.error(
+      `[agentbridge] pair "${pair.pairId}" (slot ${pair.slot}) — control :${controlPort}, ` +
+        `codex :${pair.ports.appPort}/:${pair.ports.proxyPort}`,
+    );
+  }
 
   lifecycle.clearKilled();
 
@@ -31,7 +52,7 @@ export async function runClaude(args: string[]) {
   // Once published to the official marketplace, switch to --channels.
   const fullArgs = [
     "--dangerously-load-development-channels", channelEntry,
-    ...args,
+    ...rest,
   ];
 
   const child = spawn("claude", fullArgs, {

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -2,13 +2,25 @@ import { spawn } from "node:child_process";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { DaemonClient } from "../daemon-client";
 import { DaemonLifecycle } from "../daemon-lifecycle";
+import { BUILD_INFO } from "../build-info";
+import { guardAgentBridgeEnv, normalizeEnvGuardMode } from "../env-guard";
 import { parsePositiveIntEnv } from "../env-utils";
 import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
+import { appendTraceEvent, pickRelevantEnv } from "../trace-log";
 
 /** Flags that AgentBridge owns and will inject automatically. */
 const OWNED_FLAGS = ["--channels", "--dangerously-load-development-channels"];
 
 export async function runClaude(args: string[]) {
+  const originalEnv = { ...process.env };
+  const envGuardResult = guardAgentBridgeEnv({
+    cwd: process.cwd(),
+    env: process.env,
+    mode: normalizeEnvGuardMode(process.env.AGENTBRIDGE_ENV_GUARD),
+    allowStrict: true,
+    log: (msg) => console.error(msg),
+  });
+
   // Strip `--pair <name>` before anything else; the rest flows through to claude.
   const { pairFlag, rest } = parsePairFlag(args);
 
@@ -27,6 +39,9 @@ export async function runClaude(args: string[]) {
   }
 
   if (pair.warning) console.error(`[agentbridge] ⚠️  ${pair.warning}`);
+  if (process.env.AGENTBRIDGE_TRACE === "1") {
+    traceCliStart("cli.claude.start", args, originalEnv, envGuardResult.action, pair);
+  }
 
   const stateDir = pair.stateDir;
   const controlPort = pair.ports.controlPort;
@@ -45,11 +60,10 @@ export async function runClaude(args: string[]) {
 
   // Conflict guard: refuse to launch a SECOND Claude frontend into a pair that
   // already has a LIVE one (the confirmed "smart" behaviour: live → error here,
-  // stale/none → fall through and let admission take over). Skipped in manual
-  // mode (power-user single-pair). Fail-open on any probe error.
-  if (!pair.manual) {
-    await assertPairNotLive(lifecycle, pair);
-  }
+  // stale/none → fall through and let admission take over). Also applies in
+  // explicit manual mode so manual sessions do not silently fight over attach.
+  // Fail-open on any probe error.
+  await assertPairNotLive(lifecycle, pair);
 
   lifecycle.clearKilled();
 
@@ -85,6 +99,38 @@ export async function runClaude(args: string[]) {
     console.error(`Error starting Claude Code: ${err.message}`);
     process.exit(1);
   });
+}
+
+function traceCliStart(
+  event: string,
+  args: string[],
+  originalEnv: NodeJS.ProcessEnv,
+  envGuardAction: string,
+  pair: PairResolution,
+) {
+  try {
+    appendTraceEvent({
+      cwd: process.cwd(),
+      event,
+      pid: process.pid,
+      argv: ["agentbridge", "claude", ...args],
+      env: process.env,
+      data: {
+        originalEnv: pickRelevantEnv(originalEnv),
+        effectiveEnv: pickRelevantEnv(process.env),
+        envGuardAction,
+        pairId: pair.pairId,
+        pairName: pair.name,
+        manual: pair.manual,
+        slot: pair.slot,
+        stateDir: pair.stateDir.dir,
+        ports: pair.ports,
+        build: BUILD_INFO,
+      },
+    });
+  } catch {
+    // Trace logging is diagnostic only.
+  }
 }
 
 /**

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -192,6 +192,8 @@ export async function runCodex(args: string[]) {
     process.exit(1);
   }
 
+  if (pair.warning) console.error(`[agentbridge] ⚠️  ${pair.warning}`);
+
   const stateDir = pair.stateDir;
   const controlPort = pair.ports.controlPort;
 

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -10,9 +10,10 @@ import {
   mkdirSync,
 } from "node:fs";
 import { dirname } from "node:path";
-import { StateDirResolver } from "../state-dir";
 import { ConfigService } from "../config-service";
 import { DaemonLifecycle } from "../daemon-lifecycle";
+import { pairScopedCommand } from "../pair-command";
+import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
 import { StderrRingBuffer } from "../stderr-ring-buffer";
 import { checkOwnedFlagConflicts } from "./claude";
 
@@ -125,19 +126,22 @@ export function buildCodexArgs(userArgs: string[], proxyUrl: string): BuildArgsR
 }
 
 export async function runCodex(args: string[]) {
-  // Check for owned flag conflicts
-  checkOwnedFlagConflicts(args, "agentbridge codex", OWNED_FLAGS);
+  // Strip `--pair <name>` first; the rest flows through to codex.
+  const { pairFlag, rest } = parsePairFlag(args);
+
+  // Check for owned flag conflicts (on the real codex args, not the pair flag).
+  checkOwnedFlagConflicts(rest, "agentbridge codex", OWNED_FLAGS);
 
   // Specifically check for --enable tui_app_server (not all --enable values)
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--enable" && args[i + 1] === "tui_app_server") {
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === "--enable" && rest[i + 1] === "tui_app_server") {
       console.error(`Error: "--enable tui_app_server" is automatically set by agentbridge codex.`);
       console.error("");
       console.error("If you need full control over these flags, use the native command directly:");
       console.error("  codex [your flags here]");
       process.exit(1);
     }
-    if (args[i] === "--enable=tui_app_server") {
+    if (rest[i] === "--enable=tui_app_server") {
       console.error(`Error: "--enable=tui_app_server" is automatically set by agentbridge codex.`);
       console.error("");
       console.error("If you need full control over these flags, use the native command directly:");
@@ -146,16 +150,31 @@ export async function runCodex(args: string[]) {
     }
   }
 
-  const stateDir = new StateDirResolver();
-  const configService = new ConfigService();
-  const config = configService.loadOrDefault();
-  const controlPort = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
+  // Resolve the pair and inject its env BEFORE ensureRunning, so the daemon this
+  // launches binds this pair's Codex app-server / proxy / control ports.
+  let pair: PairResolution;
+  try {
+    pair = await applyPairEnv({ pairFlag });
+  } catch (err: any) {
+    console.error(`[agentbridge] ${err.message}`);
+    process.exit(1);
+  }
+
+  const stateDir = pair.stateDir;
+  const controlPort = pair.ports.controlPort;
 
   const lifecycle = new DaemonLifecycle({
     stateDir,
     controlPort,
     log: (msg) => console.error(`[agentbridge] ${msg}`),
   });
+
+  if (!pair.manual) {
+    console.error(
+      `[agentbridge] pair "${pair.pairId}" (slot ${pair.slot}) — control :${controlPort}, ` +
+        `codex :${pair.ports.appPort}/:${pair.ports.proxyPort}`,
+    );
+  }
 
   // Ensure daemon is running
   console.error("[agentbridge] Ensuring daemon is running...");
@@ -165,7 +184,7 @@ export async function runCodex(args: string[]) {
     console.error("[agentbridge] Daemon is ready.");
   } catch (err: any) {
     console.error(`[agentbridge] Failed to start daemon: ${err.message}`);
-    console.error("[agentbridge] Try: agentbridge kill && agentbridge claude");
+    console.error(`[agentbridge] Try: ${pairScopedCommand("kill")} && ${pairScopedCommand("claude")}`);
     process.exit(1);
   }
 
@@ -175,8 +194,13 @@ export async function runCodex(args: string[]) {
   if (status?.proxyUrl) {
     proxyUrl = status.proxyUrl;
   } else {
-    proxyUrl = `ws://127.0.0.1:${config.codex.proxyPort}`;
-    console.error(`[agentbridge] No daemon status found, using config default: ${proxyUrl}`);
+    // Mirror exactly how the daemon resolves its proxy port (daemon.ts:39):
+    // CODEX_PROXY_PORT (set by applyPairEnv in pair mode; user-set in manual mode)
+    // else the project config. This is correct for BOTH multi-pair (env carries
+    // the slot's port) and manual/legacy mode (config may be a custom port).
+    const fallbackProxyPort = process.env.CODEX_PROXY_PORT ?? String(new ConfigService().loadOrDefault().codex.proxyPort);
+    proxyUrl = `ws://127.0.0.1:${fallbackProxyPort}`;
+    console.error(`[agentbridge] No daemon status found, using fallback proxy port: ${proxyUrl}`);
   }
 
   try {
@@ -239,7 +263,7 @@ export async function runCodex(args: string[]) {
     }
   }
 
-  const { fullArgs } = buildCodexArgs(args, proxyUrl);
+  const { fullArgs } = buildCodexArgs(rest, proxyUrl);
 
   // Capture the last 64KB of child stderr so the "ERROR: ..." line from
   // codex-rs on ExitReason::Fatal survives even when stdio is inherited by

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -4,12 +4,13 @@ import {
   writeSync,
   closeSync,
   writeFileSync,
+  readFileSync,
   unlinkSync,
   appendFileSync,
   existsSync,
   mkdirSync,
 } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { ConfigService } from "../config-service";
 import { DaemonLifecycle } from "../daemon-lifecycle";
 import { pairScopedCommand } from "../pair-command";
@@ -125,9 +126,40 @@ export function buildCodexArgs(userArgs: string[], proxyUrl: string): BuildArgsR
   return { fullArgs: [...bridgeFlags, ...userArgs], injectedBridgeFlags: true };
 }
 
+/**
+ * Best-effort warning when the project's AGENTS.md has an AgentBridge marker block
+ * from an OLDER version that predates the collaboration contract now living in
+ * AGENTS.md. The daemon no longer appends that contract (message markers /
+ * git-write rules / role guidance) to every message, so an un-refreshed AGENTS.md
+ * would leave Codex without it. Read-only; never blocks startup; silent when there
+ * is no block (project simply hasn't been `abg init`-ed in this dir).
+ */
+function warnIfStaleAgentsMdContract(cwd: string): void {
+  try {
+    const agentsPath = join(cwd, "AGENTS.md");
+    if (!existsSync(agentsPath)) return;
+    const content = readFileSync(agentsPath, "utf-8");
+    if (!content.includes("<!-- AgentBridge:start -->")) return; // no block → not an upgrade-drift case
+    if (content.includes("Git operations — FORBIDDEN for you")) return; // already has the new contract
+    console.error(
+      "[agentbridge] ⚠️ Your AGENTS.md AgentBridge block predates the Codex collaboration contract " +
+        "(message markers / git-write rules / role guidance).",
+    );
+    console.error(
+      "[agentbridge]    Re-run `abg init` to refresh it — Codex now relies on AGENTS.md for that contract " +
+        "(it is no longer injected into every message).",
+    );
+  } catch {
+    /* best-effort; never block startup */
+  }
+}
+
 export async function runCodex(args: string[]) {
   // Strip `--pair <name>` first; the rest flows through to codex.
   const { pairFlag, rest } = parsePairFlag(args);
+
+  // Read-only nudge if this project's AGENTS.md contract block is stale (pre-upgrade).
+  warnIfStaleAgentsMdContract(process.cwd());
 
   // Check for owned flag conflicts (on the real codex args, not the pair flag).
   checkOwnedFlagConflicts(rest, "agentbridge codex", OWNED_FLAGS);

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -1,4 +1,5 @@
 import { spawn, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   openSync,
   writeSync,
@@ -6,16 +7,24 @@ import {
   writeFileSync,
   readFileSync,
   unlinkSync,
-  appendFileSync,
   existsSync,
   mkdirSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
+import { checkAgentsMdContract } from "../agents-contract";
 import { ConfigService } from "../config-service";
+import { BUILD_INFO } from "../build-info";
 import { DaemonLifecycle } from "../daemon-lifecycle";
+import { guardAgentBridgeEnv, normalizeEnvGuardMode } from "../env-guard";
 import { pairScopedCommand } from "../pair-command";
+import { appendRotatingLog } from "../rotating-log";
 import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
 import { StderrRingBuffer } from "../stderr-ring-buffer";
+import {
+  readUsableCurrentThread,
+  type CurrentThreadState,
+} from "../thread-state";
+import { appendTraceEvent, pickRelevantEnv, redactArgv } from "../trace-log";
 import { checkOwnedFlagConflicts } from "./claude";
 
 /**
@@ -29,7 +38,7 @@ function appendWrapperLog(path: string, entry: string): void {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
-    appendFileSync(path, `[${new Date().toISOString()}] ${entry}\n`, "utf-8");
+    appendRotatingLog(path, `[${new Date().toISOString()}] ${entry}\n`);
   } catch {
     /* ignore */
   }
@@ -93,6 +102,91 @@ export interface BuildArgsResult {
   injectedBridgeFlags: boolean;
 }
 
+export interface AgentBridgeCodexArgs {
+  rest: string[];
+  forceNew: boolean;
+  resumeCurrent: boolean;
+}
+
+export interface ResolveCodexResumeResult {
+  rest: string[];
+  mode: "new" | "auto-resume" | "resume-current" | "passthrough";
+  thread?: CurrentThreadState;
+  error?: string;
+}
+
+export function parseAgentBridgeCodexArgs(args: string[]): AgentBridgeCodexArgs {
+  const rest: string[] = [];
+  let forceNew = false;
+  let resumeCurrent = false;
+
+  for (const arg of args) {
+    if (arg === "--new") {
+      forceNew = true;
+      continue;
+    }
+    if (arg === "resume-current") {
+      resumeCurrent = true;
+      continue;
+    }
+    rest.push(arg);
+  }
+
+  return { rest, forceNew, resumeCurrent };
+}
+
+export function resolveCodexResumeArgs(
+  parsed: AgentBridgeCodexArgs,
+  pair: PairResolution,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolveCodexResumeResult {
+  if (parsed.forceNew && parsed.resumeCurrent) {
+    return {
+      rest: parsed.rest,
+      mode: "new",
+      error: "`--new` cannot be combined with `resume-current`.",
+    };
+  }
+
+  if (parsed.forceNew) {
+    return { rest: parsed.rest, mode: "new" };
+  }
+
+  const identity = {
+    stateDir: pair.stateDir,
+    pairId: pair.manual ? null : pair.pairId,
+    pairName: pair.name,
+    cwd: process.cwd(),
+  };
+
+  const current = readUsableCurrentThread(identity, env);
+  if (parsed.resumeCurrent) {
+    if (!current) {
+      return {
+        rest: parsed.rest,
+        mode: "resume-current",
+        error:
+          "No verified current Codex thread for this pair. Start a new one with `abg codex --new`, or resume a specific thread with `abg codex resume <threadId>`.",
+      };
+    }
+    return {
+      rest: ["resume", current.threadId, ...parsed.rest],
+      mode: "resume-current",
+      thread: current,
+    };
+  }
+
+  if (parsed.rest.length === 0 && current) {
+    return {
+      rest: ["resume", current.threadId],
+      mode: "auto-resume",
+      thread: current,
+    };
+  }
+
+  return { rest: parsed.rest, mode: "passthrough" };
+}
+
 /**
  * Build the final codex command-line arguments, positioning bridge flags so
  * clap parses them as options of the actually-invoked (sub)command.
@@ -126,54 +220,40 @@ export function buildCodexArgs(userArgs: string[], proxyUrl: string): BuildArgsR
   return { fullArgs: [...bridgeFlags, ...userArgs], injectedBridgeFlags: true };
 }
 
-/**
- * Best-effort warning when the project's AGENTS.md has an AgentBridge marker block
- * from an OLDER version that predates the collaboration contract now living in
- * AGENTS.md. The daemon no longer appends that contract (message markers /
- * git-write rules / role guidance) to every message, so an un-refreshed AGENTS.md
- * would leave Codex without it. Read-only; never blocks startup; silent when there
- * is no block (project simply hasn't been `abg init`-ed in this dir).
- */
-function warnIfStaleAgentsMdContract(cwd: string): void {
-  try {
-    const agentsPath = join(cwd, "AGENTS.md");
-    if (!existsSync(agentsPath)) return;
-    const content = readFileSync(agentsPath, "utf-8");
-    if (!content.includes("<!-- AgentBridge:start -->")) return; // no block → not an upgrade-drift case
-    if (content.includes("Git operations — FORBIDDEN for you")) return; // already has the new contract
-    console.error(
-      "[agentbridge] ⚠️ Your AGENTS.md AgentBridge block predates the Codex collaboration contract " +
-        "(message markers / git-write rules / role guidance).",
-    );
-    console.error(
-      "[agentbridge]    Re-run `abg init` to refresh it — Codex now relies on AGENTS.md for that contract " +
-        "(it is no longer injected into every message).",
-    );
-  } catch {
-    /* best-effort; never block startup */
-  }
-}
-
 export async function runCodex(args: string[]) {
+  const originalEnv = { ...process.env };
+  const envGuardResult = guardAgentBridgeEnv({
+    cwd: process.cwd(),
+    env: process.env,
+    mode: normalizeEnvGuardMode(process.env.AGENTBRIDGE_ENV_GUARD),
+    allowStrict: true,
+    log: (msg) => console.error(msg),
+  });
+
   // Strip `--pair <name>` first; the rest flows through to codex.
   const { pairFlag, rest } = parsePairFlag(args);
+  const wrapperArgs = parseAgentBridgeCodexArgs(rest);
 
-  // Read-only nudge if this project's AGENTS.md contract block is stale (pre-upgrade).
-  warnIfStaleAgentsMdContract(process.cwd());
+  // AGENTS.md is managed exclusively by `abg init`. Startup never writes or
+  // blocks on it — only nudge once on stderr if the contract is missing/stale.
+  const agentsContract = checkAgentsMdContract(process.cwd());
+  if (!agentsContract.fresh) {
+    console.error(`[agentbridge] ${agentsContract.message}`);
+  }
 
-  // Check for owned flag conflicts (on the real codex args, not the pair flag).
-  checkOwnedFlagConflicts(rest, "agentbridge codex", OWNED_FLAGS);
+  // Check for owned flag conflicts (on the real codex args, not the pair flag or wrapper flags).
+  checkOwnedFlagConflicts(wrapperArgs.rest, "agentbridge codex", OWNED_FLAGS);
 
   // Specifically check for --enable tui_app_server (not all --enable values)
-  for (let i = 0; i < rest.length; i++) {
-    if (rest[i] === "--enable" && rest[i + 1] === "tui_app_server") {
+  for (let i = 0; i < wrapperArgs.rest.length; i++) {
+    if (wrapperArgs.rest[i] === "--enable" && wrapperArgs.rest[i + 1] === "tui_app_server") {
       console.error(`Error: "--enable tui_app_server" is automatically set by agentbridge codex.`);
       console.error("");
       console.error("If you need full control over these flags, use the native command directly:");
       console.error("  codex [your flags here]");
       process.exit(1);
     }
-    if (rest[i] === "--enable=tui_app_server") {
+    if (wrapperArgs.rest[i] === "--enable=tui_app_server") {
       console.error(`Error: "--enable=tui_app_server" is automatically set by agentbridge codex.`);
       console.error("");
       console.error("If you need full control over these flags, use the native command directly:");
@@ -193,9 +273,13 @@ export async function runCodex(args: string[]) {
   }
 
   if (pair.warning) console.error(`[agentbridge] ⚠️  ${pair.warning}`);
+  if (process.env.AGENTBRIDGE_TRACE === "1") {
+    traceCliStart("cli.codex.start", args, originalEnv, envGuardResult.action, pair);
+  }
 
   const stateDir = pair.stateDir;
   const controlPort = pair.ports.controlPort;
+  guardNoLiveManagedTui(stateDir);
 
   const lifecycle = new DaemonLifecycle({
     stateDir,
@@ -297,7 +381,16 @@ export async function runCodex(args: string[]) {
     }
   }
 
-  const { fullArgs } = buildCodexArgs(rest, proxyUrl);
+  const resumeArgs = resolveCodexResumeArgs(wrapperArgs, pair);
+  if (resumeArgs.error) {
+    console.error(`[agentbridge] ${resumeArgs.error}`);
+    process.exit(1);
+  }
+  if (resumeArgs.mode === "auto-resume" || resumeArgs.mode === "resume-current") {
+    console.error(`[agentbridge] Resuming current Codex thread ${resumeArgs.thread!.threadId}`);
+  }
+
+  const { fullArgs } = buildCodexArgs(resumeArgs.rest, proxyUrl);
 
   // Capture the last 64KB of child stderr so the "ERROR: ..." line from
   // codex-rs on ExitReason::Fatal survives even when stdio is inherited by
@@ -309,7 +402,7 @@ export async function runCodex(args: string[]) {
   stateDir.ensure();
   appendWrapperLog(
     wrapperLogPath,
-    `spawn: codex ${fullArgs.map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}`,
+    `spawn: codex ${redactArgv(fullArgs).map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}`,
   );
 
   const child = spawn("codex", fullArgs, {
@@ -399,6 +492,90 @@ export async function runCodex(args: string[]) {
     console.error(`Error starting Codex: ${err.message}`);
     process.exit(1);
   });
+}
+
+function traceCliStart(
+  event: string,
+  args: string[],
+  originalEnv: NodeJS.ProcessEnv,
+  envGuardAction: string,
+  pair: PairResolution,
+) {
+  try {
+    appendTraceEvent({
+      cwd: process.cwd(),
+      event,
+      pid: process.pid,
+      argv: ["agentbridge", "codex", ...args],
+      env: process.env,
+      data: {
+        originalEnv: pickRelevantEnv(originalEnv),
+        effectiveEnv: pickRelevantEnv(process.env),
+        envGuardAction,
+        pairId: pair.pairId,
+        pairName: pair.name,
+        manual: pair.manual,
+        slot: pair.slot,
+        stateDir: pair.stateDir.dir,
+        ports: pair.ports,
+        build: BUILD_INFO,
+      },
+    });
+  } catch {
+    // Trace logging is diagnostic only.
+  }
+}
+
+function guardNoLiveManagedTui(stateDir: PairResolution["stateDir"]) {
+  const pid = readTuiPid(stateDir);
+  if (!pid) return;
+  if (!isProcessAlive(pid)) {
+    try { unlinkSync(stateDir.tuiPidFile); } catch {}
+    return;
+  }
+  if (!isManagedCodexTuiProcess(pid)) {
+    appendWrapperLog(stateDir.codexWrapperLogFile, `stale tui pid file pointed at unmanaged live pid=${pid}; removing`);
+    try { unlinkSync(stateDir.tuiPidFile); } catch {}
+    return;
+  }
+
+  console.error(`[agentbridge] This pair already has a managed Codex TUI running (pid ${pid}).`);
+  console.error(`[agentbridge] Use that terminal, or stop it with: ${pairScopedCommand("kill")}`);
+  process.exit(1);
+}
+
+function readTuiPid(stateDir: PairResolution["stateDir"]): number | null {
+  try {
+    const raw = readFileSync(stateDir.tuiPidFile, "utf-8").trim();
+    if (!raw) return null;
+    const pid = Number.parseInt(raw, 10);
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isManagedCodexTuiProcess(pid: number): boolean {
+  try {
+    const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
+    return (
+      cmd.includes("codex") &&
+      cmd.includes("--enable") &&
+      cmd.includes("tui_app_server") &&
+      cmd.includes("--remote")
+    );
+  } catch {
+    return false;
+  }
 }
 
 function proxyHealthUrl(proxyUrl: string): string {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,222 @@
+import { existsSync, statSync } from "node:fs";
+import { BUILD_INFO, formatBuildInfo, sameRuntimeContract } from "../build-info";
+import { inspectAgentBridgeEnv } from "../env-guard";
+import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
+import { readRawCurrentThread, readUsableCurrentThread } from "../thread-state";
+import { scanResumePollution } from "../resume-pollution";
+import type { DaemonStatus } from "../control-protocol";
+
+type CheckStatus = "ok" | "warn" | "fail";
+
+interface DoctorCheck {
+  name: string;
+  status: CheckStatus;
+  detail: string;
+}
+
+interface DoctorReport {
+  cwd: string;
+  pair: {
+    pairId: string;
+    name: string;
+    manual: boolean;
+    slot: number | null;
+    stateDir: string;
+    ports: PairResolution["ports"];
+  };
+  env: ReturnType<typeof inspectAgentBridgeEnv>;
+  daemon: {
+    health: DaemonStatus | null;
+    ready: DaemonStatus | null;
+    buildDrift: boolean | null;
+  };
+  checks: DoctorCheck[];
+}
+
+export async function runDoctor(args: string[] = []) {
+  if (args[0] === "resume-pollution") {
+    runResumePollution(args.slice(1));
+    return;
+  }
+
+  const json = args.includes("--json");
+  const agent = args.includes("--agent");
+  const { pairFlag, rest } = parsePairFlag(args.filter((arg) => arg !== "--json" && arg !== "--agent"));
+  const unknown = rest.filter((arg) => arg.startsWith("-"));
+  if (unknown.length > 0) {
+    console.error(`Unknown doctor option(s): ${unknown.join(", ")}`);
+    console.error("Usage: abg doctor [--pair <name|id>] [--json] [--agent]");
+    process.exit(1);
+  }
+
+  let pair: PairResolution;
+  try {
+    pair = await applyPairEnv({ pairFlag });
+  } catch (err: any) {
+    console.error(`[agentbridge] ${err.message}`);
+    process.exit(1);
+  }
+
+  const report = await buildDoctorReport(pair);
+  if (agent) {
+    report.checks.push({
+      name: "agent backend",
+      status: "warn",
+      detail: "--agent is reserved for read-only delegated analysis; static diagnostics were run locally in this build.",
+    });
+  }
+
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  printDoctorReport(report);
+}
+
+function runResumePollution(args: string[]) {
+  const json = args.includes("--json");
+  const apply = args.includes("--apply");
+  const codexHomeIndex = args.indexOf("--codex-home");
+  const codexHome = codexHomeIndex >= 0 ? args[codexHomeIndex + 1] : undefined;
+  if (codexHomeIndex >= 0 && !codexHome) {
+    console.error("Usage: abg doctor resume-pollution [--json] [--apply] [--codex-home <path>]");
+    process.exit(1);
+  }
+  const report = scanResumePollution({ codexHome, apply });
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  const renameCount = report.candidates.filter((c) => c.action === "rename").length;
+  const deleteCount = report.candidates.filter((c) => c.action === "delete").length;
+  console.log(
+    `Resume pollution scan: ${report.candidates.length} candidate(s) ` +
+      `(${renameCount} rename, ${deleteCount} delete) from ${report.dbPath}`,
+  );
+  if (report.backupDir) console.log(`Backup: ${report.backupDir}`);
+  for (const candidate of report.candidates) {
+    if (candidate.action === "delete") {
+      const verb = apply ? "deleted" : "would delete";
+      console.log(`${verb} ${candidate.id}: ${candidate.reason}`);
+    } else {
+      const verb = apply ? "updated" : "would rename";
+      console.log(`${verb} ${candidate.id}: ${candidate.reason}`);
+      console.log(`  title: ${candidate.replacementTitle}`);
+    }
+  }
+  if (apply) {
+    console.log(`Applied: ${report.renamed} renamed, ${report.deleted} deleted.`);
+  } else if (report.candidates.length > 0) {
+    console.log(
+      "Dry-run only. Re-run with --apply to rename/delete Codex sessions after backing up state.",
+    );
+  }
+}
+
+async function buildDoctorReport(pair: PairResolution): Promise<DoctorReport> {
+  const cwd = process.cwd();
+  const env = inspectAgentBridgeEnv({ cwd, env: process.env });
+  const health = await fetchDaemonStatus(pair.ports.controlPort, "/healthz");
+  const ready = await fetchDaemonStatus(pair.ports.controlPort, "/readyz");
+  // Drift keys on the runtime contract (version/commit/contractVersion), not the
+  // bundle kind — a dist daemon vs a plugin launcher is not real drift.
+  const buildDrift = health?.build ? !sameRuntimeContract(health.build, BUILD_INFO) : health ? true : null;
+  const rawThread = readRawCurrentThread(pair.stateDir);
+  const usableThread = readUsableCurrentThread({
+    stateDir: pair.stateDir,
+    pairId: pair.manual ? null : pair.pairId,
+    pairName: pair.name,
+    cwd,
+  });
+
+  const checks: DoctorCheck[] = [];
+  checks.push({
+    name: "env",
+    status: env.ok ? "ok" : "fail",
+    detail: env.ok ? "AgentBridge env matches cwd" : env.reasons.join("; "),
+  });
+  checks.push({
+    name: "daemon health",
+    status: health ? "ok" : "warn",
+    detail: health ? `healthz reachable pid=${health.pid}` : `no daemon reachable on :${pair.ports.controlPort}`,
+  });
+  checks.push({
+    name: "daemon readiness",
+    status: ready ? "ok" : health ? "warn" : "warn",
+    detail: ready ? `ready thread=${ready.threadId ?? "none"}` : "readyz is not OK",
+  });
+  checks.push({
+    name: "build drift",
+    status: buildDrift === false ? "ok" : buildDrift === true ? "fail" : "warn",
+    detail:
+      buildDrift === false
+        ? `runtime matches launcher ${formatBuildInfo(BUILD_INFO)}`
+        : buildDrift === true
+          ? `runtime ${formatBuildInfo(health?.build)} differs from launcher ${formatBuildInfo(BUILD_INFO)}`
+          : "daemon build unavailable because daemon is not reachable",
+  });
+  checks.push({
+    name: "current thread",
+    status: usableThread ? "ok" : rawThread ? "warn" : "warn",
+    detail: usableThread
+      ? `current=${usableThread.threadId}`
+      : rawThread
+        ? `stored ${rawThread.threadId} is ${rawThread.status} or missing rollout`
+        : "no current-thread.json for this pair",
+  });
+
+  for (const [name, path] of [
+    ["daemon log", pair.stateDir.logFile],
+    ["codex wrapper log", pair.stateDir.codexWrapperLogFile],
+  ] as const) {
+    checks.push(logCheck(name, path));
+  }
+
+  return {
+    cwd,
+    pair: {
+      pairId: pair.pairId,
+      name: pair.name,
+      manual: pair.manual,
+      slot: pair.slot,
+      stateDir: pair.stateDir.dir,
+      ports: pair.ports,
+    },
+    env,
+    daemon: { health, ready, buildDrift },
+    checks,
+  };
+}
+
+function logCheck(name: string, path: string): DoctorCheck {
+  if (!existsSync(path)) {
+    return { name, status: "warn", detail: `missing: ${path}` };
+  }
+  const stat = statSync(path);
+  return { name, status: "ok", detail: `${path} (${stat.size} bytes)` };
+}
+
+async function fetchDaemonStatus(port: number, path: "/healthz" | "/readyz"): Promise<DaemonStatus | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 500);
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, { signal: controller.signal });
+    if (!response.ok) return null;
+    return (await response.json()) as DaemonStatus;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function printDoctorReport(report: DoctorReport) {
+  console.log(`AgentBridge doctor: ${report.pair.pairId}`);
+  console.log(`cwd: ${report.cwd}`);
+  console.log(`state: ${report.pair.stateDir}`);
+  console.log(`ports: ${report.pair.ports.appPort}/${report.pair.ports.proxyPort}/${report.pair.ports.controlPort}`);
+  for (const check of report.checks) {
+    console.log(`${check.status.toUpperCase().padEnd(4)} ${check.name}: ${check.detail}`);
+  }
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -5,6 +5,7 @@ import { ConfigService } from "../config-service";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { findPackageRoot, registerMarketplace } from "./pkg-root";
 import { upsertMarkedSection } from "../marker-section";
+import { compareVersions } from "../version-utils";
 import {
   MARKER_ID,
   CLAUDE_MD_SECTION,
@@ -113,19 +114,6 @@ function checkCodex() {
     console.error("  Install Codex: https://github.com/openai/codex");
     process.exit(1);
   }
-}
-
-/** Compare semver strings. Returns -1, 0, or 1. */
-function compareVersions(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {
-    const va = pa[i] ?? 0;
-    const vb = pb[i] ?? 0;
-    if (va < vb) return -1;
-    if (va > vb) return 1;
-  }
-  return 0;
 }
 
 /**

--- a/src/cli/kill.ts
+++ b/src/cli/kill.ts
@@ -5,7 +5,7 @@ import { DaemonLifecycle, isProcessAlive } from "../daemon-lifecycle";
 import { PairError, detectLegacyRootDaemon, type PairEntry, type PairPorts } from "../pair-registry";
 import {
   computeBaseDir,
-  findPair,
+  findPairForFlag,
   listPairs,
   parseKillArgs,
   portsForEntry,
@@ -46,13 +46,22 @@ export async function runKill(args: string[] = []) {
   const results: StopResult[] = [];
   let restartCommand = "agentbridge claude";
   if (parsed.pairFlag !== undefined) {
-    const pair = findPair(base, parsed.pairFlag);
+    // The friendly name is scoped to the current directory (same name elsewhere
+    // is a different pair); findPairForFlag composes it with the cwd, falling
+    // back to a raw pairId match for ids copied from `abg pairs`.
+    let pair: PairEntry | null;
+    try {
+      pair = findPairForFlag(base, process.cwd(), parsed.pairFlag);
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
     if (!pair) {
-      console.log(`No such pair: ${parsed.pairFlag}`);
+      console.log(`No such pair: "${parsed.pairFlag}" in ${process.cwd()}`);
       printKnownPairs(base);
       return;
     }
-    restartCommand = `agentbridge claude --pair ${parsed.pairFlag}`;
+    restartCommand = `agentbridge --pair ${pair.name ?? parsed.pairFlag} claude`;
     results.push(await stopPairEntry(base, pair));
   } else {
     for (const pair of listPairs(base)) {
@@ -98,14 +107,15 @@ function validateKillArgs(args: string[]): string | "help" | null {
 function printKillUsage() {
   console.log(`
 Usage: abg kill [--all]
-       abg kill --pair <id>
+       abg [--pair <name|id>] kill
 
 Stops AgentBridge daemon/TUI processes.
 
 Options:
-  --pair <id>   Stop only one registered pair.
-  --all         Stop all registered pairs and any legacy-root daemon.
-  --help, -h    Show this help message.
+  --pair <name|id>  Stop only one pair — a cwd-scoped name (e.g. "main") or a
+                    full pair id from "abg pairs".
+  --all             Stop all registered pairs and any legacy-root daemon.
+  --help, -h        Show this help message.
 
 No arguments are equivalent to --all.
 `.trim());
@@ -179,7 +189,7 @@ function printSummary(results: StopResult[], restartCommand: string) {
   if (failed > 0) {
     console.log(`${failed} target${failed === 1 ? "" : "s"} reported errors; see log lines above.`);
   }
-  console.log("Registry entries were preserved. Use `abg pairs rm <id>` to stop and release a slot.");
+  console.log("Registry entries were preserved. Use `abg pairs rm <name|id>` to stop and release a slot.");
 }
 
 async function killManagedCodexTui(

--- a/src/cli/kill.ts
+++ b/src/cli/kill.ts
@@ -1,39 +1,190 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync, unlinkSync } from "node:fs";
-import { StateDirResolver } from "../state-dir";
+import { join } from "node:path";
 import { DaemonLifecycle, isProcessAlive } from "../daemon-lifecycle";
+import { PairError, detectLegacyRootDaemon, type PairEntry, type PairPorts } from "../pair-registry";
+import {
+  computeBaseDir,
+  findPair,
+  listPairs,
+  parseKillArgs,
+  portsForEntry,
+} from "../pair-resolver";
+import { StateDirResolver } from "../state-dir";
 
-export async function runKill() {
-  console.log("AgentBridge Kill — stopping daemon and managed Codex TUI\n");
+type LogFn = (msg: string) => void;
 
-  const stateDir = new StateDirResolver();
-  const controlPort = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
+export interface StopResult {
+  label: string;
+  daemonKilled: boolean;
+  tuiKilled: boolean;
+  error?: unknown;
+}
 
-  const lifecycle = new DaemonLifecycle({
-    stateDir,
-    controlPort,
-    log: (msg) => console.log(`  ${msg}`),
-  });
-
-  // Mark the daemon as intentionally stopped before terminating the process.
-  // This closes the reconnect race where the frontend sees the disconnect
-  // before the sentinel is written and relaunches the daemon.
-  lifecycle.markKilled();
-  const tuiKilled = await killManagedCodexTui(stateDir, (msg) => console.log(`  ${msg}`));
-  const killed = await lifecycle.kill();
-
-  if (killed || tuiKilled) {
-    console.log("\nAgentBridge stopped.");
-    console.log("Please restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to fully disconnect.");
-  } else {
-    console.log("\nNo running AgentBridge daemon or managed Codex TUI found.");
-    console.log("Stale state files cleaned up (if any).");
+export async function runKill(args: string[] = []) {
+  const argError = validateKillArgs(args);
+  if (argError === "help") {
+    printKillUsage();
+    return;
   }
+  if (argError) {
+    console.error(`Error: ${argError}`);
+    printKillUsage();
+    process.exit(1);
+  }
+
+  const parsed = parseKillArgs(args);
+
+  if (parsed.pairFlag !== undefined && parsed.all) {
+    console.error('Error: use either "--pair <name>" or "--all", not both.');
+    process.exit(1);
+  }
+
+  const base = computeBaseDir();
+  console.log("AgentBridge Kill — stopping AgentBridge pair processes\n");
+
+  const results: StopResult[] = [];
+  let restartCommand = "agentbridge claude";
+  if (parsed.pairFlag !== undefined) {
+    const pair = findPair(base, parsed.pairFlag);
+    if (!pair) {
+      console.log(`No such pair: ${parsed.pairFlag}`);
+      printKnownPairs(base);
+      return;
+    }
+    restartCommand = `agentbridge claude --pair ${parsed.pairFlag}`;
+    results.push(await stopPairEntry(base, pair));
+  } else {
+    for (const pair of listPairs(base)) {
+      results.push(await stopPairEntry(base, pair));
+    }
+    const legacy = detectLegacyRootDaemon(base);
+    if (legacy) {
+      results.push(await stopStateDir("(legacy-root)", new StateDirResolver(base), {
+        appPort: 4500,
+        proxyPort: 4501,
+        controlPort: legacy.controlPort,
+      }));
+    }
+  }
+
+  printSummary(results, restartCommand);
+}
+
+function validateKillArgs(args: string[]): string | "help" | null {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--help" || arg === "-h") return "help";
+    if (arg === "--all") continue;
+    if (arg === "--pair") {
+      const value = args[i + 1];
+      if (value === undefined || value.startsWith("-")) {
+        return 'Missing value for "--pair".';
+      }
+      i++;
+      continue;
+    }
+    if (arg.startsWith("--pair=")) {
+      if (arg.slice("--pair=".length).length === 0) {
+        return 'Missing value for "--pair".';
+      }
+      continue;
+    }
+    return `Unknown kill argument: ${arg}`;
+  }
+  return null;
+}
+
+function printKillUsage() {
+  console.log(`
+Usage: abg kill [--all]
+       abg kill --pair <id>
+
+Stops AgentBridge daemon/TUI processes.
+
+Options:
+  --pair <id>   Stop only one registered pair.
+  --all         Stop all registered pairs and any legacy-root daemon.
+  --help, -h    Show this help message.
+
+No arguments are equivalent to --all.
+`.trim());
+}
+
+export async function stopPairEntry(base: string, pair: PairEntry): Promise<StopResult> {
+  const ports = portsForEntry(pair);
+  const stateDir = new StateDirResolver(join(base, "pairs", pair.pairId));
+  return stopStateDir(pair.pairId, stateDir, ports);
+}
+
+async function stopStateDir(label: string, stateDir: StateDirResolver, ports: PairPorts): Promise<StopResult> {
+  const prefix = `  [${label} ${ports.appPort}/${ports.proxyPort}/${ports.controlPort}]`;
+  const log: LogFn = (msg) => console.log(`${prefix} ${msg}`);
+
+  console.log(`${prefix} stopping`);
+  try {
+    const lifecycle = new DaemonLifecycle({
+      stateDir,
+      controlPort: ports.controlPort,
+      log,
+    });
+
+    lifecycle.markKilled();
+    const tuiKilled = await killManagedCodexTui(stateDir, log);
+    const daemonKilled = await lifecycle.kill();
+    return { label, daemonKilled, tuiKilled };
+  } catch (error) {
+    log(`ERROR: ${error instanceof Error ? error.message : String(error)}`);
+    return { label, daemonKilled: false, tuiKilled: false, error };
+  }
+}
+
+function printKnownPairs(base: string) {
+  try {
+    const pairs = listPairs(base);
+    if (pairs.length === 0) {
+      console.log("No pairs registered.");
+      return;
+    }
+    console.log("Known pairs:");
+    for (const pair of pairs) {
+      const ports = portsForEntry(pair);
+      console.log(`  ${pair.pairId} (slot ${pair.slot}, ports ${ports.appPort}/${ports.proxyPort}/${ports.controlPort})`);
+    }
+  } catch (error) {
+    if (error instanceof PairError) {
+      console.log(`Could not read pair registry: ${error.message}`);
+      return;
+    }
+    throw error;
+  }
+}
+
+function printSummary(results: StopResult[], restartCommand: string) {
+  if (results.length === 0) {
+    console.log("No pairs registered.");
+    return;
+  }
+
+  const stopped = results.filter((r) => r.daemonKilled || r.tuiKilled).length;
+  const failed = results.filter((r) => r.error).length;
+  console.log("");
+  if (stopped > 0) {
+    console.log("AgentBridge stopped.");
+    console.log(`Please restart Claude Code (\`${restartCommand}\`), switch to a new conversation, or run \`/resume\` to fully disconnect.`);
+  } else {
+    console.log("No running AgentBridge daemon or managed Codex TUI found.");
+  }
+  console.log(`Stopped ${stopped}/${results.length} target${results.length === 1 ? "" : "s"}.`);
+  if (failed > 0) {
+    console.log(`${failed} target${failed === 1 ? "" : "s"} reported errors; see log lines above.`);
+  }
+  console.log("Registry entries were preserved. Use `abg pairs rm <id>` to stop and release a slot.");
 }
 
 async function killManagedCodexTui(
   stateDir: StateDirResolver,
-  log: (msg: string) => void,
+  log: LogFn,
   gracefulTimeoutMs = 3000,
 ): Promise<boolean> {
   const pid = readTuiPid(stateDir);
@@ -103,10 +254,10 @@ function isManagedCodexTuiProcess(pid: number): boolean {
   try {
     const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
     return (
-      cmd.includes("codex")
-      && cmd.includes("--enable")
-      && cmd.includes("tui_app_server")
-      && cmd.includes("--remote")
+      cmd.includes("codex") &&
+      cmd.includes("--enable") &&
+      cmd.includes("tui_app_server") &&
+      cmd.includes("--remote")
     );
   } catch {
     return false;

--- a/src/cli/kill.ts
+++ b/src/cli/kill.ts
@@ -48,7 +48,7 @@ export async function runKill(args: string[] = []) {
   if (parsed.pairFlag !== undefined) {
     // The friendly name is scoped to the current directory (same name elsewhere
     // is a different pair); findPairForFlag composes it with the cwd, falling
-    // back to a raw pairId match for ids copied from `abg pairs`.
+    // back to a raw pairId match for an id copied from `abg pairs` — same cwd only.
     let pair: PairEntry | null;
     try {
       pair = findPairForFlag(base, process.cwd(), parsed.pairFlag);
@@ -112,8 +112,8 @@ Usage: abg kill [--all]
 Stops AgentBridge daemon/TUI processes.
 
 Options:
-  --pair <name|id>  Stop only one pair — a cwd-scoped name (e.g. "main") or a
-                    full pair id from "abg pairs".
+  --pair <name|id>  Stop only one pair — a cwd-scoped name (e.g. "main") or the
+                    same pair id when run from that directory.
   --all             Stop all registered pairs and any legacy-root daemon.
   --help, -h        Show this help message.
 

--- a/src/cli/pairs.ts
+++ b/src/cli/pairs.ts
@@ -3,7 +3,7 @@ import { DaemonLifecycle } from "../daemon-lifecycle";
 import { detectLegacyRootDaemon, type PairEntry, type PairPorts } from "../pair-registry";
 import {
   computeBaseDir,
-  findPair,
+  findPairForFlag,
   listPairs,
   portsForEntry,
   removePair,
@@ -13,6 +13,7 @@ import { stopPairEntry } from "./kill";
 
 interface PairRow {
   pairId: string;
+  name: string;
   slot: number | null;
   ports: PairPorts;
   source: PairEntry["source"] | "legacy";
@@ -31,7 +32,7 @@ export async function runPairs(args: string[] = []) {
 
   if (command && command !== "list" && command !== "--json") {
     console.error(`Unknown pairs command: ${command}`);
-    console.error("Usage: abg pairs [--json] | abg pairs rm <id>");
+    console.error("Usage: abg pairs [--json] | abg pairs rm <name|id>");
     process.exit(1);
   }
 
@@ -45,16 +46,24 @@ export async function runPairs(args: string[] = []) {
 }
 
 async function runRemove(args: string[]) {
-  const pairId = args[0];
-  if (!pairId) {
-    console.error("Error: `abg pairs rm <id>` requires a pair id.");
+  const flag = args[0];
+  if (!flag) {
+    console.error("Error: `abg pairs rm <name|id>` requires a pair name or id.");
     process.exit(1);
   }
 
   const base = computeBaseDir();
-  const pair = findPair(base, pairId);
+  // Accept a cwd-scoped friendly name (e.g. "work") OR a raw composite id copied
+  // from `abg pairs` — same resolution kill uses, for consistency.
+  let pair: PairEntry | null;
+  try {
+    pair = findPairForFlag(base, process.cwd(), flag);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
   if (!pair) {
-    console.log(`No such pair: ${pairId}`);
+    console.log(`No such pair: "${flag}" in ${process.cwd()}`);
     printKnownPairs(base);
     return;
   }
@@ -75,6 +84,7 @@ async function collectRows(): Promise<PairRow[]> {
   if (legacy) {
     rows.push({
       pairId: "(legacy-root)",
+      name: "-",
       slot: null,
       ports: { appPort: 4500, proxyPort: 4501, controlPort: legacy.controlPort },
       source: "legacy",
@@ -101,6 +111,7 @@ async function rowForPair(base: string, pair: PairEntry): Promise<PairRow> {
 
   return {
     pairId: pair.pairId,
+    name: pair.name ?? "-",
     slot: pair.slot,
     ports,
     source: pair.source,
@@ -117,6 +128,7 @@ function printTable(rows: PairRow[]) {
   }
 
   const data = rows.map((row) => ({
+    name: row.name,
     pairId: row.pairId,
     slot: row.slot === null ? "-" : String(row.slot),
     ports: `${row.ports.appPort}/${row.ports.proxyPort}/${row.ports.controlPort}`,
@@ -127,6 +139,7 @@ function printTable(rows: PairRow[]) {
   }));
 
   const headers = {
+    name: "name",
     pairId: "pairId",
     slot: "slot",
     ports: "app/proxy/control",
@@ -147,6 +160,7 @@ function printTable(rows: PairRow[]) {
 
   const line = (row: Record<keyof typeof headers, string>) =>
     [
+      row.name.padEnd(widths.name),
       row.pairId.padEnd(widths.pairId),
       row.slot.padEnd(widths.slot),
       row.ports.padEnd(widths.ports),
@@ -159,6 +173,7 @@ function printTable(rows: PairRow[]) {
   console.log(line(headers));
   console.log(
     [
+      "-".repeat(widths.name),
       "-".repeat(widths.pairId),
       "-".repeat(widths.slot),
       "-".repeat(widths.ports),

--- a/src/cli/pairs.ts
+++ b/src/cli/pairs.ts
@@ -1,0 +1,186 @@
+import { join } from "node:path";
+import { DaemonLifecycle } from "../daemon-lifecycle";
+import { detectLegacyRootDaemon, type PairEntry, type PairPorts } from "../pair-registry";
+import {
+  computeBaseDir,
+  findPair,
+  listPairs,
+  portsForEntry,
+  removePair,
+} from "../pair-resolver";
+import { StateDirResolver } from "../state-dir";
+import { stopPairEntry } from "./kill";
+
+interface PairRow {
+  pairId: string;
+  slot: number | null;
+  ports: PairPorts;
+  source: PairEntry["source"] | "legacy";
+  cwd: string;
+  running: boolean;
+  pid: number | null;
+}
+
+export async function runPairs(args: string[] = []) {
+  const [command, ...rest] = args;
+
+  if (command === "rm") {
+    await runRemove(rest);
+    return;
+  }
+
+  if (command && command !== "list" && command !== "--json") {
+    console.error(`Unknown pairs command: ${command}`);
+    console.error("Usage: abg pairs [--json] | abg pairs rm <id>");
+    process.exit(1);
+  }
+
+  const json = command === "--json" || rest.includes("--json");
+  const rows = await collectRows();
+  if (json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+  printTable(rows);
+}
+
+async function runRemove(args: string[]) {
+  const pairId = args[0];
+  if (!pairId) {
+    console.error("Error: `abg pairs rm <id>` requires a pair id.");
+    process.exit(1);
+  }
+
+  const base = computeBaseDir();
+  const pair = findPair(base, pairId);
+  if (!pair) {
+    console.log(`No such pair: ${pairId}`);
+    printKnownPairs(base);
+    return;
+  }
+
+  await stopPairEntry(base, pair);
+  const removed = await removePair(base, pair.pairId);
+  if (removed) {
+    console.log(`Removed pair ${removed.pairId}; slot ${removed.slot} is now available.`);
+  } else {
+    console.log(`Pair ${pair.pairId} was already absent from the registry.`);
+  }
+}
+
+async function collectRows(): Promise<PairRow[]> {
+  const base = computeBaseDir();
+  const rows = await Promise.all(listPairs(base).map((pair) => rowForPair(base, pair)));
+  const legacy = detectLegacyRootDaemon(base);
+  if (legacy) {
+    rows.push({
+      pairId: "(legacy-root)",
+      slot: null,
+      ports: { appPort: 4500, proxyPort: 4501, controlPort: legacy.controlPort },
+      source: "legacy",
+      cwd: base,
+      running: true,
+      pid: legacy.pid,
+    });
+  }
+  return rows;
+}
+
+async function rowForPair(base: string, pair: PairEntry): Promise<PairRow> {
+  const ports = portsForEntry(pair);
+  const stateDir = new StateDirResolver(join(base, "pairs", pair.pairId));
+  const lifecycle = new DaemonLifecycle({
+    stateDir,
+    controlPort: ports.controlPort,
+    log: () => {},
+  });
+  const [running, status] = await Promise.all([
+    lifecycle.isHealthy(),
+    Promise.resolve(lifecycle.readStatus()),
+  ]);
+
+  return {
+    pairId: pair.pairId,
+    slot: pair.slot,
+    ports,
+    source: pair.source,
+    cwd: pair.cwd,
+    running,
+    pid: typeof status?.pid === "number" ? status.pid : null,
+  };
+}
+
+function printTable(rows: PairRow[]) {
+  if (rows.length === 0) {
+    console.log("No pairs registered.");
+    return;
+  }
+
+  const data = rows.map((row) => ({
+    pairId: row.pairId,
+    slot: row.slot === null ? "-" : String(row.slot),
+    ports: `${row.ports.appPort}/${row.ports.proxyPort}/${row.ports.controlPort}`,
+    source: row.source,
+    cwd: row.cwd,
+    status: row.running ? "running" : "stopped",
+    pid: row.pid === null ? "-" : String(row.pid),
+  }));
+
+  const headers = {
+    pairId: "pairId",
+    slot: "slot",
+    ports: "app/proxy/control",
+    source: "source",
+    status: "status",
+    pid: "pid",
+    cwd: "cwd",
+  };
+  const widths = Object.fromEntries(
+    Object.keys(headers).map((key) => [
+      key,
+      Math.max(
+        headers[key as keyof typeof headers].length,
+        ...data.map((row) => row[key as keyof typeof row].length),
+      ),
+    ]),
+  ) as Record<keyof typeof headers, number>;
+
+  const line = (row: Record<keyof typeof headers, string>) =>
+    [
+      row.pairId.padEnd(widths.pairId),
+      row.slot.padEnd(widths.slot),
+      row.ports.padEnd(widths.ports),
+      row.source.padEnd(widths.source),
+      row.status.padEnd(widths.status),
+      row.pid.padEnd(widths.pid),
+      row.cwd,
+    ].join("  ");
+
+  console.log(line(headers));
+  console.log(
+    [
+      "-".repeat(widths.pairId),
+      "-".repeat(widths.slot),
+      "-".repeat(widths.ports),
+      "-".repeat(widths.source),
+      "-".repeat(widths.status),
+      "-".repeat(widths.pid),
+      "-".repeat(widths.cwd),
+    ].join("  "),
+  );
+  for (const row of data) {
+    console.log(line(row));
+  }
+}
+
+function printKnownPairs(base: string) {
+  const pairs = listPairs(base);
+  if (pairs.length === 0) {
+    console.log("No pairs registered.");
+    return;
+  }
+  console.log("Known pairs:");
+  for (const pair of pairs) {
+    console.log(`  ${pair.pairId}`);
+  }
+}

--- a/src/cli/pairs.ts
+++ b/src/cli/pairs.ts
@@ -9,6 +9,7 @@ import {
   removePair,
 } from "../pair-resolver";
 import { StateDirResolver } from "../state-dir";
+import { readRawCurrentThread } from "../thread-state";
 import { stopPairEntry } from "./kill";
 
 interface PairRow {
@@ -20,6 +21,9 @@ interface PairRow {
   cwd: string;
   running: boolean;
   pid: number | null;
+  threadId: string | null;
+  threadStatus: string | null;
+  threadUpdatedAt: string | null;
 }
 
 export async function runPairs(args: string[] = []) {
@@ -30,19 +34,20 @@ export async function runPairs(args: string[] = []) {
     return;
   }
 
-  if (command && command !== "list" && command !== "--json") {
+  if (command && command !== "list" && command !== "--json" && command !== "--threads") {
     console.error(`Unknown pairs command: ${command}`);
-    console.error("Usage: abg pairs [--json] | abg pairs rm <name|id>");
+    console.error("Usage: abg pairs [--json] [--threads] | abg pairs rm <name|id>");
     process.exit(1);
   }
 
   const json = command === "--json" || rest.includes("--json");
+  const includeThreads = rest.includes("--threads") || args.includes("--threads");
   const rows = await collectRows();
   if (json) {
     console.log(JSON.stringify(rows, null, 2));
     return;
   }
-  printTable(rows);
+  printTable(rows, { includeThreads });
 }
 
 async function runRemove(args: string[]) {
@@ -91,6 +96,9 @@ async function collectRows(): Promise<PairRow[]> {
       cwd: base,
       running: true,
       pid: legacy.pid,
+      threadId: null,
+      threadStatus: null,
+      threadUpdatedAt: null,
     });
   }
   return rows;
@@ -108,6 +116,7 @@ async function rowForPair(base: string, pair: PairEntry): Promise<PairRow> {
     lifecycle.isHealthy(),
     Promise.resolve(lifecycle.readStatus()),
   ]);
+  const thread = readRawCurrentThread(stateDir);
 
   return {
     pairId: pair.pairId,
@@ -118,10 +127,13 @@ async function rowForPair(base: string, pair: PairEntry): Promise<PairRow> {
     cwd: pair.cwd,
     running,
     pid: typeof status?.pid === "number" ? status.pid : null,
+    threadId: thread?.threadId ?? null,
+    threadStatus: thread?.status ?? null,
+    threadUpdatedAt: thread?.updatedAt ?? null,
   };
 }
 
-function printTable(rows: PairRow[]) {
+function printTable(rows: PairRow[], options: { includeThreads?: boolean } = {}) {
   if (rows.length === 0) {
     console.log("No pairs registered.");
     return;
@@ -136,6 +148,8 @@ function printTable(rows: PairRow[]) {
     cwd: row.cwd,
     status: row.running ? "running" : "stopped",
     pid: row.pid === null ? "-" : String(row.pid),
+    thread: row.threadId === null ? "-" : row.threadId,
+    threadStatus: row.threadStatus === null ? "-" : row.threadStatus,
   }));
 
   const headers = {
@@ -146,10 +160,15 @@ function printTable(rows: PairRow[]) {
     source: "source",
     status: "status",
     pid: "pid",
+    thread: "threadId",
+    threadStatus: "thread",
     cwd: "cwd",
   };
+  const visibleKeys = options.includeThreads
+    ? ["name", "pairId", "slot", "ports", "source", "status", "pid", "thread", "threadStatus", "cwd"] as const
+    : ["name", "pairId", "slot", "ports", "source", "status", "pid", "cwd"] as const;
   const widths = Object.fromEntries(
-    Object.keys(headers).map((key) => [
+    visibleKeys.map((key) => [
       key,
       Math.max(
         headers[key as keyof typeof headers].length,
@@ -159,29 +178,11 @@ function printTable(rows: PairRow[]) {
   ) as Record<keyof typeof headers, number>;
 
   const line = (row: Record<keyof typeof headers, string>) =>
-    [
-      row.name.padEnd(widths.name),
-      row.pairId.padEnd(widths.pairId),
-      row.slot.padEnd(widths.slot),
-      row.ports.padEnd(widths.ports),
-      row.source.padEnd(widths.source),
-      row.status.padEnd(widths.status),
-      row.pid.padEnd(widths.pid),
-      row.cwd,
-    ].join("  ");
+    visibleKeys.map((key) => row[key].padEnd(widths[key])).join("  ");
 
   console.log(line(headers));
   console.log(
-    [
-      "-".repeat(widths.name),
-      "-".repeat(widths.pairId),
-      "-".repeat(widths.slot),
-      "-".repeat(widths.ports),
-      "-".repeat(widths.source),
-      "-".repeat(widths.status),
-      "-".repeat(widths.pid),
-      "-".repeat(widths.cwd),
-    ].join("  "),
+    visibleKeys.map((key) => "-".repeat(widths[key])).join("  "),
   );
   for (const row of data) {
     console.log(line(row));

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -29,6 +29,18 @@ import {
   type AppServerTrackedRequestMethod,
   type TurnStartParams,
 } from "./app-server-protocol";
+import {
+  CODEX_TRANSPORT_ENV,
+  TcpToUnixRelay,
+  type CodexTransport,
+  codexListenArg,
+  codexSocketPath,
+  ensureSocketDir,
+  parseTransportMode,
+  removeSocketFile,
+  resolveCodexTransport,
+  waitForUnixWsReady,
+} from "./codex-transport";
 
 interface TuiSocketData {
   connId: number;
@@ -60,6 +72,12 @@ interface PendingServerResponse {
 interface PendingRequest {
   method: AppServerTrackedRequestMethod;
   threadId?: string;
+  /**
+   * Monotonic "thread switch" sequence (latest-issued) for thread/start and
+   * thread/resume. Used so an out-of-order OLD response can't clobber the active
+   * thread the user most recently switched to (#70).
+   */
+  threadSwitchSeq?: number;
 }
 
 export class CodexAdapter extends EventEmitter {
@@ -69,6 +87,12 @@ export class CodexAdapter extends EventEmitter {
   private appServerWs: WebSocket | null = null;
   private tuiWs: ServerWebSocket<TuiSocketData> | null = null;
   private proxyServer: ReturnType<typeof Bun.serve> | null = null;
+  // #85 transport: how Codex app-server is reached. In "unix" mode the adapter
+  // still connects to ws://127.0.0.1:appPort, but a TcpToUnixRelay bridges that
+  // TCP port to Codex's unix socket (Codex builds may drop ws:// listen support).
+  private transport: CodexTransport = "ws";
+  private socketPath: string | null = null;
+  private relay: TcpToUnixRelay | null = null;
   private threadId: string | null = null;
   // Reserve negative ids for bridge-originated requests so they never collide
   // with proxy-rewritten TUI request ids.
@@ -90,6 +114,14 @@ export class CodexAdapter extends EventEmitter {
   private pendingRequests = new Map<string, PendingRequest>();
   private activeTurnIds = new Set<string>();
   turnInProgress = false;
+  // #69: per-turn inactivity watchdog. A lost `turn/completed` would otherwise
+  // leave turnInProgress=true forever and permanently block injection. Each
+  // active turn gets a timer (keyed identically to activeTurnIds) that is
+  // refreshed on any app-server notification and, on expiry, force-completes the
+  // turn so Claude is never locked out.
+  private turnWatchdogs = new Map<string, ReturnType<typeof setTimeout>>();
+  // #70: latest-issued thread-switch sequence (see PendingRequest.threadSwitchSeq).
+  private threadSwitchSeq = 0;
 
   // Proxy-layer id rewriting: upstream uses globally unique ids
   private nextProxyId = 100000;
@@ -155,9 +187,19 @@ export class CodexAdapter extends EventEmitter {
 
   async start() {
     this.intentionalDisconnect = false;
+    // #85: pick the Codex transport. checkPorts still applies in both modes —
+    // in unix mode the relay (not Codex) binds appPort, but the port must still
+    // be free for the relay to bind it; proxyPort is always ours.
     await this.checkPorts();
-    this.log(`Spawning codex app-server on ${this.appServerUrl}`);
-    this.proc = spawn("codex", ["app-server", "--listen", this.appServerUrl], {
+    this.resolveTransport();
+
+    const listen = codexListenArg(this.transport, this.appPort, this.socketPath ?? "");
+    if (this.transport === "unix" && this.socketPath) {
+      ensureSocketDir(this.socketPath);
+      removeSocketFile(this.socketPath); // clear any stale socket from a prior run
+    }
+    this.log(`Spawning codex app-server (transport=${this.transport}) --listen ${listen}`);
+    this.proc = spawn("codex", ["app-server", "--listen", listen], {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
@@ -169,13 +211,31 @@ export class CodexAdapter extends EventEmitter {
     const stdoutRl = createInterface({ input: this.proc.stdout! });
     stdoutRl.on("line", (l) => this.log(`[codex-stdout] ${l}`));
 
-    await this.waitForHealthy();
+    if (this.transport === "unix" && this.socketPath) {
+      // Codex's unix listener does NOT serve HTTP /healthz — probe readiness via
+      // a WS upgrade against the socket, then stand up the TCP↔unix relay so the
+      // adapter's unchanged `new WebSocket(ws://127.0.0.1:appPort)` reaches it.
+      await waitForUnixWsReady(this.socketPath);
+      this.relay = new TcpToUnixRelay("127.0.0.1", this.appPort, this.socketPath, (m) => this.log(`[relay] ${m}`));
+      await this.relay.start();
+      this.log(`Transport relay ready: ws://127.0.0.1:${this.appPort} → unix://${this.socketPath}`);
+    } else {
+      await this.waitForHealthy();
+    }
 
     // Connect to app-server once, keep it alive permanently
     await this.connectToAppServer();
 
     this.startProxy();
     this.log(`Proxy ready on ${this.proxyUrl}`);
+  }
+
+  /** #85: resolve the transport (env-driven, `auto` probes ws support) and the unix socket path. */
+  private resolveTransport() {
+    const mode = parseTransportMode(process.env[CODEX_TRANSPORT_ENV]);
+    this.transport = resolveCodexTransport(mode);
+    this.socketPath = this.transport === "unix" ? codexSocketPath(this.appPort) : null;
+    this.log(`Codex transport mode=${mode} resolved=${this.transport}`);
   }
 
   /** Disconnect the bridge (proxy + app-server WS) without killing the Codex process. */
@@ -201,7 +261,21 @@ export class CodexAdapter extends EventEmitter {
     }
     this.proxyServer?.stop();
     this.proxyServer = null;
+    // #85: tear down the transport relay and remove the unix socket file.
+    if (this.relay) {
+      this.relay.stop();
+      this.relay = null;
+    }
+    if (this.socketPath) removeSocketFile(this.socketPath);
     this.clearResponseTrackingState();
+    // #69: an intentional disconnect must synchronously drop turn state +
+    // watchdog timers. We cannot rely on handleAppServerClose for this: we set
+    // appServerWs=null above, and the close callback is async (and may be
+    // skipped entirely if the socket was already gone), so without this the
+    // turnInProgress flag and a pending watchdog timer leak past disconnect().
+    // emitCompleted stays false — an intentional teardown is not a real turn
+    // completion and must not signal "Codex finished" downstream.
+    this.resetTurnState("adapter disconnect");
   }
 
   /** Fully stop: disconnect bridge AND kill the Codex process. */
@@ -350,8 +424,7 @@ export class CodexAdapter extends EventEmitter {
     // pendingServerRequests — those must survive the intentional reconnect
     // so they can be replayed after the TUI completes thread/resume.
     this.clearResponseTrackingStateForAppServerReconnect();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server reconnect for new TUI session");
 
     try {
       await this.connectToAppServer(false);
@@ -430,8 +503,7 @@ export class CodexAdapter extends EventEmitter {
     // Approval request/response ids are scoped to the current app-server session.
     // If the socket reconnects, replaying old approval state would forward stale ids.
     this.clearResponseTrackingState();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server connection closed");
     if (!intentional) {
       this.scheduleReconnect();
     }
@@ -1053,6 +1125,19 @@ export class CodexAdapter extends EventEmitter {
   private handleAppServerPayload(raw: string): string | null {
     try {
       const parsed: unknown = JSON.parse(raw);
+      // #69: ANY inbound app-server message proves the turn is alive — refresh
+      // the inactivity watchdog(s) here, at the single inbound funnel. This
+      // MUST be broader than the modeled notification set: Codex streams many
+      // notification types we deliberately do NOT forward (item/agentReasoning/
+      // delta, item/commandExecution/*, item/fileChange/*, …). A long but
+      // actively-streaming turn (e.g. a multi-minute build) emits only these
+      // "unknown" notifications between turn/started and turn/completed; if we
+      // refreshed only on the handful in isAppServerNotification() we would
+      // force-complete a live turn. Responses and server requests count as
+      // activity too. (refreshTurnWatchdogs() no-ops when no turn is active.)
+      if (typeof parsed === "object" && parsed !== null) {
+        this.refreshTurnWatchdogs();
+      }
       // Short-circuit: response carries an id that matches a pending
       // session-restore replay? Consume it and suppress forwarding to
       // the TUI (which didn't send the request and would be confused).
@@ -1254,6 +1339,9 @@ export class CodexAdapter extends EventEmitter {
 
   private handleServerNotification(msg: AppServerNotification) {
     const { method, params } = msg;
+    // Note: the inactivity watchdog is refreshed for ALL inbound messages at
+    // the handleAppServerPayload funnel (see #69 there), not here — this method
+    // only runs for the modeled subset, which would miss the long-build case.
     switch (method) {
       case "turn/started":
         this.markTurnStarted(params?.turn?.id);
@@ -1327,6 +1415,12 @@ export class CodexAdapter extends EventEmitter {
         pending.threadId = threadId;
       }
     }
+    // #70: stamp explicit thread switches (thread/start, thread/resume) with the
+    // latest-issued sequence so an out-of-order OLD response can't clobber the
+    // thread the user most recently switched to.
+    if (method === "thread/start" || method === "thread/resume") {
+      pending.threadSwitchSeq = ++this.threadSwitchSeq;
+    }
 
     if (this.pendingRequests.has(key)) {
       this.log(`WARNING: overwriting pending request for key ${key}`);
@@ -1360,6 +1454,16 @@ export class CodexAdapter extends EventEmitter {
 
     switch (pending.method) {
       case "thread/start": {
+        // #70: ignore an out-of-order OLD thread switch. Only the response to
+        // the most-recently-issued thread/start|resume may mutate activeThreadId
+        // or drop orphans — a stale one would clobber the thread the user just
+        // switched to and re-orphan its in-flight approvals.
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(
+            `Ignoring stale thread/start response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`,
+          );
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/start response ${key}`);
@@ -1371,6 +1475,14 @@ export class CodexAdapter extends EventEmitter {
         break;
       }
       case "thread/resume": {
+        // #70: same staleness guard as thread/start — a late resume response
+        // must not steal activeThreadId back from a newer switch.
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(
+            `Ignoring stale thread/resume response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`,
+          );
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/resume response ${key}`);
@@ -1384,11 +1496,30 @@ export class CodexAdapter extends EventEmitter {
         break;
       }
       case "turn/start":
+        // #70: a turn/start response carries the threadId the turn ran against.
+        // Only adopt it when it agrees with the active thread (or none is set
+        // yet). If the user has already switched threads, a late turn/start must
+        // not drag activeThreadId back to the abandoned thread.
         if (pending.threadId) {
-          this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          if (this.threadId === null || this.threadId === pending.threadId) {
+            this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          } else {
+            this.log(
+              `Ignoring turn/start response ${key} threadId=${pending.threadId} (active thread is ${this.threadId})`,
+            );
+          }
         }
         break;
     }
+  }
+
+  /**
+   * #70: true only if this pending request is the most-recently-issued explicit
+   * thread switch (thread/start | thread/resume). Out-of-order responses to
+   * superseded switches return false and must not mutate activeThreadId.
+   */
+  private isLatestThreadSwitch(pending: PendingRequest): boolean {
+    return pending.threadSwitchSeq === this.threadSwitchSeq;
   }
 
   private setActiveThreadId(threadId: string, reason: string) {
@@ -1408,11 +1539,11 @@ export class CodexAdapter extends EventEmitter {
 
   private markTurnStarted(turnId?: string) {
     const wasInProgress = this.turnInProgress;
-    if (typeof turnId === "string" && turnId.length > 0) {
-      this.activeTurnIds.add(turnId);
-    } else {
-      this.activeTurnIds.add(`unknown:${Date.now()}`);
-    }
+    // Compute the key ONCE and use it for both the set and the watchdog so the
+    // two never diverge (incl. the no-turn-id `unknown:` fallback).
+    const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
+    this.activeTurnIds.add(turnKey);
+    this.scheduleTurnWatchdog(turnKey);
 
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
@@ -1423,11 +1554,89 @@ export class CodexAdapter extends EventEmitter {
   private markTurnCompleted(turnId?: string) {
     if (typeof turnId === "string" && turnId.length > 0) {
       this.activeTurnIds.delete(turnId);
+      this.clearTurnWatchdog(turnId);
     } else {
       this.activeTurnIds.clear();
+      this.clearAllTurnWatchdogs();
     }
 
     this.turnInProgress = this.activeTurnIds.size > 0;
+  }
+
+  /** Inactivity timeout for a turn (env-overridable; default 5 minutes). */
+  private turnWatchdogMs(): number {
+    const v = Number(process.env.AGENTBRIDGE_TURN_WATCHDOG_MS);
+    return Number.isFinite(v) && v > 0 ? v : 300_000;
+  }
+
+  /** (Re)arm the inactivity watchdog for a turn. Replaces any existing timer. */
+  private scheduleTurnWatchdog(turnKey: string) {
+    this.clearTurnWatchdog(turnKey);
+    const timer = setTimeout(() => {
+      if (!this.activeTurnIds.has(turnKey)) return;
+      this.log(
+        `WARNING: turn ${turnKey} watchdog fired after ${this.turnWatchdogMs()}ms of inactivity — ` +
+        `assuming a lost turn/completed; force-completing to unblock injection`,
+      );
+      this.forceCompleteTurn(turnKey);
+    }, this.turnWatchdogMs());
+    // Never keep the process/test runner alive on account of a watchdog.
+    timer.unref?.();
+    this.turnWatchdogs.set(turnKey, timer);
+  }
+
+  private clearTurnWatchdog(turnKey: string) {
+    const timer = this.turnWatchdogs.get(turnKey);
+    if (timer) {
+      clearTimeout(timer);
+      this.turnWatchdogs.delete(turnKey);
+    }
+  }
+
+  private clearAllTurnWatchdogs() {
+    for (const timer of this.turnWatchdogs.values()) clearTimeout(timer);
+    this.turnWatchdogs.clear();
+  }
+
+  /**
+   * Refresh every active turn's watchdog — called on any app-server notification
+   * so the watchdog measures INACTIVITY, not total turn duration (a genuinely
+   * long but active turn keeps streaming events and is never force-completed).
+   */
+  private refreshTurnWatchdogs() {
+    if (this.turnWatchdogs.size === 0) return;
+    for (const turnKey of [...this.turnWatchdogs.keys()]) {
+      this.scheduleTurnWatchdog(turnKey);
+    }
+  }
+
+  /** Force-complete a single turn (watchdog expiry path). */
+  private forceCompleteTurn(turnKey: string) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.delete(turnKey);
+    this.clearTurnWatchdog(turnKey);
+    this.turnInProgress = this.activeTurnIds.size > 0;
+    if (wasInProgress && !this.turnInProgress) {
+      this.emit("turnCompleted");
+    }
+  }
+
+  /**
+   * Clear all turn state (active ids + watchdogs) and recompute busy. Single
+   * source of truth used by app-server close / disconnect / stop so no path
+   * clears the ids without also clearing the watchdog timers.
+   */
+  private resetTurnState(reason: string, emitCompleted = false) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.clear();
+    this.clearAllTurnWatchdogs();
+    this.turnInProgress = false;
+    if (emitCompleted && wasInProgress) {
+      this.emit("turnCompleted");
+    }
+    if (wasInProgress) {
+      this.log(`Turn state reset (${reason})`);
+    }
   }
 
   private requestKey(id: unknown): string | null {

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -29,6 +29,18 @@ import {
   type AppServerTrackedRequestMethod,
   type TurnStartParams,
 } from "./app-server-protocol";
+import {
+  CODEX_TRANSPORT_ENV,
+  TcpToUnixRelay,
+  type CodexTransport,
+  codexListenArg,
+  codexSocketPath,
+  ensureSocketDir,
+  parseTransportMode,
+  removeSocketFile,
+  resolveCodexTransport,
+  waitForUnixWsReady,
+} from "./codex-transport";
 
 interface TuiSocketData {
   connId: number;
@@ -75,6 +87,12 @@ export class CodexAdapter extends EventEmitter {
   private appServerWs: WebSocket | null = null;
   private tuiWs: ServerWebSocket<TuiSocketData> | null = null;
   private proxyServer: ReturnType<typeof Bun.serve> | null = null;
+  // #85 transport: how Codex app-server is reached. In "unix" mode the adapter
+  // still connects to ws://127.0.0.1:appPort, but a TcpToUnixRelay bridges that
+  // TCP port to Codex's unix socket (Codex builds may drop ws:// listen support).
+  private transport: CodexTransport = "ws";
+  private socketPath: string | null = null;
+  private relay: TcpToUnixRelay | null = null;
   private threadId: string | null = null;
   // Reserve negative ids for bridge-originated requests so they never collide
   // with proxy-rewritten TUI request ids.
@@ -169,9 +187,19 @@ export class CodexAdapter extends EventEmitter {
 
   async start() {
     this.intentionalDisconnect = false;
+    // #85: pick the Codex transport. checkPorts still applies in both modes —
+    // in unix mode the relay (not Codex) binds appPort, but the port must still
+    // be free for the relay to bind it; proxyPort is always ours.
     await this.checkPorts();
-    this.log(`Spawning codex app-server on ${this.appServerUrl}`);
-    this.proc = spawn("codex", ["app-server", "--listen", this.appServerUrl], {
+    this.resolveTransport();
+
+    const listen = codexListenArg(this.transport, this.appPort, this.socketPath ?? "");
+    if (this.transport === "unix" && this.socketPath) {
+      ensureSocketDir(this.socketPath);
+      removeSocketFile(this.socketPath); // clear any stale socket from a prior run
+    }
+    this.log(`Spawning codex app-server (transport=${this.transport}) --listen ${listen}`);
+    this.proc = spawn("codex", ["app-server", "--listen", listen], {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
@@ -183,13 +211,31 @@ export class CodexAdapter extends EventEmitter {
     const stdoutRl = createInterface({ input: this.proc.stdout! });
     stdoutRl.on("line", (l) => this.log(`[codex-stdout] ${l}`));
 
-    await this.waitForHealthy();
+    if (this.transport === "unix" && this.socketPath) {
+      // Codex's unix listener does NOT serve HTTP /healthz — probe readiness via
+      // a WS upgrade against the socket, then stand up the TCP↔unix relay so the
+      // adapter's unchanged `new WebSocket(ws://127.0.0.1:appPort)` reaches it.
+      await waitForUnixWsReady(this.socketPath);
+      this.relay = new TcpToUnixRelay("127.0.0.1", this.appPort, this.socketPath, (m) => this.log(`[relay] ${m}`));
+      await this.relay.start();
+      this.log(`Transport relay ready: ws://127.0.0.1:${this.appPort} → unix://${this.socketPath}`);
+    } else {
+      await this.waitForHealthy();
+    }
 
     // Connect to app-server once, keep it alive permanently
     await this.connectToAppServer();
 
     this.startProxy();
     this.log(`Proxy ready on ${this.proxyUrl}`);
+  }
+
+  /** #85: resolve the transport (env-driven, `auto` probes ws support) and the unix socket path. */
+  private resolveTransport() {
+    const mode = parseTransportMode(process.env[CODEX_TRANSPORT_ENV]);
+    this.transport = resolveCodexTransport(mode);
+    this.socketPath = this.transport === "unix" ? codexSocketPath(this.appPort) : null;
+    this.log(`Codex transport mode=${mode} resolved=${this.transport}`);
   }
 
   /** Disconnect the bridge (proxy + app-server WS) without killing the Codex process. */
@@ -215,6 +261,12 @@ export class CodexAdapter extends EventEmitter {
     }
     this.proxyServer?.stop();
     this.proxyServer = null;
+    // #85: tear down the transport relay and remove the unix socket file.
+    if (this.relay) {
+      this.relay.stop();
+      this.relay = null;
+    }
+    if (this.socketPath) removeSocketFile(this.socketPath);
     this.clearResponseTrackingState();
     // #69: an intentional disconnect must synchronously drop turn state +
     // watchdog timers. We cannot rely on handleAppServerClose for this: we set

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -60,6 +60,12 @@ interface PendingServerResponse {
 interface PendingRequest {
   method: AppServerTrackedRequestMethod;
   threadId?: string;
+  /**
+   * Monotonic "thread switch" sequence (latest-issued) for thread/start and
+   * thread/resume. Used so an out-of-order OLD response can't clobber the active
+   * thread the user most recently switched to (#70).
+   */
+  threadSwitchSeq?: number;
 }
 
 export class CodexAdapter extends EventEmitter {
@@ -90,6 +96,14 @@ export class CodexAdapter extends EventEmitter {
   private pendingRequests = new Map<string, PendingRequest>();
   private activeTurnIds = new Set<string>();
   turnInProgress = false;
+  // #69: per-turn inactivity watchdog. A lost `turn/completed` would otherwise
+  // leave turnInProgress=true forever and permanently block injection. Each
+  // active turn gets a timer (keyed identically to activeTurnIds) that is
+  // refreshed on any app-server notification and, on expiry, force-completes the
+  // turn so Claude is never locked out.
+  private turnWatchdogs = new Map<string, ReturnType<typeof setTimeout>>();
+  // #70: latest-issued thread-switch sequence (see PendingRequest.threadSwitchSeq).
+  private threadSwitchSeq = 0;
 
   // Proxy-layer id rewriting: upstream uses globally unique ids
   private nextProxyId = 100000;
@@ -202,6 +216,14 @@ export class CodexAdapter extends EventEmitter {
     this.proxyServer?.stop();
     this.proxyServer = null;
     this.clearResponseTrackingState();
+    // #69: an intentional disconnect must synchronously drop turn state +
+    // watchdog timers. We cannot rely on handleAppServerClose for this: we set
+    // appServerWs=null above, and the close callback is async (and may be
+    // skipped entirely if the socket was already gone), so without this the
+    // turnInProgress flag and a pending watchdog timer leak past disconnect().
+    // emitCompleted stays false — an intentional teardown is not a real turn
+    // completion and must not signal "Codex finished" downstream.
+    this.resetTurnState("adapter disconnect");
   }
 
   /** Fully stop: disconnect bridge AND kill the Codex process. */
@@ -350,8 +372,7 @@ export class CodexAdapter extends EventEmitter {
     // pendingServerRequests — those must survive the intentional reconnect
     // so they can be replayed after the TUI completes thread/resume.
     this.clearResponseTrackingStateForAppServerReconnect();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server reconnect for new TUI session");
 
     try {
       await this.connectToAppServer(false);
@@ -430,8 +451,7 @@ export class CodexAdapter extends EventEmitter {
     // Approval request/response ids are scoped to the current app-server session.
     // If the socket reconnects, replaying old approval state would forward stale ids.
     this.clearResponseTrackingState();
-    this.activeTurnIds.clear();
-    this.turnInProgress = false;
+    this.resetTurnState("app-server connection closed");
     if (!intentional) {
       this.scheduleReconnect();
     }
@@ -1053,6 +1073,19 @@ export class CodexAdapter extends EventEmitter {
   private handleAppServerPayload(raw: string): string | null {
     try {
       const parsed: unknown = JSON.parse(raw);
+      // #69: ANY inbound app-server message proves the turn is alive — refresh
+      // the inactivity watchdog(s) here, at the single inbound funnel. This
+      // MUST be broader than the modeled notification set: Codex streams many
+      // notification types we deliberately do NOT forward (item/agentReasoning/
+      // delta, item/commandExecution/*, item/fileChange/*, …). A long but
+      // actively-streaming turn (e.g. a multi-minute build) emits only these
+      // "unknown" notifications between turn/started and turn/completed; if we
+      // refreshed only on the handful in isAppServerNotification() we would
+      // force-complete a live turn. Responses and server requests count as
+      // activity too. (refreshTurnWatchdogs() no-ops when no turn is active.)
+      if (typeof parsed === "object" && parsed !== null) {
+        this.refreshTurnWatchdogs();
+      }
       // Short-circuit: response carries an id that matches a pending
       // session-restore replay? Consume it and suppress forwarding to
       // the TUI (which didn't send the request and would be confused).
@@ -1254,6 +1287,9 @@ export class CodexAdapter extends EventEmitter {
 
   private handleServerNotification(msg: AppServerNotification) {
     const { method, params } = msg;
+    // Note: the inactivity watchdog is refreshed for ALL inbound messages at
+    // the handleAppServerPayload funnel (see #69 there), not here — this method
+    // only runs for the modeled subset, which would miss the long-build case.
     switch (method) {
       case "turn/started":
         this.markTurnStarted(params?.turn?.id);
@@ -1327,6 +1363,12 @@ export class CodexAdapter extends EventEmitter {
         pending.threadId = threadId;
       }
     }
+    // #70: stamp explicit thread switches (thread/start, thread/resume) with the
+    // latest-issued sequence so an out-of-order OLD response can't clobber the
+    // thread the user most recently switched to.
+    if (method === "thread/start" || method === "thread/resume") {
+      pending.threadSwitchSeq = ++this.threadSwitchSeq;
+    }
 
     if (this.pendingRequests.has(key)) {
       this.log(`WARNING: overwriting pending request for key ${key}`);
@@ -1360,6 +1402,16 @@ export class CodexAdapter extends EventEmitter {
 
     switch (pending.method) {
       case "thread/start": {
+        // #70: ignore an out-of-order OLD thread switch. Only the response to
+        // the most-recently-issued thread/start|resume may mutate activeThreadId
+        // or drop orphans — a stale one would clobber the thread the user just
+        // switched to and re-orphan its in-flight approvals.
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(
+            `Ignoring stale thread/start response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`,
+          );
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/start response ${key}`);
@@ -1371,6 +1423,14 @@ export class CodexAdapter extends EventEmitter {
         break;
       }
       case "thread/resume": {
+        // #70: same staleness guard as thread/start — a late resume response
+        // must not steal activeThreadId back from a newer switch.
+        if (!this.isLatestThreadSwitch(pending)) {
+          this.log(
+            `Ignoring stale thread/resume response ${key} (seq=${pending.threadSwitchSeq} < latest=${this.threadSwitchSeq})`,
+          );
+          break;
+        }
         const threadId = message?.result?.thread?.id;
         if (typeof threadId === "string" && threadId.length > 0) {
           this.setActiveThreadId(threadId, `thread/resume response ${key}`);
@@ -1384,11 +1444,30 @@ export class CodexAdapter extends EventEmitter {
         break;
       }
       case "turn/start":
+        // #70: a turn/start response carries the threadId the turn ran against.
+        // Only adopt it when it agrees with the active thread (or none is set
+        // yet). If the user has already switched threads, a late turn/start must
+        // not drag activeThreadId back to the abandoned thread.
         if (pending.threadId) {
-          this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          if (this.threadId === null || this.threadId === pending.threadId) {
+            this.setActiveThreadId(pending.threadId, `turn/start response ${key}`);
+          } else {
+            this.log(
+              `Ignoring turn/start response ${key} threadId=${pending.threadId} (active thread is ${this.threadId})`,
+            );
+          }
         }
         break;
     }
+  }
+
+  /**
+   * #70: true only if this pending request is the most-recently-issued explicit
+   * thread switch (thread/start | thread/resume). Out-of-order responses to
+   * superseded switches return false and must not mutate activeThreadId.
+   */
+  private isLatestThreadSwitch(pending: PendingRequest): boolean {
+    return pending.threadSwitchSeq === this.threadSwitchSeq;
   }
 
   private setActiveThreadId(threadId: string, reason: string) {
@@ -1408,11 +1487,11 @@ export class CodexAdapter extends EventEmitter {
 
   private markTurnStarted(turnId?: string) {
     const wasInProgress = this.turnInProgress;
-    if (typeof turnId === "string" && turnId.length > 0) {
-      this.activeTurnIds.add(turnId);
-    } else {
-      this.activeTurnIds.add(`unknown:${Date.now()}`);
-    }
+    // Compute the key ONCE and use it for both the set and the watchdog so the
+    // two never diverge (incl. the no-turn-id `unknown:` fallback).
+    const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
+    this.activeTurnIds.add(turnKey);
+    this.scheduleTurnWatchdog(turnKey);
 
     this.turnInProgress = this.activeTurnIds.size > 0;
     if (!wasInProgress && this.turnInProgress) {
@@ -1423,11 +1502,89 @@ export class CodexAdapter extends EventEmitter {
   private markTurnCompleted(turnId?: string) {
     if (typeof turnId === "string" && turnId.length > 0) {
       this.activeTurnIds.delete(turnId);
+      this.clearTurnWatchdog(turnId);
     } else {
       this.activeTurnIds.clear();
+      this.clearAllTurnWatchdogs();
     }
 
     this.turnInProgress = this.activeTurnIds.size > 0;
+  }
+
+  /** Inactivity timeout for a turn (env-overridable; default 5 minutes). */
+  private turnWatchdogMs(): number {
+    const v = Number(process.env.AGENTBRIDGE_TURN_WATCHDOG_MS);
+    return Number.isFinite(v) && v > 0 ? v : 300_000;
+  }
+
+  /** (Re)arm the inactivity watchdog for a turn. Replaces any existing timer. */
+  private scheduleTurnWatchdog(turnKey: string) {
+    this.clearTurnWatchdog(turnKey);
+    const timer = setTimeout(() => {
+      if (!this.activeTurnIds.has(turnKey)) return;
+      this.log(
+        `WARNING: turn ${turnKey} watchdog fired after ${this.turnWatchdogMs()}ms of inactivity — ` +
+        `assuming a lost turn/completed; force-completing to unblock injection`,
+      );
+      this.forceCompleteTurn(turnKey);
+    }, this.turnWatchdogMs());
+    // Never keep the process/test runner alive on account of a watchdog.
+    timer.unref?.();
+    this.turnWatchdogs.set(turnKey, timer);
+  }
+
+  private clearTurnWatchdog(turnKey: string) {
+    const timer = this.turnWatchdogs.get(turnKey);
+    if (timer) {
+      clearTimeout(timer);
+      this.turnWatchdogs.delete(turnKey);
+    }
+  }
+
+  private clearAllTurnWatchdogs() {
+    for (const timer of this.turnWatchdogs.values()) clearTimeout(timer);
+    this.turnWatchdogs.clear();
+  }
+
+  /**
+   * Refresh every active turn's watchdog — called on any app-server notification
+   * so the watchdog measures INACTIVITY, not total turn duration (a genuinely
+   * long but active turn keeps streaming events and is never force-completed).
+   */
+  private refreshTurnWatchdogs() {
+    if (this.turnWatchdogs.size === 0) return;
+    for (const turnKey of [...this.turnWatchdogs.keys()]) {
+      this.scheduleTurnWatchdog(turnKey);
+    }
+  }
+
+  /** Force-complete a single turn (watchdog expiry path). */
+  private forceCompleteTurn(turnKey: string) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.delete(turnKey);
+    this.clearTurnWatchdog(turnKey);
+    this.turnInProgress = this.activeTurnIds.size > 0;
+    if (wasInProgress && !this.turnInProgress) {
+      this.emit("turnCompleted");
+    }
+  }
+
+  /**
+   * Clear all turn state (active ids + watchdogs) and recompute busy. Single
+   * source of truth used by app-server close / disconnect / stop so no path
+   * clears the ids without also clearing the watchdog timers.
+   */
+  private resetTurnState(reason: string, emitCompleted = false) {
+    const wasInProgress = this.turnInProgress;
+    this.activeTurnIds.clear();
+    this.clearAllTurnWatchdogs();
+    this.turnInProgress = false;
+    if (emitCompleted && wasInProgress) {
+      this.emit("turnCompleted");
+    }
+    if (wasInProgress) {
+      this.log(`Turn state reset (${reason})`);
+    }
   }
 
   private requestKey(id: unknown): string | null {

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -12,8 +12,8 @@
 import { spawn, execSync, type ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
 import { EventEmitter } from "node:events";
-import { appendFileSync } from "node:fs";
 import { StateDirResolver } from "./state-dir";
+import { appendRotatingLog } from "./rotating-log";
 import type { BridgeMessage } from "./types";
 import type { ServerWebSocket } from "bun";
 import {
@@ -108,6 +108,8 @@ export class CodexAdapter extends EventEmitter {
     tuiWs: ServerWebSocket<TuiSocketData>;
     appServerWs: WebSocket | null;
     buffer: string[];
+    initialized: boolean;
+    initializationReplayed: boolean;
   }>();
 
   private agentMessageBuffers = new Map<string, string[]>();
@@ -117,9 +119,17 @@ export class CodexAdapter extends EventEmitter {
   // #69: per-turn inactivity watchdog. A lost `turn/completed` would otherwise
   // leave turnInProgress=true forever and permanently block injection. Each
   // active turn gets a timer (keyed identically to activeTurnIds) that is
-  // refreshed on any app-server notification and, on expiry, force-completes the
-  // turn so Claude is never locked out.
+  // refreshed on any app-server notification and, on expiry, marks the turn as
+  // stalled. It must NOT complete the turn: a long silent command is still a
+  // live busy turn until Codex emits turn/completed or the connection is reset.
   private turnWatchdogs = new Map<string, ReturnType<typeof setTimeout>>();
+  // turnStalled must fire AT MOST ONCE per turn: the watchdog is intentionally
+  // NOT cleared on stall (the turn stays busy), so every subsequent app-server
+  // notification re-arms it and a later expiry would emit a duplicate stalled
+  // notification. This set records turnIds already reported stalled so we
+  // suppress repeats; a turnId is removed when its turn completes/resets or a
+  // new turn starts, so a genuinely new stall in a later turn still notifies.
+  private stalledTurnIds = new Set<string>();
   // #70: latest-issued thread-switch sequence (see PendingRequest.threadSwitchSeq).
   private threadSwitchSeq = 0;
 
@@ -823,7 +833,13 @@ export class CodexAdapter extends EventEmitter {
     // Store the appWs handle immediately (not just in onopen) so that
     // onTuiDisconnect can close it even if the picker disconnects before
     // the app-server WS finishes connecting.
-    const entry = { tuiWs: ws, appServerWs: appWs, buffer: [] as string[] };
+    const entry = {
+      tuiWs: ws,
+      appServerWs: appWs,
+      buffer: [] as string[],
+      initialized: false,
+      initializationReplayed: false,
+    };
     this.secondaryConnections.set(connId, entry);
 
     appWs.onopen = () => {
@@ -977,11 +993,13 @@ export class CodexAdapter extends EventEmitter {
     // Route secondary (picker) connection messages to their own app-server WS
     const secondary = this.secondaryConnections.get(connId);
     if (secondary) {
-      if (secondary.appServerWs && secondary.appServerWs.readyState === WebSocket.OPEN) {
-        try { secondary.appServerWs.send(data); } catch {}
-      } else {
-        secondary.buffer.push(data);
+      const method = this.detectJsonMethod(data);
+      if (method === "initialize" || method === "initialized") {
+        secondary.initialized = true;
+      } else if (!secondary.initialized) {
+        this.ensureSecondaryInitialized(secondary, connId);
       }
+      this.sendOrBufferSecondary(secondary, data);
       return;
     }
 
@@ -1120,6 +1138,54 @@ export class CodexAdapter extends EventEmitter {
     }
   }
 
+  private detectJsonMethod(raw: string): string | undefined {
+    try {
+      const parsed = JSON.parse(raw);
+      return typeof parsed?.method === "string" ? parsed.method : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private ensureSecondaryInitialized(
+    secondary: {
+      appServerWs: WebSocket | null;
+      buffer: string[];
+      initialized: boolean;
+      initializationReplayed: boolean;
+    },
+    connId: number,
+  ) {
+    if (secondary.initializationReplayed) return;
+    secondary.initializationReplayed = true;
+
+    if (!this.lastInitializeRaw) {
+      this.log(`Secondary conn #${connId}: no cached initialize available before first non-initialize request`);
+      return;
+    }
+
+    this.log(`Secondary conn #${connId}: replaying cached initialize before picker request`);
+    this.sendOrBufferSecondary(secondary, this.lastInitializeRaw);
+    if (this.lastInitializedRaw) {
+      this.sendOrBufferSecondary(secondary, this.lastInitializedRaw);
+    }
+    secondary.initialized = true;
+  }
+
+  private sendOrBufferSecondary(
+    secondary: {
+      appServerWs: WebSocket | null;
+      buffer: string[];
+    },
+    raw: string,
+  ) {
+    if (secondary.appServerWs && secondary.appServerWs.readyState === WebSocket.OPEN) {
+      try { secondary.appServerWs.send(raw); } catch {}
+    } else {
+      secondary.buffer.push(raw);
+    }
+  }
+
   // ── Response Patching ──────────────────────────────────────
 
   private handleAppServerPayload(raw: string): string | null {
@@ -1133,7 +1199,7 @@ export class CodexAdapter extends EventEmitter {
       // actively-streaming turn (e.g. a multi-minute build) emits only these
       // "unknown" notifications between turn/started and turn/completed; if we
       // refreshed only on the handful in isAppServerNotification() we would
-      // force-complete a live turn. Responses and server requests count as
+      // mark a live turn stalled. Responses and server requests count as
       // activity too. (refreshTurnWatchdogs() no-ops when no turn is active.)
       if (typeof parsed === "object" && parsed !== null) {
         this.refreshTurnWatchdogs();
@@ -1287,6 +1353,12 @@ export class CodexAdapter extends EventEmitter {
     if (!isNaN(numericId) && this.consumeBridgeRequestId(numericId)) {
       if (parsed.error) {
         this.log(`Bridge-originated request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
+        // A bridge-originated request is always an injected turn/start. If Codex
+        // REJECTS it (error response) before any turn/started, no turn ever goes
+        // in-progress, so resetTurnState's wasInProgress-gated turnAborted never
+        // fires. Signal the abort here so daemon-level per-turn state (the
+        // require_reply tracker) is not stranded on a turn that never started.
+        this.emit("turnAborted", `injected turn/start rejected: ${parsed.error.message ?? "unknown error"}`);
       } else {
         this.log(`Bridge-originated request completed (id ${responseId})`);
       }
@@ -1527,6 +1599,7 @@ export class CodexAdapter extends EventEmitter {
 
     const previousThreadId = this.threadId;
     this.threadId = threadId;
+    this.emit("threadChanged", { threadId, previousThreadId, reason });
 
     if (previousThreadId) {
       this.log(`Active thread changed: ${previousThreadId} → ${threadId} (${reason})`);
@@ -1543,6 +1616,10 @@ export class CodexAdapter extends EventEmitter {
     // two never diverge (incl. the no-turn-id `unknown:` fallback).
     const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
     this.activeTurnIds.add(turnKey);
+    // A new turn must be eligible to notify on stall even if a prior turn
+    // reused the same id (e.g. the `unknown:` fallback is time-stamped, but
+    // real ids could repeat across reconnects).
+    this.stalledTurnIds.delete(turnKey);
     this.scheduleTurnWatchdog(turnKey);
 
     this.turnInProgress = this.activeTurnIds.size > 0;
@@ -1555,9 +1632,11 @@ export class CodexAdapter extends EventEmitter {
     if (typeof turnId === "string" && turnId.length > 0) {
       this.activeTurnIds.delete(turnId);
       this.clearTurnWatchdog(turnId);
+      this.stalledTurnIds.delete(turnId);
     } else {
       this.activeTurnIds.clear();
       this.clearAllTurnWatchdogs();
+      this.stalledTurnIds.clear();
     }
 
     this.turnInProgress = this.activeTurnIds.size > 0;
@@ -1576,9 +1655,9 @@ export class CodexAdapter extends EventEmitter {
       if (!this.activeTurnIds.has(turnKey)) return;
       this.log(
         `WARNING: turn ${turnKey} watchdog fired after ${this.turnWatchdogMs()}ms of inactivity — ` +
-        `assuming a lost turn/completed; force-completing to unblock injection`,
+        `marking stalled but keeping Codex busy until a real completion or reconnect`,
       );
-      this.forceCompleteTurn(turnKey);
+      this.markTurnStalled(turnKey);
     }, this.turnWatchdogMs());
     // Never keep the process/test runner alive on account of a watchdog.
     timer.unref?.();
@@ -1601,7 +1680,7 @@ export class CodexAdapter extends EventEmitter {
   /**
    * Refresh every active turn's watchdog — called on any app-server notification
    * so the watchdog measures INACTIVITY, not total turn duration (a genuinely
-   * long but active turn keeps streaming events and is never force-completed).
+   * long but active turn keeps streaming events and is never marked stalled).
    */
   private refreshTurnWatchdogs() {
     if (this.turnWatchdogs.size === 0) return;
@@ -1610,15 +1689,18 @@ export class CodexAdapter extends EventEmitter {
     }
   }
 
-  /** Force-complete a single turn (watchdog expiry path). */
-  private forceCompleteTurn(turnKey: string) {
-    const wasInProgress = this.turnInProgress;
-    this.activeTurnIds.delete(turnKey);
-    this.clearTurnWatchdog(turnKey);
-    this.turnInProgress = this.activeTurnIds.size > 0;
-    if (wasInProgress && !this.turnInProgress) {
-      this.emit("turnCompleted");
-    }
+  /** Mark a turn stalled without clearing busy state (watchdog expiry path). */
+  private markTurnStalled(turnKey: string) {
+    if (!this.activeTurnIds.has(turnKey)) return;
+    this.turnInProgress = true;
+    // Emit at most once per turn: a stalled turn keeps its watchdog armed, so
+    // later notifications can re-fire it. Suppress repeats for the same turnId.
+    if (this.stalledTurnIds.has(turnKey)) return;
+    this.stalledTurnIds.add(turnKey);
+    this.emit("turnStalled", {
+      turnId: turnKey,
+      inactivityMs: this.turnWatchdogMs(),
+    });
   }
 
   /**
@@ -1630,11 +1712,18 @@ export class CodexAdapter extends EventEmitter {
     const wasInProgress = this.turnInProgress;
     this.activeTurnIds.clear();
     this.clearAllTurnWatchdogs();
+    this.stalledTurnIds.clear();
     this.turnInProgress = false;
-    if (emitCompleted && wasInProgress) {
-      this.emit("turnCompleted");
-    }
     if (wasInProgress) {
+      if (emitCompleted) {
+        this.emit("turnCompleted");
+      } else {
+        // The turn ended WITHOUT a normal completion (app-server close / reconnect
+        // / stop). Signal an abort so daemon-level per-turn state (e.g. the
+        // require_reply tracker) can be cleared instead of stranded onto a later
+        // turn — turnCompleted is the ONLY other reset signal the daemon gets.
+        this.emit("turnAborted", reason);
+      }
       this.log(`Turn state reset (${reason})`);
     }
   }
@@ -1852,6 +1941,6 @@ export class CodexAdapter extends EventEmitter {
   private log(msg: string) {
     const line = `[${new Date().toISOString()}] [CodexAdapter] ${msg}\n`;
     process.stderr.write(line);
-    try { appendFileSync(this.logFile, line); } catch {}
+    try { appendRotatingLog(this.logFile, line); } catch {}
   }
 }

--- a/src/codex-transport.ts
+++ b/src/codex-transport.ts
@@ -1,0 +1,334 @@
+/**
+ * Codex transport selection + TCP↔AF_UNIX relay (#85).
+ *
+ * Background: the adapter always connects to the Codex app-server with
+ * `new WebSocket(ws://127.0.0.1:<appPort>)`. Some Codex builds drop `ws://`
+ * from `app-server --listen` (removed in 0.131.0-alpha.9, restored in 0.131.0
+ * stable / present in 0.135.0), while `unix://` works across versions.
+ *
+ * To keep the adapter (and its secondary "picker" connections) byte-for-byte
+ * unchanged when only a unix socket is available, we run a transparent
+ * TCP↔AF_UNIX relay: a `net` server listens on 127.0.0.1:<appPort> and forwards
+ * raw bytes to/from the Codex unix socket. The WebSocket upgrade + frames pass
+ * through, with ONE rewrite: the relay strips the `Sec-WebSocket-Extensions`
+ * header from the client's upgrade request, because Bun's `new WebSocket()`
+ * always offers `permessage-deflate` and Codex's unix listener closes the
+ * connection on that offer (verified empirically against codex 0.135.0).
+ *
+ * Verified facts (codex 0.135.0, see scripts/probe-codex-unix*.mjs):
+ *   - `--listen` supports stdio:// (default), unix://, unix://PATH, ws://IP:PORT, off.
+ *   - The unix listener speaks WebSocket (HTTP 101 upgrade), NOT raw/LSP JSON-RPC.
+ *   - The unix listener does NOT serve the HTTP `/healthz` endpoint → unix-mode
+ *     readiness is a WS-upgrade probe, not an HTTP fetch.
+ *
+ * stdio transport is intentionally deferred: the adapter opens a primary plus
+ * several picker WebSocket connections, which a single stdio stream cannot model.
+ */
+
+import { createServer, connect, type Server, type Socket } from "node:net";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+/** How the adapter reaches the Codex app-server. */
+export type CodexTransport = "ws" | "unix";
+
+/** User-facing selection, including `auto` (probe + fall back). */
+export type CodexTransportMode = "auto" | "ws" | "unix";
+
+export const CODEX_TRANSPORT_ENV = "AGENTBRIDGE_CODEX_TRANSPORT";
+
+const HEADER_SEP = "\r\n\r\n";
+const EXTENSIONS_HEADER_RE = /^sec-websocket-extensions:/i;
+/** Cap on buffered upgrade-header bytes before we give up rewriting and pass through. */
+const MAX_UPGRADE_HEADER_BYTES = 64 * 1024;
+
+/**
+ * Parse the transport mode from an env value. Unknown / empty → `auto`.
+ * Accepts case-insensitively so `WS`/`Unix`/`AUTO` all work.
+ */
+export function parseTransportMode(raw: string | undefined): CodexTransportMode {
+  switch ((raw ?? "").trim().toLowerCase()) {
+    case "ws":
+      return "ws";
+    case "unix":
+      return "unix";
+    case "auto":
+    case "":
+      return "auto";
+    default:
+      return "auto";
+  }
+}
+
+/**
+ * Detect whether this Codex build still supports `ws://` for `app-server
+ * --listen` by parsing `codex app-server --help`. Returns true if the help text
+ * advertises `ws://`. If the probe cannot run (codex missing/erroring), returns
+ * `true` so `auto` preserves today's ws behavior rather than switching paths on
+ * a broken install.
+ */
+export function probeCodexWsSupport(
+  runHelp: () => string | null = defaultRunCodexAppServerHelp,
+): boolean {
+  const help = runHelp();
+  if (help === null) return true; // inconclusive → keep current (ws) behavior
+  return help.includes("ws://");
+}
+
+function defaultRunCodexAppServerHelp(): string | null {
+  try {
+    const res = spawnSync("codex", ["app-server", "--help"], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    if (res.error || typeof res.stdout !== "string") return null;
+    return res.stdout + (res.stderr ?? "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a concrete transport from a mode. `auto` probes ws support and falls
+ * back to `unix`. `ws`/`unix` are honored as-is (no probe).
+ */
+export function resolveCodexTransport(
+  mode: CodexTransportMode,
+  runHelp: () => string | null = defaultRunCodexAppServerHelp,
+): CodexTransport {
+  if (mode === "ws") return "ws";
+  if (mode === "unix") return "unix";
+  return probeCodexWsSupport(runHelp) ? "ws" : "unix";
+}
+
+/**
+ * Short, per-user, per-port unix socket path that stays under the macOS
+ * `sun_path` limit (~104 bytes incl. NUL). We deliberately avoid the platform
+ * state dir (which can be a long "~/Library/Application Support/…" path) and
+ * use a uid-scoped dir under the OS temp dir instead.
+ *
+ * Layout: <tmp>/agentbridge-<uid>/codex-<appPort>.sock
+ * The appPort is unique per pair (slot N → 4500 + N*10), so distinct pairs get
+ * distinct sockets without any extra hashing.
+ */
+export function codexSocketPath(appPort: number, baseTmpDir: string = tmpdir()): string {
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  const dir = join(baseTmpDir, `agentbridge-${uid}`);
+  const path = join(dir, `codex-${appPort}.sock`);
+  if (path.length >= 104) {
+    throw new Error(
+      `Codex unix socket path is too long for the platform (${path.length} >= 104): ${path}. ` +
+      `Set a shorter TMPDIR or use ${CODEX_TRANSPORT_ENV}=ws.`,
+    );
+  }
+  return path;
+}
+
+/** Ensure the parent dir of a socket exists with owner-only perms (0700). */
+export function ensureSocketDir(socketPath: string): void {
+  const dir = socketPath.slice(0, socketPath.lastIndexOf("/"));
+  if (!dir) return;
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // mkdir's `mode` only applies when the dir is CREATED. Enforce owner-only
+  // perms even if it pre-existed with looser permissions (CWE-377: the path is
+  // predictable under /tmp). If we cannot chmod it — e.g. another local user
+  // owns a squatted dir — fail loudly rather than expose Codex's control socket.
+  try {
+    chmodSync(dir, 0o700);
+  } catch (err) {
+    throw new Error(
+      `Refusing to use Codex socket dir ${dir}: cannot enforce 0700 perms ` +
+      `(${(err as Error).message}). Remove it or set a private TMPDIR.`,
+    );
+  }
+}
+
+/** Remove a stale socket file (best-effort; ignores if already gone). */
+export function removeSocketFile(socketPath: string): void {
+  try {
+    rmSync(socketPath, { force: true });
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+/** The `--listen` argument value for a given transport. */
+export function codexListenArg(transport: CodexTransport, appPort: number, socketPath: string): string {
+  return transport === "unix" ? `unix://${socketPath}` : `ws://127.0.0.1:${appPort}`;
+}
+
+/**
+ * Strip the `Sec-WebSocket-Extensions` header line from an HTTP upgrade request
+ * header block (the text before the first CRLFCRLF). Returns the cleaned header
+ * text (without the trailing separator). Other headers are preserved verbatim.
+ */
+export function stripWebSocketExtensions(headerBlock: string): string {
+  return headerBlock
+    .split("\r\n")
+    .filter((line) => !EXTENSIONS_HEADER_RE.test(line))
+    .join("\r\n");
+}
+
+/**
+ * Transparent TCP→AF_UNIX relay. Listens on `tcpHost:tcpPort` and forwards each
+ * accepted TCP connection to a fresh unix-socket connection. The only rewrite is
+ * stripping `Sec-WebSocket-Extensions` from the upgrade request (see file header);
+ * everything else — WS frames in both directions — is byte-for-byte verbatim.
+ * One unix connection per inbound TCP connection (primary + N pickers).
+ */
+export class TcpToUnixRelay {
+  private server: Server | null = null;
+  private readonly pairs = new Set<{ tcp: Socket; unix: Socket }>();
+
+  constructor(
+    private readonly tcpHost: string,
+    private readonly tcpPort: number,
+    private readonly unixPath: string,
+    private readonly log: (msg: string) => void = () => {},
+  ) {}
+
+  /** Start listening. Rejects if the TCP port cannot be bound. */
+  start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const server = createServer((tcp) => this.handleConnection(tcp));
+      const onListenError = (err: Error) => {
+        server.removeListener("listening", onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.removeListener("error", onListenError);
+        // Post-listen errors must never throw: log and keep serving.
+        server.on("error", (err) => this.log(`relay server error: ${err.message}`));
+        this.server = server;
+        resolve();
+      };
+      server.once("error", onListenError);
+      server.once("listening", onListening);
+      server.listen(this.tcpPort, this.tcpHost);
+    });
+  }
+
+  private handleConnection(tcp: Socket): void {
+    const unix = connect(this.unixPath);
+    const pair = { tcp, unix };
+    this.pairs.add(pair);
+
+    let closed = false;
+    const teardown = () => {
+      if (closed) return;
+      closed = true;
+      this.pairs.delete(pair);
+      tcp.destroy();
+      unix.destroy();
+    };
+
+    // C→S: intercept ONLY the first HTTP header block to strip
+    // Sec-WebSocket-Extensions, then hand the rest to pipe() (which gives us
+    // backpressure for free). S→C is always verbatim.
+    let head = Buffer.alloc(0);
+    const onData = (chunk: Buffer) => {
+      head = Buffer.concat([head, chunk]);
+      const sep = head.indexOf(HEADER_SEP);
+      if (sep === -1) {
+        // Not a complete header block yet. If it grows implausibly large it is
+        // not an HTTP upgrade — stop rewriting and pass everything through.
+        if (head.length > MAX_UPGRADE_HEADER_BYTES) {
+          tcp.removeListener("data", onData);
+          unix.write(head);
+          head = Buffer.alloc(0);
+          tcp.pipe(unix);
+        }
+        return;
+      }
+      tcp.removeListener("data", onData);
+      const headers = head.subarray(0, sep).toString("utf8");
+      const rest = head.subarray(sep + HEADER_SEP.length);
+      unix.write(stripWebSocketExtensions(headers) + HEADER_SEP);
+      head = Buffer.alloc(0);
+      // Put any post-header bytes back so pipe() forwards them in order with
+      // proper backpressure.
+      if (rest.length) tcp.unshift(rest);
+      tcp.pipe(unix);
+    };
+    tcp.on("data", onData);
+    unix.pipe(tcp);
+
+    tcp.on("error", (e) => { this.log(`relay tcp error: ${e.message}`); teardown(); });
+    unix.on("error", (e) => { this.log(`relay unix error: ${e.message}`); teardown(); });
+    tcp.on("close", teardown);
+    unix.on("close", teardown);
+  }
+
+  /** Number of live relayed connection pairs (for tests/diagnostics). */
+  get connectionCount(): number {
+    return this.pairs.size;
+  }
+
+  /** The actually-bound TCP port (resolves an ephemeral `tcpPort=0` after start). */
+  get port(): number {
+    const addr = this.server?.address();
+    return addr && typeof addr === "object" ? addr.port : this.tcpPort;
+  }
+
+  /** Stop listening and tear down all live relayed connections. */
+  stop(): void {
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+    }
+    for (const { tcp, unix } of this.pairs) {
+      tcp.destroy();
+      unix.destroy();
+    }
+    this.pairs.clear();
+  }
+}
+
+/**
+ * Readiness probe for unix transport: the Codex unix listener does NOT serve
+ * HTTP `/healthz`, so we instead attempt a WebSocket upgrade directly against
+ * the unix socket and treat an HTTP 101 as "ready". Retries until the listener
+ * is up. Resolves on success, rejects after exhausting retries.
+ */
+export async function waitForUnixWsReady(
+  socketPath: string,
+  maxRetries = 40,
+  delayMs = 250,
+): Promise<void> {
+  for (let i = 0; i < maxRetries; i++) {
+    if (await attemptUnixWsUpgrade(socketPath)) return;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  throw new Error(`Codex unix app-server at ${socketPath} did not become ready`);
+}
+
+/** Single WS-upgrade attempt against a unix socket. Resolves true on HTTP 101. */
+function attemptUnixWsUpgrade(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      try { socket.destroy(); } catch { /* ignore */ }
+      resolve(ok);
+    };
+    const socket = connect(socketPath, () => {
+      // A fixed sample key — we never read frames, only the status line, so the
+      // accept value does not need verifying. No extensions offered (see strip).
+      socket.write(
+        "GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+      );
+    });
+    let buf = "";
+    socket.on("data", (d) => {
+      buf += d.toString("utf8");
+      if (buf.includes("\r\n")) done(buf.startsWith("HTTP/1.1 101"));
+    });
+    socket.on("error", () => done(false));
+    socket.on("close", () => done(false));
+    setTimeout(() => done(false), 1500);
+  });
+}

--- a/src/collaboration-content.ts
+++ b/src/collaboration-content.ts
@@ -76,4 +76,23 @@ AgentBridge is a **transparent proxy** on your side. You do **not** have a tool 
 1. When you receive a complex task, **proactively propose a division of labor** in your response (Claude will receive it).
 2. State what you'll handle and what you'd like Claude to take on.
 3. Ask for Claude's agreement or counter-proposal before proceeding.
-4. After task completion, **cross-review** each other's work.`;
+4. After task completion, **cross-review** each other's work.
+
+### Message markers
+Put a marker at the **very start** of each \`agentMessage\` (it must be the first text — e.g. \`[IMPORTANT] Task done\`, not \`Task done [IMPORTANT]\`):
+- \`[IMPORTANT]\` — decisions, reviews, completions, blockers
+- \`[STATUS]\` — progress updates
+- \`[FYI]\` — background context
+
+Keep \`agentMessage\` for high-value communication only.
+
+### Git operations — FORBIDDEN for you
+You MUST NOT run git **write** commands: \`commit\`, \`push\`, \`pull\`, \`fetch\`, \`checkout -b\`, \`branch\`, \`merge\`, \`rebase\`, \`cherry-pick\`, \`tag\`, \`stash\`. They write the \`.git\` directory (blocked by your sandbox) and will hang your session. Read-only git (\`status\`, \`log\`, \`diff\`, \`show\`, \`rev-parse\`) is fine. Delegate **all** git writes to Claude: report what you changed and let Claude handle branching, committing, and pushing.
+
+### Role guidance
+- Your default role: **Implementer, Executor, Verifier**.
+- Analytical / review tasks: **Independent Analysis & Convergence**.
+- Implementation tasks: **Architect → Builder → Critic**.
+- Debugging tasks: **Hypothesis → Experiment → Interpretation**.
+- Do not blindly follow Claude — challenge with evidence when you disagree.
+- Use explicit collaboration phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:".`;

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -16,12 +16,22 @@ export type ControlClientMessage =
   | { type: "claude_connect" }
   | { type: "claude_disconnect" }
   | { type: "claude_to_codex"; requestId: string; message: BridgeMessage; requireReply?: boolean }
-  | { type: "status" };
+  | { type: "status" }
+  // Non-attaching probe: ask the daemon whether it already has a LIVE Claude
+  // frontend attached, WITHOUT contesting/attaching this socket. Used by the
+  // `abg claude` CLI conflict guard so a second session in the same pair errors
+  // out up front instead of evicting a live incumbent (issue #68 admission still
+  // arbitrates the authoritative live/stale decision at actual attach time).
+  | { type: "probe_incumbent" };
 
 export type ControlServerMessage =
   | { type: "codex_to_claude"; message: BridgeMessage }
   | { type: "claude_to_codex_result"; requestId: string; success: boolean; error?: string }
-  | { type: "status"; status: DaemonStatus };
+  | { type: "status"; status: DaemonStatus }
+  // Reply to `probe_incumbent`. `connected` = a Claude frontend socket is
+  // currently attached; `alive` = it responded to a liveness ping (a half-open
+  // dead incumbent reports connected:true, alive:false → safe to take over).
+  | { type: "incumbent_status"; connected: boolean; alive: boolean };
 
 /** WebSocket close code sent by the daemon when a newer Claude session replaces the current one. */
 export const CLOSE_CODE_REPLACED = 4001;

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -8,6 +8,8 @@ export interface DaemonStatus {
   proxyUrl: string;
   appServerUrl: string;
   pid: number;
+  /** Multi-pair identity for diagnostics; null in legacy/manual single-pair mode. */
+  pairId?: string | null;
 }
 
 export type ControlClientMessage =

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -1,4 +1,15 @@
 import type { BridgeMessage } from "./types";
+import type { AgentBridgeBuildInfo } from "./build-info";
+
+export interface ControlClientIdentity {
+  pairId?: string | null;
+  pairName?: string | null;
+  cwd?: string;
+  baseDir?: string | null;
+  stateDir?: string | null;
+  clientPid?: number;
+  contractVersion?: number;
+}
 
 export interface DaemonStatus {
   bridgeReady: boolean;
@@ -10,10 +21,13 @@ export interface DaemonStatus {
   pid: number;
   /** Multi-pair identity for diagnostics; null in legacy/manual single-pair mode. */
   pairId?: string | null;
+  cwd?: string | null;
+  stateDir?: string | null;
+  build?: AgentBridgeBuildInfo;
 }
 
 export type ControlClientMessage =
-  | { type: "claude_connect" }
+  | { type: "claude_connect"; identity?: ControlClientIdentity }
   | { type: "claude_disconnect" }
   | { type: "claude_to_codex"; requestId: string; message: BridgeMessage; requireReply?: boolean }
   | { type: "status" }
@@ -50,3 +64,6 @@ export const CLOSE_CODE_EVICTED_STALE = 4002;
  * (the in-flight probe will conclude within LIVENESS_PROBE_TIMEOUT_MS).
  */
 export const CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
+
+/** WebSocket close code reserved for pair/cwd identity mismatch enforcement. */
+export const CLOSE_CODE_PAIR_MISMATCH = 4004;

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -12,6 +12,7 @@ interface DaemonClientEvents {
   disconnect: [];
   rejected: [number];
   status: [DaemonStatus];
+  incumbentStatus: [{ connected: boolean; alive: boolean }];
 }
 
 let nextSocketId = 0;
@@ -125,6 +126,52 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     });
   }
 
+  /**
+   * Ask the daemon whether it already has a LIVE Claude frontend attached,
+   * WITHOUT attaching this socket (so it never contests the incumbent).
+   *
+   * Fail-OPEN: on timeout, a closed socket, or an older daemon that doesn't
+   * understand `probe_incumbent` (it stays silent), this resolves to
+   * `{ connected:false, alive:false }` so the conflict guard never blocks a
+   * legitimate launch on a probe failure — admission (#68) is the backstop.
+   */
+  async probeIncumbent(timeoutMs = 3000): Promise<{ connected: boolean; alive: boolean }> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return { connected: false, alive: false };
+    }
+
+    return await new Promise((resolve) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      const finish = (value: { connected: boolean; alive: boolean }) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        this.off("incumbentStatus", onStatus);
+        this.off("disconnect", onDisconnect);
+        this.off("rejected", onRejected);
+        resolve(value);
+      };
+
+      const onStatus = (s: { connected: boolean; alive: boolean }) => finish(s);
+      const onDisconnect = () => finish({ connected: false, alive: false });
+      const onRejected = () => finish({ connected: false, alive: false });
+
+      this.on("incumbentStatus", onStatus);
+      this.on("disconnect", onDisconnect);
+      this.on("rejected", onRejected);
+
+      timer = setTimeout(() => finish({ connected: false, alive: false }), timeoutMs);
+
+      try {
+        this.send({ type: "probe_incumbent" });
+      } catch {
+        finish({ connected: false, alive: false });
+      }
+    });
+  }
+
   async disconnect() {
     if (!this.ws) return;
 
@@ -187,6 +234,9 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
         }
         case "status":
           this.emit("status", message.status);
+          return;
+        case "incumbent_status":
+          this.emit("incumbentStatus", { connected: message.connected, alive: message.alive });
           return;
       }
     };

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -4,8 +4,9 @@ import {
   CLOSE_CODE_REPLACED,
   CLOSE_CODE_EVICTED_STALE,
   CLOSE_CODE_PROBE_IN_PROGRESS,
+  CLOSE_CODE_PAIR_MISMATCH,
 } from "./control-protocol";
-import type { ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
+import type { ControlClientIdentity, ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
 
 interface DaemonClientEvents {
   codexMessage: [BridgeMessage];
@@ -16,6 +17,10 @@ interface DaemonClientEvents {
 }
 
 let nextSocketId = 0;
+
+export interface DaemonClientOptions {
+  identity?: ControlClientIdentity;
+}
 
 export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   private ws: WebSocket | null = null;
@@ -29,7 +34,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     }
   >();
 
-  constructor(private readonly url: string) {
+  constructor(private readonly url: string, private readonly options: DaemonClientOptions = {}) {
     super();
   }
 
@@ -77,15 +82,18 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   }
 
   attachClaude() {
-    this.send({ type: "claude_connect" });
+    this.send({
+      type: "claude_connect",
+      ...(this.options.identity ? { identity: this.options.identity } : {}),
+    });
   }
 
-  async attachClaudeAndWaitForStatus(timeoutMs = 1000): Promise<boolean> {
+  async attachClaudeAndWaitForStatus(timeoutMs = 1000): Promise<DaemonStatus | null> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      return false;
+      return null;
     }
 
-    return await new Promise<boolean>((resolve) => {
+    return await new Promise<DaemonStatus | null>((resolve) => {
       let settled = false;
       let timer: ReturnType<typeof setTimeout> | null = null;
 
@@ -101,27 +109,27 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
         this.off("disconnect", onDisconnect);
       };
 
-      const finish = (value: boolean) => {
+      const finish = (value: DaemonStatus | null) => {
         cleanup();
         resolve(value);
       };
 
-      const onStatus = () => finish(true);
-      const onRejected = () => finish(false);
-      const onDisconnect = () => finish(false);
+      const onStatus = (status: DaemonStatus) => finish(status);
+      const onRejected = () => finish(null);
+      const onDisconnect = () => finish(null);
 
       this.on("status", onStatus);
       this.on("rejected", onRejected);
       this.on("disconnect", onDisconnect);
 
       timer = setTimeout(() => {
-        finish(false);
+        finish(null);
       }, timeoutMs);
 
       try {
         this.attachClaude();
       } catch {
-        finish(false);
+        finish(null);
       }
     });
   }
@@ -250,7 +258,8 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
         if (
           event.code === CLOSE_CODE_REPLACED ||
           event.code === CLOSE_CODE_EVICTED_STALE ||
-          event.code === CLOSE_CODE_PROBE_IN_PROGRESS
+          event.code === CLOSE_CODE_PROBE_IN_PROGRESS ||
+          event.code === CLOSE_CODE_PAIR_MISMATCH
         ) {
           this.emit("rejected", event.code);
         } else {

--- a/src/daemon-identity.ts
+++ b/src/daemon-identity.ts
@@ -1,0 +1,41 @@
+import {
+  CLOSE_CODE_PAIR_MISMATCH,
+  type ControlClientIdentity,
+} from "./control-protocol";
+
+export interface ClaudeIdentityValidationInput {
+  expectedPairId: string | null;
+  daemonCwd: string;
+  identity?: ControlClientIdentity;
+  allowIdentityless?: boolean;
+}
+
+export type ClaudeIdentityValidationResult =
+  | { ok: true }
+  | { ok: false; closeCode: number; reason: string };
+
+export function validateClaudeClientIdentity(
+  input: ClaudeIdentityValidationInput,
+): ClaudeIdentityValidationResult {
+  if (!input.expectedPairId) return { ok: true };
+  if (!input.identity) {
+    return input.allowIdentityless
+      ? { ok: true }
+      : { ok: false, closeCode: CLOSE_CODE_PAIR_MISMATCH, reason: "missing client identity" };
+  }
+  if (input.identity.pairId !== input.expectedPairId) {
+    return {
+      ok: false,
+      closeCode: CLOSE_CODE_PAIR_MISMATCH,
+      reason: `pair mismatch: expected ${input.expectedPairId}, got ${input.identity.pairId ?? "<none>"}`,
+    };
+  }
+  if (!input.identity.cwd || input.identity.cwd !== input.daemonCwd) {
+    return {
+      ok: false,
+      closeCode: CLOSE_CODE_PAIR_MISMATCH,
+      reason: `cwd mismatch: expected ${input.daemonCwd}, got ${input.identity.cwd ?? "<none>"}`,
+    };
+  }
+  return { ok: true };
+}

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -3,9 +3,11 @@ import { existsSync, readFileSync, unlinkSync, writeFileSync, openSync, closeSyn
 import { fileURLToPath } from "node:url";
 import { StateDirResolver } from "./state-dir";
 
-// When bundled into a Claude Code plugin, the frontend runs from the plugin
-// cache directory and must launch the sibling daemon bundle from there.
-const DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY ?? "./daemon.ts";
+// In source/dev mode this module is loaded from src/*.ts and can launch the
+// sibling daemon.ts directly. In bundled CLI/plugin mode it is loaded from a
+// generated *.js bundle, so the daemon must be a sibling daemon.js artifact.
+const DEFAULT_DAEMON_ENTRY = import.meta.url.endsWith(".ts") ? "./daemon.ts" : "./daemon.js";
+const DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 const DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 
 export interface DaemonLifecycleOptions {

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -1,6 +1,7 @@
 import { spawn, execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { BUILD_INFO, formatBuildInfo, sameRuntimeContract } from "./build-info";
 import { StateDirResolver } from "./state-dir";
 import { parsePositiveIntEnv } from "./env-utils";
 import type { DaemonStatus } from "./control-protocol";
@@ -18,6 +19,7 @@ const DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 // healthz-OK/readyz-503 zombie so we replace it instead of hanging the full ~10s.
 const REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES", 12);
 const REUSE_READY_DELAY_MS = 250;
+const HEALTH_FETCH_TIMEOUT_MS = 500;
 
 export interface DaemonLifecycleOptions {
   stateDir: StateDirResolver;
@@ -60,7 +62,7 @@ export class DaemonLifecycle {
   /** Fetch the daemon's /healthz status body (null if unreachable / non-OK / unparseable). */
   private async fetchStatus(): Promise<DaemonStatus | null> {
     try {
-      const response = await fetch(this.healthUrl);
+      const response = await fetchWithTimeout(this.healthUrl);
       if (!response.ok) return null;
       return (await response.json()) as DaemonStatus;
     } catch {
@@ -85,6 +87,17 @@ export class DaemonLifecycle {
     return reported !== expected;
   }
 
+  private isBuildDrifted(status: DaemonStatus | null): boolean {
+    if (process.env.AGENTBRIDGE_ALLOW_BUILD_DRIFT === "1") return false;
+    const runtime = status?.build;
+    if (!runtime) return true;
+    // Compare the runtime CONTRACT (version/commit/contractVersion), NOT `bundle`:
+    // the dist CLI and the Claude Code plugin launch co-equal daemons from the same
+    // source for the same pair, so a bundle-kind difference must not trigger a
+    // destructive replace (that would replace-war the two launchers).
+    return !sameRuntimeContract(runtime, BUILD_INFO);
+  }
+
   /** Ensure daemon is running: reuse a healthy one, replace a bad/foreign one, else launch. */
   async ensureRunning(): Promise<void> {
     // Fast path: something answers /healthz on our control port. But healthz 200 only
@@ -96,6 +109,14 @@ export class DaemonLifecycle {
         this.log(
           `Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` +
             `but this pair is ${this.expectedPairId} — replacing foreign daemon`,
+        );
+        await this.replaceUnhealthyDaemon(status?.pid);
+        return;
+      }
+      if (this.isBuildDrifted(status)) {
+        this.log(
+          `Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` +
+            `but launcher is ${formatBuildInfo(BUILD_INFO)} — replacing drifted daemon`,
         );
         await this.replaceUnhealthyDaemon(status?.pid);
         return;
@@ -152,12 +173,24 @@ export class DaemonLifecycle {
         return;
       }
       // Re-check under the lock: a concurrent launcher may have just started one.
-      if ((await this.isHealthy()) && !this.isForeignDaemon(await this.fetchStatus())) {
-        try {
-          await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
-          return;
-        } catch {
-          // not ready → fall through to (re)launch under this lock
+      if (await this.isHealthy()) {
+        const status = await this.fetchStatus();
+        if (this.isForeignDaemon(status) || this.isBuildDrifted(status)) {
+          this.log(
+            `Daemon on control port ${this.controlPort} is not reusable under startup lock ` +
+              `(pair=${status?.pairId ?? "<none>"}, build=${formatBuildInfo(status?.build)}) — replacing`,
+          );
+          await this.kill(3000, status?.pid);
+        } else {
+          try {
+            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            return;
+          } catch {
+            this.log(
+              `Daemon on control port ${this.controlPort} is healthy but not ready under startup lock — replacing`,
+            );
+            await this.kill(3000, status?.pid);
+          }
         }
       }
       this.launch();
@@ -168,7 +201,7 @@ export class DaemonLifecycle {
   /** Check if daemon health endpoint responds. */
   async isHealthy(): Promise<boolean> {
     try {
-      const response = await fetch(this.healthUrl);
+      const response = await fetchWithTimeout(this.healthUrl);
       return response.ok;
     } catch {
       return false;
@@ -187,7 +220,7 @@ export class DaemonLifecycle {
   /** Check if daemon is ready to accept Codex TUI connections. */
   async isReady(): Promise<boolean> {
     try {
-      const response = await fetch(this.readyUrl);
+      const response = await fetchWithTimeout(this.readyUrl);
       return response.ok;
     } catch {
       return false;
@@ -214,7 +247,7 @@ export class DaemonLifecycle {
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       if (await this.isReady()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status)) return; // ready + ours (or manual mode)
+        if (!this.isForeignDaemon(status) && !this.isBuildDrifted(status)) return; // ready + ours + current build
       }
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
@@ -335,7 +368,7 @@ export class DaemonLifecycle {
       // Re-check under the lock: the daemon may have readied or been replaced already.
       if (await this.isHealthy()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status)) {
+        if (!this.isForeignDaemon(status) && !this.isBuildDrifted(status)) {
           try {
             await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return; // someone else already fixed it — don't kill
@@ -508,6 +541,16 @@ export class DaemonLifecycle {
   private cleanup(): void {
     this.removePidFile();
     this.removeStatusFile();
+  }
+}
+
+async function fetchWithTimeout(url: string, timeoutMs = HEALTH_FETCH_TIMEOUT_MS): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -2,6 +2,8 @@ import { spawn, execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { StateDirResolver } from "./state-dir";
+import { parsePositiveIntEnv } from "./env-utils";
+import type { DaemonStatus } from "./control-protocol";
 
 // In source/dev mode this module is loaded from src/*.ts and can launch the
 // sibling daemon.ts directly. In bundled CLI/plugin mode it is loaded from a
@@ -9,6 +11,13 @@ import { StateDirResolver } from "./state-dir";
 const DEFAULT_DAEMON_ENTRY = import.meta.url.endsWith(".ts") ? "./daemon.ts" : "./daemon.js";
 const DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 const DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
+
+// Short readiness window for VALIDATING an already-running daemon (the reuse path),
+// distinct from a fresh launch's full waitForReady(). ~3s (12×250ms): long enough for
+// a sane daemon / legit slow boot to report ready, short enough to fail fast on a
+// healthz-OK/readyz-503 zombie so we replace it instead of hanging the full ~10s.
+const REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES", 12);
+const REUSE_READY_DELAY_MS = 250;
 
 export interface DaemonLifecycleOptions {
   stateDir: StateDirResolver;
@@ -43,11 +52,68 @@ export class DaemonLifecycle {
     return `ws://127.0.0.1:${this.controlPort}/ws`;
   }
 
-  /** Ensure daemon is running: check health, check pid, start if needed. */
+  /** This pair's expected daemon identity (null in legacy/manual single-pair mode). */
+  private get expectedPairId(): string | null {
+    return process.env.AGENTBRIDGE_PAIR_ID || null;
+  }
+
+  /** Fetch the daemon's /healthz status body (null if unreachable / non-OK / unparseable). */
+  private async fetchStatus(): Promise<DaemonStatus | null> {
+    try {
+      const response = await fetch(this.healthUrl);
+      if (!response.ok) return null;
+      return (await response.json()) as DaemonStatus;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * True when this pair expects a specific pairId and the live daemon is NOT ours —
+   * a foreign daemon squatting our control port. In pair mode (expected pairId set),
+   * a missing/null reported pairId is ALSO foreign: an old daemon built before pairId
+   * shipped, or a manual daemon, must not be silently reused by a named pair — that is
+   * exactly the squatting the hardening exists to prevent. In manual/legacy mode
+   * (no expected pairId), any reported pairId is acceptable.
+   */
+  private isForeignDaemon(status: DaemonStatus | null): boolean {
+    const expected = this.expectedPairId;
+    if (!expected) return false; // manual/legacy — no enforcement
+    if (!status) return false; // unreachable/unparseable status — don't force-replace
+    const reported = status.pairId;
+    if (reported == null) return true; // pair-mode + no reported identity = foreign
+    return reported !== expected;
+  }
+
+  /** Ensure daemon is running: reuse a healthy one, replace a bad/foreign one, else launch. */
   async ensureRunning(): Promise<void> {
+    // Fast path: something answers /healthz on our control port. But healthz 200 only
+    // proves the control server is alive — NOT that codex bootstrapped, nor that the
+    // daemon belongs to THIS pair. Distinguish reuse-able from replace-able:
     if (await this.isHealthy()) {
-      await this.waitForReady();
-      return;
+      const status = await this.fetchStatus();
+      if (this.isForeignDaemon(status)) {
+        this.log(
+          `Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` +
+            `but this pair is ${this.expectedPairId} — replacing foreign daemon`,
+        );
+        await this.replaceUnhealthyDaemon(status?.pid);
+        return;
+      }
+      try {
+        // Short window: a sane daemon (or a legit slow boot) reports ready within ~3s.
+        await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+        return; // healthy + ready → reuse
+      } catch {
+        // healthz-OK but never ready within the reuse window → bad/zombie daemon
+        // (e.g. codex bootstrap failed: healthz 200 / readyz 503 forever). Replace it
+        // instead of the old behaviour of hanging ~10s then abandoning it in place.
+        this.log(
+          `Daemon on control port ${this.controlPort} is healthy but not ready within reuse window — replacing`,
+        );
+        await this.replaceUnhealthyDaemon(status?.pid);
+        return;
+      }
     }
 
     const existingPid = this.readPid();
@@ -56,12 +122,14 @@ export class DaemonLifecycle {
         // Verify the live process is actually our daemon, not an OS-reused PID
         if (this.isDaemonProcess(existingPid)) {
           try {
-            await this.waitForReady(12, 250);
+            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
           } catch {
-            throw new Error(
-              `Found existing daemon process ${existingPid}, but control port ${this.controlPort} never became ready.`,
-            );
+            // Live daemon process but control port never became ready → replace it
+            // (old behaviour threw and left the zombie in place).
+            this.log(`Existing daemon process ${existingPid} never became ready — replacing`);
+            await this.replaceUnhealthyDaemon(existingPid);
+            return;
           }
         }
         // Live process but NOT our daemon — stale PID reused by OS
@@ -70,21 +138,31 @@ export class DaemonLifecycle {
       this.removeStalePidFile();
     }
 
-    // Acquire startup lock to prevent concurrent launches
-    const lockAcquired = this.acquireLock();
-    if (!lockAcquired) {
-      // Another process is launching the daemon — wait for it
-      this.log("Another process is starting the daemon, waiting for readiness...");
-      await this.waitForReady();
-      return;
-    }
-
-    try {
+    // Nothing usable running — launch a fresh daemon under the strict lock.
+    await this.withStartupLockStrict(async (locked) => {
+      if (!locked) {
+        // Another process holds the lock and is launching/replacing — just wait.
+        this.log("Another process holds the startup lock, waiting for readiness+identity...");
+        // Contended branch: the lock holder is doing the fix-up. Wait for a daemon
+        // that is BOTH ready AND ours — a foreign daemon becoming ready behind the
+        // lock holder is the other pair repairing their own daemon; adopting it
+        // would squat the wrong pair. Manual mode is handled by waitForReadyAndOurs
+        // (it short-circuits the identity check).
+        await this.waitForReadyAndOurs();
+        return;
+      }
+      // Re-check under the lock: a concurrent launcher may have just started one.
+      if ((await this.isHealthy()) && !this.isForeignDaemon(await this.fetchStatus())) {
+        try {
+          await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+          return;
+        } catch {
+          // not ready → fall through to (re)launch under this lock
+        }
+      }
       this.launch();
       await this.waitForReady();
-    } finally {
-      this.releaseLock();
-    }
+    });
   }
 
   /** Check if daemon health endpoint responds. */
@@ -123,6 +201,26 @@ export class DaemonLifecycle {
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
     throw new Error(`Timed out waiting for AgentBridge daemon readiness on ${this.readyUrl}`);
+  }
+
+  /**
+   * Wait for the daemon to be ready AND belong to this pair. Used in contended-lock
+   * branches where another launcher is the one doing the fix-up — we must not return
+   * just because the daemon reported ready, since that daemon may be foreign (the
+   * other pair repairing their own daemon). In manual mode (no expected pairId) this
+   * is equivalent to waitForReady.
+   */
+  async waitForReadyAndOurs(maxRetries = 40, delayMs = 250): Promise<void> {
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      if (await this.isReady()) {
+        const status = await this.fetchStatus();
+        if (!this.isForeignDaemon(status)) return; // ready + ours (or manual mode)
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    throw new Error(
+      `Timed out waiting for AgentBridge daemon readiness+identity on ${this.readyUrl} (control port ${this.controlPort})`,
+    );
   }
 
   /** Read daemon status from status.json. */
@@ -215,14 +313,67 @@ export class DaemonLifecycle {
   }
 
   /**
-   * Try to acquire the startup lock file exclusively.
-   * Returns true if the lock was acquired, false if another process holds it.
+   * Replace a bad/foreign daemon holding our control port. Done under a STRICT startup
+   * lock so two concurrent launchers never kill each other's fresh daemon. Inside the
+   * lock we RE-CHECK whether the daemon is still bad (another launcher may have already
+   * fixed it) before killing. `statusPid` (from the /healthz body) is preferred for the
+   * kill so a foreign daemon whose pid file we don't own is still reachable.
    */
-  private acquireLock(depth = 0): boolean {
-    if (depth > 1) {
-      this.log("Lock acquisition failed after retry, proceeding without lock");
-      return true;
+  private async replaceUnhealthyDaemon(statusPid?: number): Promise<void> {
+    await this.withStartupLockStrict(async (locked) => {
+      if (!locked) {
+        // Another launcher holds the lock and will replace/launch — just wait.
+        this.log("Another process holds the startup lock, waiting for readiness+identity...");
+        // Contended branch: the lock holder is doing the fix-up. Wait for a daemon
+        // that is BOTH ready AND ours — a foreign daemon becoming ready behind the
+        // lock holder is the other pair repairing their own daemon; adopting it
+        // would squat the wrong pair. Manual mode is handled by waitForReadyAndOurs
+        // (it short-circuits the identity check).
+        await this.waitForReadyAndOurs();
+        return;
+      }
+      // Re-check under the lock: the daemon may have readied or been replaced already.
+      if (await this.isHealthy()) {
+        const status = await this.fetchStatus();
+        if (!this.isForeignDaemon(status)) {
+          try {
+            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            return; // someone else already fixed it — don't kill
+          } catch {
+            // still not ready → fall through to kill + relaunch
+          }
+        }
+      }
+      this.log(`Killing unhealthy daemon on control port ${this.controlPort} and relaunching`);
+      await this.kill(3000, statusPid);
+      this.launch();
+      await this.waitForReady();
+    });
+  }
+
+  /**
+   * Run `fn` while holding the startup lock, serializing destructive replace/launch.
+   * Unlike the old acquireLock's depth>1 bypass, this NEVER proceeds destructively
+   * without the lock: if a LIVE process holds it, `fn` is invoked with locked=false
+   * (the caller should just wait for readiness, not kill/launch). Stale locks (dead
+   * holder) are reclaimed once.
+   */
+  private async withStartupLockStrict<T>(fn: (locked: boolean) => Promise<T>): Promise<T> {
+    const locked = this.acquireLockStrict();
+    try {
+      return await fn(locked);
+    } finally {
+      if (locked) this.releaseLock();
     }
+  }
+
+  /**
+   * Acquire the startup lock WITHOUT bypass-on-contention. Returns false if a live
+   * holder exists (so destructive replacement stays serialized); reclaims a stale lock
+   * left by a dead holder, retrying exactly once. On a non-EEXIST error (permissions,
+   * etc.) returns false — strict mode refuses to proceed destructively unlocked.
+   */
+  private acquireLockStrict(reclaimed = false): boolean {
     this.stateDir.ensure();
     try {
       const fd = openSync(this.stateDir.lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
@@ -231,26 +382,22 @@ export class DaemonLifecycle {
       return true;
     } catch (err: any) {
       if (err.code === "EEXIST") {
-        // Check if the lock holder is still alive — recover from stale locks
-        // left by crashed launchers
+        if (reclaimed) return false; // already retried once after reclaiming
         try {
           const holderPid = Number.parseInt(readFileSync(this.stateDir.lockFile, "utf-8").trim(), 10);
           if (Number.isFinite(holderPid) && !isProcessAlive(holderPid)) {
-            this.log(`Stale lock file from dead process ${holderPid}, removing`);
+            this.log(`Stale startup lock from dead process ${holderPid}, reclaiming`);
             this.releaseLock();
-            return this.acquireLock(depth + 1);
+            return this.acquireLockStrict(true);
           }
         } catch {
-          // Can't read lock file — remove and retry
-          this.log("Cannot read lock file, removing stale lock");
-          this.releaseLock();
-          return this.acquireLock(depth + 1);
+          // Can't read the lock holder — treat as contended; do NOT bypass.
+          return false;
         }
-        return false;
+        return false; // live holder — contended
       }
-      // Non-EEXIST error (permissions, etc.) — log and proceed without lock
-      this.log(`Warning: could not acquire startup lock: ${err.message}`);
-      return true;
+      this.log(`Could not acquire strict startup lock: ${err.message}`);
+      return false;
     }
   }
 
@@ -265,8 +412,12 @@ export class DaemonLifecycle {
    * Kill daemon process precisely.
    * Returns true if a process was found and killed.
    */
-  async kill(gracefulTimeoutMs = 3000): Promise<boolean> {
-    const pid = this.readPid();
+  async kill(gracefulTimeoutMs = 3000, pidOverride?: number): Promise<boolean> {
+    // pidOverride lets us target a daemon reported via /healthz body whose pid file
+    // we don't own (e.g. a foreign daemon squatting our control port). Falls back to
+    // the pid file. The isDaemonProcess() guard below still prevents killing a
+    // non-AgentBridge process if the OS reused the pid.
+    const pid = pidOverride ?? this.readPid();
     if (!pid) {
       this.log("No daemon pid file found");
       this.cleanup();
@@ -324,23 +475,39 @@ export class DaemonLifecycle {
    * process when the OS has reused a stale PID.
    */
   private isDaemonProcess(pid: number): boolean {
-    // Always verify via process command line — status.json/pid files can be
-    // stale and matching PIDs only proves two local files agree, not that
-    // the live process is actually AgentBridge.
+    // Verify via process command line that this PID is actually our daemon, not
+    // an OS-reused PID belonging to some unrelated process. Match on the
+    // executable basename being a daemon-role script (`daemon.{ts,js}` for
+    // production, `*-daemon.{ts,js}` for the e2e harness's fake) — NOT on the
+    // loose substring "daemon", which would also match e.g. a test file named
+    // `daemon-self-heal.test.ts` invoked by an IDE runner.
     try {
       const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-      return cmd.includes("daemon") && (cmd.includes("agentbridge") || cmd.includes("agent_bridge"));
+      // Match: .../<anything>-daemon.js or .../<anything>-daemon.ts as a runnable
+      // argument (preceded by whitespace/path-sep, followed by whitespace or EOL).
+      // We additionally require the command to mention the agentbridge package OR
+      // the repo dir to avoid matching some unrelated `*-daemon.js` from another
+      // project.
+      const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
+      const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
+      return hasDaemonEntry && hasAgentbridge;
     } catch {
       // ps failed — process may have exited between our check and the ps call
       return false;
     }
   }
 
-  /** Clean up all state files. */
+  /**
+   * Clean up daemon state files (pid + status). Does NOT touch the startup lock:
+   * kill() runs INSIDE withStartupLockStrict's held section during a replace, and
+   * releasing the lock here would let a concurrent launcher grab it mid-replace and
+   * double-launch (the bug a strict lock exists to prevent). The lock's lifecycle is
+   * owned solely by withStartupLockStrict's finally; stale locks left by a dead holder
+   * are reclaimed by acquireLockStrict.
+   */
   private cleanup(): void {
     this.removePidFile();
     this.removeStatusFile();
-    this.releaseLock();
   }
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -734,6 +734,8 @@ function writeStatusFile() {
     appServerUrl: codex.appServerUrl,
     controlPort: CONTROL_PORT,
     pid: process.pid,
+    // Pair identity for diagnostics (null in legacy/manual single-pair mode).
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
   });
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -487,6 +487,7 @@ function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
  */
 async function handleProbeIncumbent(ws: ServerWebSocket<ControlSocketData>) {
   const occupant = attachedClaude;
+  log(`probe_incumbent from #${ws.data.clientId}: occupant=${occupant ? "#" + occupant.data.clientId : "none"} readyState=${occupant?.readyState}`);
   if (!occupant || occupant === ws || occupant.readyState !== WebSocket.OPEN) {
     sendProtocolMessage(ws, { type: "incumbent_status", connected: false, alive: false });
     return;
@@ -505,6 +506,7 @@ async function handleProbeIncumbent(ws: ServerWebSocket<ControlSocketData>) {
   const alive = await probeLiveness(occupant, LIVENESS_PROBE_TIMEOUT_MS);
   // The probe awaited; re-read state in case the incumbent closed meanwhile.
   const stillConnected = attachedClaude === occupant && occupant.readyState === WebSocket.OPEN;
+  log(`probe_incumbent reply to #${ws.data.clientId}: connected=${stillConnected} alive=${stillConnected && alive}`);
   sendProtocolMessage(ws, {
     type: "incumbent_status",
     connected: stillConnected,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -27,7 +27,10 @@ import { probeLiveness as probeLivenessImpl } from "./liveness-probe";
 interface ControlSocketData {
   clientId: number;
   attached: boolean;
+  /** Wall-clock of the last pong (used only for the contest diagnostic log). */
   lastPongAt: number;
+  /** Monotonic pong counter — the liveness probe's source of truth (see liveness-probe.ts). */
+  pongCount: number;
 }
 
 const stateDir = new StateDirResolver();
@@ -256,7 +259,7 @@ function startControlServer() {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
 
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now() } })) {
+      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0 } })) {
         return undefined;
       }
 
@@ -281,6 +284,7 @@ function startControlServer() {
       },
       pong: (ws: ServerWebSocket<ControlSocketData>) => {
         ws.data.lastPongAt = Date.now();
+        ws.data.pongCount++;
       },
     },
   });
@@ -521,7 +525,7 @@ async function probeLiveness(
   return probeLivenessImpl(
     {
       get readyState() { return ws.readyState; },
-      get lastPongAt() { return ws.data.lastPongAt; },
+      get pongCount() { return ws.data.pongCount; },
       ping: () => { ws.ping(); },
     },
     { timeoutMs, pollMs: LIVENESS_PROBE_POLL_MS },

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -308,6 +308,11 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
     case "status":
       sendStatus(ws);
       return;
+    case "probe_incumbent":
+      handleProbeIncumbent(ws).catch((err) => {
+        log(`handleProbeIncumbent threw for #${ws.data.clientId}: ${err?.message ?? err}`);
+      });
+      return;
     case "claude_to_codex": {
       if (message.message.source !== "claude") {
         sendProtocolMessage(ws, {
@@ -465,6 +470,46 @@ function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
   scheduleClaudeDisconnectNotification(ws.data.clientId);
 
   scheduleIdleShutdown();
+}
+
+/**
+ * Answer a non-attaching `probe_incumbent` request: does this daemon currently
+ * have a LIVE Claude frontend attached? The asking socket (`ws`) is the CLI's
+ * throwaway control connection — it never attaches, so it can never be the
+ * occupant and probing it has no side effect on admission.
+ *
+ * Semantics mirror the challenge-on-contest path (issue #68):
+ *   - no occupant / closed occupant            → { connected:false, alive:false }
+ *   - a real contest probe already in flight    → { connected:true,  alive:true } (defer)
+ *   - otherwise actively ping the incumbent      → alive = pong observed in time
+ * A half-open dead incumbent reports connected:true, alive:false, telling the CLI
+ * it is safe to launch and let admission evict the stale frontend.
+ */
+async function handleProbeIncumbent(ws: ServerWebSocket<ControlSocketData>) {
+  const occupant = attachedClaude;
+  if (!occupant || occupant === ws || occupant.readyState !== WebSocket.OPEN) {
+    sendProtocolMessage(ws, { type: "incumbent_status", connected: false, alive: false });
+    return;
+  }
+  // A real challenge-on-contest decision is already running — defer to it (report
+  // live so the CLI guard errs on the safe side and does not race the admission).
+  if (challengeInProgress) {
+    sendProtocolMessage(ws, { type: "incumbent_status", connected: true, alive: true });
+    return;
+  }
+  // Deliberately do NOT set challengeInProgress here: this is a read-only probe,
+  // not a contest. Setting it would make a genuine concurrent claude_connect get
+  // bounced with CLOSE_CODE_PROBE_IN_PROGRESS (a ~3s reconnect delay) even though
+  // the probing socket never intends to attach. A real contest that races this
+  // probe just runs its own ping concurrently — harmless (ping is idempotent).
+  const alive = await probeLiveness(occupant, LIVENESS_PROBE_TIMEOUT_MS);
+  // The probe awaited; re-read state in case the incumbent closed meanwhile.
+  const stillConnected = attachedClaude === occupant && occupant.readyState === WebSocket.OPEN;
+  sendProtocolMessage(ws, {
+    type: "incumbent_status",
+    connected: stillConnected,
+    alive: stillConnected && alive,
+  });
 }
 
 async function probeLiveness(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 
-import { appendFileSync } from "node:fs";
 import type { ServerWebSocket } from "bun";
+import { daemonStatusBuildInfo } from "./build-info";
 import { CodexAdapter } from "./codex-adapter";
+import { validateClaudeClientIdentity } from "./daemon-identity";
 import {
   REPLY_REQUIRED_INSTRUCTION,
   StatusBuffer,
@@ -19,7 +20,15 @@ import {
   CLOSE_CODE_PROBE_IN_PROGRESS,
 } from "./control-protocol";
 import { parsePositiveIntEnv } from "./env-utils";
-import type { ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
+import { ReplyRequiredTracker } from "./reply-required-tracker";
+import { persistCurrentThreadWithRolloutRetry } from "./thread-state";
+import { appendRotatingLog } from "./rotating-log";
+import type {
+  ControlClientIdentity,
+  ControlClientMessage,
+  ControlServerMessage,
+  DaemonStatus,
+} from "./control-protocol";
 import type { BridgeMessage } from "./types";
 import { probeLiveness as probeLivenessImpl } from "./liveness-probe";
 
@@ -30,6 +39,7 @@ interface ControlSocketData {
   lastPongAt: number;
   /** Monotonic pong counter — the liveness probe's source of truth (see liveness-probe.ts). */
   pongCount: number;
+  identity?: ControlClientIdentity;
 }
 
 const stateDir = new StateDirResolver();
@@ -57,6 +67,7 @@ const BOOTSTRAP_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_BOOTSTRAP_TIMEOUT_
 // codex's port not yet released). After these, the daemon self-exits — further
 // replacement is owned by the lifecycle (ensureRunning), not by retrying forever here.
 const CODEX_BOOT_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_CODEX_BOOT_RETRIES", 2);
+const ALLOW_IDENTITYLESS_CLIENT = process.env.AGENTBRIDGE_COMPAT_IDENTITYLESS === "1";
 
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 
@@ -70,8 +81,7 @@ let nextSystemMessageId = 0;
 let codexBootstrapped = false;
 let attentionWindowTimer: ReturnType<typeof setTimeout> | null = null;
 let inAttentionWindow = false;
-let replyRequired = false;
-let replyReceivedDuringTurn = false;
+const replyTracker = new ReplyRequiredTracker();
 let shuttingDown = false;
 let bootDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
 let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
@@ -134,10 +144,10 @@ codex.on("agentMessage", (msg: BridgeMessage) => {
   if (msg.source !== "codex") return;
   const result = classifyMessage(msg.content, FILTER_MODE);
 
-  // When replyRequired is active, force-forward ALL messages regardless of marker
-  if (replyRequired) {
+  // When require_reply is armed, force-forward ALL messages regardless of marker
+  if (replyTracker.isArmed) {
     log(`Codex → Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
-    replyReceivedDuringTurn = true;
+    replyTracker.noteForwarded();
     if (statusBuffer.size > 0) {
       statusBuffer.flush("reply-required message arrived");
     }
@@ -176,8 +186,10 @@ codex.on("turnCompleted", () => {
   log("Codex turn completed");
   statusBuffer.flush("turn completed");
 
-  // Check if reply was required but Codex didn't send any agentMessage
-  if (replyRequired && !replyReceivedDuringTurn) {
+  // Check if reply was required but Codex didn't send any agentMessage, then
+  // clear the reply-required state.
+  const { warnReplyMissing } = replyTracker.consumeOnTurnComplete();
+  if (warnReplyMissing) {
     log("⚠️ Reply was required but Codex did not send any agentMessage");
     emitToClaude(
       systemMessage(
@@ -186,10 +198,6 @@ codex.on("turnCompleted", () => {
       ),
     );
   }
-
-  // Reset reply-required state
-  replyRequired = false;
-  replyReceivedDuringTurn = false;
 
   emitToClaude(
     systemMessage(
@@ -200,6 +208,24 @@ codex.on("turnCompleted", () => {
   startAttentionWindow();
 });
 
+codex.on("turnAborted", (reason: string) => {
+  // A turn ended without a normal turn/completed (app-server close / reconnect /
+  // stop). Clear the require_reply tracker so its armed state cannot be inherited
+  // by a later, unrelated turn (force-forward leak + misattributed warning).
+  log(`Codex turn aborted (${reason}) — clearing reply-required state`);
+  replyTracker.reset();
+});
+
+codex.on("turnStalled", (event: { turnId: string; inactivityMs: number }) => {
+  log(`Codex turn stalled (${event.turnId}, inactivity ${event.inactivityMs}ms)`);
+  emitToClaude(
+    systemMessage(
+      "system_turn_stalled",
+      `⚠️ Codex has been silent for ${event.inactivityMs}ms while a turn is still in progress. AgentBridge is keeping the turn busy and will not send a fake completion; wait for Codex to finish or reconnect the TUI if it is stuck.`,
+    ),
+  );
+});
+
 codex.on("ready", (threadId: string) => {
   tuiConnectionState.markBridgeReady();
   log(`Codex ready — thread ${threadId}`);
@@ -208,6 +234,29 @@ codex.on("ready", (threadId: string) => {
   emitToClaude(
     systemMessage("system_ready", currentReadyMessage()),
   );
+});
+
+codex.on("threadChanged", (event: { threadId: string; previousThreadId: string | null; reason: string }) => {
+  broadcastStatus();
+  void persistCurrentThreadWithRolloutRetry(
+    {
+      stateDir,
+      pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+      pairName: process.env.AGENTBRIDGE_PAIR_NAME,
+      cwd: process.cwd(),
+    },
+    event.threadId,
+    event.reason,
+    {
+      log,
+      // Abandon this loop the moment a newer thread switch supersedes it, so a
+      // lingering retry cannot clobber current-thread.json with an abandoned
+      // threadId (which would auto-resume the wrong thread or break resume).
+      shouldContinue: () => codex.activeThreadId === event.threadId,
+    },
+  ).catch((err) => {
+    log(`Failed to persist current thread ${event.threadId}: ${err?.message ?? err}`);
+  });
 });
 
 codex.on("tuiConnected", (connId: number) => {
@@ -231,6 +280,7 @@ codex.on("error", (err: Error) => {
 codex.on("exit", (code: number | null) => {
   log(`Codex process exited (code ${code})`);
   codexBootstrapped = false;
+  replyTracker.reset(); // any in-flight require_reply turn is gone with the process
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
@@ -305,7 +355,18 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
 
   switch (message.type) {
     case "claude_connect":
-      attachClaude(ws).catch((err) => {
+      const admission = validateClaudeClientIdentity({
+        expectedPairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+        daemonCwd: process.cwd(),
+        identity: message.identity,
+        allowIdentityless: ALLOW_IDENTITYLESS_CLIENT,
+      });
+      if (!admission.ok) {
+        log(`Rejecting Claude frontend #${ws.data.clientId}: ${admission.reason}`);
+        ws.close(admission.closeCode, admission.reason);
+        return;
+      }
+      attachClaude(ws, message.identity).catch((err) => {
         log(`attachClaude threw for #${ws.data.clientId}: ${err?.message ?? err}`);
       });
       return;
@@ -349,9 +410,6 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
       let contentToSend = message.message.content;
       if (requireReply) {
         contentToSend += REPLY_REQUIRED_INSTRUCTION;
-        replyRequired = true;
-        replyReceivedDuringTurn = false;
-        log(`Reply required flag set for this message`);
       }
       log(`Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
       const injected = codex.injectMessage(contentToSend);
@@ -368,6 +426,14 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
         });
         return;
       }
+      // Arm reply-required tracking ONLY after a successful injection: a turn has
+      // now started, so turnCompleted will reset it. Arming before this guard
+      // (on a rejected injection, e.g. Codex busy) would strand the flag on an
+      // unrelated in-flight turn and silently lose this require_reply request.
+      if (requireReply) {
+        replyTracker.arm();
+        log(`Reply required flag set for this message`);
+      }
       clearAttentionWindow(); // Claude successfully replied, end attention window
       sendProtocolMessage(ws, {
         type: "claude_to_codex_result",
@@ -379,7 +445,7 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
   }
 }
 
-async function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
+async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: ControlClientIdentity) {
   const occupant = attachedClaude;
   if (occupant && occupant !== ws && occupant.readyState !== WebSocket.CLOSED) {
     // Slot is occupied by another socket that hasn't yet shown us FIN.
@@ -442,10 +508,13 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
   }
 
   clearPendingClaudeDisconnect("Claude frontend attached");
+  ws.data.identity = identity;
   attachedClaude = ws;
   ws.data.attached = true;
   cancelIdleShutdown();
-  log(`Claude frontend attached (#${ws.data.clientId})`);
+  log(
+    `Claude frontend attached (#${ws.data.clientId}, pair=${identity?.pairId ?? "<none>"}, cwd=${identity?.cwd ?? "<unknown>"})`,
+  );
 
   statusBuffer.flush("claude reconnected");
   sendStatus(ws);
@@ -716,6 +785,9 @@ function currentStatus(): DaemonStatus {
     // control port (wrong pairId) and replace it instead of reusing it. null in
     // legacy/manual single-pair mode (no pairId enforcement there).
     pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    cwd: process.cwd(),
+    stateDir: stateDir.dir,
+    build: daemonStatusBuildInfo(),
   };
 }
 
@@ -752,6 +824,9 @@ function writeStatusFile() {
     pid: process.pid,
     // Pair identity for diagnostics (null in legacy/manual single-pair mode).
     pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    cwd: process.cwd(),
+    stateDir: stateDir.dir,
+    build: daemonStatusBuildInfo(),
   });
 }
 
@@ -865,7 +940,7 @@ function log(msg: string) {
   const line = `[${new Date().toISOString()}] [AgentBridgeDaemon] ${msg}\n`;
   process.stderr.write(line);
   try {
-    appendFileSync(stateDir.logFile, line);
+    appendRotatingLog(stateDir.logFile, line);
   } catch {}
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,7 +4,6 @@ import { appendFileSync } from "node:fs";
 import type { ServerWebSocket } from "bun";
 import { CodexAdapter } from "./codex-adapter";
 import {
-  BRIDGE_CONTRACT_REMINDER,
   REPLY_REQUIRED_INSTRUCTION,
   StatusBuffer,
   classifyMessage,
@@ -66,9 +65,6 @@ let replyReceivedDuringTurn = false;
 let shuttingDown = false;
 let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
 let claudeDisconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let claudeOnlineNoticeSent = false;
-let claudeOfflineNoticeShown = false;
-let codexCollaborationKickoffSent = false;
 let lastAttachStatusSentTs = 0;
 const ATTACH_STATUS_COOLDOWN_MS = 30_000; // Don't re-send status on rapid reattach
 
@@ -104,7 +100,10 @@ const tuiConnectionState = new TuiConnectionState({
         `✅ Codex TUI reconnected (conn #${connId}). Bridge restored, communication can continue.`,
       ),
     );
-    codex.injectMessage("✅ Claude Code is still online, bridge restored. Bidirectional communication can continue.");
+    // No status notice injected into Codex: runtime online/offline/reconnect events
+    // can only go through turn/start, which pollutes the Codex thread/title and can
+    // trigger spurious responses (see the kickoff removal). Codex resumes normally
+    // on the next real Claude message.
   },
 });
 
@@ -188,11 +187,6 @@ codex.on("turnCompleted", () => {
     ),
   );
   startAttentionWindow();
-
-  // Retry Claude-online notice if it was deferred while the turn was in progress.
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
 });
 
 codex.on("ready", (threadId: string) => {
@@ -203,10 +197,6 @@ codex.on("ready", (threadId: string) => {
   emitToClaude(
     systemMessage("system_ready", currentReadyMessage()),
   );
-
-  if (attachedClaude && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
 });
 
 codex.on("tuiConnected", (connId: number) => {
@@ -233,8 +223,6 @@ codex.on("exit", (code: number | null) => {
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
-  claudeOnlineNoticeSent = false;
-  claudeOfflineNoticeShown = false;
   emitToClaude(
     systemMessage(
       "system_codex_exit",
@@ -339,15 +327,19 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
       }
 
       const requireReply = !!message.requireReply;
-      let contentWithReminder = message.message.content + "\n\n" + BRIDGE_CONTRACT_REMINDER;
+      // The static bridge contract (markers / git-forbidden / role guidance) now
+      // lives in AGENTS.md (injected by `abg init`), so it is no longer appended to
+      // every message — appending it polluted every Codex turn and the thread title.
+      // Only the DYNAMIC reply-required instruction is appended, on demand.
+      let contentToSend = message.message.content;
       if (requireReply) {
-        contentWithReminder += REPLY_REQUIRED_INSTRUCTION;
+        contentToSend += REPLY_REQUIRED_INSTRUCTION;
         replyRequired = true;
         replyReceivedDuringTurn = false;
         log(`Reply required flag set for this message`);
       }
       log(`Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-      const injected = codex.injectMessage(contentWithReminder);
+      const injected = codex.injectMessage(contentToSend);
       if (!injected) {
         const reason = codex.turnInProgress
           ? "Codex is busy executing a turn. Wait for it to finish before sending another message."
@@ -458,10 +450,6 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>) {
   }
 
   lastAttachStatusSentTs = now;
-
-  if (tuiConnectionState.canReply() && shouldNotifyCodexClaudeOnline()) {
-    notifyCodexClaudeOnline();
-  }
 }
 
 function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
@@ -627,25 +615,10 @@ function scheduleClaudeDisconnectNotification(clientId: number) {
       return;
     }
 
-    if (!tuiConnectionState.canReply()) {
-      log(
-        `Suppressing Claude disconnect notification for client #${clientId} because Codex cannot reply`,
-      );
-      return;
-    }
-
-    if (!claudeOnlineNoticeSent) {
-      log(
-        `Suppressing Claude disconnect notification for client #${clientId} because Claude was never announced online`,
-      );
-      return;
-    }
-
-    codex.injectMessage(
-      "⚠️ Claude Code went offline. AgentBridge is still running in the background; it will reconnect automatically when Claude reopens.",
-    );
-    claudeOnlineNoticeSent = false;
-    claudeOfflineNoticeShown = true;
+    // Runtime offline events are no longer injected into Codex: the only channel
+    // (turn/start) pollutes the Codex thread/title and can trigger spurious
+    // responses. Logged for ops; Codex simply receives no further messages until
+    // Claude reconnects (the static collaboration context lives in AGENTS.md).
     log(`Claude disconnect persisted past grace window (client #${clientId})`);
   }, CLAUDE_DISCONNECT_GRACE_MS);
 }
@@ -733,33 +706,6 @@ function currentWaitingMessage() {
 
 function currentReadyMessage() {
   return `✅ Codex TUI connected (${codex.activeThreadId}). Bridge ready.`;
-}
-
-function notifyCodexClaudeOnline(): boolean {
-  const message = !codexCollaborationKickoffSent
-    ? [
-        "🤝 Claude Code has connected via AgentBridge.",
-        "You are now in a multi-agent collaboration session.",
-        "When you receive a complex task, propose a division of labor to Claude.",
-        "Claude can send you messages — they will appear as injected user messages.",
-        "Respond naturally and Claude will receive your output via AgentBridge.",
-      ].join("\n")
-    : "✅ AgentBridge connected to Claude Code.";
-
-  const delivered = codex.injectMessage(message);
-  if (!delivered) {
-    log("Deferred Claude-online notice to Codex — will retry after current turn completes");
-    return false;
-  }
-
-  claudeOnlineNoticeSent = true;
-  claudeOfflineNoticeShown = false;
-  codexCollaborationKickoffSent = true;
-  return true;
-}
-
-function shouldNotifyCodexClaudeOnline() {
-  return !claudeOnlineNoticeSent || claudeOfflineNoticeShown;
 }
 
 function systemMessage(idPrefix: string, content: string): BridgeMessage {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -47,6 +47,16 @@ const FILTER_MODE: FilterMode =
   (process.env.AGENTBRIDGE_FILTER_MODE as FilterMode) === "full" ? "full" : "filtered";
 const IDLE_SHUTDOWN_MS = parseInt(process.env.AGENTBRIDGE_IDLE_SHUTDOWN_MS ?? String(config.idleShutdownSeconds * 1000), 10);
 const ATTENTION_WINDOW_MS = parseInt(process.env.AGENTBRIDGE_ATTENTION_WINDOW_MS ?? String(config.turnCoordination.attentionWindowSeconds * 1000), 10);
+// Bootstrap-readiness watchdog: if the Codex layer never becomes ready within this
+// window the daemon self-exits to release its control port (prevents the
+// healthz-200/readyz-503 zombie). Default 45s is deliberately > the worst-case
+// bootCodex retry budget (CODEX_BOOT_RETRIES+1 attempts × ~10s codex.start internal
+// timeout + 1s/2s backoff ≈ 33s) so it never cuts off a legitimately-retrying boot.
+const BOOTSTRAP_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_BOOTSTRAP_TIMEOUT_MS", 45000);
+// In-daemon bounded retries for a transient Codex bootstrap failure (e.g. a just-killed
+// codex's port not yet released). After these, the daemon self-exits — further
+// replacement is owned by the lifecycle (ensureRunning), not by retrying forever here.
+const CODEX_BOOT_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_CODEX_BOOT_RETRIES", 2);
 
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 
@@ -63,6 +73,7 @@ let inAttentionWindow = false;
 let replyRequired = false;
 let replyReceivedDuringTurn = false;
 let shuttingDown = false;
+let bootDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
 let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
 let claudeDisconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let lastAttachStatusSentTs = 0;
@@ -230,6 +241,10 @@ codex.on("exit", (code: number | null) => {
     ),
   );
   broadcastStatus();
+  // Codex died after a successful boot (a dead proc is not auto-respawned). Re-arm
+  // the readiness watchdog so that if it does not come back and no TUI is using us,
+  // the daemon self-exits instead of lingering as a healthz-200/readyz-503 zombie.
+  armBootDeadline();
 });
 
 function startControlServer() {
@@ -697,6 +712,10 @@ function currentStatus(): DaemonStatus {
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
     pid: process.pid,
+    // Pair identity so ensureRunning() can detect a foreign daemon squatting this
+    // control port (wrong pairId) and replace it instead of reusing it. null in
+    // legacy/manual single-pair mode (no pairId enforcement there).
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
   };
 }
 
@@ -740,35 +759,88 @@ function removeStatusFile() {
   daemonLifecycle.removeStatusFile();
 }
 
+/**
+ * Arm the bootstrap-readiness watchdog. If the Codex layer is not ready within
+ * BOOTSTRAP_TIMEOUT_MS (and no TUI is actively using us), self-exit to release the
+ * control port. This is the ONLY backstop for the case where codex.start() HANGS
+ * (never resolves/rejects), so bootCodex's retry/self-exit never runs — without it
+ * the process lingers as a healthz-200/readyz-503 zombie and ensureRunning() keeps
+ * reusing it. bootCodex clears it on success; codex 'exit' re-arms it.
+ */
+function armBootDeadline() {
+  // The deadline is an ABSOLUTE start-up window — not a recurring idle timer. If a
+  // timer is already armed, leave it alone: re-arming on every codex 'exit' would let
+  // a codex crash-loop keep the daemon alive past BOOTSTRAP_TIMEOUT_MS forever. Only
+  // the very first call (right after writePidFile/startControlServer) sets the timer;
+  // subsequent 'exit' events must not extend the deadline.
+  if (bootDeadlineTimer) return;
+  bootDeadlineTimer = setTimeout(() => {
+    bootDeadlineTimer = null;
+    if (codexBootstrapped) return; // became ready in time — nothing to do
+    if (tuiConnectionState.snapshot().tuiConnected) return; // a TUI is actively using it
+    log(`Codex not ready within bootstrap deadline (${BOOTSTRAP_TIMEOUT_MS}ms) — self-exiting to release control port`);
+    shutdown("codex not ready within bootstrap deadline", 1);
+  }, BOOTSTRAP_TIMEOUT_MS);
+  // Don't let the watchdog itself keep the event loop alive.
+  bootDeadlineTimer.unref?.();
+}
+
+function clearBootDeadline() {
+  if (bootDeadlineTimer) {
+    clearTimeout(bootDeadlineTimer);
+    bootDeadlineTimer = null;
+  }
+}
+
 async function bootCodex() {
   log("Starting AgentBridge daemon...");
   log(`Codex app-server: ${codex.appServerUrl}`);
   log(`Codex proxy: ${codex.proxyUrl}`);
   log(`Control server: ws://127.0.0.1:${CONTROL_PORT}/ws`);
 
-  try {
-    await codex.start();
-    codexBootstrapped = true;
-    writeStatusFile();
-
-    emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));
-    broadcastStatus();
-  } catch (err: any) {
-    log(`Failed to start Codex: ${err.message}`);
-    emitToClaude(
-      systemMessage(
-        "system_codex_start_failed",
-        `❌ AgentBridge failed to start Codex app-server: ${err.message}`,
-      ),
-    );
-    broadcastStatus();
+  for (let attempt = 0; attempt <= CODEX_BOOT_RETRIES; attempt++) {
+    try {
+      await codex.start();
+      codexBootstrapped = true;
+      clearBootDeadline(); // codex up — cancel the self-exit watchdog
+      writeStatusFile();
+      emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));
+      broadcastStatus();
+      return;
+    } catch (err: any) {
+      const attemptsLeft = CODEX_BOOT_RETRIES - attempt;
+      log(`Failed to start Codex (attempt ${attempt + 1}/${CODEX_BOOT_RETRIES + 1}): ${err.message}`);
+      if (attemptsLeft > 0) {
+        const backoffMs = 1000 * (attempt + 1); // 1s, 2s, … — covers transient failures (e.g. a just-killed codex's port not yet released)
+        log(`Retrying Codex bootstrap in ${backoffMs}ms (${attemptsLeft} attempt(s) left)...`);
+        await new Promise((r) => setTimeout(r, backoffMs));
+        if (shuttingDown) return; // a deadline/signal fired during backoff
+        continue;
+      }
+      // Retries exhausted: notify Claude, then SELF-EXIT to release the control port.
+      // Staying alive here is exactly what created the healthz-200/readyz-503 zombie
+      // that ensureRunning() then reused. Releasing the port lets the next
+      // ensureRunning() launch a clean daemon. Replacement beyond this is owned by the
+      // lifecycle, not by retrying forever in-process.
+      emitToClaude(
+        systemMessage(
+          "system_codex_start_failed",
+          `❌ AgentBridge failed to start Codex app-server after ${CODEX_BOOT_RETRIES + 1} attempts: ${err.message}`,
+        ),
+      );
+      broadcastStatus();
+      shutdown("codex bootstrap failed", 1);
+      return; // shutdown() calls process.exit; explicit return also makes the
+      // "shutdown ⇒ stop" intent clear and guards the already-shutting-down path.
+    }
   }
 }
 
-function shutdown(reason: string) {
+function shutdown(reason: string, exitCode = 0) {
   if (shuttingDown) return;
   shuttingDown = true;
   log(`Shutting down daemon (${reason})...`);
+  clearBootDeadline();
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);
   clearPendingClaudeDisconnect(`daemon shutdown (${reason})`);
   controlServer?.stop();
@@ -776,7 +848,7 @@ function shutdown(reason: string) {
   codex.stop();
   removePidFile();
   removeStatusFile();
-  process.exit(0);
+  process.exit(exitCode);
 }
 
 process.on("SIGINT", () => shutdown("SIGINT"));
@@ -807,4 +879,8 @@ if (daemonLifecycle.wasKilled()) {
 
 writePidFile();
 startControlServer();
+// Arm the readiness watchdog BEFORE bootCodex: if codex.start() hangs (never
+// resolves/rejects), bootCodex's retry/self-exit never runs, so this deadline is
+// the only thing that releases the control port. bootCodex clears it on success.
+armBootDeadline();
 void bootCodex();

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -541,6 +541,99 @@ describe("E2E: CLI surface", () => {
     });
   }, 20000);
 
+  test("agentbridge kill --pair scopes the restart hint to that pair", async () => {
+    await withHarness(async (harness) => {
+      const pairId = "work";
+      const pairStateDir = join(harness.stateDir, "pairs", pairId);
+      mkdirSync(pairStateDir, { recursive: true });
+      writeFileSync(
+        join(harness.stateDir, "pairs", "registry.json"),
+        JSON.stringify(
+          {
+            version: 1,
+            pairs: [
+              {
+                pairId,
+                slot: 0,
+                cwd: harness.projectDir,
+                source: "flag",
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      );
+
+      const pairPorts = await Promise.all([reservePort(), reservePort(), reservePort()]);
+      const [controlPort, appPort, proxyPort] = pairPorts.map((reservation) => reservation.port);
+      for (const reservation of pairPorts) {
+        await reservation.release();
+      }
+
+      const daemon = spawn(process.execPath, ["run", harness.fakeDaemonPath], {
+        cwd: harness.projectDir,
+        env: {
+          ...harness.env,
+          AGENTBRIDGE_STATE_DIR: pairStateDir,
+          AGENTBRIDGE_CONTROL_PORT: String(controlPort),
+          CODEX_WS_PORT: String(appPort),
+          CODEX_PROXY_PORT: String(proxyPort),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const trackedDaemon: TrackedProcess = { child: daemon, stdout: [], stderr: [] };
+      daemon.stdout?.on("data", (chunk) => trackedDaemon.stdout.push(chunk.toString()));
+      daemon.stderr?.on("data", (chunk) => trackedDaemon.stderr.push(chunk.toString()));
+
+      try {
+        await waitFor(() => existsSync(join(pairStateDir, "daemon.pid")), 80, 50);
+
+        const result = await harness.runCli(["kill", "--pair", pairId]);
+
+        expect(result.code).toBe(0);
+        expect(result.stdout).toContain("AgentBridge stopped.");
+        expect(result.stdout).toContain("Please restart Claude Code (`agentbridge claude --pair work`)");
+        expect(result.stdout).not.toContain("Please restart Claude Code (`agentbridge claude`)");
+      } finally {
+        await stopProcess(trackedDaemon);
+      }
+    });
+  }, 20000);
+
+  test("agentbridge kill --help prints usage without stopping a running daemon", async () => {
+    await withHarness(async (harness) => {
+      await harness.startManagedFakeDaemon();
+      const pid = harness.readPid();
+      expect(pid).not.toBeNull();
+
+      const result = await harness.runCli(["kill", "--help"]);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("Usage: abg kill");
+      expect(result.stdout).toContain("--pair <id>");
+      expect(pid && isProcessAlive(pid)).toBe(true);
+      expect(existsSync(join(harness.stateDir, "killed"))).toBe(false);
+    });
+  }, 20000);
+
+  test("agentbridge kill rejects unknown flags without stopping a running daemon", async () => {
+    await withHarness(async (harness) => {
+      await harness.startManagedFakeDaemon();
+      const pid = harness.readPid();
+      expect(pid).not.toBeNull();
+
+      const result = await harness.runCli(["kill", "--badflag"]);
+
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("Unknown kill argument: --badflag");
+      expect(pid && isProcessAlive(pid)).toBe(true);
+      expect(existsSync(join(harness.stateDir, "killed"))).toBe(false);
+    });
+  }, 20000);
+
   test("bridge stays idle and does not relaunch daemon after kill writes the killed sentinel", async () => {
     await withHarness(async (harness) => {
       const bridge = await harness.spawnBridge();

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -135,6 +135,13 @@ class CliE2EHarness {
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      // Strip any pair env leaked from a real `abg claude` session in the parent
+      // shell. computeBaseDir() prefers AGENTBRIDGE_BASE_DIR, so a leaked value
+      // would make the CLI read the developer's REAL registry instead of this
+      // test's tmp stateDir, breaking pair/kill isolation (undefined → omitted).
+      AGENTBRIDGE_BASE_DIR: undefined,
+      AGENTBRIDGE_PAIR_ID: undefined,
+      AGENTBRIDGE_PAIR_NAME: undefined,
       AGENTBRIDGE_STATE_DIR: stateDir,
       AGENTBRIDGE_CONTROL_PORT: String(controlPort),
       AGENTBRIDGE_DAEMON_ENTRY: fakeDaemonPath,
@@ -595,7 +602,7 @@ describe("E2E: CLI surface", () => {
 
         expect(result.code).toBe(0);
         expect(result.stdout).toContain("AgentBridge stopped.");
-        expect(result.stdout).toContain("Please restart Claude Code (`agentbridge claude --pair work`)");
+        expect(result.stdout).toContain("Please restart Claude Code (`agentbridge --pair work claude`)");
         expect(result.stdout).not.toContain("Please restart Claude Code (`agentbridge claude`)");
       } finally {
         await stopProcess(trackedDaemon);
@@ -613,7 +620,7 @@ describe("E2E: CLI surface", () => {
 
       expect(result.code).toBe(0);
       expect(result.stdout).toContain("Usage: abg kill");
-      expect(result.stdout).toContain("--pair <id>");
+      expect(result.stdout).toContain("--pair <name|id>");
       expect(pid && isProcessAlive(pid)).toBe(true);
       expect(existsSync(join(harness.stateDir, "killed"))).toBe(false);
     });

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { spawn, type ChildProcess } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:net";
 import { fileURLToPath } from "node:url";
+import { derivePairId, portsForSlot } from "./pair-registry";
 
 const CLI_PATH = fileURLToPath(new URL("./cli.ts", import.meta.url));
 const BRIDGE_PATH = fileURLToPath(new URL("./bridge.ts", import.meta.url));
@@ -34,6 +35,7 @@ interface PortReservation {
 class CliE2EHarness {
   readonly rootDir: string;
   readonly projectDir: string;
+  readonly baseDir: string;
   readonly stateDir: string;
   readonly binDir: string;
   readonly shimLogDir: string;
@@ -52,6 +54,7 @@ class CliE2EHarness {
   private constructor(
     rootDir: string,
     projectDir: string,
+    baseDir: string,
     stateDir: string,
     binDir: string,
     shimLogDir: string,
@@ -65,6 +68,7 @@ class CliE2EHarness {
   ) {
     this.rootDir = rootDir;
     this.projectDir = projectDir;
+    this.baseDir = baseDir;
     this.stateDir = stateDir;
     this.binDir = binDir;
     this.shimLogDir = shimLogDir;
@@ -85,12 +89,14 @@ class CliE2EHarness {
   static async create(options: HarnessOptions = {}): Promise<CliE2EHarness> {
     const rootDir = mkdtempSync(join(tmpdir(), "agentbridge-cli-e2e-"));
     const projectDir = join(rootDir, "project");
+    const baseDir = join(rootDir, "base");
     const stateDir = join(rootDir, "state");
     const binDir = join(rootDir, "bin");
     const shimLogDir = join(rootDir, "shim-logs");
     const fakeDaemonPath = join(rootDir, "agentbridge-fake-daemon.ts");
     const fakeDaemonLaunchLog = join(rootDir, "fake-daemon-launches.jsonl");
     mkdirSync(projectDir, { recursive: true });
+    mkdirSync(baseDir, { recursive: true });
     mkdirSync(stateDir, { recursive: true });
     mkdirSync(binDir, { recursive: true });
     mkdirSync(shimLogDir, { recursive: true });
@@ -135,13 +141,13 @@ class CliE2EHarness {
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       PATH: `${binDir}:${process.env.PATH ?? ""}`,
-      // Strip any pair env leaked from a real `abg claude` session in the parent
-      // shell. computeBaseDir() prefers AGENTBRIDGE_BASE_DIR, so a leaked value
-      // would make the CLI read the developer's REAL registry instead of this
-      // test's tmp stateDir, breaking pair/kill isolation (undefined → omitted).
+      // Pair-mode CLI paths (`--pair ...`) use AGENTBRIDGE_BASE_DIR, while
+      // manual-mode paths below use AGENTBRIDGE_STATE_DIR. Keep both isolated
+      // under this harness root so tests never touch the developer's registry.
       AGENTBRIDGE_BASE_DIR: undefined,
       AGENTBRIDGE_PAIR_ID: undefined,
       AGENTBRIDGE_PAIR_NAME: undefined,
+      AGENTBRIDGE_MANUAL: "1",
       AGENTBRIDGE_STATE_DIR: stateDir,
       AGENTBRIDGE_CONTROL_PORT: String(controlPort),
       AGENTBRIDGE_DAEMON_ENTRY: fakeDaemonPath,
@@ -156,6 +162,7 @@ class CliE2EHarness {
     return new CliE2EHarness(
       rootDir,
       projectDir,
+      baseDir,
       stateDir,
       binDir,
       shimLogDir,
@@ -184,10 +191,7 @@ class CliE2EHarness {
 
     const proc = this.spawnProcess(process.execPath, ["run", CLI_PATH, ...args], {
       cwd: this.projectDir,
-      env: {
-        ...this.env,
-        ...extraEnv,
-      },
+      env: this.envForArgs(args, extraEnv),
     });
     return waitForExit(proc, timeoutMs);
   }
@@ -199,10 +203,7 @@ class CliE2EHarness {
 
     return this.spawnProcess(process.execPath, ["run", CLI_PATH, ...args], {
       cwd: this.projectDir,
-      env: {
-        ...this.env,
-        ...extraEnv,
-      },
+      env: this.envForArgs(args, extraEnv),
     });
   }
 
@@ -301,6 +302,15 @@ class CliE2EHarness {
       await sleep(100);
     }
 
+    for (const pid of this.readAllStatePids()) {
+      if (pid && isProcessAlive(pid)) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {}
+        await sleep(100);
+      }
+    }
+
     for (const reservation of this.portReservations) {
       try {
         await reservation.release();
@@ -308,6 +318,25 @@ class CliE2EHarness {
     }
 
     rmSync(this.rootDir, { recursive: true, force: true });
+  }
+
+  private readAllStatePids(): number[] {
+    const pids: number[] = [];
+    const visit = (dir: string) => {
+      if (!existsSync(dir)) return;
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          visit(path);
+          continue;
+        }
+        if (entry.name !== "daemon.pid" && entry.name !== "codex-tui.pid") continue;
+        const pid = Number.parseInt(readFileSync(path, "utf-8").trim(), 10);
+        if (Number.isFinite(pid)) pids.push(pid);
+      }
+    };
+    visit(this.rootDir);
+    return [...new Set(pids)];
   }
 
   private async releaseDaemonPortReservations(): Promise<void> {
@@ -327,6 +356,14 @@ class CliE2EHarness {
     }
 
     await this.daemonPortReleasePromise;
+  }
+
+  private envForArgs(args: string[], extraEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+    return {
+      ...this.env,
+      ...(usesPairMode(args) ? { AGENTBRIDGE_BASE_DIR: this.baseDir } : {}),
+      ...extraEnv,
+    };
   }
 
   private spawnProcess(
@@ -550,19 +587,23 @@ describe("E2E: CLI surface", () => {
 
   test("agentbridge kill --pair scopes the restart hint to that pair", async () => {
     await withHarness(async (harness) => {
-      const pairId = "work";
-      const pairStateDir = join(harness.stateDir, "pairs", pairId);
+      const pairName = "work";
+      const pairId = derivePairId(harness.projectDir, pairName);
+      const pairSlot = await reservePairSlot();
+      const pairStateDir = join(harness.baseDir, "pairs", pairId);
+      mkdirSync(join(harness.baseDir, "pairs"), { recursive: true });
       mkdirSync(pairStateDir, { recursive: true });
       writeFileSync(
-        join(harness.stateDir, "pairs", "registry.json"),
+        join(harness.baseDir, "pairs", "registry.json"),
         JSON.stringify(
           {
             version: 1,
             pairs: [
               {
                 pairId,
-                slot: 0,
+                slot: pairSlot.slot,
                 cwd: harness.projectDir,
+                name: pairName,
                 source: "flag",
                 createdAt: new Date().toISOString(),
               },
@@ -574,9 +615,8 @@ describe("E2E: CLI surface", () => {
         "utf-8",
       );
 
-      const pairPorts = await Promise.all([reservePort(), reservePort(), reservePort()]);
-      const [controlPort, appPort, proxyPort] = pairPorts.map((reservation) => reservation.port);
-      for (const reservation of pairPorts) {
+      const { appPort, proxyPort, controlPort } = pairSlot.ports;
+      for (const reservation of pairSlot.reservations) {
         await reservation.release();
       }
 
@@ -598,7 +638,7 @@ describe("E2E: CLI surface", () => {
       try {
         await waitFor(() => existsSync(join(pairStateDir, "daemon.pid")), 80, 50);
 
-        const result = await harness.runCli(["kill", "--pair", pairId]);
+        const result = await harness.runCli(["kill", "--pair", pairName]);
 
         expect(result.code).toBe(0);
         expect(result.stdout).toContain("AgentBridge stopped.");
@@ -862,6 +902,61 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function usesPairMode(args: string[]): boolean {
+  return args.some((arg) => arg === "--pair" || arg.startsWith("--pair="));
+}
+
+async function reservePairSlot(): Promise<{ slot: number; ports: ReturnType<typeof portsForSlot>; reservations: PortReservation[] }> {
+  for (let slot = 20; slot < 200; slot++) {
+    const ports = portsForSlot(slot);
+    const reservations: PortReservation[] = [];
+    try {
+      reservations.push(await reserveSpecificPort(ports.appPort));
+      reservations.push(await reserveSpecificPort(ports.proxyPort));
+      reservations.push(await reserveSpecificPort(ports.controlPort));
+      return { slot, ports, reservations };
+    } catch {
+      for (const reservation of reservations) {
+        try {
+          await reservation.release();
+        } catch {}
+      }
+    }
+  }
+  throw new Error("No free AgentBridge pair slot available for test");
+}
+
+async function reserveSpecificPort(port: number): Promise<PortReservation> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.unref();
+
+      let released = false;
+      resolve({
+        port,
+        release: () => new Promise<void>((releaseResolve, releaseReject) => {
+          if (released) {
+            releaseResolve();
+            return;
+          }
+
+          released = true;
+          server.close((err) => {
+            if (err) {
+              releaseReject(err);
+              return;
+            }
+            releaseResolve();
+          });
+        }),
+      });
+    });
+  });
+}
+
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -935,6 +1030,12 @@ const statusFile = join(stateDir, "status.json");
 const killedFile = join(stateDir, "killed");
 const proxyUrl = \`ws://127.0.0.1:\${proxyPort}\`;
 const appServerUrl = \`ws://127.0.0.1:\${appPort}\`;
+const build = {
+  version: "0.0.0-source",
+  commit: "source",
+  bundle: "source",
+  contractVersion: 1,
+};
 
 if (existsSync(killedFile)) {
   process.exit(0);
@@ -958,6 +1059,10 @@ function currentStatus() {
     proxyUrl,
     appServerUrl,
     pid: process.pid,
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    cwd: process.cwd(),
+    stateDir,
+    build,
   };
 }
 
@@ -966,6 +1071,10 @@ writeFileSync(statusFile, JSON.stringify({
   appServerUrl,
   controlPort,
   pid: process.pid,
+  pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+  cwd: process.cwd(),
+  stateDir,
+  build,
 }, null, 2) + "\\n", "utf-8");
 
 let cleanedUp = false;

--- a/src/env-guard.ts
+++ b/src/env-guard.ts
@@ -1,0 +1,117 @@
+import { derivePairId } from "./pair-registry";
+
+export type EnvGuardMode = "off" | "warn" | "fix" | "strict";
+
+export interface EnvGuardInspection {
+  ok: boolean;
+  expectedPairId: string | null;
+  actualPairId: string | null;
+  pairName: string | null;
+  reasons: string[];
+}
+
+export interface EnvGuardResult extends EnvGuardInspection {
+  action: "none" | "warned" | "fixed" | "strict_failed";
+}
+
+const GENERATED_ENV_KEYS = [
+  "AGENTBRIDGE_BASE_DIR",
+  "AGENTBRIDGE_PAIR_ID",
+  "AGENTBRIDGE_PAIR_NAME",
+  "AGENTBRIDGE_STATE_DIR",
+  "AGENTBRIDGE_CONTROL_PORT",
+  "AGENTBRIDGE_MODE",
+  "AGENTBRIDGE_FILTER_MODE",
+  "AGENTBRIDGE_MAX_BUFFERED_MESSAGES",
+  "AGENTBRIDGE_CODEX_TRANSPORT",
+  "CODEX_WS_PORT",
+  "CODEX_PROXY_PORT",
+] as const;
+
+export function normalizeEnvGuardMode(raw: string | undefined, fallback: EnvGuardMode = "fix"): EnvGuardMode {
+  if (raw === "off" || raw === "warn" || raw === "fix" || raw === "strict") return raw;
+  return fallback;
+}
+
+export function inspectAgentBridgeEnv(opts: {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+}): EnvGuardInspection {
+  const env = opts.env ?? process.env;
+  const actualPairId = nonEmpty(env.AGENTBRIDGE_PAIR_ID);
+  const pairName = nonEmpty(env.AGENTBRIDGE_PAIR_NAME) ?? "main";
+  const stateDir = nonEmpty(env.AGENTBRIDGE_STATE_DIR);
+  const baseDir = nonEmpty(env.AGENTBRIDGE_BASE_DIR);
+  const manualOptIn = env.AGENTBRIDGE_MANUAL === "1";
+  const manualRuntimeEnv =
+    !!stateDir ||
+    !!nonEmpty(env.AGENTBRIDGE_CONTROL_PORT) ||
+    !!nonEmpty(env.CODEX_WS_PORT) ||
+    !!nonEmpty(env.CODEX_PROXY_PORT);
+  const expectedPairId = actualPairId ? derivePairId(opts.cwd, pairName) : null;
+  const reasons: string[] = [];
+
+  if (!actualPairId && manualRuntimeEnv && !manualOptIn) {
+    reasons.push("AgentBridge runtime env is set without AGENTBRIDGE_PAIR_ID or AGENTBRIDGE_MANUAL=1");
+  }
+
+  if (actualPairId && expectedPairId && actualPairId !== expectedPairId) {
+    reasons.push(`AGENTBRIDGE_PAIR_ID=${actualPairId} does not match cwd-derived ${expectedPairId}`);
+  }
+
+  if (actualPairId && stateDir && !stateDir.endsWith(`/pairs/${actualPairId}`)) {
+    reasons.push(`AGENTBRIDGE_STATE_DIR does not end with /pairs/${actualPairId}`);
+  }
+
+  if (actualPairId && baseDir && stateDir && !stateDir.startsWith(`${baseDir}/`)) {
+    reasons.push("AGENTBRIDGE_BASE_DIR and AGENTBRIDGE_STATE_DIR disagree");
+  }
+
+  return {
+    ok: reasons.length === 0,
+    expectedPairId,
+    actualPairId,
+    pairName,
+    reasons,
+  };
+}
+
+export function guardAgentBridgeEnv(opts: {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  mode?: EnvGuardMode;
+  allowStrict?: boolean;
+  log?: (message: string) => void;
+}): EnvGuardResult {
+  const env = opts.env ?? process.env;
+  const mode = normalizeEnvGuardMode(opts.mode, "fix");
+  const effectiveMode = mode === "strict" && opts.allowStrict === false ? "fix" : mode;
+  const inspection = inspectAgentBridgeEnv({ cwd: opts.cwd, env });
+
+  if (effectiveMode === "off" || inspection.ok) {
+    return { ...inspection, action: "none" };
+  }
+
+  const message =
+    `stale AgentBridge environment detected for ${opts.cwd}: ${inspection.reasons.join("; ")}`;
+
+  if (effectiveMode === "strict") {
+    throw new Error(message);
+  }
+
+  opts.log?.(`[agentbridge] ${message}`);
+
+  if (effectiveMode === "warn") {
+    return { ...inspection, action: "warned" };
+  }
+
+  for (const key of GENERATED_ENV_KEYS) {
+    delete env[key];
+  }
+  opts.log?.("[agentbridge] cleared stale AgentBridge environment variables");
+  return { ...inspection, action: "fixed" };
+}
+
+function nonEmpty(value: string | undefined): string | null {
+  return value && value.length > 0 ? value : null;
+}

--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -2,8 +2,9 @@ export function parsePositiveIntEnv(
   name: string,
   fallback: number,
   log: (message: string) => void = () => {},
+  env: NodeJS.ProcessEnv = process.env,
 ): number {
-  const raw = process.env[name];
+  const raw = env[name];
   if (raw == null || raw === "") return fallback;
 
   // Use Number() (not parseInt) so values like "1.5" and "10abc" fail validation

--- a/src/liveness-probe.ts
+++ b/src/liveness-probe.ts
@@ -2,9 +2,9 @@
  * Liveness probe for half-open WebSocket detection.
  *
  * Sends a WebSocket ping and waits up to `timeoutMs` for a pong. Returns true
- * if a pong is observed (via `lastPongAt` monotonically advancing past the
- * baseline snapshot). Used by challenge-on-contest admission in daemon.ts to
- * detect half-open dead peers that still report readyState=OPEN (issue #68).
+ * if a NEW pong is observed (via `pongCount` advancing past the snapshot taken
+ * before ping()). Used by challenge-on-contest admission in daemon.ts to detect
+ * half-open dead peers that still report readyState=OPEN (issue #68).
  *
  * Accepts a minimal probe target interface so the loop can be unit-tested
  * against an in-memory fake without spinning up a real WebSocket.
@@ -14,11 +14,18 @@ export interface ProbeTarget {
   /** WebSocket.OPEN = 1. Anything else aborts the probe. */
   readyState: number;
   /**
-   * Monotonic timestamp (ms) of the last pong frame observed. Caller updates
-   * this from the `pong` handler. The probe only trusts values strictly
-   * greater than the baseline taken before ping().
+   * Monotonic COUNT of pong frames observed. The caller increments this in its
+   * `pong` handler. A counter — not a timestamp — because the previous design
+   * (`baseline = max(lastPongAt, now())`, then wait for `lastPongAt > baseline`)
+   * false-negatived whenever the localhost ping→pong round-trip completed within
+   * the same millisecond the probe started: the pong handler set
+   * `lastPongAt = Date.now()`, which equalled `baseline`, and `baseline > baseline`
+   * is false. On localhost that happened ~70% of probes, so LIVE frontends were
+   * judged dead and wrongly evicted on contest (the root cause of spurious
+   * "stopped responding to liveness probes" evictions). A counter increment is
+   * unambiguous and clock-granularity independent.
    */
-  lastPongAt: number;
+  pongCount: number;
   /** Send a ping frame. May throw synchronously on a failed write. */
   ping(): void;
 }
@@ -45,14 +52,13 @@ export async function probeLiveness(
 
   if (target.readyState !== OPEN) return false;
 
-  // Defensive baseline: take max(lastPongAt, now()) so that ONLY pongs that
-  // physically arrive after we initiated the probe count as proof of liveness.
-  // Why: with Bun's `sendPings: true`, background heartbeat pongs also update
-  // lastPongAt, so a pong from a prior heartbeat that landed just before us
-  // would falsely satisfy `lastPongAt > target.lastPongAt`. Using `now()` as
-  // the floor anchors the probe to wall-clock time, not to whatever past pong
-  // happened to be recorded last.
-  const baseline = Math.max(target.lastPongAt, now());
+  // Snapshot the pong COUNT before pinging. Any pong observed after this snapshot
+  // — the reply to our ping, or a concurrent Bun keepalive pong — proves the peer
+  // is alive. Pongs that arrived before the snapshot are already folded into
+  // `baseline`, so a stale pre-probe pong can never be mistaken for fresh liveness.
+  // (No wall-clock comparison: the old `lastPongAt > max(lastPongAt, now())` check
+  // false-negatived on same-millisecond localhost round-trips — see ProbeTarget.)
+  const baseline = target.pongCount;
   try {
     target.ping();
   } catch {
@@ -61,9 +67,9 @@ export async function probeLiveness(
 
   const deadline = now() + timeoutMs;
   while (now() < deadline) {
-    if (target.lastPongAt > baseline) return true;
+    if (target.pongCount > baseline) return true;
     if (target.readyState !== OPEN) return false;
     await sleep(pollMs);
   }
-  return target.lastPongAt > baseline;
+  return target.pongCount > baseline;
 }

--- a/src/message-filter.ts
+++ b/src/message-filter.ts
@@ -34,31 +34,16 @@ export function classifyMessage(content: string, mode: FilterMode): FilterResult
   }
 }
 
-const BRIDGE_CONTRACT_REMINDER = `[Bridge Contract] When sending agentMessage, put the marker at the very start of the message:
-- [IMPORTANT] for decisions, reviews, completions, blockers
-- [STATUS] for progress updates
-- [FYI] for background context
-The marker MUST be the first text in the message (e.g. "[IMPORTANT] Task done", not "Task done [IMPORTANT]").
-Keep agentMessage for high-value communication only.
-
-[Git Operations — FORBIDDEN]
-You MUST NOT execute any git write commands. This includes but is not limited to:
-git commit, git push, git pull, git fetch, git checkout -b, git branch, git merge, git rebase, git cherry-pick, git tag, git stash.
-These commands write to the .git directory, which is blocked by your sandbox. Attempting them will cause your session to hang indefinitely.
-Read-only git commands (git status, git log, git diff, git show, git rev-parse) are allowed.
-All git write operations must be delegated to Claude Code via agentMessage. Report what you changed and let Claude handle branching, committing, and pushing.
-
-[Role Guidance for Codex]
-- Your default role: Implementer, Executor, Verifier
-- Analytical/review tasks: Independent Analysis & Convergence
-- Implementation tasks: Architect -> Builder -> Critic
-- Debugging tasks: Hypothesis -> Experiment -> Interpretation
-- Do not blindly follow Claude - challenge with evidence when you disagree
-- Use explicit collaboration phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:"`;
-
+// NOTE: the static "bridge contract" (message markers, git-write prohibition,
+// Codex role guidance) used to be appended to EVERY claude→codex message here.
+// It now lives once in AGENTS_MD_SECTION (src/collaboration-content.ts), injected
+// into the project's AGENTS.md by `abg init` and loaded by Codex on startup.
+// Appending it per-message polluted every Codex thread + its resume title, so it
+// was removed. AGENTS.md is the single source of truth for that contract now.
+// Only the DYNAMIC, per-message reply-required instruction remains here.
 const REPLY_REQUIRED_INSTRUCTION = `\n\n[⚠️ REPLY REQUIRED] Claude has explicitly requested a reply. You MUST send an agentMessage with [IMPORTANT] marker containing your response. This is a mandatory requirement — do not skip or use [STATUS]/[FYI] markers for this reply.`;
 
-export { BRIDGE_CONTRACT_REMINDER, REPLY_REQUIRED_INSTRUCTION };
+export { REPLY_REQUIRED_INSTRUCTION };
 
 export class StatusBuffer {
   private buffer: BridgeMessage[] = [];

--- a/src/pair-command.ts
+++ b/src/pair-command.ts
@@ -1,0 +1,24 @@
+/**
+ * Render a user-facing `agentbridge` command suggestion scoped to the current
+ * pair.
+ *
+ * In multi-pair mode the resolver sets `AGENTBRIDGE_PAIR_ID`, and that env is
+ * inherited by the daemon, the plugin MCP server (bridge), and the codex
+ * wrapper. User-facing hints ("start Codex with…", "restart with…", "run kill
+ * to reset") MUST carry `--pair <id>` in that mode — otherwise a user following
+ * the hint in a named-pair session would connect to a different (cwd-derived)
+ * pair, or run a bare `agentbridge kill` that stops ALL pairs.
+ *
+ * In legacy/manual single-pair mode `AGENTBRIDGE_PAIR_ID` is unset, so the bare
+ * command is returned (unchanged behaviour).
+ *
+ * @param cmd the subcommand + its own args, e.g. "codex" or "claude --resume".
+ */
+export function pairScopedCommand(cmd: string): string {
+  const pairId = process.env.AGENTBRIDGE_PAIR_ID;
+  if (!pairId) return `agentbridge ${cmd}`;
+  // Insert `--pair <id>` right after the subcommand so it precedes any extra args.
+  const [sub, ...rest] = cmd.split(" ");
+  const tail = rest.length > 0 ? ` ${rest.join(" ")}` : "";
+  return `agentbridge ${sub} --pair ${pairId}${tail}`;
+}

--- a/src/pair-command.ts
+++ b/src/pair-command.ts
@@ -1,3 +1,5 @@
+import { computeBaseDir, findPair } from "./pair-resolver";
+
 /**
  * Render a user-facing `agentbridge` command suggestion scoped to the current
  * pair.
@@ -17,9 +19,23 @@
 export function pairScopedCommand(cmd: string): string {
   const pairId = process.env.AGENTBRIDGE_PAIR_ID;
   if (!pairId) return `agentbridge ${cmd}`;
-  // Prefer the friendly, cwd-scoped name (e.g. "main") when available; it is what
-  // the user types. The hint is meant to be run from the same project directory.
-  const selector = process.env.AGENTBRIDGE_PAIR_NAME || pairId;
+  // Prefer the friendly, cwd-scoped name (e.g. "main") — it is what the user types.
+  let selector = process.env.AGENTBRIDGE_PAIR_NAME;
+  if (!selector) {
+    // applyPairEnv always sets AGENTBRIDGE_PAIR_NAME alongside AGENTBRIDGE_PAIR_ID,
+    // but an OLD daemon/bridge process (started before NAME shipped) or a partially
+    // injected env can leave it unset. Recover the friendly name from the registry by
+    // pairId — best-effort: ANY failure (missing / corrupt / unreadable registry, no
+    // matching entry, empty name) falls back to the pairId. With the resolver's raw-id
+    // fallback in place, even a bare pairId hint now resolves correctly, so this is
+    // belt-and-suspenders, not load-bearing — and a hint must never throw while
+    // rendering a bridge notification.
+    try {
+      selector = findPair(computeBaseDir(), pairId)?.name || pairId;
+    } catch {
+      selector = pairId;
+    }
+  }
   // `--pair <name>` goes BEFORE the subcommand (the supported position).
   return `agentbridge --pair ${selector} ${cmd}`;
 }

--- a/src/pair-command.ts
+++ b/src/pair-command.ts
@@ -17,8 +17,9 @@
 export function pairScopedCommand(cmd: string): string {
   const pairId = process.env.AGENTBRIDGE_PAIR_ID;
   if (!pairId) return `agentbridge ${cmd}`;
-  // Insert `--pair <id>` right after the subcommand so it precedes any extra args.
-  const [sub, ...rest] = cmd.split(" ");
-  const tail = rest.length > 0 ? ` ${rest.join(" ")}` : "";
-  return `agentbridge ${sub} --pair ${pairId}${tail}`;
+  // Prefer the friendly, cwd-scoped name (e.g. "main") when available; it is what
+  // the user types. The hint is meant to be run from the same project directory.
+  const selector = process.env.AGENTBRIDGE_PAIR_NAME || pairId;
+  // `--pair <name>` goes BEFORE the subcommand (the supported position).
+  return `agentbridge --pair ${selector} ${cmd}`;
 }

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -1,0 +1,673 @@
+import { execFileSync } from "node:child_process";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  linkSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:net";
+import { createHash, randomUUID } from "node:crypto";
+import { hostname, userInfo } from "node:os";
+import { basename, join } from "node:path";
+
+/**
+ * Pair registry — the single shared resource of the multi-pair feature.
+ *
+ * Each Claude+Codex pair runs as an isolated daemon instance with its own
+ * port triple (slot) and state dir. This module owns:
+ *   - deterministic slot -> port arithmetic (slot 0 == the classic 4500/4501/4502)
+ *   - cross-process slot allocation guarded by an atomic lock file (temp + link(2))
+ *   - pairId validation / derivation (filesystem-path safe)
+ *   - legacy-root daemon detection (pre-multi-pair installs)
+ *   - port probing to surface external squatters without silently shifting slots
+ *
+ * It is intentionally free of any process.env / argv / StateDirResolver coupling
+ * so it can be unit-tested with a temp base dir and real concurrent processes.
+ * The base dir is always passed in explicitly.
+ */
+
+export const PAIR_BASE_PORT = 4500;
+export const PAIR_SLOT_STRIDE = 10;
+export const PAIR_ID_REGEX = /^[A-Za-z0-9._-]{1,64}$/;
+
+const LOCK_FILE_NAME = ".registry.lock";
+const REGISTRY_FILE_NAME = "registry.json";
+const LOCK_DEADLINE_MS = 10_000;
+/** Grace before a lock file with unreadable owner content is treated as orphaned (vs corrupt/transient). */
+const ORPHAN_GRACE_MS = 3_000;
+const LEGACY_ROOT_CONTROL_PORT = 4502;
+
+/** Windows reserved device names — rejected so a pairId is portable as a path segment. */
+const WINDOWS_RESERVED_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
+export interface PairPorts {
+  /** Codex app-server port (CODEX_WS_PORT). */
+  appPort: number;
+  /** Codex proxy port (CODEX_PROXY_PORT). */
+  proxyPort: number;
+  /** Control WS / health port (AGENTBRIDGE_CONTROL_PORT). */
+  controlPort: number;
+}
+
+export interface PairEntry {
+  pairId: string;
+  slot: number;
+  cwd: string;
+  source: "flag" | "cwd";
+  createdAt: string;
+}
+
+export interface RegistryFile {
+  version: 1;
+  pairs: PairEntry[];
+}
+
+export interface ResolvedPair {
+  pairId: string;
+  slot: number;
+  ports: PairPorts;
+  stateDir: string;
+  entry: PairEntry;
+}
+
+export type PairErrorCode =
+  | "PAIR_PORTS_BUSY"
+  | "PAIR_ID_INVALID"
+  | "PAIR_LOCK_TIMEOUT"
+  | "PAIR_REGISTRY_CORRUPT"
+  | "PAIR_LEGACY_ROOT_DAEMON";
+
+export class PairError extends Error {
+  readonly code: PairErrorCode;
+  readonly details?: Record<string, unknown>;
+
+  constructor(code: PairErrorCode, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.name = "PairError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Highest slot whose control port (base + slot*stride + 2) still fits in a uint16. */
+export const MAX_PAIR_SLOT = Math.floor((65535 - 2 - PAIR_BASE_PORT) / PAIR_SLOT_STRIDE);
+
+/** Deterministic slot -> port triple. slot 0 == classic 4500/4501/4502. */
+export function portsForSlot(slot: number): PairPorts {
+  if (!Number.isInteger(slot) || slot < 0) {
+    throw new PairError("PAIR_ID_INVALID", `Invalid slot: ${slot}`);
+  }
+  if (slot > MAX_PAIR_SLOT) {
+    throw new PairError(
+      "PAIR_ID_INVALID",
+      `Slot ${slot} exceeds the maximum (${MAX_PAIR_SLOT}); ports would overflow 65535.`,
+      { slot, maxSlot: MAX_PAIR_SLOT },
+    );
+  }
+  const base = PAIR_BASE_PORT + slot * PAIR_SLOT_STRIDE;
+  return { appPort: base, proxyPort: base + 1, controlPort: base + 2 };
+}
+
+/**
+ * Validate an explicit `--pair <name>`. Returns the canonical id.
+ * Rejects path separators, `.`/`..`, whitespace, empty, and over-length names
+ * so the id is always safe to use as a directory name.
+ */
+export function validatePairId(raw: string): string {
+  const id = raw.trim();
+  // Windows treats `CON`, `CON.txt`, `NUL.log`, … all as the reserved device —
+  // check the segment before the first dot, not just the whole string.
+  const deviceBase = id.split(".")[0] ?? "";
+  if (
+    id === "." ||
+    id === ".." ||
+    !PAIR_ID_REGEX.test(id) ||
+    id.endsWith(".") || // trailing dot is illegal on Windows path segments
+    WINDOWS_RESERVED_RE.test(deviceBase)
+  ) {
+    throw new PairError(
+      "PAIR_ID_INVALID",
+      `Invalid --pair name: ${JSON.stringify(raw)}. Allowed: letters, digits, "." "_" "-", 1-64 chars ` +
+        `(not "." / ".." / a trailing dot / a reserved name like CON, NUL, COM1).`,
+      { raw },
+    );
+  }
+  return id;
+}
+
+/**
+ * Derive a stable, fs-safe pairId from the current working directory.
+ * Uses realpath so symlinked cwds map to the same id; appends a short hash
+ * of the real path to guarantee uniqueness across same-basename projects.
+ */
+export function derivePairIdFromCwd(cwd: string): string {
+  let real: string;
+  try {
+    real = realpathSync(cwd);
+  } catch {
+    real = cwd;
+  }
+  const hash = createHash("sha256").update(real).digest("hex").slice(0, 8);
+  const rawBase = basename(real) || "root";
+  // Slugify the basename through the allowed charset; collapse runs of illegal chars.
+  const slug = rawBase
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  const id = slug ? `${slug}-${hash}` : hash;
+  // Guaranteed to satisfy validatePairId by construction.
+  return id;
+}
+
+/**
+ * Smallest non-negative slot not present in the entry set.
+ * Uses the SET of used slots (not entry count) so a freed middle slot is reused.
+ */
+export function pickLowestFreeSlot(entries: readonly PairEntry[]): number {
+  const used = new Set(entries.map((e) => e.slot));
+  let slot = 0;
+  while (used.has(slot)) slot++;
+  return slot;
+}
+
+// ---------------------------------------------------------------------------
+// Registry file I/O (integrity only — concurrency is the lock's job)
+// ---------------------------------------------------------------------------
+
+function pairsDir(base: string): string {
+  return join(base, "pairs");
+}
+
+function registryPath(base: string): string {
+  return join(pairsDir(base), REGISTRY_FILE_NAME);
+}
+
+/** Read the registry, returning an empty one if absent. Throws on corruption. */
+export function readRegistry(base: string): RegistryFile {
+  const path = registryPath(base);
+  if (!existsSync(path)) return { version: 1, pairs: [] };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (err) {
+    throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry JSON is not parseable at ${path}: ${(err as Error).message}`, {
+      path,
+    });
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    (parsed as RegistryFile).version !== 1 ||
+    !Array.isArray((parsed as RegistryFile).pairs)
+  ) {
+    throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry shape is invalid at ${path}`, { path });
+  }
+
+  // Validate entries: a tampered/corrupt registry with duplicate slots or pairIds
+  // would silently put two pairs on the same ports — reject it loudly instead.
+  const entries = (parsed as RegistryFile).pairs;
+  const seenSlots = new Set<number>();
+  const seenIds = new Set<string>();
+  for (const e of entries) {
+    // Charset-validate the stored pairId too: a tampered registry with
+    // `"pairId": "../.."` flows straight into join(base,"pairs",pairId) in kill/pairs.
+    const idValid =
+      e && typeof e.pairId === "string" && e.pairId !== "." && e.pairId !== ".." && PAIR_ID_REGEX.test(e.pairId);
+    if (!idValid || !Number.isInteger(e.slot) || e.slot < 0) {
+      throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry has a malformed entry at ${path}`, { path, entry: e });
+    }
+    const lower = e.pairId.toLowerCase();
+    if (seenSlots.has(e.slot) || seenIds.has(lower)) {
+      throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry has duplicate slot/pairId at ${path}`, {
+        path,
+        pairId: e.pairId,
+        slot: e.slot,
+      });
+    }
+    seenSlots.add(e.slot);
+    seenIds.add(lower);
+  }
+  return parsed as RegistryFile;
+}
+
+/** Atomically replace the registry file (temp + fsync + rename). */
+export function writeRegistry(base: string, reg: RegistryFile): void {
+  mkdirSync(pairsDir(base), { recursive: true });
+  const target = registryPath(base);
+  const tmp = `${target}.tmp.${process.pid}`;
+  const data = JSON.stringify(reg, null, 2) + "\n";
+  const fd = openSync(tmp, "w");
+  try {
+    writeFileSync(fd, data);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(tmp, target);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-process lock
+// ---------------------------------------------------------------------------
+
+interface LockOwner {
+  pid: number;
+  createdAt: number;
+  nonce: string;
+  hostname?: string;
+  uid?: number;
+}
+
+function lockFilePath(base: string): string {
+  return join(pairsDir(base), LOCK_FILE_NAME);
+}
+
+function readLockOwner(lockFile: string): LockOwner | null {
+  try {
+    const parsed = JSON.parse(readFileSync(lockFile, "utf-8")) as LockOwner;
+    if (typeof parsed.pid === "number" && typeof parsed.nonce === "string") return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** `process.kill(pid, 0)` liveness, but treat EPERM (exists, not signalable by us) as ALIVE. */
+function pidLooksAlive(pid: number): boolean {
+  // pid <= 0 is never a real holder: process.kill(0, 0) targets the current
+  // process GROUP and "succeeds", which would wrongly mark a corrupt
+  // `{pid:0}` lock as live and deadlock acquisition. Negatives are signal-broadcast
+  // semantics, not a pid. Treat all of these as dead so the lock is reclaimable.
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: any) {
+    return err?.code === "EPERM";
+  }
+}
+
+function lockFileAgeMs(lockFile: string): number {
+  try {
+    return Date.now() - statSync(lockFile).mtimeMs;
+  } catch {
+    return Number.POSITIVE_INFINITY; // gone — let the caller re-attempt acquire
+  }
+}
+
+function safeHostname(): string | undefined {
+  try {
+    return hostname();
+  } catch {
+    return undefined;
+  }
+}
+
+function safeUid(): number | undefined {
+  try {
+    return userInfo().uid;
+  } catch {
+    return undefined;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Whether the lock currently at `lockFile` is reclaimable: a DEAD owner, or
+ * (defensively) unreadable content older than the orphan grace. A LIVE owner is
+ * never stale — we never steal a live holder's lock.
+ */
+function lockIsStale(lockFile: string): boolean {
+  const owner = readLockOwner(lockFile);
+  if (owner) return !pidLooksAlive(owner.pid);
+  // Atomic link-acquire means a live lock always has complete content, so an
+  // unreadable owner is corruption — reclaim only once it's older than the grace.
+  return lockFileAgeMs(lockFile) > ORPHAN_GRACE_MS;
+}
+
+/**
+ * Remove a stale primary lock — race-free against a fresh acquirer, even when a
+ * reclaimer stalls or crashes mid-reclaim.
+ *
+ * Earlier fixes could not close the hazard: a reclaimer's "owner is dead"
+ * decision can go stale, and removing the primary lock can evict a lock a fresh
+ * holder just acquired (duplicate-slot bug). The TTL-force-remove of the reclaim
+ * lock reopened it for a >grace-stalled reclaimer.
+ *
+ * Final design (no TTL stealing anywhere):
+ *   1. Serialize reclaimers through a reclaim lock acquired by atomic `link`,
+ *      whose owner carries a pid + nonce — exactly like the primary lock.
+ *   2. The reclaim lock is itself reclaimed ONLY when its owner is DEAD (or its
+ *      content is unreadable and old) — NEVER stolen from a live (even wedged)
+ *      reclaimer. A contended-but-live reclaim lock just makes us wait.
+ *   3. While holding it, verify we still own it (nonce), then unlink the primary
+ *      lock only if it is still stale.
+ *
+ * Why a stale unlink can never delete a LIVE primary lock:
+ *   - A reclaimer wedged (alive) before its unlink is never preempted (rule 2),
+ *     so its eventual unlink is still valid — the primary was the same dead lock
+ *     the whole time (no one else could reclaim or acquire it while held).
+ *   - A reclaimer that DIES before its unlink simply cannot resume to run a stale
+ *     unlink; a later reclaimer reclaims the (now dead) reclaim lock and re-checks.
+ *   There is no path where a preempted reclaimer resumes and removes a live lock.
+ */
+function attemptReclaim(lockFile: string): void {
+  const reclaimLock = `${lockFile}.reclaim`;
+  const myNonce = randomUUID();
+  const ownerJson = JSON.stringify({
+    pid: process.pid,
+    createdAt: Date.now(),
+    nonce: myNonce,
+    hostname: safeHostname(),
+    uid: safeUid(),
+  } satisfies LockOwner);
+
+  const tmp = `${reclaimLock}.acq.${process.pid}.${randomUUID()}`;
+  let held = false;
+  try {
+    writeFileSync(tmp, ownerJson);
+    try {
+      linkSync(tmp, reclaimLock); // atomic; EEXIST if another reclaimer holds it
+      held = true;
+    } catch (err: any) {
+      if (err?.code === "EEXIST") {
+        // Clear it ONLY if its owner is dead/orphaned (never a live reclaimer),
+        // then return so the next loop iteration re-acquires it cleanly — we never
+        // unlink-then-link in one step, so two clearers can't both end up holding.
+        if (lockIsStale(reclaimLock)) {
+          try {
+            unlinkSync(reclaimLock);
+          } catch {}
+        }
+        return;
+      }
+      throw err;
+    }
+  } finally {
+    try {
+      unlinkSync(tmp);
+    } catch {}
+  }
+
+  if (!held) return;
+  try {
+    // Confirm we still own the reclaim lock (guards the dead-lock acquisition
+    // race), then remove the primary lock only if it is still stale.
+    if (readLockOwner(reclaimLock)?.nonce !== myNonce) return;
+    if (lockIsStale(lockFile)) {
+      try {
+        unlinkSync(lockFile);
+      } catch {}
+    }
+  } finally {
+    if (readLockOwner(reclaimLock)?.nonce === myNonce) {
+      try {
+        unlinkSync(reclaimLock);
+      } catch {}
+    }
+  }
+}
+
+/**
+ * Run `fn` while holding a cross-process lock on the registry.
+ *
+ * Acquire is a single atomic step with NO publication gap: the owner metadata is
+ * written to a unique temp file first, then `link(2)`'d onto the canonical lock
+ * path. `link` fails EEXIST if the lock is held, and the instant the lock path
+ * exists its content (the owner) is already complete — so a contender can never
+ * observe an "ownerless" live lock and wrongly reclaim it.
+ *
+ * Correctness rules (hardened via cross-review):
+ *   - NEVER steal a lock from a LIVE owner — even a long-held one — because a
+ *     paused/stalled owner could resume mid-critical-section and write a stale
+ *     registry (lost update). A live holder past the deadline ⇒ PAIR_LOCK_TIMEOUT.
+ *   - Reclaim only a DEAD owner, or (defensively) a lock whose content is
+ *     unreadable AND older than ORPHAN_GRACE_MS (corruption / partial crash).
+ *   - Reclamation is serialized through a dedicated reclaim lock and re-confirms
+ *     staleness before removing the primary lock (see attemptReclaim), so racing
+ *     reclaimers can't evict a fresh holder's lock.
+ */
+export async function withRegistryLock<T>(base: string, fn: () => Promise<T> | T): Promise<T> {
+  mkdirSync(pairsDir(base), { recursive: true });
+  const lockFile = lockFilePath(base);
+  const deadline = Date.now() + LOCK_DEADLINE_MS;
+  const myNonce = randomUUID();
+  const ownerJson = JSON.stringify({
+    pid: process.pid,
+    createdAt: Date.now(),
+    nonce: myNonce,
+    hostname: safeHostname(),
+    uid: safeUid(),
+  } satisfies LockOwner);
+
+  for (;;) {
+    // Atomic acquire: write owner to a unique temp file, then link it onto the
+    // canonical lock path. The temp name is unique per attempt so concurrent
+    // acquirers never clash on it.
+    const tmp = `${lockFile}.acq.${process.pid}.${randomUUID()}`;
+    let acquired = false;
+    try {
+      writeFileSync(tmp, ownerJson);
+      try {
+        linkSync(tmp, lockFile); // atomic test-and-set; EEXIST if held
+        acquired = true;
+      } catch (err: any) {
+        if (err?.code !== "EEXIST") throw err;
+      }
+    } finally {
+      try {
+        unlinkSync(tmp);
+      } catch {}
+    }
+
+    if (acquired) {
+      try {
+        return await fn();
+      } finally {
+        // A live owner is never reclaimed, so this is normally still our lock —
+        // only remove it if we still own it (defense in depth).
+        const current = readLockOwner(lockFile);
+        if (!current || current.nonce === myNonce) {
+          try {
+            unlinkSync(lockFile);
+          } catch {}
+        }
+      }
+    }
+
+    // Held by someone — reclaim if stale (serialized + re-confirmed under a
+    // reclaim lock so we can't evict a fresh holder), otherwise wait.
+    if (lockIsStale(lockFile)) {
+      attemptReclaim(lockFile);
+    }
+
+    if (Date.now() >= deadline) {
+      throw new PairError("PAIR_LOCK_TIMEOUT", `Timed out acquiring registry lock at ${lockFile}`, {
+        holderPid: readLockOwner(lockFile)?.pid,
+      });
+    }
+    await sleep(25 + Math.floor(Math.random() * 50));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy-root daemon detection
+// ---------------------------------------------------------------------------
+
+function isDaemonProcess(pid: number): boolean {
+  try {
+    const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
+    return cmd.includes("daemon") && (cmd.includes("agentbridge") || cmd.includes("agent_bridge"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect a pre-multi-pair daemon that wrote its pid directly at <base>/daemon.pid
+ * (the classic single-pair layout) and is still alive on control port 4502.
+ * Returns its pid, or null.
+ */
+export function detectLegacyRootDaemon(base: string): { pid: number; controlPort: number } | null {
+  const rootPidFile = join(base, "daemon.pid");
+  if (!existsSync(rootPidFile)) return null;
+  let pid: number;
+  try {
+    const raw = readFileSync(rootPidFile, "utf-8").trim();
+    pid = Number.parseInt(raw, 10);
+  } catch {
+    return null;
+  }
+  if (!Number.isFinite(pid) || !pidLooksAlive(pid) || !isDaemonProcess(pid)) return null;
+  return { pid, controlPort: LEGACY_ROOT_CONTROL_PORT };
+}
+
+// ---------------------------------------------------------------------------
+// Port probing
+// ---------------------------------------------------------------------------
+
+/** Resolve true if the TCP port is free to bind on 127.0.0.1. */
+export function probePortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+function pidOnPort(port: number): number | undefined {
+  try {
+    const out = execFileSync("lsof", ["-ti", `:${port}`, "-sTCP:LISTEN"], { encoding: "utf-8" }).trim();
+    const first = out.split(/\s+/)[0];
+    const pid = Number.parseInt(first ?? "", 10);
+    return Number.isFinite(pid) ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public allocation entrypoint
+// ---------------------------------------------------------------------------
+
+export interface ResolvePairOptions {
+  pairFlag?: string;
+  cwd: string;
+  /**
+   * Probe the allocated ports for an external squatter after allocation
+   * (default true). Production always probes; tests that exercise pure slot
+   * allocation set this false so they don't depend on which ports happen to be
+   * free on the host.
+   */
+  probePorts?: boolean;
+}
+
+/**
+ * Resolve (and, if new, allocate) the pair for this invocation.
+ *
+ * Allocation happens under the cross-process lock; port probing happens after
+ * releasing it (probing is slow and must not serialize all CLI starts). Re-running
+ * for the same pair is idempotent — the slot is reused and a healthy daemon on the
+ * control port is treated as "already running", not a conflict.
+ */
+export async function resolvePair(base: string, opts: ResolvePairOptions): Promise<ResolvedPair> {
+  // `pairFlag != null` (rather than truthiness) so an explicit-but-empty `--pair`
+  // (a missing value) surfaces a clear PAIR_ID_INVALID instead of silently
+  // falling back to cwd derivation.
+  const hasFlag = opts.pairFlag != null;
+  const pairId = hasFlag ? validatePairId(opts.pairFlag as string) : derivePairIdFromCwd(opts.cwd);
+  const source: PairEntry["source"] = hasFlag ? "flag" : "cwd";
+  const lower = pairId.toLowerCase();
+
+  const { slot, entry, isNew } = await withRegistryLock(base, () => {
+    const reg = readRegistry(base);
+    const existing = reg.pairs.find((p) => p.pairId.toLowerCase() === lower);
+    if (existing) return { slot: existing.slot, entry: existing, isNew: false };
+
+    const newSlot = pickLowestFreeSlot(reg.pairs);
+    if (newSlot === 0) {
+      const legacy = detectLegacyRootDaemon(base);
+      if (legacy) {
+        throw new PairError(
+          "PAIR_LEGACY_ROOT_DAEMON",
+          `A pre-multi-pair AgentBridge daemon is running at the legacy location ` +
+            `(pid ${legacy.pid}, control port ${legacy.controlPort}). Run "abg kill" to stop it, then retry — ` +
+            `your new session would otherwise collide on port ${legacy.controlPort}.`,
+          { pid: legacy.pid, controlPort: legacy.controlPort },
+        );
+      }
+    }
+    // Validate the slot's ports BEFORE persisting, so slot exhaustion throws
+    // without leaving an invalid (out-of-range) entry in the registry.
+    portsForSlot(newSlot);
+    const newEntry: PairEntry = {
+      pairId,
+      slot: newSlot,
+      cwd: opts.cwd,
+      source,
+      createdAt: new Date().toISOString(),
+    };
+    writeRegistry(base, { version: 1, pairs: [...reg.pairs, newEntry] });
+    return { slot: newSlot, entry: newEntry, isNew: true };
+  });
+
+  const ports = portsForSlot(slot);
+
+  // Probe ports ONLY for a brand-new slot allocation. For an existing pair
+  // (idempotent re-run) the daemon may already own these ports, or a concurrent
+  // same-pair launch may be mid-bind — so we defer conflict detection to the
+  // daemon's own bind + health check rather than risk a false PAIR_PORTS_BUSY.
+  //
+  // Note: a new entry is durably committed (under the lock) before this probe.
+  // A probe failure leaves a reserved "ghost" slot that a re-run reuses
+  // idempotently or that `abg pairs rm` clears. Probing is a best-effort
+  // external-squatter check, not a correctness guarantee (port use is TOCTOU);
+  // the daemon's bind is the final arbiter.
+  if (isNew && opts.probePorts !== false) {
+    for (const port of [ports.appPort, ports.proxyPort, ports.controlPort]) {
+      if (!(await probePortFree(port))) {
+        throw new PairError(
+          "PAIR_PORTS_BUSY",
+          `Port ${port} (pair "${pairId}", slot ${slot}) is already in use by another process. ` +
+            `Free it or remove the conflicting pair; AgentBridge will not silently move slots.`,
+          { port, slot, pairId, pid: pidOnPort(port) },
+        );
+      }
+    }
+  }
+
+  // Use the registry's canonical pairId (case preserved from first registration),
+  // NOT the caller's casing — otherwise `--pair Foo` then `--pair foo` would split
+  // one logical pair across two state dirs on a case-sensitive filesystem.
+  return { pairId: entry.pairId, slot, ports, stateDir: join(pairsDir(base), entry.pairId), entry };
+}
+
+/** Remove a pair entry from the registry (frees its slot). Returns the removed entry or null. */
+export async function removePairEntry(base: string, pairId: string): Promise<PairEntry | null> {
+  const lower = pairId.toLowerCase();
+  return withRegistryLock(base, () => {
+    const reg = readRegistry(base);
+    const found = reg.pairs.find((p) => p.pairId.toLowerCase() === lower) ?? null;
+    if (!found) return null;
+    writeRegistry(base, { version: 1, pairs: reg.pairs.filter((p) => p.pairId.toLowerCase() !== lower) });
+    return found;
+  });
+}

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -86,6 +86,13 @@ export interface ResolvedPair {
   /** Friendly, cwd-scoped name ({@link DEFAULT_PAIR_NAME} when no `--pair` given). */
   name: string;
   entry: PairEntry;
+  /**
+   * Non-blocking advisory the CLI prints to stderr (never thrown, never persisted).
+   * Set when a raw pairId matched a pair from a DIFFERENT cwd (reused, but project
+   * context differs), or when the flag LOOKS like a full pairId yet matched nothing
+   * so a new pair was allocated (likely a pasted/typed pairId mistaken for a name).
+   */
+  warning?: string;
 }
 
 export type PairErrorCode =
@@ -640,9 +647,11 @@ export interface ResolvePairOptions {
  * control port is treated as "already running", not a conflict.
  *
  * UPGRADE NOTE: the pairId scheme changed to the cwd-scoped `<name>-<hash>` form.
- * Entries written by an older build (verbatim `--pair` ids, or a different
- * cwd-derivation) will NOT be matched here, so a launch allocates a fresh slot
- * rather than reusing the legacy one. The legacy entry remains visible in
+ * Entries written by an older build (a different cwd-derivation) will NOT match the
+ * scoped (name + cwd) lookup, so a launch allocates a fresh slot rather than reusing
+ * the legacy one — EXCEPT when an explicit `--pair <verbatim-id>` equals an existing
+ * pairId verbatim: the step-2 raw fallback below then reuses that entry (the
+ * `abg --pair <pairId>` recovery path). The legacy entry remains visible in
  * `abg pairs` and is reclaimable with `abg pairs rm <id>` or `abg kill`
  * (kill-all stops every registered pair regardless of id shape). We intentionally
  * do not auto-migrate: the old id format is ambiguous and this is pre-v1.
@@ -661,12 +670,27 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
   const pairId = derivePairId(opts.cwd, name);
   const source: PairEntry["source"] = hasFlag ? "flag" : "cwd";
   const lower = pairId.toLowerCase();
+  // Raw match key: the flag verbatim (validated/trimmed into `name`), in case it is
+  // ALREADY a full pairId copied from `abg pairs` (which is cwd-independent).
+  const flagLower = name.toLowerCase();
 
-  const { slot, entry, isNew } = await withRegistryLock(base, () => {
+  const { slot, entry, isNew, matchedRaw } = await withRegistryLock(base, () => {
     const reg = readRegistry(base);
-    const existing = reg.pairs.find((p) => p.pairId.toLowerCase() === lower);
-    if (existing) return { slot: existing.slot, entry: existing, isNew: false };
+    // 1) Scoped (name + cwd) match first: a friendly name in THIS directory always
+    //    wins, so normal `--pair main` is unaffected and a foreign raw pairId can
+    //    never steal a legitimate current-cwd name.
+    const scoped = reg.pairs.find((p) => p.pairId.toLowerCase() === lower);
+    if (scoped) return { slot: scoped.slot, entry: scoped, isNew: false, matchedRaw: false };
+    // 2) Raw pairId fallback: the flag itself IS an already-registered pairId.
+    //    Mirrors findPairForFlag() so a launch (`abg --pair <id> codex`) agrees with
+    //    kill/pairs, and fixes the double-hash strand where passing a full pairId
+    //    silently spawned a brand-new empty pair with no peer.
+    if (hasFlag) {
+      const raw = reg.pairs.find((p) => p.pairId.toLowerCase() === flagLower);
+      if (raw) return { slot: raw.slot, entry: raw, isNew: false, matchedRaw: true };
+    }
 
+    // 3) No match → allocate a fresh slot for the cwd-scoped pairId.
     const newSlot = pickLowestFreeSlot(reg.pairs);
     if (newSlot === 0) {
       const legacy = detectLegacyRootDaemon(base);
@@ -692,7 +716,7 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
       createdAt: new Date().toISOString(),
     };
     writeRegistry(base, { version: 1, pairs: [...reg.pairs, newEntry] });
-    return { slot: newSlot, entry: newEntry, isNew: true };
+    return { slot: newSlot, entry: newEntry, isNew: true, matchedRaw: false };
   });
 
   const ports = portsForSlot(slot);
@@ -724,6 +748,22 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
   // NOT the caller's casing — otherwise `--pair Foo` then `--pair foo` would split
   // one logical pair across two state dirs on a case-sensitive filesystem.
   // `entry.name` is backfilled for entries written before the `name` field shipped.
+  // Non-blocking advisory for two confusing cases (CLI prints to stderr; never
+  // thrown, never persisted). matchedRaw implies isNew === false, so these are
+  // mutually exclusive.
+  let warning: string | undefined;
+  if (matchedRaw && entry.cwd !== opts.cwd) {
+    warning =
+      `--pair ${opts.pairFlag ?? name} matched pair "${entry.pairId}" registered for ${entry.cwd} ` +
+      `(you are in ${opts.cwd}); reusing it. Pass a short name (e.g. "${entry.name ?? DEFAULT_PAIR_NAME}") ` +
+      `if you meant a pair in THIS directory.`;
+  } else if (isNew && hasFlag && /-[0-9a-f]{8}$/i.test(name)) {
+    warning =
+      `--pair ${opts.pairFlag ?? name} looks like a full pair id, but no registered pair matched; ` +
+      `creating a NEW pair named "${name}". Pass a short name (e.g. "main") or run \`abg pairs\` ` +
+      `to see existing pairs.`;
+  }
+
   return {
     pairId: entry.pairId,
     slot,
@@ -731,6 +771,7 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
     stateDir: join(pairsDir(base), entry.pairId),
     name: entry.name ?? name,
     entry,
+    warning,
   };
 }
 

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -37,6 +37,8 @@ import { basename, join } from "node:path";
 export const PAIR_BASE_PORT = 4500;
 export const PAIR_SLOT_STRIDE = 10;
 export const PAIR_ID_REGEX = /^[A-Za-z0-9._-]{1,64}$/;
+/** Friendly pair name used when no `--pair <name>` is given. Scoped to the cwd. */
+export const DEFAULT_PAIR_NAME = "main";
 
 const LOCK_FILE_NAME = ".registry.lock";
 const REGISTRY_FILE_NAME = "registry.json";
@@ -61,6 +63,12 @@ export interface PairEntry {
   pairId: string;
   slot: number;
   cwd: string;
+  /**
+   * Friendly, cwd-scoped name the user typed (or {@link DEFAULT_PAIR_NAME} when
+   * none was given). Display-only — the `pairId` remains the canonical key.
+   * Optional so registries written before this field shipped still read cleanly.
+   */
+  name?: string;
   source: "flag" | "cwd";
   createdAt: string;
 }
@@ -75,6 +83,8 @@ export interface ResolvedPair {
   slot: number;
   ports: PairPorts;
   stateDir: string;
+  /** Friendly, cwd-scoped name ({@link DEFAULT_PAIR_NAME} when no `--pair` given). */
+  name: string;
   entry: PairEntry;
 }
 
@@ -169,6 +179,47 @@ export function derivePairIdFromCwd(cwd: string): string {
   const id = slug ? `${slug}-${hash}` : hash;
   // Guaranteed to satisfy validatePairId by construction.
   return id;
+}
+
+/**
+ * Derive a stable, fs-safe pairId for a NAMED pair scoped to a directory.
+ *
+ * The id is `<name-slug>-<8-char hash of realpath(cwd)>`. Scoping the hash to the
+ * cwd is the whole point: the SAME friendly name (e.g. "main") in two different
+ * directories resolves to two DISTINCT pairs, so they never collide on a slot /
+ * daemon / set of ports. Two different names in the SAME directory also stay
+ * distinct (different slug prefix, same hash suffix).
+ *
+ * `name` must already be validated via {@link validatePairId} (or be
+ * {@link DEFAULT_PAIR_NAME}). The slug is re-sanitised + length-capped defensively
+ * so the composite always satisfies {@link PAIR_ID_REGEX} (≤ 41 chars).
+ */
+export function derivePairId(cwd: string, name: string): string {
+  let real: string;
+  try {
+    real = realpathSync(cwd);
+  } catch {
+    real = cwd;
+  }
+  // Hash BOTH the cwd AND the (already validated) name. Hashing the name is what
+  // makes two distinct names in the same directory provably distinct even when
+  // their cosmetic slug sanitises to the same string — e.g. "main" vs "-main-"
+  // both slug to "main", and "---" slugs to empty. Without the name in the hash
+  // those would collide on one slot/daemon. The NUL separator stops (cwd, name)
+  // pairs from aliasing across the boundary.
+  // Lowercase the name in the hash so casing variants ("Foo" vs "foo") map to
+  // the SAME pair (the registry canonicalises by lowercased pairId). The slug
+  // below keeps the original case purely for display.
+  const hash = createHash("sha256").update(real).update("\0").update(name.toLowerCase()).digest("hex").slice(0, 8);
+  const slug =
+    name
+      .replace(/[^A-Za-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 32) || "pair";
+  // The hex hash suffix guarantees the id never ends in a dot and is never
+  // a pure "." / "..", so the only invariant left to the slug is the charset.
+  // The slug is purely cosmetic now; the hash alone guarantees uniqueness.
+  return `${slug}-${hash}`;
 }
 
 /**
@@ -587,13 +638,27 @@ export interface ResolvePairOptions {
  * releasing it (probing is slow and must not serialize all CLI starts). Re-running
  * for the same pair is idempotent — the slot is reused and a healthy daemon on the
  * control port is treated as "already running", not a conflict.
+ *
+ * UPGRADE NOTE: the pairId scheme changed to the cwd-scoped `<name>-<hash>` form.
+ * Entries written by an older build (verbatim `--pair` ids, or a different
+ * cwd-derivation) will NOT be matched here, so a launch allocates a fresh slot
+ * rather than reusing the legacy one. The legacy entry remains visible in
+ * `abg pairs` and is reclaimable with `abg pairs rm <id>` or `abg kill`
+ * (kill-all stops every registered pair regardless of id shape). We intentionally
+ * do not auto-migrate: the old id format is ambiguous and this is pre-v1.
  */
 export async function resolvePair(base: string, opts: ResolvePairOptions): Promise<ResolvedPair> {
   // `pairFlag != null` (rather than truthiness) so an explicit-but-empty `--pair`
   // (a missing value) surfaces a clear PAIR_ID_INVALID instead of silently
-  // falling back to cwd derivation.
+  // falling back to the default name.
+  //
+  // The friendly NAME is always scoped to the cwd: with a flag it is the
+  // validated `--pair <name>`; without one it is DEFAULT_PAIR_NAME ("main").
+  // The canonical pairId composes the name with a hash of the cwd, so the same
+  // name in two directories is two distinct pairs (see derivePairId).
   const hasFlag = opts.pairFlag != null;
-  const pairId = hasFlag ? validatePairId(opts.pairFlag as string) : derivePairIdFromCwd(opts.cwd);
+  const name = hasFlag ? validatePairId(opts.pairFlag as string) : DEFAULT_PAIR_NAME;
+  const pairId = derivePairId(opts.cwd, name);
   const source: PairEntry["source"] = hasFlag ? "flag" : "cwd";
   const lower = pairId.toLowerCase();
 
@@ -622,6 +687,7 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
       pairId,
       slot: newSlot,
       cwd: opts.cwd,
+      name,
       source,
       createdAt: new Date().toISOString(),
     };
@@ -657,7 +723,15 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
   // Use the registry's canonical pairId (case preserved from first registration),
   // NOT the caller's casing — otherwise `--pair Foo` then `--pair foo` would split
   // one logical pair across two state dirs on a case-sensitive filesystem.
-  return { pairId: entry.pairId, slot, ports, stateDir: join(pairsDir(base), entry.pairId), entry };
+  // `entry.name` is backfilled for entries written before the `name` field shipped.
+  return {
+    pairId: entry.pairId,
+    slot,
+    ports,
+    stateDir: join(pairsDir(base), entry.pairId),
+    name: entry.name ?? name,
+    entry,
+  };
 }
 
 /** Remove a pair entry from the registry (frees its slot). Returns the removed entry or null. */

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -100,7 +100,8 @@ export type PairErrorCode =
   | "PAIR_ID_INVALID"
   | "PAIR_LOCK_TIMEOUT"
   | "PAIR_REGISTRY_CORRUPT"
-  | "PAIR_LEGACY_ROOT_DAEMON";
+  | "PAIR_LEGACY_ROOT_DAEMON"
+  | "PAIR_CROSS_CWD";
 
 export class PairError extends Error {
   readonly code: PairErrorCode;
@@ -639,6 +640,15 @@ export interface ResolvePairOptions {
 }
 
 /**
+ * Outcome of the under-lock allocation pass. Either a resolved slot/entry, or a
+ * cross-cwd sentinel that defers a PAIR_CROSS_CWD throw until the lock is released
+ * (throwing while holding the registry lock would strand it).
+ */
+type PairAllocation =
+  | { slot: number; entry: PairEntry; isNew: boolean; matchedRaw: boolean }
+  | { crossCwd: PairEntry };
+
+/**
  * Resolve (and, if new, allocate) the pair for this invocation.
  *
  * Allocation happens under the cross-process lock; port probing happens after
@@ -671,10 +681,11 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
   const source: PairEntry["source"] = hasFlag ? "flag" : "cwd";
   const lower = pairId.toLowerCase();
   // Raw match key: the flag verbatim (validated/trimmed into `name`), in case it is
-  // ALREADY a full pairId copied from `abg pairs` (which is cwd-independent).
+  // ALREADY a full pairId copied from `abg pairs` (reused only for the SAME cwd; a
+  // cross-cwd raw match is rejected below).
   const flagLower = name.toLowerCase();
 
-  const { slot, entry, isNew, matchedRaw } = await withRegistryLock(base, () => {
+  const allocation = await withRegistryLock(base, (): PairAllocation => {
     const reg = readRegistry(base);
     // 1) Scoped (name + cwd) match first: a friendly name in THIS directory always
     //    wins, so normal `--pair main` is unaffected and a foreign raw pairId can
@@ -685,9 +696,20 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
     //    Mirrors findPairForFlag() so a launch (`abg --pair <id> codex`) agrees with
     //    kill/pairs, and fixes the double-hash strand where passing a full pairId
     //    silently spawned a brand-new empty pair with no peer.
+    //
+    //    A pair is scoped to its directory: only reuse a raw match when it belongs to
+    //    THIS cwd (the `abg --pair <pairId>` same-dir recovery path). A raw match from a
+    //    DIFFERENT cwd is an error — return a sentinel and throw AFTER releasing the lock
+    //    (never throw while holding it). The identity layer would reject a cross-cwd
+    //    attach anyway, so failing loud here keeps the two layers in agreement.
     if (hasFlag) {
       const raw = reg.pairs.find((p) => p.pairId.toLowerCase() === flagLower);
-      if (raw) return { slot: raw.slot, entry: raw, isNew: false, matchedRaw: true };
+      if (raw) {
+        if (raw.cwd === opts.cwd) {
+          return { slot: raw.slot, entry: raw, isNew: false, matchedRaw: true };
+        }
+        return { crossCwd: raw };
+      }
     }
 
     // 3) No match → allocate a fresh slot for the cwd-scoped pairId.
@@ -719,6 +741,21 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
     return { slot: newSlot, entry: newEntry, isNew: true, matchedRaw: false };
   });
 
+  // Cross-cwd raw match: thrown OUTSIDE the lock. A pair is scoped to its directory,
+  // so passing a full pairId from another directory is an error, not a silent reuse.
+  if ("crossCwd" in allocation) {
+    const raw = allocation.crossCwd;
+    throw new PairError(
+      "PAIR_CROSS_CWD",
+      `--pair ${opts.pairFlag ?? name} refers to pair "${raw.pairId}" registered for ${raw.cwd}, ` +
+        `but you are in ${opts.cwd}. A pair is scoped to its directory — cd into that directory ` +
+        `to use it, or pass a short name to create/use a pair here.`,
+      { pairId: raw.pairId, registeredCwd: raw.cwd, cwd: opts.cwd },
+    );
+  }
+
+  const { slot, entry, isNew, matchedRaw } = allocation;
+
   const ports = portsForSlot(slot);
 
   // Probe ports ONLY for a brand-new slot allocation. For an existing pair
@@ -726,14 +763,14 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
   // same-pair launch may be mid-bind — so we defer conflict detection to the
   // daemon's own bind + health check rather than risk a false PAIR_PORTS_BUSY.
   //
-  // Note: a new entry is durably committed (under the lock) before this probe.
-  // A probe failure leaves a reserved "ghost" slot that a re-run reuses
-  // idempotently or that `abg pairs rm` clears. Probing is a best-effort
-  // external-squatter check, not a correctness guarantee (port use is TOCTOU);
-  // the daemon's bind is the final arbiter.
+  // Note: probing is a best-effort external-squatter check, not a correctness
+  // guarantee (port use is TOCTOU); the daemon's bind is the final arbiter.
+  // If probing fails, remove the just-created registry entry under the lock so
+  // a transient external squatter does not strand a ghost slot.
   if (isNew && opts.probePorts !== false) {
     for (const port of [ports.appPort, ports.proxyPort, ports.controlPort]) {
       if (!(await probePortFree(port))) {
+        await removeAllocatedPairIfUnchanged(base, pairId, slot);
         throw new PairError(
           "PAIR_PORTS_BUSY",
           `Port ${port} (pair "${pairId}", slot ${slot}) is already in use by another process. ` +
@@ -748,21 +785,18 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
   // NOT the caller's casing — otherwise `--pair Foo` then `--pair foo` would split
   // one logical pair across two state dirs on a case-sensitive filesystem.
   // `entry.name` is backfilled for entries written before the `name` field shipped.
-  // Non-blocking advisory for two confusing cases (CLI prints to stderr; never
-  // thrown, never persisted). matchedRaw implies isNew === false, so these are
-  // mutually exclusive.
+  // Non-blocking advisory (CLI prints to stderr; never thrown, never persisted).
+  // A raw match is now only ever a SAME-cwd recovery (cross-cwd throws above), so the
+  // sole remaining advisory is the pairId-shaped flag that matched nothing.
   let warning: string | undefined;
-  if (matchedRaw && entry.cwd !== opts.cwd) {
-    warning =
-      `--pair ${opts.pairFlag ?? name} matched pair "${entry.pairId}" registered for ${entry.cwd} ` +
-      `(you are in ${opts.cwd}); reusing it. Pass a short name (e.g. "${entry.name ?? DEFAULT_PAIR_NAME}") ` +
-      `if you meant a pair in THIS directory.`;
-  } else if (isNew && hasFlag && /-[0-9a-f]{8}$/i.test(name)) {
+  if (isNew && hasFlag && /-[0-9a-f]{8}$/i.test(name)) {
     warning =
       `--pair ${opts.pairFlag ?? name} looks like a full pair id, but no registered pair matched; ` +
       `creating a NEW pair named "${name}". Pass a short name (e.g. "main") or run \`abg pairs\` ` +
       `to see existing pairs.`;
   }
+  // matchedRaw (same-cwd recovery) intentionally produces no warning.
+  void matchedRaw;
 
   return {
     pairId: entry.pairId,
@@ -773,6 +807,15 @@ export async function resolvePair(base: string, opts: ResolvePairOptions): Promi
     entry,
     warning,
   };
+}
+
+async function removeAllocatedPairIfUnchanged(base: string, pairId: string, slot: number): Promise<void> {
+  await withRegistryLock(base, () => {
+    const reg = readRegistry(base);
+    const nextPairs = reg.pairs.filter((pair) => !(pair.pairId === pairId && pair.slot === slot));
+    if (nextPairs.length === reg.pairs.length) return;
+    writeRegistry(base, { version: 1, pairs: nextPairs });
+  });
 }
 
 /** Remove a pair entry from the registry (frees its slot). Returns the removed entry or null. */

--- a/src/pair-resolver.ts
+++ b/src/pair-resolver.ts
@@ -31,6 +31,8 @@ export interface PairResolution {
   name: string;
   /** True when running in legacy/manual single-pair mode (env pinned, no --pair). */
   manual: boolean;
+  /** Non-blocking advisory (cross-cwd raw match / pairId-looking new alloc); CLI prints to stderr. */
+  warning?: string;
 }
 
 /**
@@ -161,6 +163,7 @@ export async function applyPairEnv(opts: { pairFlag?: string }): Promise<PairRes
     stateDir: new StateDirResolver(resolved.stateDir),
     name: resolved.name,
     manual: false,
+    warning: resolved.warning,
   };
 }
 
@@ -188,7 +191,10 @@ export function findPair(base: string, pairId: string): PairEntry | null {
 export function findPairForFlag(base: string, cwd: string, flag: string): PairEntry | null {
   const name = validatePairId(flag);
   const scopedId = derivePairId(cwd, name);
-  return findPair(base, scopedId) ?? findPair(base, flag);
+  // Raw fallback uses the validated/trimmed `name` (NOT the raw `flag`) so kill/pairs
+  // and launch (resolvePair, which validates first) agree on whitespace — a quoted
+  // `--pair "  <id>  "` resolves to the same pair in both paths.
+  return findPair(base, scopedId) ?? findPair(base, name);
 }
 
 /** Ports for a pair entry (convenience for kill/pairs). */

--- a/src/pair-resolver.ts
+++ b/src/pair-resolver.ts
@@ -1,0 +1,179 @@
+import { StateDirResolver } from "./state-dir";
+import {
+  type PairEntry,
+  type PairPorts,
+  portsForSlot,
+  readRegistry,
+  removePairEntry,
+  resolvePair,
+} from "./pair-registry";
+
+/**
+ * Pair resolution glue — the env-injection seam between the pure pair registry
+ * and the CLI's process-env world.
+ *
+ * The CLI entrypoints (`runClaude` / `runCodex`) call `applyPairEnv` at the very
+ * top: it allocates/looks-up the pair's slot and sets the four env vars that the
+ * rest of the system already reads (state dir + the three ports). The existing
+ * StateDirResolver / DaemonLifecycle / daemon then "just work", and the spawned
+ * `claude` / `codex` children inherit the env, so the plugin's MCP server and
+ * the Codex proxy connect to the right per-pair daemon.
+ */
+
+export interface PairResolution {
+  pairId: string;
+  slot: number | null;
+  ports: PairPorts;
+  stateDir: StateDirResolver;
+  /** True when running in legacy/manual single-pair mode (env pinned, no --pair). */
+  manual: boolean;
+}
+
+/**
+ * The registry base dir (the dir that contains `pairs/`).
+ *
+ * `AGENTBRIDGE_BASE_DIR` is the dedicated, unambiguous base override. It is
+ * preferred over `AGENTBRIDGE_STATE_DIR` precisely because `applyPairEnv`
+ * rewrites `AGENTBRIDGE_STATE_DIR` to the PER-PAIR dir (`<base>/pairs/<id>`):
+ * a child process (`abg pairs`, `abg kill`) that inherits the pair env must
+ * still resolve the registry at the real base, not at the pair's own state dir.
+ * Falls back to `AGENTBRIDGE_STATE_DIR` (relocated single base) then the platform default.
+ */
+export function computeBaseDir(): string {
+  // `||` (not `??`) so an empty-string env is treated as unset rather than a
+  // valid relative path.
+  return (
+    process.env.AGENTBRIDGE_BASE_DIR ||
+    process.env.AGENTBRIDGE_STATE_DIR ||
+    StateDirResolver.platformBaseDir()
+  );
+}
+
+/** Extract `--pair <name>` / `--pair=<name>`, returning the remaining args untouched. */
+export function parsePairFlag(args: string[]): { pairFlag?: string; rest: string[] } {
+  const rest: string[] = [];
+  let pairFlag: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--pair") {
+      const next = args[i + 1];
+      // Consume the value only if it looks like a value (not another flag / EOL).
+      // A missing value becomes "" so resolution throws a clear PAIR_ID_INVALID
+      // instead of silently falling back to a cwd-derived pair.
+      if (next !== undefined && !next.startsWith("-")) {
+        pairFlag = next;
+        i++;
+      } else {
+        pairFlag = "";
+      }
+      continue;
+    }
+    if (a.startsWith("--pair=")) {
+      pairFlag = a.slice("--pair=".length);
+      continue;
+    }
+    rest.push(a);
+  }
+  return { pairFlag, rest };
+}
+
+/** Parse `abg kill` flags: `--all` and/or `--pair <name>`. No flag ⇒ kill all. */
+export function parseKillArgs(args: string[]): { all: boolean; pairFlag?: string } {
+  let all = false;
+  let pairFlag: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--all") {
+      all = true;
+      continue;
+    }
+    if (a === "--pair") {
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith("-")) {
+        pairFlag = next;
+        i++;
+      } else {
+        pairFlag = "";
+      }
+      continue;
+    }
+    if (a.startsWith("--pair=")) {
+      pairFlag = a.slice("--pair=".length);
+    }
+  }
+  return { all, pairFlag };
+}
+
+/**
+ * Resolve the pair for this invocation and inject its env so downstream code and
+ * spawned children pick up the right state dir + ports.
+ *
+ * Manual/legacy mode: if the caller explicitly pinned the state dir or any port
+ * via env AND gave no `--pair`, behave exactly like the classic single pair
+ * (no registry, no slot) — this preserves power-user overrides and the existing
+ * e2e harness. An explicit `--pair` always forces multi-pair resolution.
+ */
+export async function applyPairEnv(opts: { pairFlag?: string }): Promise<PairResolution> {
+  // Truthiness (not `!= null`) so an empty-string env counts as unset.
+  const explicitEnv =
+    !!process.env.AGENTBRIDGE_STATE_DIR ||
+    !!process.env.AGENTBRIDGE_CONTROL_PORT ||
+    !!process.env.CODEX_WS_PORT ||
+    !!process.env.CODEX_PROXY_PORT;
+
+  if (opts.pairFlag === undefined && explicitEnv) {
+    const stateDir = new StateDirResolver();
+    const controlPort = Number.parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
+    const appPort = Number.parseInt(process.env.CODEX_WS_PORT ?? "4500", 10);
+    const proxyPort = Number.parseInt(process.env.CODEX_PROXY_PORT ?? "4501", 10);
+    return {
+      pairId: "(manual)",
+      slot: null,
+      ports: { appPort, proxyPort, controlPort },
+      stateDir,
+      manual: true,
+    };
+  }
+
+  const base = computeBaseDir();
+  const resolved = await resolvePair(base, { pairFlag: opts.pairFlag, cwd: process.cwd() });
+
+  // Pin the base explicitly so child processes (abg pairs / kill, spawned tools)
+  // resolve the SAME registry even though AGENTBRIDGE_STATE_DIR below is rewritten
+  // to the per-pair dir.
+  process.env.AGENTBRIDGE_BASE_DIR = base;
+  process.env.AGENTBRIDGE_PAIR_ID = resolved.pairId;
+  process.env.AGENTBRIDGE_STATE_DIR = resolved.stateDir;
+  process.env.AGENTBRIDGE_CONTROL_PORT = String(resolved.ports.controlPort);
+  process.env.CODEX_WS_PORT = String(resolved.ports.appPort);
+  process.env.CODEX_PROXY_PORT = String(resolved.ports.proxyPort);
+
+  return {
+    pairId: resolved.pairId,
+    slot: resolved.slot,
+    ports: resolved.ports,
+    stateDir: new StateDirResolver(resolved.stateDir),
+    manual: false,
+  };
+}
+
+/** All registered pairs (for `abg pairs`). */
+export function listPairs(base: string): PairEntry[] {
+  return readRegistry(base).pairs;
+}
+
+/** Look up a single pair entry by id (case-insensitive), without allocating. */
+export function findPair(base: string, pairId: string): PairEntry | null {
+  const lower = pairId.toLowerCase();
+  return readRegistry(base).pairs.find((p) => p.pairId.toLowerCase() === lower) ?? null;
+}
+
+/** Ports for a pair entry (convenience for kill/pairs). */
+export function portsForEntry(entry: PairEntry): PairPorts {
+  return portsForSlot(entry.slot);
+}
+
+/** Remove a pair entry from the registry, freeing its slot. */
+export async function removePair(base: string, pairId: string): Promise<PairEntry | null> {
+  return removePairEntry(base, pairId);
+}

--- a/src/pair-resolver.ts
+++ b/src/pair-resolver.ts
@@ -2,10 +2,12 @@ import { StateDirResolver } from "./state-dir";
 import {
   type PairEntry,
   type PairPorts,
+  derivePairId,
   portsForSlot,
   readRegistry,
   removePairEntry,
   resolvePair,
+  validatePairId,
 } from "./pair-registry";
 
 /**
@@ -25,6 +27,8 @@ export interface PairResolution {
   slot: number | null;
   ports: PairPorts;
   stateDir: StateDirResolver;
+  /** Friendly, cwd-scoped name ("main" by default; "(manual)" in legacy mode). */
+  name: string;
   /** True when running in legacy/manual single-pair mode (env pinned, no --pair). */
   manual: boolean;
 }
@@ -131,6 +135,7 @@ export async function applyPairEnv(opts: { pairFlag?: string }): Promise<PairRes
       slot: null,
       ports: { appPort, proxyPort, controlPort },
       stateDir,
+      name: "(manual)",
       manual: true,
     };
   }
@@ -143,6 +148,7 @@ export async function applyPairEnv(opts: { pairFlag?: string }): Promise<PairRes
   // to the per-pair dir.
   process.env.AGENTBRIDGE_BASE_DIR = base;
   process.env.AGENTBRIDGE_PAIR_ID = resolved.pairId;
+  process.env.AGENTBRIDGE_PAIR_NAME = resolved.name;
   process.env.AGENTBRIDGE_STATE_DIR = resolved.stateDir;
   process.env.AGENTBRIDGE_CONTROL_PORT = String(resolved.ports.controlPort);
   process.env.CODEX_WS_PORT = String(resolved.ports.appPort);
@@ -153,6 +159,7 @@ export async function applyPairEnv(opts: { pairFlag?: string }): Promise<PairRes
     slot: resolved.slot,
     ports: resolved.ports,
     stateDir: new StateDirResolver(resolved.stateDir),
+    name: resolved.name,
     manual: false,
   };
 }
@@ -166,6 +173,22 @@ export function listPairs(base: string): PairEntry[] {
 export function findPair(base: string, pairId: string): PairEntry | null {
   const lower = pairId.toLowerCase();
   return readRegistry(base).pairs.find((p) => p.pairId.toLowerCase() === lower) ?? null;
+}
+
+/**
+ * Resolve `--pair <flag>` to a registry entry the way a launch would.
+ *
+ * The friendly name is scoped to `cwd` (same name in another directory is a
+ * different pair), so kill/pairs must compose it with the cwd hash first. Falls
+ * back to a raw pairId match so an explicit composite id copied from `abg pairs`
+ * (which is cwd-independent) also resolves regardless of where it is run.
+ *
+ * Throws PAIR_ID_INVALID (via validatePairId) for a malformed flag.
+ */
+export function findPairForFlag(base: string, cwd: string, flag: string): PairEntry | null {
+  const name = validatePairId(flag);
+  const scopedId = derivePairId(cwd, name);
+  return findPair(base, scopedId) ?? findPair(base, flag);
 }
 
 /** Ports for a pair entry (convenience for kill/pairs). */

--- a/src/pair-resolver.ts
+++ b/src/pair-resolver.ts
@@ -114,10 +114,10 @@ export function parseKillArgs(args: string[]): { all: boolean; pairFlag?: string
  * Resolve the pair for this invocation and inject its env so downstream code and
  * spawned children pick up the right state dir + ports.
  *
- * Manual/legacy mode: if the caller explicitly pinned the state dir or any port
- * via env AND gave no `--pair`, behave exactly like the classic single pair
- * (no registry, no slot) — this preserves power-user overrides and the existing
- * e2e harness. An explicit `--pair` always forces multi-pair resolution.
+ * Manual/legacy mode: only when the caller explicitly opts in with
+ * `AGENTBRIDGE_MANUAL=1`, pinned state-dir/port env, and no `--pair`, behave
+ * like the classic single pair (no registry, no slot). Stale runtime env without
+ * the opt-in is ignored and overwritten by cwd-scoped pair resolution.
  */
 export async function applyPairEnv(opts: { pairFlag?: string }): Promise<PairResolution> {
   // Truthiness (not `!= null`) so an empty-string env counts as unset.
@@ -127,7 +127,7 @@ export async function applyPairEnv(opts: { pairFlag?: string }): Promise<PairRes
     !!process.env.CODEX_WS_PORT ||
     !!process.env.CODEX_PROXY_PORT;
 
-  if (opts.pairFlag === undefined && explicitEnv) {
+  if (opts.pairFlag === undefined && explicitEnv && process.env.AGENTBRIDGE_MANUAL === "1") {
     const stateDir = new StateDirResolver();
     const controlPort = Number.parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
     const appPort = Number.parseInt(process.env.CODEX_WS_PORT ?? "4500", 10);
@@ -182,19 +182,25 @@ export function findPair(base: string, pairId: string): PairEntry | null {
  * Resolve `--pair <flag>` to a registry entry the way a launch would.
  *
  * The friendly name is scoped to `cwd` (same name in another directory is a
- * different pair), so kill/pairs must compose it with the cwd hash first. Falls
- * back to a raw pairId match so an explicit composite id copied from `abg pairs`
- * (which is cwd-independent) also resolves regardless of where it is run.
+ * different pair), so kill/pairs must compose it with the cwd hash first. A raw
+ * pairId only resolves when it belongs to THIS cwd; cross-cwd raw matches are
+ * rejected so `kill` / `pairs rm` never cross directory boundaries.
  *
  * Throws PAIR_ID_INVALID (via validatePairId) for a malformed flag.
  */
 export function findPairForFlag(base: string, cwd: string, flag: string): PairEntry | null {
   const name = validatePairId(flag);
   const scopedId = derivePairId(cwd, name);
+  const scoped = findPair(base, scopedId);
+  if (scoped) return scoped;
+
   // Raw fallback uses the validated/trimmed `name` (NOT the raw `flag`) so kill/pairs
   // and launch (resolvePair, which validates first) agree on whitespace — a quoted
-  // `--pair "  <id>  "` resolves to the same pair in both paths.
-  return findPair(base, scopedId) ?? findPair(base, name);
+  // `--pair "  <id>  "` resolves to the same pair in both paths. Only reuse it when
+  // the registry entry belongs to THIS cwd; cross-cwd raw matches are treated as
+  // not found so pair operations stay directory-scoped.
+  const raw = findPair(base, name);
+  return raw && raw.cwd === cwd ? raw : null;
 }
 
 /** Ports for a pair entry (convenience for kill/pairs). */

--- a/src/reply-required-tracker.ts
+++ b/src/reply-required-tracker.ts
@@ -1,0 +1,53 @@
+/**
+ * Coordinates the `require_reply` state for a single Codex turn.
+ *
+ * When Claude sends a reply with `require_reply`, the daemon must:
+ *   (a) force-forward EVERY subsequent Codex message to Claude (bypassing the
+ *       STATUS/FYI message filter) until the turn completes, and
+ *   (b) warn if the turn finishes without Codex sending any agentMessage.
+ *
+ * CRITICAL ordering invariant: `arm()` must be called ONLY after the message was
+ * successfully injected (a turn actually started). Arming before a *rejected*
+ * injection — the common case where Codex is busy mid-turn — would strand the
+ * armed state on an unrelated in-flight turn: that unrelated turn's chatter would
+ * be force-forwarded as if it were the required reply, and when it completes the
+ * "reply missing" warning would be wrongly skipped, silently losing Claude's real
+ * require_reply request. Keeping the arm/consume/reset transitions in one place
+ * makes that invariant explicit and testable.
+ */
+export class ReplyRequiredTracker {
+  private armed = false;
+  private forwardedDuringTurn = false;
+
+  /** True while a require_reply turn is in flight (force-forward is active). */
+  get isArmed(): boolean {
+    return this.armed;
+  }
+
+  /** Arm tracking for a require_reply turn that was successfully injected. */
+  arm(): void {
+    this.armed = true;
+    this.forwardedDuringTurn = false;
+  }
+
+  /** Record that a Codex message was force-forwarded to Claude during the turn. */
+  noteForwarded(): void {
+    if (this.armed) this.forwardedDuringTurn = true;
+  }
+
+  /**
+   * Consume at turn completion: returns whether to emit the "reply required but
+   * none arrived" warning, then clears the state.
+   */
+  consumeOnTurnComplete(): { warnReplyMissing: boolean } {
+    const warnReplyMissing = this.armed && !this.forwardedDuringTurn;
+    this.reset();
+    return { warnReplyMissing };
+  }
+
+  /** Clear without warning (e.g. disconnect / reconnect / shutdown). */
+  reset(): void {
+    this.armed = false;
+    this.forwardedDuringTurn = false;
+  }
+}

--- a/src/resume-pollution.ts
+++ b/src/resume-pollution.ts
@@ -1,0 +1,234 @@
+import { Database } from "bun:sqlite";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { codexHome as defaultCodexHome } from "./thread-state";
+
+export type PollutionAction = "rename" | "delete";
+
+export interface PollutionCandidate {
+  id: string;
+  cwd: string;
+  rolloutPath: string;
+  title: string;
+  firstUserMessage: string;
+  preview: string;
+  action: PollutionAction;
+  replacementTitle: string;
+  replacementFirstUserMessage: string;
+  replacementPreview: string;
+  reason: string;
+}
+
+export interface PollutionReport {
+  codexHome: string;
+  dbPath: string;
+  scanned: number;
+  candidates: PollutionCandidate[];
+  applied: number;
+  renamed: number;
+  deleted: number;
+  backupDir?: string;
+}
+
+const KICKOFF_FINGERPRINTS = [
+  "Claude Code has connected via AgentBridge",
+  "You are now in a multi-agent collaboration session",
+  "When you receive a complex task, propose a division of labor to Claude",
+];
+
+export function isKickoffText(text: string | null | undefined): boolean {
+  if (!text) return false;
+  return KICKOFF_FINGERPRINTS.some((fingerprint) => text.includes(fingerprint));
+}
+
+export function extractFirstRealUserMessage(rolloutPath: string): string | null {
+  if (!existsSync(rolloutPath)) return null;
+  const raw = readFileSync(rolloutPath, "utf-8");
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let entry: any;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = extractUserText(entry);
+    if (!message) continue;
+    if (isSyntheticUserMessage(message)) continue;
+    return message.trim();
+  }
+  return null;
+}
+
+export function scanResumePollution(options: {
+  codexHome?: string;
+  dbPath?: string;
+  apply?: boolean;
+  now?: string;
+} = {}): PollutionReport {
+  const codexHome = options.codexHome ?? defaultCodexHome();
+  const dbPath = options.dbPath ?? join(codexHome, "state_5.sqlite");
+  if (!existsSync(dbPath)) {
+    return { codexHome, dbPath, scanned: 0, candidates: [], applied: 0, renamed: 0, deleted: 0 };
+  }
+
+  const db = options.apply ? new Database(dbPath) : new Database(dbPath, { readonly: true });
+  try {
+    const rows = db.query(`
+      select id, cwd, rollout_path as rolloutPath, title,
+             first_user_message as firstUserMessage, preview
+      from threads
+      where archived = 0 and (
+        first_user_message like '%AgentBridge%' or
+        first_user_message like '%multi-agent collaboration%' or
+        title like '%AgentBridge%' or
+        title like '%multi-agent collaboration%' or
+        preview like '%AgentBridge%' or
+        preview like '%multi-agent collaboration%'
+      )
+      order by updated_at desc
+    `).all() as Array<{
+      id: string;
+      cwd: string;
+      rolloutPath: string;
+      title: string;
+      firstUserMessage: string;
+      preview: string;
+    }>;
+
+    const candidates: PollutionCandidate[] = [];
+    for (const row of rows) {
+      const pollutedFields = [
+        isKickoffText(row.title) ? "title" : null,
+        isKickoffText(row.firstUserMessage) ? "first_user_message" : null,
+        isKickoffText(row.preview) ? "preview" : null,
+      ].filter(Boolean);
+      if (pollutedFields.length === 0) continue;
+
+      const realMessage = extractFirstRealUserMessage(row.rolloutPath);
+      if (!realMessage) {
+        // Kickoff-only session with no real user work — meaningless, delete it.
+        candidates.push({
+          id: row.id,
+          cwd: row.cwd,
+          rolloutPath: row.rolloutPath,
+          title: row.title,
+          firstUserMessage: row.firstUserMessage,
+          preview: row.preview,
+          action: "delete",
+          replacementTitle: row.title,
+          replacementFirstUserMessage: row.firstUserMessage,
+          replacementPreview: row.preview,
+          reason: `kickoff-only, polluted ${pollutedFields.join(", ")}`,
+        });
+        continue;
+      }
+
+      // Session has real work — relabel the polluted metadata, keep the row.
+      candidates.push({
+        id: row.id,
+        cwd: row.cwd,
+        rolloutPath: row.rolloutPath,
+        title: row.title,
+        firstUserMessage: row.firstUserMessage,
+        preview: row.preview,
+        action: "rename",
+        replacementTitle: isKickoffText(row.title) ? sidebarTitle(realMessage) : row.title,
+        replacementFirstUserMessage: isKickoffText(row.firstUserMessage) ? realMessage : row.firstUserMessage,
+        replacementPreview: isKickoffText(row.preview) ? previewText(realMessage) : row.preview,
+        reason: `polluted ${pollutedFields.join(", ")}`,
+      });
+    }
+
+    let renamed = 0;
+    let deleted = 0;
+    let backupDir: string | undefined;
+    if (options.apply && candidates.length > 0) {
+      // Always back up state files BEFORE any destructive write.
+      backupDir = backupCodexStateFiles(dbPath, options.now);
+      const update = db.prepare(`
+        update threads
+        set title = ?,
+            first_user_message = ?,
+            preview = ?
+        where id = ?
+      `);
+      const remove = db.prepare(`delete from threads where id = ?`);
+      const tx = db.transaction((items: PollutionCandidate[]) => {
+        for (const item of items) {
+          if (item.action === "delete") {
+            remove.run(item.id);
+            deleted++;
+          } else {
+            update.run(
+              item.replacementTitle,
+              item.replacementFirstUserMessage,
+              item.replacementPreview,
+              item.id,
+            );
+            renamed++;
+          }
+        }
+      });
+      tx(candidates);
+    }
+
+    const applied = renamed + deleted;
+    return { codexHome, dbPath, scanned: rows.length, candidates, applied, renamed, deleted, backupDir };
+  } finally {
+    db.close();
+  }
+}
+
+export function backupCodexStateFiles(dbPath: string, now = new Date().toISOString()): string {
+  const safeStamp = now.replace(/[:.]/g, "-");
+  const base = join(dirname(dbPath), "agentbridge-backups", `resume-pollution-${safeStamp}`);
+  mkdirSync(base, { recursive: true });
+  for (const path of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    if (!existsSync(path)) continue;
+    const target = join(base, path.split("/").pop()!);
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(path, target);
+  }
+  return base;
+}
+
+function extractUserText(entry: any): string | null {
+  if (entry?.type === "event_msg" && entry.payload?.type === "user_message") {
+    return typeof entry.payload.message === "string" ? entry.payload.message : null;
+  }
+  if (entry?.type === "response_item" && entry.payload?.type === "message" && entry.payload?.role === "user") {
+    const content = entry.payload.content;
+    if (!Array.isArray(content)) return null;
+    const parts = content
+      .map((item: any) => typeof item?.text === "string" ? item.text : typeof item?.input_text?.text === "string" ? item.input_text.text : null)
+      .filter((part: string | null): part is string => !!part);
+    return parts.length > 0 ? parts.join("\n") : null;
+  }
+  return null;
+}
+
+function isSyntheticUserMessage(message: string): boolean {
+  return (
+    isKickoffText(message) ||
+    message.includes("AGENTS.md instructions for") ||
+    message.includes("<environment_context>")
+  );
+}
+
+function sidebarTitle(message: string): string {
+  return compact(message).slice(0, 80);
+}
+
+function previewText(message: string): string {
+  return compact(message).slice(0, 160);
+}
+
+function compact(message: string): string {
+  return message.replace(/\s+/g, " ").trim();
+}

--- a/src/rotating-log.ts
+++ b/src/rotating-log.ts
@@ -1,0 +1,36 @@
+import { appendFileSync, existsSync, mkdirSync, renameSync, statSync, unlinkSync } from "node:fs";
+import { dirname } from "node:path";
+
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_KEEP = 3;
+
+export function appendRotatingLog(
+  path: string,
+  content: string,
+  options: { maxBytes?: number; keep?: number } = {},
+): void {
+  const maxBytes = options.maxBytes ?? Number(process.env.AGENTBRIDGE_LOG_MAX_BYTES || DEFAULT_MAX_BYTES);
+  const keep = options.keep ?? Number(process.env.AGENTBRIDGE_LOG_ROTATE_KEEP || DEFAULT_KEEP);
+  mkdirSync(dirname(path), { recursive: true });
+  rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep);
+  appendFileSync(path, content, "utf-8");
+}
+
+function rotateIfNeeded(path: string, incomingBytes: number, maxBytes: number, keep: number): void {
+  if (!Number.isFinite(maxBytes) || maxBytes <= 0 || keep <= 0) return;
+  if (!existsSync(path)) return;
+  const size = statSync(path).size;
+  if (size + incomingBytes <= maxBytes) return;
+
+  for (let index = keep; index >= 1; index--) {
+    const current = `${path}.${index}`;
+    const next = `${path}.${index + 1}`;
+    if (!existsSync(current)) continue;
+    if (index === keep) {
+      unlinkSync(current);
+    } else {
+      renameSync(current, next);
+    }
+  }
+  renameSync(path, `${path}.1`);
+}

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -78,4 +78,13 @@ export class StateDirResolver {
   get killedFile(): string {
     return join(this.stateDir, "killed");
   }
+
+  /**
+   * Cache for the update-notifier: `{ lastCheckMs, latest }`. Machine/user-global
+   * (not per-project) so the daily npm check runs once per machine, not once per
+   * project — see src/update-notifier.ts.
+   */
+  get updateCheckFile(): string {
+    return join(this.stateDir, "update-check.json");
+  }
 }

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -15,16 +15,26 @@ import { homedir, platform } from "node:os";
 export class StateDirResolver {
   private readonly stateDir: string;
 
+  /**
+   * The platform default base directory, with NO override applied.
+   *
+   * Single source of truth for both the resolver and the multi-pair layer
+   * (`pair-resolver.ts`), which nests each pair under `<base>/pairs/<id>/`.
+   * Keeping this static avoids the base-dir logic drifting between the two.
+   */
+  static platformBaseDir(): string {
+    if (platform() === "darwin") {
+      return join(homedir(), "Library", "Application Support", "AgentBridge");
+    }
+    const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+    return join(xdgState, "agentbridge");
+  }
+
   constructor(envOverride?: string) {
     const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
-    if (override) {
-      this.stateDir = override;
-    } else if (platform() === "darwin") {
-      this.stateDir = join(homedir(), "Library", "Application Support", "AgentBridge");
-    } else {
-      const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-      this.stateDir = join(xdgState, "agentbridge");
-    }
+    // Treat an empty string as "unset" (master behaviour) — `??` alone would
+    // accept "" and resolve all state files relative to cwd.
+    this.stateDir = override && override.length > 0 ? override : StateDirResolver.platformBaseDir();
   }
 
   /** Ensure the state directory exists. */

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -88,4 +88,13 @@ export class StateDirResolver {
   get killedFile(): string {
     return join(this.stateDir, "killed");
   }
+
+  /**
+   * Cache for the update-notifier: `{ lastCheckMs, latest }`. Machine/user-global
+   * (not per-project) so the daily npm check runs once per machine, not once per
+   * project — see src/update-notifier.ts.
+   */
+  get updateCheckFile(): string {
+    return join(this.stateDir, "update-check.json");
+  }
 }

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -68,6 +68,10 @@ export class StateDirResolver {
     return join(this.stateDir, "ports.json");
   }
 
+  get currentThreadFile(): string {
+    return join(this.stateDir, "current-thread.json");
+  }
+
   get logFile(): string {
     return join(this.stateDir, "agentbridge.log");
   }

--- a/src/thread-state.ts
+++ b/src/thread-state.ts
@@ -1,0 +1,227 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import type { StateDirResolver } from "./state-dir";
+
+export type CurrentThreadStatus = "pending" | "current";
+
+export interface CurrentThreadState {
+  version: 1;
+  status: CurrentThreadStatus;
+  pairId: string | null;
+  pairName?: string;
+  cwd: string;
+  threadId: string;
+  updatedAt: string;
+  reason?: string;
+  rolloutPath?: string;
+  rolloutVerifiedAt?: string;
+  tag?: string;
+}
+
+export interface ThreadIdentity {
+  stateDir: StateDirResolver;
+  pairId: string | null;
+  pairName?: string;
+  cwd: string;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function threadTag(identity: ThreadIdentity): string {
+  const name = identity.pairName ?? identity.pairId ?? "manual";
+  return `abg:${name}:${identity.cwd}`;
+}
+
+export function codexHome(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join(homedir(), ".codex");
+}
+
+function atomicWriteJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
+}
+
+export function readRawCurrentThread(stateDir: StateDirResolver): CurrentThreadState | null {
+  try {
+    const parsed = JSON.parse(readFileSync(stateDir.currentThreadFile, "utf-8"));
+    if (
+      parsed?.version === 1 &&
+      typeof parsed.threadId === "string" &&
+      parsed.threadId.length > 0 &&
+      (parsed.status === "pending" || parsed.status === "current") &&
+      typeof parsed.cwd === "string"
+    ) {
+      return parsed as CurrentThreadState;
+    }
+  } catch {
+    // Missing/corrupt state is treated as no usable mapping. Doctor can report it later.
+  }
+  return null;
+}
+
+export function findCodexRolloutFile(
+  threadId: string,
+  env: NodeJS.ProcessEnv = process.env,
+  maxEntries = 20000,
+): string | null {
+  const sessionsDir = join(codexHome(env), "sessions");
+  if (!threadId || !existsSync(sessionsDir)) return null;
+
+  const exactName = `rollout-${threadId}.jsonl`;
+  const stack = [sessionsDir];
+  let visited = 0;
+
+  while (stack.length > 0 && visited < maxEntries) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      visited++;
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(path);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+
+      const name = basename(entry.name);
+      if (name === exactName || (name.startsWith("rollout-") && name.endsWith(".jsonl") && name.includes(threadId))) {
+        return path;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function writePendingCurrentThread(
+  identity: ThreadIdentity,
+  threadId: string,
+  reason?: string,
+): CurrentThreadState {
+  const state: CurrentThreadState = {
+    version: 1,
+    status: "pending",
+    pairId: identity.pairId,
+    pairName: identity.pairName,
+    cwd: identity.cwd,
+    threadId,
+    updatedAt: nowIso(),
+    reason,
+    tag: threadTag(identity),
+  };
+  atomicWriteJson(identity.stateDir.currentThreadFile, state);
+  return state;
+}
+
+export function promoteCurrentThreadIfRolloutExists(
+  identity: ThreadIdentity,
+  threadId: string,
+  reason?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): CurrentThreadState {
+  const rolloutPath = findCodexRolloutFile(threadId, env);
+  const state: CurrentThreadState = {
+    version: 1,
+    status: rolloutPath ? "current" : "pending",
+    pairId: identity.pairId,
+    pairName: identity.pairName,
+    cwd: identity.cwd,
+    threadId,
+    updatedAt: nowIso(),
+    reason,
+    tag: threadTag(identity),
+    ...(rolloutPath ? { rolloutPath, rolloutVerifiedAt: nowIso() } : {}),
+  };
+  atomicWriteJson(identity.stateDir.currentThreadFile, state);
+  return state;
+}
+
+export async function persistCurrentThreadWithRolloutRetry(
+  identity: ThreadIdentity,
+  threadId: string,
+  reason: string,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    attempts?: number;
+    delayMs?: number;
+    log?: (message: string) => void;
+    /**
+     * Guard checked before every write. Return false to ABANDON a now-stale
+     * loop: when a newer thread switch supersedes this one, the daemon fires a
+     * fresh retry loop, and this (older) loop must stop writing — otherwise the
+     * two loops race and the stale one can clobber current-thread.json with an
+     * abandoned threadId (wrong/broken auto-resume). Default: always continue.
+     */
+    shouldContinue?: () => boolean;
+  } = {},
+): Promise<CurrentThreadState | null> {
+  const env = options.env ?? process.env;
+  const attempts = options.attempts ?? 20;
+  const delayMs = options.delayMs ?? 250;
+  const shouldContinue = options.shouldContinue ?? (() => true);
+
+  if (!shouldContinue()) return null;
+  writePendingCurrentThread(identity, threadId, reason);
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (!shouldContinue()) {
+      options.log?.(`Abandoned current-thread persistence for ${threadId}: a newer thread became active`);
+      return null;
+    }
+    const state = promoteCurrentThreadIfRolloutExists(identity, threadId, reason, env);
+    if (state.status === "current") {
+      options.log?.(`Current Codex thread persisted: ${threadId} (${state.rolloutPath})`);
+      return state;
+    }
+    if (attempt < attempts) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  if (!shouldContinue()) return null;
+  options.log?.(`Current Codex thread left pending because no rollout file was found: ${threadId}`);
+  return readRawCurrentThread(identity.stateDir) ?? writePendingCurrentThread(identity, threadId, reason);
+}
+
+export function readUsableCurrentThread(
+  identity: ThreadIdentity,
+  env: NodeJS.ProcessEnv = process.env,
+): CurrentThreadState | null {
+  const state = readRawCurrentThread(identity.stateDir);
+  if (!state) return null;
+  if (state.status !== "current") return null;
+  if (state.pairId !== identity.pairId) return null;
+  if (state.cwd !== identity.cwd) return null;
+
+  if (state.rolloutPath && existsSync(state.rolloutPath)) return state;
+
+  const rolloutPath = findCodexRolloutFile(state.threadId, env);
+  if (!rolloutPath) return null;
+
+  const repaired: CurrentThreadState = {
+    ...state,
+    rolloutPath,
+    rolloutVerifiedAt: nowIso(),
+    updatedAt: nowIso(),
+  };
+  atomicWriteJson(identity.stateDir.currentThreadFile, repaired);
+  return repaired;
+}

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -1,0 +1,123 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const SECRET_KEY_RE = /(token|secret|password|passwd|api[_-]?key|auth|cookie|session)/i;
+const SECRET_ARG_RE = /^--?(?:token|secret|password|passwd|apikey|api-key|api_key|auth|cookie|session)(?:=.*)?$/i;
+
+/** Only these env-key prefixes are eligible to appear in a trace event. */
+const RELEVANT_ENV_RE = /^(AGENTBRIDGE_|CODEX_)/;
+
+export interface TraceEventInput {
+  cwd: string;
+  event: string;
+  pid?: number;
+  argv?: string[];
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  timestamp?: string;
+  data?: Record<string, unknown>;
+}
+
+export function redactEnv(env: NodeJS.ProcessEnv | Record<string, string | undefined>): Record<string, string | undefined> {
+  const redacted: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    redacted[key] = SECRET_KEY_RE.test(key) && value !== undefined ? "<redacted>" : value;
+  }
+  return redacted;
+}
+
+/**
+ * Allowlist an env snapshot down to AgentBridge/Codex-owned keys, then redact.
+ *
+ * A full `process.env` must never be written to a trace file — it commonly
+ * holds `DATABASE_URL`, `*_DSN`, cloud credentials, etc. that no AgentBridge
+ * diagnostic needs. Keep only `AGENTBRIDGE_*` / `CODEX_*` keys, and still run
+ * those through secret redaction (e.g. a hypothetical `CODEX_API_KEY`).
+ */
+export function pickRelevantEnv(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  const picked: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (!RELEVANT_ENV_RE.test(key)) continue;
+    picked[key] = SECRET_KEY_RE.test(key) && value !== undefined ? "<redacted>" : value;
+  }
+  return picked;
+}
+
+export function redactArgv(argv: string[]): string[] {
+  const redacted: string[] = [];
+  let redactNext = false;
+  for (const arg of argv) {
+    if (redactNext) {
+      redacted.push("<redacted>");
+      redactNext = false;
+      continue;
+    }
+    if (SECRET_ARG_RE.test(arg)) {
+      if (arg.includes("=")) {
+        const [key] = arg.split("=", 1);
+        redacted.push(`${key}=<redacted>`);
+      } else {
+        redacted.push(arg);
+        redactNext = true;
+      }
+      continue;
+    }
+    redacted.push(arg);
+  }
+  return redacted;
+}
+
+export function traceLogPath(cwd: string, timestamp: string): string {
+  const day = timestamp.slice(0, 10);
+  return join(cwd, ".agentbridge", "logs", `trace-${day}.jsonl`);
+}
+
+export function appendTraceEvent(input: TraceEventInput): string {
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const path = traceLogPath(input.cwd, timestamp);
+  const event = {
+    timestamp,
+    event: input.event,
+    cwd: input.cwd,
+    pid: input.pid ?? process.pid,
+    ...(input.argv ? { argv: redactArgv(input.argv) } : {}),
+    ...(input.env ? { env: pickRelevantEnv(input.env) } : {}),
+    ...(input.data ? { data: redactData(input.data) } : {}),
+  };
+
+  mkdirSync(join(input.cwd, ".agentbridge", "logs"), { recursive: true });
+  appendFileSync(path, JSON.stringify(event) + "\n", "utf-8");
+  return path;
+}
+
+/** A `data` field that is an env snapshot (key ends in "env", value is a plain object). */
+function isEnvSnapshot(key: string, value: unknown): boolean {
+  return /env$/i.test(key) && !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function redactData(value: unknown, key = ""): unknown {
+  if (typeof value === "string") {
+    return SECRET_KEY_RE.test(key) ? "<redacted>" : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactData(item, key));
+  }
+  if (value && typeof value === "object") {
+    const redacted: Record<string, unknown> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      if (SECRET_KEY_RE.test(childKey)) {
+        redacted[childKey] = "<redacted>";
+      } else if (isEnvSnapshot(childKey, childValue)) {
+        // A nested env snapshot (env / originalEnv / effectiveEnv) must be
+        // allowlisted, never written in full — `redactData`'s key-name redaction
+        // alone would pass DATABASE_URL/*_DSN through verbatim.
+        redacted[childKey] = pickRelevantEnv(childValue as Record<string, string | undefined>);
+      } else {
+        redacted[childKey] = redactData(childValue, childKey);
+      }
+    }
+    return redacted;
+  }
+  return value;
+}

--- a/src/unit-test/agents-contract.test.ts
+++ b/src/unit-test/agents-contract.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checkAgentsMdContract,
+  isFreshAgentsMdContract,
+} from "../agents-contract";
+
+const FRESH_BODY = [
+  "<!-- AgentBridge:start -->",
+  "AgentBridge is a transparent proxy.",
+  "Do not bypass it.",
+  "Use sendToClaude to talk back.",
+  "Git operations are handled by Claude.",
+  "Roles: Implementer, Executor, Verifier.",
+  "<!-- AgentBridge:end -->",
+].join("\n");
+
+describe("agents contract (read-only)", () => {
+  test("missing AGENTS.md is never created and reports not-fresh", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-agents-"));
+    try {
+      const result = checkAgentsMdContract(root);
+      expect(result.exists).toBe(false);
+      expect(result.fresh).toBe(false);
+      expect(result.message).toContain("abg init");
+      // The check must NEVER write the file.
+      expect(existsSync(join(root, "AGENTS.md"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("stale AGENTS.md is left untouched and reports not-fresh", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-agents-"));
+    try {
+      const original = "# Rules\n\n<!-- AgentBridge:start -->\nold\n<!-- AgentBridge:end -->\n";
+      writeFileSync(join(root, "AGENTS.md"), original, "utf-8");
+      const result = checkAgentsMdContract(root);
+      expect(result.exists).toBe(true);
+      expect(result.fresh).toBe(false);
+      expect(result.message).toContain("abg init");
+      // The file content must remain exactly as written — no auto-fix.
+      expect(readFileSync(join(root, "AGENTS.md"), "utf-8")).toBe(original);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fresh AGENTS.md reports fresh:true without throwing", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-agents-"));
+    try {
+      writeFileSync(join(root, "AGENTS.md"), `# Rules\n\n${FRESH_BODY}\n`, "utf-8");
+      const result = checkAgentsMdContract(root);
+      expect(result.exists).toBe(true);
+      expect(result.fresh).toBe(true);
+      expect(result.message).toContain("up to date");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("isFreshAgentsMdContract recognizes a complete contract block", () => {
+    expect(isFreshAgentsMdContract(FRESH_BODY)).toBe(true);
+    expect(isFreshAgentsMdContract("# Rules\n")).toBe(false);
+    expect(
+      isFreshAgentsMdContract("<!-- AgentBridge:start -->\nold\n<!-- AgentBridge:end -->"),
+    ).toBe(false);
+  });
+});

--- a/src/unit-test/bridge-disabled-state.test.ts
+++ b/src/unit-test/bridge-disabled-state.test.ts
@@ -1,7 +1,25 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { disabledReplyError } from "../bridge-disabled-state";
 
 describe("bridge disabled-state messaging", () => {
+  // These assert the bare `agentbridge claude` / `agentbridge kill` hint
+  // substrings, i.e. manual/no-pair mode. Clear any pair env that may have
+  // leaked from another test so pairScopedCommand renders the bare command.
+  let savedId: string | undefined;
+  let savedName: string | undefined;
+  beforeEach(() => {
+    savedId = process.env.AGENTBRIDGE_PAIR_ID;
+    savedName = process.env.AGENTBRIDGE_PAIR_NAME;
+    delete process.env.AGENTBRIDGE_PAIR_ID;
+    delete process.env.AGENTBRIDGE_PAIR_NAME;
+  });
+  afterEach(() => {
+    if (savedId === undefined) delete process.env.AGENTBRIDGE_PAIR_ID;
+    else process.env.AGENTBRIDGE_PAIR_ID = savedId;
+    if (savedName === undefined) delete process.env.AGENTBRIDGE_PAIR_NAME;
+    else process.env.AGENTBRIDGE_PAIR_NAME = savedName;
+  });
+
   test("kill-disabled sessions explain how to reconnect", () => {
     expect(disabledReplyError("killed")).toContain("disabled by `agentbridge kill`");
     expect(disabledReplyError("killed")).toContain("/resume");

--- a/src/unit-test/build-info.test.ts
+++ b/src/unit-test/build-info.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BUILD_INFO,
+  daemonStatusBuildInfo,
+  sameBuildInfo,
+  sameRuntimeContract,
+  type AgentBridgeBuildInfo,
+} from "../build-info";
+
+const base: AgentBridgeBuildInfo = {
+  version: "0.1.6",
+  commit: "6c24127",
+  bundle: "dist",
+  contractVersion: 1,
+};
+
+describe("build info", () => {
+  test("exposes stable runtime build metadata for daemon status", () => {
+    expect(BUILD_INFO.version).toBeString();
+    expect(BUILD_INFO.commit).toBeString();
+    expect(BUILD_INFO.bundle).toMatch(/^(source|dist|plugin)$/);
+    expect(BUILD_INFO.contractVersion).toBeNumber();
+  });
+
+  test("serializes into the daemon status payload shape", () => {
+    expect(daemonStatusBuildInfo()).toEqual({
+      version: BUILD_INFO.version,
+      commit: BUILD_INFO.commit,
+      bundle: BUILD_INFO.bundle,
+      contractVersion: BUILD_INFO.contractVersion,
+    });
+  });
+
+  test("sameRuntimeContract ignores bundle kind (dist vs plugin are interchangeable)", () => {
+    expect(sameRuntimeContract(base, { ...base, bundle: "plugin" })).toBe(true);
+    expect(sameRuntimeContract(base, { ...base, bundle: "source" })).toBe(true);
+    // sameBuildInfo, used only for diagnostics, still distinguishes the bundle.
+    expect(sameBuildInfo(base, { ...base, bundle: "plugin" })).toBe(false);
+  });
+
+  test("sameRuntimeContract still detects a real upgrade (version/commit/contract)", () => {
+    expect(sameRuntimeContract(base, { ...base, commit: "deadbee" })).toBe(false);
+    expect(sameRuntimeContract(base, { ...base, version: "0.1.7" })).toBe(false);
+    expect(sameRuntimeContract(base, { ...base, contractVersion: 2 })).toBe(false);
+    expect(sameRuntimeContract(base, null)).toBe(false);
+    expect(sameRuntimeContract(base, { ...base })).toBe(true);
+  });
+});

--- a/src/unit-test/cli-toplevel.test.ts
+++ b/src/unit-test/cli-toplevel.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { parseTopLevel } from "../cli";
+
+describe("parseTopLevel — leading --pair before the subcommand", () => {
+  test("no args → undefined command", () => {
+    expect(parseTopLevel([])).toEqual({ command: undefined, restArgs: [] });
+  });
+
+  test("bare subcommand passes through unchanged", () => {
+    expect(parseTopLevel(["claude", "--resume"])).toEqual({
+      command: "claude",
+      restArgs: ["--resume"],
+    });
+  });
+
+  test("leading --pair <name> is re-attached in front of a pair-aware command", () => {
+    expect(parseTopLevel(["--pair", "work", "claude", "--resume"])).toEqual({
+      command: "claude",
+      restArgs: ["--pair", "work", "--resume"],
+    });
+  });
+
+  test("leading --pair=<name> is re-attached too", () => {
+    expect(parseTopLevel(["--pair=work", "codex", "--model", "o3"])).toEqual({
+      command: "codex",
+      restArgs: ["--pair=work", "--model", "o3"],
+    });
+  });
+
+  test("leading --pair works for kill", () => {
+    expect(parseTopLevel(["--pair", "work", "kill"])).toEqual({
+      command: "kill",
+      restArgs: ["--pair", "work"],
+    });
+  });
+
+  test("classic trailing --pair is left in place (command's own parser handles it)", () => {
+    expect(parseTopLevel(["claude", "--pair", "work"])).toEqual({
+      command: "claude",
+      restArgs: ["--pair", "work"],
+    });
+  });
+
+  test("--pair with a missing value (next is a flag) does not swallow the flag", () => {
+    // "--pair" then "claude" — "claude" is a value (not a flag), so it is taken
+    // as the pair name and there is no command. This mirrors parsePairFlag's
+    // value-consumption rule and surfaces a clear downstream error.
+    expect(parseTopLevel(["--pair", "claude"])).toEqual({
+      command: undefined,
+      restArgs: [],
+    });
+    // But a following FLAG is never consumed as the name.
+    expect(parseTopLevel(["--pair", "--help"])).toEqual({
+      command: "--help",
+      restArgs: [],
+    });
+  });
+
+  test("leading --pair before a non-pair-aware command is dropped", () => {
+    // `pairs` does not take --pair; the leading token is ignored rather than
+    // breaking the pairs argument parser.
+    expect(parseTopLevel(["--pair", "work", "pairs"])).toEqual({
+      command: "pairs",
+      restArgs: [],
+    });
+  });
+
+  test("--help / --version pass through as the command", () => {
+    expect(parseTopLevel(["--help"]).command).toBe("--help");
+    expect(parseTopLevel(["--version"]).command).toBe("--version");
+  });
+});

--- a/src/unit-test/cli.test.ts
+++ b/src/unit-test/cli.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import { compareVersions } from "../cli/init";
 import { checkOwnedFlagConflicts } from "../cli/claude";
-import { buildCodexArgs } from "../cli/codex";
+import {
+  buildCodexArgs,
+  parseAgentBridgeCodexArgs,
+  resolveCodexResumeArgs,
+} from "../cli/codex";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { StateDirResolver } from "../state-dir";
+import { promoteCurrentThreadIfRolloutExists } from "../thread-state";
 
 describe("CLI: version comparison", () => {
   test("equal versions return 0", () => {
@@ -242,5 +251,77 @@ describe("CLI: buildCodexArgs", () => {
     const r = buildCodexArgs(["a"], PROXY);
     expect(r.fullArgs).toEqual(["a"]);
     expect(r.injectedBridgeFlags).toBe(false);
+  });
+});
+
+describe("CLI: AgentBridge Codex resume args", () => {
+  function makePair(root: string) {
+    return {
+      pairId: "main-12345678",
+      slot: 0,
+      ports: { appPort: 4500, proxyPort: 4501, controlPort: 4502 },
+      stateDir: new StateDirResolver(join(root, "pair-state")),
+      name: "main",
+      manual: false,
+    };
+  }
+
+  test("--new is consumed by AgentBridge and disables auto-resume", () => {
+    const parsed = parseAgentBridgeCodexArgs(["--new", "--model", "o3"]);
+    expect(parsed).toEqual({ rest: ["--model", "o3"], forceNew: true, resumeCurrent: false });
+
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-cli-resume-"));
+    try {
+      const result = resolveCodexResumeArgs(parsed, makePair(root));
+      expect(result).toEqual({ rest: ["--model", "o3"], mode: "new" });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("bare codex auto-resumes only a rollout-backed current thread", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-cli-resume-"));
+    const codexHome = mkdtempSync(join(tmpdir(), "agentbridge-codex-home-"));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(root);
+      const pair = makePair(root);
+      const cwd = process.cwd();
+      const sessionsDir = join(codexHome, "sessions", "2026", "06", "02");
+      mkdirSync(sessionsDir, { recursive: true });
+      writeFileSync(join(sessionsDir, "rollout-thread-abc.jsonl"), "{}\n", "utf-8");
+      promoteCurrentThreadIfRolloutExists(
+        { stateDir: pair.stateDir, pairId: pair.pairId, pairName: pair.name, cwd },
+        "thread-abc",
+        "test",
+        { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+      );
+
+      const result = resolveCodexResumeArgs(
+        parseAgentBridgeCodexArgs([]),
+        pair,
+        { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+      );
+      expect(result.mode).toBe("auto-resume");
+      expect(result.rest).toEqual(["resume", "thread-abc"]);
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("resume-current errors when no verified current thread exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-cli-resume-"));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(root);
+      const result = resolveCodexResumeArgs(parseAgentBridgeCodexArgs(["resume-current"]), makePair(root));
+      expect(result.mode).toBe("resume-current");
+      expect(result.error).toContain("No verified current Codex thread");
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -7,6 +7,24 @@ function createAdapter() {
   return new CodexAdapter(4510, 4511) as any;
 }
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withTurnWatchdogMs<T>(ms: number, fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+  process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = String(ms);
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+    } else {
+      process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = previous;
+    }
+  }
+}
+
 describe("CodexAdapter app-server response handling", () => {
   test("forwards active mapped responses back to the current TUI id", () => {
     const adapter = createAdapter();
@@ -321,6 +339,349 @@ describe("CodexAdapter turn state machine", () => {
     expect(forwarded).not.toBeNull();
     expect(adapter.activeThreadId).toBe("thread-from-request");
     expect(readyEvents).toEqual(["thread-from-request"]);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("stale turn/start response does not overwrite a newer active thread", () => {
+    const adapter = createAdapter();
+    adapter.threadId = "thread-new";
+    adapter.tuiConnId = 1;
+
+    adapter.trackPendingRequest({
+      id: "old-turn",
+      method: "turn/start",
+      params: {
+        threadId: "thread-old",
+        input: [{ type: "text", text: "stale" }],
+      },
+    }, adapter.tuiConnId);
+
+    adapter.handleTrackedResponse(
+      { id: "old-turn", result: { turn: { id: "turn-old" } } },
+      adapter.tuiConnId,
+    );
+
+    expect(adapter.activeThreadId).toBe("thread-new");
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("stale thread switch response does not overwrite latest thread or replay buffered requests", () => {
+    const adapter = createAdapter();
+    const sent: string[] = [];
+    adapter.tuiConnId = 1;
+    adapter.tuiWs = { send: (data: string) => sent.push(data) } as any;
+
+    adapter.trackPendingRequest({ id: "old-resume", method: "thread/resume" }, adapter.tuiConnId);
+    adapter.trackPendingRequest({ id: "new-resume", method: "thread/resume" }, adapter.tuiConnId);
+
+    adapter.handleTrackedResponse(
+      { id: "new-resume", result: { thread: { id: "thread-new" } } },
+      adapter.tuiConnId,
+    );
+    expect(adapter.activeThreadId).toBe("thread-new");
+
+    adapter.pendingServerRequests = [
+      {
+        raw: JSON.stringify({
+          id: 70,
+          method: "item/fileChange/requestApproval",
+          params: { threadId: "thread-old", file: "stale.ts" },
+        }),
+        serverId: 70,
+        method: "item/fileChange/requestApproval",
+        threadId: "thread-old",
+      },
+    ];
+
+    adapter.handleTrackedResponse(
+      { id: "old-resume", result: { thread: { id: "thread-old" } } },
+      adapter.tuiConnId,
+    );
+
+    expect(adapter.activeThreadId).toBe("thread-new");
+    expect(sent).toEqual([]);
+    expect(adapter.pendingServerRequests).toHaveLength(1);
+    expect(adapter.pendingServerRequests[0].threadId).toBe("thread-old");
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("stale thread/start response does not drop buffered requests for the latest session", () => {
+    const adapter = createAdapter();
+    adapter.tuiConnId = 1;
+
+    adapter.trackPendingRequest({ id: "old-start", method: "thread/start" }, adapter.tuiConnId);
+    adapter.trackPendingRequest({ id: "new-resume", method: "thread/resume" }, adapter.tuiConnId);
+
+    adapter.handleTrackedResponse(
+      { id: "new-resume", result: { thread: { id: "thread-new" } } },
+      adapter.tuiConnId,
+    );
+
+    adapter.pendingServerRequests = [
+      {
+        raw: JSON.stringify({
+          id: 71,
+          method: "item/commandExecution/requestApproval",
+          params: { threadId: "thread-new", command: "pwd" },
+        }),
+        serverId: 71,
+        method: "item/commandExecution/requestApproval",
+        threadId: "thread-new",
+      },
+    ];
+
+    adapter.handleTrackedResponse(
+      { id: "old-start", result: { thread: { id: "thread-old" } } },
+      adapter.tuiConnId,
+    );
+
+    expect(adapter.activeThreadId).toBe("thread-new");
+    expect(adapter.pendingServerRequests).toHaveLength(1);
+    expect(adapter.pendingServerRequests[0].threadId).toBe("thread-new");
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("turn watchdog releases busy state and emits turnCompleted after inactivity", async () => {
+    await withTurnWatchdogMs(40, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "watchdog-turn" } } });
+      expect(adapter.turnInProgress).toBe(true);
+
+      await sleep(90);
+
+      expect(adapter.turnInProgress).toBe(false);
+      expect(events).toEqual(["completed"]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("turn watchdog is refreshed by ANY inbound app-server message, incl. unforwarded notification types (#69)", async () => {
+    // Regression guard for the #69 watchdog-coverage bug: Codex streams many
+    // notification types the bridge does NOT forward (item/agentReasoning/delta,
+    // item/commandExecution/*, item/fileChange/*, …). A long but actively-
+    // streaming turn (e.g. a multi-minute build) emits only these between
+    // turn/started and turn/completed. The watchdog must treat them as activity,
+    // otherwise a live turn gets force-completed. We drive them through the real
+    // handleAppServerPayload funnel (NOT handleServerNotification, which only
+    // models the small forwarded subset and would mask the bug).
+    //
+    // Timing is chosen so the test actually CATCHES the bug, not just passes,
+    // with margins wide enough to be CI-safe (this repo has a history of timing
+    // flakes — see commit 11941e6):
+    // - 400ms watchdog, armed at turn/started (t≈0), original deadline t≈400.
+    // - refresh via the unforwarded delta at t≈250 (≈150ms before the original
+    //   deadline) pushes the deadline to t≈650.
+    // - "still active" is asserted at t≈500 — PAST the original t≈400 deadline
+    //   (so WITHOUT the fix the watchdog would already have force-completed and
+    //   this assertion fails) and ≈150ms before the refreshed t≈650 deadline.
+    // - "completed" is asserted at t≈750 (≈100ms past t≈650).
+    await withTurnWatchdogMs(400, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleAppServerPayload(JSON.stringify({
+        method: "turn/started",
+        params: { turn: { id: "refresh-turn" } },
+      }));
+      expect(adapter.turnInProgress).toBe(true);
+
+      await sleep(250);
+      // An UNFORWARDED notification type — the exact case that previously did
+      // NOT refresh the watchdog (only the 5 isAppServerNotification() methods
+      // did), so a live turn streaming only reasoning deltas got force-completed.
+      adapter.handleAppServerPayload(JSON.stringify({
+        method: "item/agentReasoning/delta",
+        params: { itemId: "reasoning-1", delta: "thinking…" },
+      }));
+      await sleep(250);
+
+      // Past the ORIGINAL deadline but before the refreshed one — still active.
+      expect(adapter.turnInProgress).toBe(true);
+      expect(events).toEqual([]);
+
+      await sleep(250);
+
+      expect(adapter.turnInProgress).toBe(false);
+      expect(events).toEqual(["completed"]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("disconnect() synchronously clears turn state and cancels the watchdog (no late turnCompleted)", async () => {
+    await withTurnWatchdogMs(40, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "disconnect-turn" } } });
+      expect(adapter.turnInProgress).toBe(true);
+      expect(adapter.activeTurnIds.size).toBe(1);
+      expect(adapter.turnWatchdogs.size).toBe(1);
+
+      // Intentional teardown must drop turn state + watchdog timer immediately.
+      adapter.disconnect();
+
+      expect(adapter.turnInProgress).toBe(false);
+      expect(adapter.activeTurnIds.size).toBe(0);
+      expect(adapter.turnWatchdogs.size).toBe(0);
+      // A teardown is not a real turn completion — it must not signal "finished".
+      expect(events).toEqual([]);
+
+      // And the cancelled watchdog must not fire a late turnCompleted.
+      await sleep(90);
+      expect(events).toEqual([]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("force-completing one of several active turns keeps busy state and defers the emit", () => {
+    const adapter = createAdapter();
+    const events: string[] = [];
+    adapter.on("turnCompleted", () => events.push("completed"));
+
+    // Two concurrent turns (driven via handleServerNotification so only their
+    // own watchdogs arm — no global refresh between them).
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t2" } } });
+    expect(adapter.activeTurnIds.size).toBe(2);
+    expect(adapter.turnInProgress).toBe(true);
+
+    // One turn's watchdog fires: forceCompleteTurn must drop ONLY that turn,
+    // recompute busy from the remaining set, and NOT emit while a turn remains.
+    adapter.forceCompleteTurn("t1");
+    expect(adapter.activeTurnIds.has("t1")).toBe(false);
+    expect(adapter.turnWatchdogs.has("t1")).toBe(false);
+    expect(adapter.turnInProgress).toBe(true);
+    expect(events).toEqual([]);
+
+    // The last turn completing flips to idle → exactly one emit.
+    adapter.forceCompleteTurn("t2");
+    expect(adapter.turnInProgress).toBe(false);
+    expect(events).toEqual(["completed"]);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("a normal turn/completed cancels the watchdog so it never force-completes later", async () => {
+    await withTurnWatchdogMs(40, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+      expect(adapter.turnWatchdogs.size).toBe(1);
+
+      adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
+      expect(adapter.turnInProgress).toBe(false);
+      expect(adapter.turnWatchdogs.size).toBe(0);
+      expect(events).toEqual(["completed"]);
+
+      // The watchdog was cleared on normal completion — no SECOND (force) emit.
+      await sleep(90);
+      expect(events).toEqual(["completed"]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("handleAppServerClose cancels turn watchdogs (no late force-completion after close)", async () => {
+    await withTurnWatchdogMs(40, async () => {
+      const adapter = createAdapter();
+      const events: string[] = [];
+      adapter.on("turnCompleted", () => events.push("completed"));
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+      expect(adapter.turnWatchdogs.size).toBe(1);
+
+      // An app-server close routes through resetTurnState → clears ids + timers.
+      // (intentional avoids scheduleReconnect firing during the test.)
+      adapter.intentionalDisconnect = true;
+      adapter.handleAppServerClose();
+      expect(adapter.turnInProgress).toBe(false);
+      expect(adapter.activeTurnIds.size).toBe(0);
+      expect(adapter.turnWatchdogs.size).toBe(0);
+
+      // The cancelled watchdog must never force-complete after the connection closed.
+      await sleep(90);
+      expect(events).toEqual([]);
+
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("an inbound RESPONSE (not only a notification) refreshes the watchdog", async () => {
+    // The refresh sits ABOVE the id/notification branching in handleAppServerPayload,
+    // so responses count as turn activity too. Same robust margins as the
+    // notification-refresh test: 400ms watchdog, refresh at t≈250 (deadline→650),
+    // assert-active at t≈500 (past the original 400 deadline, before the refreshed one).
+    await withTurnWatchdogMs(400, async () => {
+      const adapter = createAdapter();
+
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+      await sleep(250);
+      adapter.handleAppServerPayload(JSON.stringify({ id: 987654, result: { ok: true } }));
+      await sleep(250);
+
+      expect(adapter.turnInProgress).toBe(true);
+
+      adapter.resetTurnState("test cleanup");
+      adapter.clearResponseTrackingState();
+    });
+  });
+
+  test("turnWatchdogMs() falls back to the 300s default for unset/invalid env values", () => {
+    const adapter = createAdapter();
+    const prev = process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+    try {
+      // "" / whitespace → 0, "0"/negative → not > 0, non-numeric → NaN,
+      // "Infinity" → !isFinite. All must fall back to the 300s default.
+      for (const bad of ["", "   ", "0", "-5", "abc", "Infinity", "NaN"]) {
+        process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = bad;
+        expect(adapter.turnWatchdogMs()).toBe(300_000);
+      }
+      delete process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+      expect(adapter.turnWatchdogMs()).toBe(300_000);
+      // A valid positive value is honored.
+      process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = "1234";
+      expect(adapter.turnWatchdogMs()).toBe(1234);
+    } finally {
+      if (prev === undefined) delete process.env.AGENTBRIDGE_TURN_WATCHDOG_MS;
+      else process.env.AGENTBRIDGE_TURN_WATCHDOG_MS = prev;
+    }
+  });
+
+  test("an error response to the LATEST thread switch leaves activeThreadId unchanged", () => {
+    const adapter = createAdapter();
+    adapter.tuiConnId = 1;
+
+    // Establish a current thread via a successful resume.
+    adapter.trackPendingRequest({ id: "r1", method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse({ id: "r1", result: { thread: { id: "thread-A" } } }, adapter.tuiConnId);
+    expect(adapter.activeThreadId).toBe("thread-A");
+
+    // The newest switch fails. The error carries a thread id too (a malformed
+    // server could) — handleTrackedResponse must return early on `error` BEFORE
+    // the switch, so this thread-B is never adopted and the active thread stays
+    // the last one that actually resolved. (Including result.thread.id here is
+    // what makes this a genuine guard for the error early-return: drop that
+    // early-return and the switch would adopt thread-B, failing this test.)
+    adapter.trackPendingRequest({ id: "r2", method: "thread/resume" }, adapter.tuiConnId);
+    adapter.handleTrackedResponse(
+      { id: "r2", error: { code: -1, message: "boom" }, result: { thread: { id: "thread-B" } } },
+      adapter.tuiConnId,
+    );
+    expect(adapter.activeThreadId).toBe("thread-A");
 
     adapter.clearResponseTrackingState();
   });

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -110,10 +110,16 @@ describe("CodexAdapter app-server response handling", () => {
     adapter.clearResponseTrackingState();
   });
 
-  test("swallows bridge-originated error responses instead of forwarding them to the TUI", () => {
+  test("swallows bridge-originated error responses instead of forwarding them to the TUI, and emits turnAborted", () => {
+    // A-1 regression: an injected turn/start rejected by Codex BEFORE any
+    // turn/started fires no wasInProgress-gated reset, which would strand the
+    // daemon's require_reply tracker. The adapter must emit turnAborted here so
+    // the daemon clears it.
     const adapter = createAdapter();
     const intercepted: Array<{ message: any; connId?: number }> = [];
     adapter.interceptServerMessage = (message: any, connId?: number) => intercepted.push({ message, connId });
+    const aborts: string[] = [];
+    adapter.on("turnAborted", (reason: string) => aborts.push(reason));
 
     adapter.trackBridgeRequestId(-2);
 
@@ -125,7 +131,21 @@ describe("CodexAdapter app-server response handling", () => {
     expect(forwarded).toBeNull();
     expect(adapter.bridgeRequestIds.has(-2)).toBe(false);
     expect(intercepted).toEqual([]);
+    expect(aborts).toHaveLength(1);
+    expect(aborts[0]).toContain("turn/start rejected");
 
+    adapter.clearResponseTrackingState();
+  });
+
+  test("a successful bridge-originated response does not emit turnAborted", () => {
+    const adapter = createAdapter();
+    const aborts: string[] = [];
+    adapter.on("turnAborted", (reason: string) => aborts.push(reason));
+
+    adapter.trackBridgeRequestId(-3);
+    adapter.handleAppServerPayload(JSON.stringify({ id: -3, result: {} }));
+
+    expect(aborts).toEqual([]);
     adapter.clearResponseTrackingState();
   });
 
@@ -245,6 +265,48 @@ describe("CodexAdapter turn state machine", () => {
     adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t2" } } });
     expect(events).toEqual(["completed"]);
     expect(adapter.turnInProgress).toBe(false);
+  });
+
+  test("resetTurnState emits turnAborted (not turnCompleted) when a turn is interrupted", () => {
+    // RB-1 regression: an app-server close / reconnect / stop resets turn state
+    // with emitCompleted=false. The daemon's require_reply tracker only resets on
+    // turnCompleted, so the adapter must emit turnAborted on these paths to keep
+    // the tracker from being stranded onto a later, unrelated turn.
+    const adapter = createAdapter();
+    const events: string[] = [];
+    adapter.on("turnCompleted", () => events.push("completed"));
+    adapter.on("turnAborted", (reason: string) => events.push(`aborted:${reason}`));
+
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    expect(adapter.turnInProgress).toBe(true);
+
+    adapter.resetTurnState("app-server connection closed", false);
+
+    expect(adapter.turnInProgress).toBe(false);
+    expect(events).toEqual(["aborted:app-server connection closed"]);
+  });
+
+  test("resetTurnState with emitCompleted=true emits turnCompleted, not turnAborted", () => {
+    const adapter = createAdapter();
+    const events: string[] = [];
+    adapter.on("turnCompleted", () => events.push("completed"));
+    adapter.on("turnAborted", () => events.push("aborted"));
+
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    adapter.resetTurnState("explicit completion", true);
+
+    expect(events).toEqual(["completed"]);
+  });
+
+  test("resetTurnState emits nothing when no turn was in progress", () => {
+    const adapter = createAdapter();
+    const events: string[] = [];
+    adapter.on("turnCompleted", () => events.push("completed"));
+    adapter.on("turnAborted", () => events.push("aborted"));
+
+    adapter.resetTurnState("idle reset", false);
+
+    expect(events).toEqual([]);
   });
 
   test("injectMessage rejects during active turn", () => {
@@ -445,19 +507,23 @@ describe("CodexAdapter turn state machine", () => {
     adapter.clearResponseTrackingState();
   });
 
-  test("turn watchdog releases busy state and emits turnCompleted after inactivity", async () => {
+  test("turn watchdog marks stalled but does not fake turnCompleted after inactivity", async () => {
     await withTurnWatchdogMs(40, async () => {
       const adapter = createAdapter();
       const events: string[] = [];
+      const stalled: Array<{ turnId: string; inactivityMs: number }> = [];
       adapter.on("turnCompleted", () => events.push("completed"));
+      adapter.on("turnStalled", (event: { turnId: string; inactivityMs: number }) => stalled.push(event));
 
       adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "watchdog-turn" } } });
       expect(adapter.turnInProgress).toBe(true);
 
       await sleep(90);
 
-      expect(adapter.turnInProgress).toBe(false);
-      expect(events).toEqual(["completed"]);
+      expect(adapter.turnInProgress).toBe(true);
+      expect(adapter.activeTurnIds.has("watchdog-turn")).toBe(true);
+      expect(events).toEqual([]);
+      expect(stalled).toEqual([{ turnId: "watchdog-turn", inactivityMs: 40 }]);
 
       adapter.clearResponseTrackingState();
     });
@@ -480,13 +546,15 @@ describe("CodexAdapter turn state machine", () => {
     // - refresh via the unforwarded delta at t≈250 (≈150ms before the original
     //   deadline) pushes the deadline to t≈650.
     // - "still active" is asserted at t≈500 — PAST the original t≈400 deadline
-    //   (so WITHOUT the fix the watchdog would already have force-completed and
+    //   (so WITHOUT the fix the watchdog would already have marked stalled and
     //   this assertion fails) and ≈150ms before the refreshed t≈650 deadline.
-    // - "completed" is asserted at t≈750 (≈100ms past t≈650).
+    // - "stalled" is asserted at t≈750 (≈100ms past t≈650).
     await withTurnWatchdogMs(400, async () => {
       const adapter = createAdapter();
       const events: string[] = [];
+      const stalled: unknown[] = [];
       adapter.on("turnCompleted", () => events.push("completed"));
+      adapter.on("turnStalled", (event: unknown) => stalled.push(event));
 
       adapter.handleAppServerPayload(JSON.stringify({
         method: "turn/started",
@@ -507,11 +575,13 @@ describe("CodexAdapter turn state machine", () => {
       // Past the ORIGINAL deadline but before the refreshed one — still active.
       expect(adapter.turnInProgress).toBe(true);
       expect(events).toEqual([]);
+      expect(stalled).toEqual([]);
 
       await sleep(250);
 
-      expect(adapter.turnInProgress).toBe(false);
-      expect(events).toEqual(["completed"]);
+      expect(adapter.turnInProgress).toBe(true);
+      expect(events).toEqual([]);
+      expect(stalled).toHaveLength(1);
 
       adapter.clearResponseTrackingState();
     });
@@ -545,10 +615,12 @@ describe("CodexAdapter turn state machine", () => {
     });
   });
 
-  test("force-completing one of several active turns keeps busy state and defers the emit", () => {
+  test("stalled turns keep busy state and never emit completion", () => {
     const adapter = createAdapter();
     const events: string[] = [];
+    const stalled: string[] = [];
     adapter.on("turnCompleted", () => events.push("completed"));
+    adapter.on("turnStalled", (event: { turnId: string }) => stalled.push(event.turnId));
 
     // Two concurrent turns (driven via handleServerNotification so only their
     // own watchdogs arm — no global refresh between them).
@@ -557,18 +629,73 @@ describe("CodexAdapter turn state machine", () => {
     expect(adapter.activeTurnIds.size).toBe(2);
     expect(adapter.turnInProgress).toBe(true);
 
-    // One turn's watchdog fires: forceCompleteTurn must drop ONLY that turn,
-    // recompute busy from the remaining set, and NOT emit while a turn remains.
-    adapter.forceCompleteTurn("t1");
-    expect(adapter.activeTurnIds.has("t1")).toBe(false);
-    expect(adapter.turnWatchdogs.has("t1")).toBe(false);
+    adapter.markTurnStalled("t1");
+    expect(adapter.activeTurnIds.has("t1")).toBe(true);
     expect(adapter.turnInProgress).toBe(true);
     expect(events).toEqual([]);
+    expect(stalled).toEqual(["t1"]);
 
-    // The last turn completing flips to idle → exactly one emit.
-    adapter.forceCompleteTurn("t2");
+    adapter.markTurnStalled("t2");
+    expect(adapter.activeTurnIds.has("t2")).toBe(true);
+    expect(adapter.turnInProgress).toBe(true);
+    expect(events).toEqual([]);
+    expect(stalled).toEqual(["t1", "t2"]);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("turnStalled is emitted at most once per turn but re-arms for a new turn", () => {
+    const adapter = createAdapter();
+    const events: string[] = [];
+    const stalled: string[] = [];
+    adapter.on("turnCompleted", () => events.push("completed"));
+    adapter.on("turnStalled", (event: { turnId: string }) => stalled.push(event.turnId));
+
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    expect(adapter.turnInProgress).toBe(true);
+
+    // First stall notifies; the watchdog is intentionally kept armed (turn stays
+    // busy), so a later expiry re-invokes markTurnStalled for the SAME turn — but
+    // that must NOT emit a duplicate notification.
+    adapter.markTurnStalled("t1");
+    adapter.markTurnStalled("t1");
+    expect(stalled).toEqual(["t1"]);
+    // Busy semantics unchanged: still in progress, never force-completed.
+    expect(adapter.turnInProgress).toBe(true);
+    expect(adapter.activeTurnIds.has("t1")).toBe(true);
+    expect(events).toEqual([]);
+
+    // A genuinely new turn must be eligible to notify on its own stall.
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
     expect(adapter.turnInProgress).toBe(false);
     expect(events).toEqual(["completed"]);
+
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t2" } } });
+    adapter.markTurnStalled("t2");
+    adapter.markTurnStalled("t2");
+    expect(stalled).toEqual(["t1", "t2"]);
+    expect(adapter.turnInProgress).toBe(true);
+    expect(events).toEqual(["completed"]);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("turnStalled re-arms when the SAME turnId is reused by a fresh turn/started", () => {
+    // Real ids can repeat across reconnects: a new turn/started for an id that
+    // previously stalled must clear the suppression so the new turn can notify.
+    const adapter = createAdapter();
+    const stalled: string[] = [];
+    adapter.on("turnStalled", (event: { turnId: string }) => stalled.push(event.turnId));
+
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "reused" } } });
+    adapter.markTurnStalled("reused");
+    adapter.markTurnStalled("reused");
+    expect(stalled).toEqual(["reused"]);
+
+    // Same id starts a fresh turn — suppression must reset.
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "reused" } } });
+    adapter.markTurnStalled("reused");
+    expect(stalled).toEqual(["reused", "reused"]);
 
     adapter.clearResponseTrackingState();
   });
@@ -1235,6 +1362,62 @@ describe("CodexAdapter server-to-client request passthrough", () => {
     }
     adapter.secondaryConnections.clear();
     adapter.clearResponseTrackingState();
+  });
+
+  test("secondary picker connection replays cached initialization before first non-initialize request", async () => {
+    const received: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, srv) {
+        if (srv.upgrade(req)) return undefined;
+        return new Response("test app-server");
+      },
+      websocket: {
+        message(_ws, raw) {
+          received.push(typeof raw === "string" ? raw : raw.toString());
+        },
+      },
+    });
+
+    const adapter = new CodexAdapter(server.port, 4511) as any;
+    adapter.log = () => {};
+    adapter.connIdCounter = 1;
+    adapter.tuiConnId = 1;
+    adapter.tuiWs = { data: { connId: 1 }, send: () => {} } as any;
+    adapter.lastInitializeRaw = JSON.stringify({
+      id: "initialize",
+      method: "initialize",
+      params: { clientInfo: { name: "codex-tui" } },
+    });
+    adapter.lastInitializedRaw = JSON.stringify({ method: "initialized" });
+
+    const secondaryWs = { data: { connId: 0 }, send: () => {}, close: () => {} } as any;
+    try {
+      adapter.onTuiConnect(secondaryWs);
+      adapter.onTuiMessage(secondaryWs, JSON.stringify({
+        id: 2,
+        method: "thread/list",
+        params: { limit: 25 },
+      }));
+
+      for (let i = 0; i < 40 && received.length < 3; i++) {
+        await sleep(25);
+      }
+
+      expect(received.map((raw) => JSON.parse(raw).method)).toEqual([
+        "initialize",
+        "initialized",
+        "thread/list",
+      ]);
+    } finally {
+      for (const sec of adapter.secondaryConnections.values()) {
+        try { sec.appServerWs?.close(); } catch {}
+      }
+      adapter.secondaryConnections.clear();
+      server.stop(true);
+      adapter.clearResponseTrackingState();
+    }
   });
 
   test("app-server close discards approval state across reconnects", () => {

--- a/src/unit-test/codex-transport.test.ts
+++ b/src/unit-test/codex-transport.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, connect, type Server, type Socket } from "node:net";
+import { rmSync, existsSync, mkdirSync, chmodSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CODEX_TRANSPORT_ENV,
+  TcpToUnixRelay,
+  codexListenArg,
+  codexSocketPath,
+  ensureSocketDir,
+  parseTransportMode,
+  probeCodexWsSupport,
+  removeSocketFile,
+  resolveCodexTransport,
+  stripWebSocketExtensions,
+  waitForUnixWsReady,
+} from "../codex-transport";
+
+const UPGRADE_WITH_EXT =
+  "GET / HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+  "Sec-WebSocket-Version: 13\r\nSec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" +
+  "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n";
+
+let testCounter = 0;
+function tmpSocket(): string {
+  // Short, unique per-test socket under tmp (stays well under SUN_LEN).
+  return join(tmpdir(), `abg-test-${process.pid}-${testCounter++}.sock`);
+}
+
+/**
+ * Minimal fake of Codex's unix listener: completes a WS upgrade with HTTP 101
+ * ONLY if the request carries no Sec-WebSocket-Extensions (mirroring the real
+ * behavior we must work around), then echoes any subsequent bytes. Records the
+ * exact header block it received so tests can assert the relay's rewrite.
+ */
+function startFakeCodexUnix(socketPath: string): Promise<{ server: Server; received: string[] }> {
+  const received: string[] = [];
+  const server = createServer((sock: Socket) => {
+    let head = Buffer.alloc(0);
+    let upgraded = false;
+    sock.on("data", (d: Buffer) => {
+      if (upgraded) { sock.write(d); return; } // echo frames verbatim
+      head = Buffer.concat([head, d]);
+      const sep = head.indexOf("\r\n\r\n");
+      if (sep === -1) return;
+      const headers = head.subarray(0, sep).toString("utf8");
+      received.push(headers);
+      const rest = head.subarray(sep + 4);
+      if (/sec-websocket-extensions/i.test(headers)) { sock.destroy(); return; } // mimic codex hard-close
+      sock.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
+      upgraded = true;
+      if (rest.length) sock.write(rest);
+    });
+    sock.on("error", () => {});
+  });
+  return new Promise((resolve) => {
+    removeSocketFile(socketPath);
+    server.listen(socketPath, () => resolve({ server, received }));
+  });
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) {
+    try { cleanups.pop()!(); } catch { /* ignore */ }
+  }
+});
+
+describe("parseTransportMode", () => {
+  test("maps known values and defaults unknown/empty to auto", () => {
+    expect(parseTransportMode("ws")).toBe("ws");
+    expect(parseTransportMode("WS")).toBe("ws");
+    expect(parseTransportMode(" unix ")).toBe("unix");
+    expect(parseTransportMode("auto")).toBe("auto");
+    expect(parseTransportMode("")).toBe("auto");
+    expect(parseTransportMode(undefined)).toBe("auto");
+    expect(parseTransportMode("garbage")).toBe("auto");
+  });
+});
+
+describe("probeCodexWsSupport / resolveCodexTransport", () => {
+  test("auto → ws when --help advertises ws://", () => {
+    const help = () => "Supported values: `stdio://`, `unix://`, `ws://IP:PORT`, `off`";
+    expect(probeCodexWsSupport(help)).toBe(true);
+    expect(resolveCodexTransport("auto", help)).toBe("ws");
+  });
+
+  test("auto → unix when --help omits ws://", () => {
+    const help = () => "Supported values: `stdio://`, `unix://`, `off`";
+    expect(probeCodexWsSupport(help)).toBe(false);
+    expect(resolveCodexTransport("auto", help)).toBe("unix");
+  });
+
+  test("auto → ws (preserve current behavior) when the probe is inconclusive", () => {
+    expect(probeCodexWsSupport(() => null)).toBe(true);
+    expect(resolveCodexTransport("auto", () => null)).toBe("ws");
+  });
+
+  test("explicit ws/unix are honored without probing", () => {
+    let probed = false;
+    const help = () => { probed = true; return "ws://"; };
+    expect(resolveCodexTransport("ws", help)).toBe("ws");
+    expect(resolveCodexTransport("unix", help)).toBe("unix");
+    expect(probed).toBe(false);
+  });
+});
+
+describe("codexSocketPath", () => {
+  test("is per-port, under the SUN_LEN limit, and dir-creatable/removable", () => {
+    const p = codexSocketPath(4500, tmpdir());
+    expect(p).toContain("codex-4500.sock");
+    expect(p.length).toBeLessThan(104);
+    const p2 = codexSocketPath(4510, tmpdir());
+    expect(p2).not.toBe(p); // distinct per pair/port
+    ensureSocketDir(p);
+    expect(existsSync(p.slice(0, p.lastIndexOf("/")))).toBe(true);
+  });
+
+  test("throws when an absurd TMPDIR would exceed the platform limit", () => {
+    const longBase = "/" + "x".repeat(120);
+    expect(() => codexSocketPath(4500, longBase)).toThrow(/too long/);
+  });
+});
+
+describe("ensureSocketDir", () => {
+  test("tightens perms to 0700 even on a pre-existing loose dir (CWE-377)", () => {
+    const dir = join(tmpdir(), `abg-permtest-${process.pid}-${testCounter++}`);
+    const sock = join(dir, "codex.sock");
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    // Pre-create the dir world-accessible (simulating a squatted/loose /tmp dir).
+    mkdirSync(dir, { recursive: true });
+    chmodSync(dir, 0o777);
+    expect(statSync(dir).mode & 0o777).toBe(0o777);
+
+    ensureSocketDir(sock);
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe("codexListenArg", () => {
+  test("renders ws:// and unix:// forms", () => {
+    expect(codexListenArg("ws", 4500, "/tmp/x.sock")).toBe("ws://127.0.0.1:4500");
+    expect(codexListenArg("unix", 4500, "/tmp/x.sock")).toBe("unix:///tmp/x.sock");
+  });
+});
+
+describe("stripWebSocketExtensions", () => {
+  test("removes only the extensions header (case-insensitive), preserving others", () => {
+    const headers = "GET / HTTP/1.1\r\nUpgrade: websocket\r\nSEC-WebSocket-Extensions: permessage-deflate\r\nSec-WebSocket-Key: abc";
+    const out = stripWebSocketExtensions(headers);
+    expect(out).not.toMatch(/extensions/i);
+    expect(out).toContain("Upgrade: websocket");
+    expect(out).toContain("Sec-WebSocket-Key: abc");
+  });
+
+  test("is a no-op when no extensions header is present", () => {
+    const headers = "GET / HTTP/1.1\r\nUpgrade: websocket";
+    expect(stripWebSocketExtensions(headers)).toBe(headers);
+  });
+});
+
+describe("TcpToUnixRelay", () => {
+  test("strips Sec-WebSocket-Extensions and forwards a full upgrade + frame echo", async () => {
+    const sock = tmpSocket();
+    const { server, received } = await startFakeCodexUnix(sock);
+    const relay = new TcpToUnixRelay("127.0.0.1", 0, sock);
+    await relay.start();
+    cleanups.push(() => { relay.stop(); server.close(); removeSocketFile(sock); });
+
+    const result = await new Promise<{ status: string; echo: string }>((resolve, reject) => {
+      const client = connect(relay.port, "127.0.0.1", () => client.write(UPGRADE_WITH_EXT));
+      let buf = Buffer.alloc(0);
+      let status = "";
+      client.on("data", (d: Buffer) => {
+        buf = Buffer.concat([buf, d]);
+        const sep = buf.indexOf("\r\n\r\n");
+        if (!status && sep !== -1) {
+          status = buf.toString("utf8", 0, buf.indexOf("\r\n"));
+          buf = buf.subarray(sep + 4);
+          client.write("PING-FRAME"); // post-upgrade bytes should echo back
+          return;
+        }
+        if (status && buf.length >= "PING-FRAME".length) {
+          resolve({ status, echo: buf.toString("utf8") });
+          client.destroy();
+        }
+      });
+      client.on("error", reject);
+      setTimeout(() => reject(new Error("relay round-trip timed out")), 3000);
+    });
+
+    expect(result.status).toBe("HTTP/1.1 101 Switching Protocols");
+    expect(result.echo).toBe("PING-FRAME");
+    // The fake server (which closes on extensions) saw a CLEANED upgrade.
+    expect(received).toHaveLength(1);
+    expect(received[0]).not.toMatch(/sec-websocket-extensions/i);
+    expect(received[0]).toContain("Sec-WebSocket-Key:");
+    expect(relay.connectionCount).toBe(1);
+  });
+
+  test("start() rejects when the TCP port cannot be bound", async () => {
+    const sock = tmpSocket();
+    const { server } = await startFakeCodexUnix(sock);
+    const blocker = new TcpToUnixRelay("127.0.0.1", 0, sock);
+    await blocker.start();
+    const port = blocker.port;
+    cleanups.push(() => { blocker.stop(); server.close(); removeSocketFile(sock); });
+
+    const conflicting = new TcpToUnixRelay("127.0.0.1", port, sock);
+    await expect(conflicting.start()).rejects.toThrow();
+  });
+
+  test("stop() tears down live connections and the listener", async () => {
+    const sock = tmpSocket();
+    const { server } = await startFakeCodexUnix(sock);
+    const relay = new TcpToUnixRelay("127.0.0.1", 0, sock);
+    await relay.start();
+    cleanups.push(() => { server.close(); removeSocketFile(sock); });
+
+    const client = connect(relay.port, "127.0.0.1");
+    await new Promise<void>((r) => client.once("connect", () => r()));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(relay.connectionCount).toBe(1);
+
+    relay.stop();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(relay.connectionCount).toBe(0);
+    client.destroy();
+  });
+});
+
+describe("waitForUnixWsReady", () => {
+  test("resolves once the unix listener answers an upgrade with 101", async () => {
+    const sock = tmpSocket();
+    const { server } = await startFakeCodexUnix(sock);
+    cleanups.push(() => { server.close(); removeSocketFile(sock); });
+    await waitForUnixWsReady(sock, 10, 50); // should resolve quickly
+  });
+
+  test("rejects when no listener ever appears", async () => {
+    const sock = tmpSocket(); // nothing listening here
+    await expect(waitForUnixWsReady(sock, 3, 30)).rejects.toThrow(/did not become ready/);
+  });
+});

--- a/src/unit-test/daemon-client-probe.test.ts
+++ b/src/unit-test/daemon-client-probe.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { DaemonClient } from "../daemon-client";
+
+/**
+ * Unit coverage for the conflict-guard protocol path (issue: `abg claude` must
+ * detect a LIVE incumbent before launching). Drives DaemonClient.probeIncumbent
+ * against a fake control WS that mimics the daemon's `probe_incumbent` handler.
+ */
+
+interface FakeServerOptions {
+  /** What to reply with on `probe_incumbent`. "silent" sends nothing; "close" drops the socket. */
+  mode: "reply" | "silent" | "close";
+  connected?: boolean;
+  alive?: boolean;
+}
+
+let server: ReturnType<typeof Bun.serve> | null = null;
+const received: string[] = [];
+
+function startFakeDaemon(opts: FakeServerOptions): string {
+  received.length = 0;
+  server = Bun.serve({
+    port: 0,
+    fetch(req, srv) {
+      if (srv.upgrade(req, { data: undefined })) return;
+      return new Response("expected a websocket upgrade", { status: 426 });
+    },
+    websocket: {
+      message(ws, raw) {
+        const text = typeof raw === "string" ? raw : raw.toString();
+        let msg: { type?: string };
+        try {
+          msg = JSON.parse(text);
+        } catch {
+          return;
+        }
+        if (msg.type) received.push(msg.type);
+        if (msg.type !== "probe_incumbent") return;
+        if (opts.mode === "silent") return;
+        if (opts.mode === "close") {
+          ws.close();
+          return;
+        }
+        ws.send(
+          JSON.stringify({
+            type: "incumbent_status",
+            connected: opts.connected ?? false,
+            alive: opts.alive ?? false,
+          }),
+        );
+      },
+    },
+  });
+  return `ws://127.0.0.1:${server.port}/ws`;
+}
+
+afterEach(() => {
+  if (server) {
+    server.stop(true);
+    server = null;
+  }
+});
+
+describe("DaemonClient.probeIncumbent", () => {
+  test("reports a live incumbent (connected + alive)", async () => {
+    const url = startFakeDaemon({ mode: "reply", connected: true, alive: true });
+    const client = new DaemonClient(url);
+    await client.connect();
+    expect(await client.probeIncumbent(1000)).toEqual({ connected: true, alive: true });
+    await client.disconnect();
+  });
+
+  test("reports a stale half-open incumbent (connected, NOT alive) so the caller can take over", async () => {
+    const url = startFakeDaemon({ mode: "reply", connected: true, alive: false });
+    const client = new DaemonClient(url);
+    await client.connect();
+    expect(await client.probeIncumbent(1000)).toEqual({ connected: true, alive: false });
+    await client.disconnect();
+  });
+
+  test("reports no incumbent when none is attached", async () => {
+    const url = startFakeDaemon({ mode: "reply", connected: false, alive: false });
+    const client = new DaemonClient(url);
+    await client.connect();
+    expect(await client.probeIncumbent(1000)).toEqual({ connected: false, alive: false });
+    await client.disconnect();
+  });
+
+  test("fails OPEN on a silent (old) daemon that never answers probe_incumbent", async () => {
+    const url = startFakeDaemon({ mode: "silent" });
+    const client = new DaemonClient(url);
+    await client.connect();
+    const start = performance.now();
+    const result = await client.probeIncumbent(150);
+    expect(result).toEqual({ connected: false, alive: false });
+    // Resolved via the timeout, not hung.
+    expect(performance.now() - start).toBeGreaterThanOrEqual(140);
+    await client.disconnect();
+  });
+
+  test("fails OPEN if the daemon drops the socket mid-probe", async () => {
+    const url = startFakeDaemon({ mode: "close" });
+    const client = new DaemonClient(url);
+    await client.connect();
+    expect(await client.probeIncumbent(1000)).toEqual({ connected: false, alive: false });
+  });
+
+  test("is non-attaching: only `probe_incumbent` is sent, never `claude_connect`", async () => {
+    const url = startFakeDaemon({ mode: "reply", connected: true, alive: true });
+    const client = new DaemonClient(url);
+    await client.connect();
+    await client.probeIncumbent(1000);
+    expect(received).toContain("probe_incumbent");
+    expect(received).not.toContain("claude_connect");
+    await client.disconnect();
+  });
+});

--- a/src/unit-test/daemon-client.test.ts
+++ b/src/unit-test/daemon-client.test.ts
@@ -153,7 +153,7 @@ describe("DaemonClient", () => {
     expect(disconnectEmitted).toBe(false);
   });
 
-  test("attachClaudeAndWaitForStatus resolves true when the daemon confirms attachment", async () => {
+  test("attachClaudeAndWaitForStatus resolves daemon status when the daemon confirms attachment", async () => {
     onServerMessage = (ws, raw) => {
       const message = JSON.parse(raw.toString());
       if (message.type === "claude_connect") {
@@ -173,10 +173,12 @@ describe("DaemonClient", () => {
     };
 
     await client.connect();
-    await expect(client.attachClaudeAndWaitForStatus(250)).resolves.toBe(true);
+    const status = await client.attachClaudeAndWaitForStatus(250);
+    expect(status?.pid).toBe(12345);
+    expect(status?.bridgeReady).toBe(true);
   });
 
-  test("attachClaudeAndWaitForStatus resolves false when the daemon rejects the attach", async () => {
+  test("attachClaudeAndWaitForStatus resolves null when the daemon rejects the attach", async () => {
     onServerMessage = (ws, raw) => {
       const message = JSON.parse(raw.toString());
       if (message.type === "claude_connect") {
@@ -185,10 +187,10 @@ describe("DaemonClient", () => {
     };
 
     await client.connect();
-    await expect(client.attachClaudeAndWaitForStatus(250)).resolves.toBe(false);
+    await expect(client.attachClaudeAndWaitForStatus(250)).resolves.toBeNull();
   });
 
-  test("attachClaudeAndWaitForStatus resolves false on timeout when daemon never responds", async () => {
+  test("attachClaudeAndWaitForStatus resolves null on timeout when daemon never responds", async () => {
     // Server intentionally swallows claude_connect — no status, no close, no anything.
     // Critical path for the recovery poller: a hung daemon must let the caller proceed.
     onServerMessage = () => {};
@@ -198,7 +200,7 @@ describe("DaemonClient", () => {
     const result = await client.attachClaudeAndWaitForStatus(150);
     const elapsed = Date.now() - start;
 
-    expect(result).toBe(false);
+    expect(result).toBeNull();
     // Must actually wait for the timeout, not resolve instantly.
     expect(elapsed).toBeGreaterThanOrEqual(140);
     // Sanity check on upper bound to catch event-listener leaks that delay GC.
@@ -380,5 +382,29 @@ describe("DaemonClient", () => {
 
     const msg = await received;
     expect(msg.type).toBe("claude_connect");
+  });
+
+  test("attachClaude includes client identity when configured", async () => {
+    const identity = {
+      pairId: "main-12345678",
+      pairName: "main",
+      cwd: "/tmp/project",
+      baseDir: "/tmp/agentbridge-base",
+      stateDir: "/tmp/agentbridge-base/pairs/main-12345678",
+      clientPid: 1234,
+      contractVersion: 1,
+    };
+    client = new DaemonClient(`ws://127.0.0.1:${serverPort}/ws`, { identity });
+    const received = new Promise<any>((resolve) => {
+      onServerMessage = (_ws: any, raw: any) => {
+        resolve(JSON.parse(typeof raw === "string" ? raw : raw.toString()));
+      };
+    });
+
+    await client.connect();
+    client.attachClaude();
+
+    const msg = await received;
+    expect(msg).toEqual({ type: "claude_connect", identity });
   });
 });

--- a/src/unit-test/daemon-identity.test.ts
+++ b/src/unit-test/daemon-identity.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { CLOSE_CODE_PAIR_MISMATCH } from "../control-protocol";
+import { validateClaudeClientIdentity } from "../daemon-identity";
+
+describe("daemon Claude identity admission", () => {
+  test("pair daemon rejects identity-less Claude clients by default", async () => {
+    const result = validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: undefined,
+      allowIdentityless: false,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      closeCode: CLOSE_CODE_PAIR_MISMATCH,
+      reason: "missing client identity",
+    });
+  });
+
+  test("pair daemon rejects pairId and cwd mismatches", () => {
+    expect(validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: { pairId: "other-aaaaaaaa", cwd: "/tmp/project" },
+      allowIdentityless: false,
+    }).ok).toBe(false);
+
+    expect(validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: { pairId: "main-12345678", cwd: "/tmp/other" },
+      allowIdentityless: false,
+    }).ok).toBe(false);
+  });
+
+  test("matching identity or explicit compat passes", () => {
+    expect(validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: { pairId: "main-12345678", cwd: "/tmp/project" },
+      allowIdentityless: false,
+    }).ok).toBe(true);
+
+    expect(validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: undefined,
+      allowIdentityless: true,
+    }).ok).toBe(true);
+  });
+});

--- a/src/unit-test/daemon-self-heal.test.ts
+++ b/src/unit-test/daemon-self-heal.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { StateDirResolver } from "../state-dir";
 import { DaemonLifecycle } from "../daemon-lifecycle";
+import { BUILD_INFO } from "../build-info";
 
 // Allocate an ephemeral free port so these tests never collide with a real
 // dev-machine daemon (4500-45xx) or each other.
@@ -82,6 +83,7 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
           appServerUrl: "",
           pid: state.pid ?? 99999,
           pairId: state.pairId,
+          build: BUILD_INFO,
         };
         if (u.pathname === "/healthz") return Response.json(body);
         if (u.pathname === "/readyz") return Response.json(body, { status: state.readyzStatus });
@@ -135,6 +137,92 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
     expect(killed).toBe(true);
     expect(launched).toBe(true);
     expect(killPid).toBe(99999); // targeted kill via the /healthz body pid, not the pid file
+  });
+
+  test("replaces a drifted daemon even when pair identity matches", async () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "mine-aaaa0000";
+    const port = await freePort();
+    const s = Bun.serve({
+      port,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const u = new URL(req.url);
+        const body = {
+          bridgeReady: true,
+          tuiConnected: true,
+          threadId: "thread",
+          queuedMessageCount: 0,
+          proxyUrl: "",
+          appServerUrl: "",
+          pid: 99999,
+          pairId: "mine-aaaa0000",
+          build: { ...BUILD_INFO, commit: "old-build" },
+        };
+        if (u.pathname === "/healthz" || u.pathname === "/readyz") return Response.json(body);
+        return new Response("ok");
+      },
+    });
+    servers.push(s);
+    const lc = lifecycle(port);
+    let killed = false;
+    let launched = false;
+    let killPid: number | undefined;
+    (lc as any).kill = async (_t?: number, pid?: number) => {
+      killed = true;
+      killPid = pid;
+      return true;
+    };
+    (lc as any).launch = () => {
+      launched = true;
+    };
+    await lc.ensureRunning();
+    expect(killed).toBe(true);
+    expect(launched).toBe(true);
+    expect(killPid).toBe(99999);
+  });
+
+  test("does NOT replace a daemon that differs only by bundle kind (dist vs plugin)", async () => {
+    // The dist CLI (`agentbridge codex`) and the Claude Code plugin bridge launch
+    // co-equal daemons from the same source for the same pair + control port. Their
+    // BUILD_INFO.bundle differs ("dist" vs "plugin") but version/commit/contract match.
+    // This MUST be reused, not replaced — otherwise the two launchers replace-war.
+    process.env.AGENTBRIDGE_PAIR_ID = "mine-aaaa0000";
+    const port = await freePort();
+    const s = Bun.serve({
+      port,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const u = new URL(req.url);
+        const body = {
+          bridgeReady: true,
+          tuiConnected: true,
+          threadId: "thread",
+          queuedMessageCount: 0,
+          proxyUrl: "",
+          appServerUrl: "",
+          pid: 99999,
+          pairId: "mine-aaaa0000",
+          // Same version/commit/contractVersion as the launcher; only `bundle` differs.
+          build: { ...BUILD_INFO, bundle: BUILD_INFO.bundle === "plugin" ? "dist" : "plugin" },
+        };
+        if (u.pathname === "/healthz" || u.pathname === "/readyz") return Response.json(body);
+        return new Response("ok");
+      },
+    });
+    servers.push(s);
+    const lc = lifecycle(port);
+    let killed = false;
+    let launched = false;
+    (lc as any).kill = async () => {
+      killed = true;
+      return true;
+    };
+    (lc as any).launch = () => {
+      launched = true;
+    };
+    await lc.ensureRunning();
+    expect(killed).toBe(false);
+    expect(launched).toBe(false);
   });
 
   test("replaces a healthz-OK but readyz-503 zombie", async () => {

--- a/src/unit-test/daemon-self-heal.test.ts
+++ b/src/unit-test/daemon-self-heal.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { StateDirResolver } from "../state-dir";
+import { DaemonLifecycle } from "../daemon-lifecycle";
+
+// Allocate an ephemeral free port so these tests never collide with a real
+// dev-machine daemon (4500-45xx) or each other.
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function selfAlive(): boolean {
+  try {
+    process.kill(process.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isProcessAliveLocal(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Covers the ensureRunning() self-heal contract: reuse a healthy/ready/matching-pair
+ * daemon, but kill+replace a foreign-pair daemon or a healthz-OK/readyz-503 zombie —
+ * while never killing a healthy-but-slow-to-boot daemon. launch()/kill() are mocked so
+ * no real daemon is spawned and no real process is signalled; a fake control server
+ * drives the healthz/readyz/pairId responses ensureRunning reacts to.
+ */
+describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () => {
+  let tempDir: string;
+  let stateDir: StateDirResolver;
+  let savedPairId: string | undefined;
+  const servers: Array<{ stop: () => void | Promise<void> }> = [];
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "abg-selfheal-test-"));
+    stateDir = new StateDirResolver(tempDir);
+    stateDir.ensure();
+    savedPairId = process.env.AGENTBRIDGE_PAIR_ID;
+    delete process.env.AGENTBRIDGE_PAIR_ID;
+  });
+
+  afterEach(async () => {
+    while (servers.length > 0) await servers.pop()!.stop();
+    if (savedPairId === undefined) delete process.env.AGENTBRIDGE_PAIR_ID;
+    else process.env.AGENTBRIDGE_PAIR_ID = savedPairId;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // Fake control server with a mutable readyz status + reported pairId.
+  function fakeDaemon(port: number, state: { readyzStatus: number; pairId: string | null; pid?: number }) {
+    const s = Bun.serve({
+      port,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const u = new URL(req.url);
+        const body = {
+          bridgeReady: false,
+          tuiConnected: false,
+          threadId: null,
+          queuedMessageCount: 0,
+          proxyUrl: "",
+          appServerUrl: "",
+          pid: state.pid ?? 99999,
+          pairId: state.pairId,
+        };
+        if (u.pathname === "/healthz") return Response.json(body);
+        if (u.pathname === "/readyz") return Response.json(body, { status: state.readyzStatus });
+        return new Response("ok");
+      },
+    });
+    servers.push(s);
+    return s;
+  }
+
+  function lifecycle(port: number) {
+    return new DaemonLifecycle({ stateDir, controlPort: port, log: () => {} });
+  }
+
+  test("reuses a healthy, ready, matching-pair daemon (no kill, no launch)", async () => {
+    const port = await freePort();
+    fakeDaemon(port, { readyzStatus: 200, pairId: null });
+    const lc = lifecycle(port);
+    let killed = false;
+    let launched = false;
+    (lc as any).kill = async () => {
+      killed = true;
+      return true;
+    };
+    (lc as any).launch = () => {
+      launched = true;
+    };
+    await lc.ensureRunning();
+    expect(killed).toBe(false);
+    expect(launched).toBe(false);
+  });
+
+  test("replaces a foreign-pair daemon squatting the control port (pairId mismatch)", async () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "mine-aaaa0000";
+    const port = await freePort();
+    // Foreign daemon: reports ready, but a DIFFERENT pairId than this pair expects.
+    fakeDaemon(port, { readyzStatus: 200, pairId: "other-bbbb1111", pid: 99999 });
+    const lc = lifecycle(port);
+    let killed = false;
+    let launched = false;
+    let killPid: number | undefined;
+    (lc as any).kill = async (_t?: number, pid?: number) => {
+      killed = true;
+      killPid = pid;
+      return true;
+    };
+    (lc as any).launch = () => {
+      launched = true;
+    };
+    await lc.ensureRunning();
+    expect(killed).toBe(true);
+    expect(launched).toBe(true);
+    expect(killPid).toBe(99999); // targeted kill via the /healthz body pid, not the pid file
+  });
+
+  test("replaces a healthz-OK but readyz-503 zombie", async () => {
+    const port = await freePort();
+    const state = { readyzStatus: 503, pairId: null as string | null };
+    fakeDaemon(port, state);
+    const lc = lifecycle(port);
+    let killed = false;
+    let launched = false;
+    (lc as any).kill = async () => {
+      killed = true;
+      return true;
+    };
+    (lc as any).launch = () => {
+      launched = true;
+      state.readyzStatus = 200; // the freshly launched replacement becomes ready
+    };
+    await lc.ensureRunning();
+    expect(killed).toBe(true);
+    expect(launched).toBe(true);
+  }, 15000);
+
+  test("does NOT kill a healthy daemon that is merely slow to become ready", async () => {
+    const port = await freePort();
+    const state = { readyzStatus: 503, pairId: null as string | null };
+    fakeDaemon(port, state);
+    // Flip to ready well within the ~3s reuse window — a legit slow boot, not a zombie.
+    setTimeout(() => {
+      state.readyzStatus = 200;
+    }, 600);
+    const lc = lifecycle(port);
+    let killed = false;
+    let launched = false;
+    (lc as any).kill = async () => {
+      killed = true;
+      return true;
+    };
+    (lc as any).launch = () => {
+      launched = true;
+    };
+    await lc.ensureRunning();
+    expect(killed).toBe(false);
+    expect(launched).toBe(false);
+  }, 15000);
+
+  test("acquireLockStrict returns false when a LIVE process holds the lock (no bypass)", () => {
+    const lc = lifecycle(20001);
+    // Simulate a live holder: write THIS (alive) process's pid into the lock file.
+    writeFileSync(stateDir.lockFile, `${process.pid}\n`);
+    expect((lc as any).acquireLockStrict()).toBe(false);
+  });
+
+  test("acquireLockStrict reclaims a stale lock left by a dead holder", () => {
+    const lc = lifecycle(20002);
+    writeFileSync(stateDir.lockFile, `9999999\n`); // not a live pid
+    expect((lc as any).acquireLockStrict()).toBe(true);
+  });
+
+  test("kill(pidOverride) refuses to signal a non-AgentBridge process", async () => {
+    const lc = lifecycle(20003);
+    // Spawn an external `sleep` process — definitely NOT an AgentBridge daemon.
+    // Using process.pid would not actually exercise the refusal path: the OLD loose
+    // `cmd.includes("daemon")` guard happens not to match the test runner's
+    // command line on current bun versions, and a real regression here could only
+    // be caught with a pid that is unambiguously NOT us.
+    const sleep = Bun.spawn(["/bin/sh", "-c", "while true; do sleep 60; done"], {
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    try {
+      const result = await lc.kill(200, sleep.pid);
+      expect(result).toBe(false);
+      expect(isProcessAliveLocal(sleep.pid)).toBe(true);
+    } finally {
+      sleep.kill("SIGKILL");
+    }
+  });
+
+  // Regression guard for the cross-review C1 fix: kill() inside the strict lock must
+  // NOT release the lock (cleanup no longer touches it), so two launchers racing to
+  // replace the SAME zombie are serialized — exactly one wins the lock and launches.
+  test("concurrent replacement of a zombie launches exactly once (strict lock serializes)", async () => {
+    const port = await freePort();
+    const state = { readyzStatus: 503, pairId: null as string | null };
+    fakeDaemon(port, state);
+    const lcA = lifecycle(port);
+    const lcB = lifecycle(port); // shares the same stateDir → same lock file
+    let launchCount = 0;
+    const mockLaunch = () => {
+      launchCount += 1;
+      state.readyzStatus = 200; // the single winning launcher's daemon becomes ready
+    };
+    (lcA as any).kill = async () => true;
+    (lcB as any).kill = async () => true;
+    (lcA as any).launch = mockLaunch;
+    (lcB as any).launch = mockLaunch;
+    await Promise.all([lcA.ensureRunning(), lcB.ensureRunning()]);
+    expect(launchCount).toBe(1); // strict lock → only one launcher replaces; the other waits
+  }, 25000);
+
+  // Regression guard for cross-review HIGH-1: in a contended-lock branch the launcher
+  // losing the race must wait for ready+OURS, not just ready. A foreign-pair daemon
+  // becoming ready behind the lock holder is the OTHER pair repairing its own daemon
+  // and must not be adopted. We hold the lock externally (no daemon ever claims it)
+  // so ensureRunning's `locked=false` path is the only branch that can run; without
+  // the pairId check it would return in ms, with it the foreign daemon never matches
+  // and waitForReadyAndOurs times out.
+  test("contended lock wait refuses a foreign-pair daemon that became ready behind us", async () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "mine-aaaa0000";
+    const port = await freePort();
+    // Foreign daemon: ready 200 from the start, but reports a DIFFERENT pairId.
+    fakeDaemon(port, { readyzStatus: 200, pairId: "other-bbbb1111", pid: 99999 });
+    // Pin the lock file from outside so acquireLockStrict returns false → ensureRunning
+    // takes the `locked=false` branch inside withStartupLockStrict → waitForReadyAndOurs.
+    writeFileSync(stateDir.lockFile, `${process.pid}\n`); // this test process holds the lock
+    const lc = lifecycle(port);
+    (lc as any).kill = async () => true;
+    (lc as any).launch = () => {};
+    const start = Date.now();
+    let rejected: Error | null = null;
+    try {
+      await lc.ensureRunning();
+    } catch (err: any) {
+      rejected = err;
+    }
+    const elapsed = Date.now() - start;
+    // Must reject (timed out waiting for ready+identity) and must have ACTUALLY waited,
+    // not short-circuited because the foreign daemon is "ready".
+    expect(rejected).not.toBeNull();
+    expect(rejected!.message).toMatch(/Timed out waiting for AgentBridge daemon readiness\+identity/);
+    expect(elapsed).toBeGreaterThanOrEqual(5000); // waitForReadyAndOurs default = 40×250ms=10s, ≥5s confirms we waited
+  }, 20000);
+
+  // Regression guard for cross-review HIGH-2: in pair mode, a missing/null reported
+  // pairId is treated as FOREIGN (a hard-paired pair must not adopt a manual/old
+  // daemon squatting its port). It is replaced with one that reports the right pairId.
+  test("pair-mode treats null reported pairId as foreign and replaces it", async () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "mine-aaaa0000";
+    const port = await freePort();
+    const state = { readyzStatus: 200, pairId: null as string | null };
+    fakeDaemon(port, state);
+    const lc = lifecycle(port);
+    let killed = false;
+    let launched = false;
+    (lc as any).kill = async () => {
+      killed = true;
+      return true;
+    };
+    (lc as any).launch = () => {
+      launched = true;
+      state.pairId = "mine-aaaa0000"; // the fresh replacement reports the right identity
+    };
+    await lc.ensureRunning();
+    expect(killed).toBe(true);
+    expect(launched).toBe(true);
+  }, 15000);
+});

--- a/src/unit-test/doctor.test.ts
+++ b/src/unit-test/doctor.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runDoctor } from "../cli/doctor";
+import { derivePairId, writeRegistry } from "../pair-registry";
+
+const ENV_KEYS = [
+  "AGENTBRIDGE_BASE_DIR",
+  "AGENTBRIDGE_PAIR_ID",
+  "AGENTBRIDGE_PAIR_NAME",
+  "AGENTBRIDGE_STATE_DIR",
+  "AGENTBRIDGE_APP_PORT",
+  "AGENTBRIDGE_PROXY_PORT",
+  "AGENTBRIDGE_CONTROL_PORT",
+  "AGENTBRIDGE_MANUAL",
+];
+
+const savedEnv = new Map<string, string | undefined>();
+let previousCwd: string;
+
+beforeEach(() => {
+  previousCwd = process.cwd();
+  for (const key of ENV_KEYS) {
+    savedEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  process.chdir(previousCwd);
+  for (const key of ENV_KEYS) {
+    const value = savedEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  savedEnv.clear();
+});
+
+async function runDoctorJson(args: string[]) {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (...parts: unknown[]) => {
+    lines.push(parts.map(String).join(" "));
+  };
+  try {
+    await runDoctor([...args, "--json"]);
+  } finally {
+    console.log = originalLog;
+  }
+  return JSON.parse(lines.join("\n"));
+}
+
+function seedPair(root: string, base: string) {
+  const pairId = derivePairId(root, "main");
+  writeRegistry(base, {
+    version: 1,
+    pairs: [{
+      pairId,
+      slot: 1234,
+      cwd: root,
+      name: "main",
+      source: "flag",
+      createdAt: "2026-06-02T00:00:00.000Z",
+    }],
+  });
+  return pairId;
+}
+
+describe("doctor command", () => {
+  test("default doctor runs static local diagnostics for the selected pair", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-doctor-"));
+    const base = mkdtempSync(join(tmpdir(), "agentbridge-doctor-base-"));
+    try {
+      process.chdir(root);
+      process.env.AGENTBRIDGE_BASE_DIR = base;
+      const pairId = seedPair(root, base);
+
+      const report = await runDoctorJson(["--pair", "main"]);
+
+      expect(report.pair.pairId).toBe(pairId);
+      expect(report.pair.slot).toBe(1234);
+      expect(report.env.ok).toBe(true);
+      expect(report.checks.map((check: { name: string }) => check.name)).toEqual([
+        "env",
+        "daemon health",
+        "daemon readiness",
+        "build drift",
+        "current thread",
+        "daemon log",
+        "codex wrapper log",
+      ]);
+      expect(report.checks.some((check: { name: string }) => check.name === "agent backend")).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("--agent remains explicit and reports static diagnostics in this build", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-doctor-"));
+    const base = mkdtempSync(join(tmpdir(), "agentbridge-doctor-base-"));
+    try {
+      process.chdir(root);
+      process.env.AGENTBRIDGE_BASE_DIR = base;
+      seedPair(root, base);
+
+      const report = await runDoctorJson(["--pair", "main", "--agent"]);
+      const agentCheck = report.checks.find((check: { name: string }) => check.name === "agent backend");
+
+      expect(agentCheck).toEqual({
+        name: "agent backend",
+        status: "warn",
+        detail: "--agent is reserved for read-only delegated analysis; static diagnostics were run locally in this build.",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/unit-test/e2e-reconnect.test.ts
+++ b/src/unit-test/e2e-reconnect.test.ts
@@ -26,15 +26,20 @@ let daemonProc: ChildProcess | null = null;
 
 function launchDaemon(): ChildProcess {
   mkdirSync(TEST_STATE_DIR, { recursive: true });
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    AGENTBRIDGE_MANUAL: "1",
+    AGENTBRIDGE_CONTROL_PORT: String(TEST_CONTROL_PORT),
+    AGENTBRIDGE_STATE_DIR: TEST_STATE_DIR,
+    CODEX_WS_PORT: String(TEST_APP_PORT),
+    CODEX_PROXY_PORT: String(TEST_PROXY_PORT),
+    AGENTBRIDGE_IDLE_SHUTDOWN_MS: "60000", // don't auto-shutdown during tests
+  };
+  delete env.AGENTBRIDGE_BASE_DIR;
+  delete env.AGENTBRIDGE_PAIR_ID;
+  delete env.AGENTBRIDGE_PAIR_NAME;
   const proc = spawn(process.execPath, ["run", DAEMON_PATH], {
-    env: {
-      ...process.env,
-      AGENTBRIDGE_CONTROL_PORT: String(TEST_CONTROL_PORT),
-      AGENTBRIDGE_STATE_DIR: TEST_STATE_DIR,
-      CODEX_WS_PORT: String(TEST_APP_PORT),
-      CODEX_PROXY_PORT: String(TEST_PROXY_PORT),
-      AGENTBRIDGE_IDLE_SHUTDOWN_MS: "60000", // don't auto-shutdown during tests
-    },
+    env,
     stdio: "pipe",
   });
   return proc;

--- a/src/unit-test/env-guard.test.ts
+++ b/src/unit-test/env-guard.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { derivePairId } from "../pair-registry";
+import {
+  guardAgentBridgeEnv,
+  inspectAgentBridgeEnv,
+  type EnvGuardMode,
+} from "../env-guard";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempCwd(name: string) {
+  const dir = mkdtempSync(join(tmpdir(), `agentbridge-env-guard-${name}-`));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("AgentBridge env guard", () => {
+  test("reports clean when pair env matches the current cwd and pair name", () => {
+    const cwd = tempCwd("clean");
+    const pairId = derivePairId(cwd, "main");
+    const env = {
+      AGENTBRIDGE_PAIR_ID: pairId,
+      AGENTBRIDGE_PAIR_NAME: "main",
+      AGENTBRIDGE_BASE_DIR: "/tmp/agentbridge-base",
+      AGENTBRIDGE_STATE_DIR: `/tmp/agentbridge-base/pairs/${pairId}`,
+      AGENTBRIDGE_CONTROL_PORT: "4502",
+      CODEX_WS_PORT: "4500",
+      CODEX_PROXY_PORT: "4501",
+    } as NodeJS.ProcessEnv;
+
+    expect(inspectAgentBridgeEnv({ cwd, env }).ok).toBe(true);
+  });
+
+  test("fix mode clears stale generated env before pair resolution can enter manual mode", () => {
+    const cwd = tempCwd("fix");
+    const oldCwd = tempCwd("old");
+    const stalePairId = derivePairId(oldCwd, "main");
+    const env = {
+      AGENTBRIDGE_PAIR_ID: stalePairId,
+      AGENTBRIDGE_PAIR_NAME: "main",
+      AGENTBRIDGE_BASE_DIR: "/tmp/stale-base",
+      AGENTBRIDGE_STATE_DIR: `/tmp/stale-base/pairs/${stalePairId}`,
+      AGENTBRIDGE_CONTROL_PORT: "4999",
+      CODEX_WS_PORT: "4997",
+      CODEX_PROXY_PORT: "4998",
+      AGENTBRIDGE_MODE: "pull",
+    } as NodeJS.ProcessEnv;
+
+    const result = guardAgentBridgeEnv({ cwd, env, mode: "fix" });
+
+    expect(result.action).toBe("fixed");
+    expect(env.AGENTBRIDGE_PAIR_ID).toBeUndefined();
+    expect(env.AGENTBRIDGE_PAIR_NAME).toBeUndefined();
+    expect(env.AGENTBRIDGE_BASE_DIR).toBeUndefined();
+    expect(env.AGENTBRIDGE_STATE_DIR).toBeUndefined();
+    expect(env.AGENTBRIDGE_CONTROL_PORT).toBeUndefined();
+    expect(env.CODEX_WS_PORT).toBeUndefined();
+    expect(env.CODEX_PROXY_PORT).toBeUndefined();
+    expect(env.AGENTBRIDGE_MODE).toBeUndefined();
+  });
+
+  test("fix mode clears manual-looking runtime env unless AGENTBRIDGE_MANUAL is explicit", () => {
+    const cwd = tempCwd("manual-env");
+    const env = {
+      AGENTBRIDGE_STATE_DIR: "/tmp/stale-manual",
+      AGENTBRIDGE_CONTROL_PORT: "4502",
+      CODEX_WS_PORT: "4500",
+      CODEX_PROXY_PORT: "4501",
+    } as NodeJS.ProcessEnv;
+
+    const result = guardAgentBridgeEnv({ cwd, env, mode: "fix" });
+
+    expect(result.action).toBe("fixed");
+    expect(env.AGENTBRIDGE_STATE_DIR).toBeUndefined();
+    expect(env.AGENTBRIDGE_CONTROL_PORT).toBeUndefined();
+    expect(env.CODEX_WS_PORT).toBeUndefined();
+    expect(env.CODEX_PROXY_PORT).toBeUndefined();
+  });
+
+  test("explicit AGENTBRIDGE_MANUAL opt-in allows manual runtime env", () => {
+    const cwd = tempCwd("manual-opt-in");
+    const env = {
+      AGENTBRIDGE_MANUAL: "1",
+      AGENTBRIDGE_STATE_DIR: "/tmp/manual",
+      AGENTBRIDGE_CONTROL_PORT: "4502",
+      CODEX_WS_PORT: "4500",
+      CODEX_PROXY_PORT: "4501",
+    } as NodeJS.ProcessEnv;
+
+    const result = guardAgentBridgeEnv({ cwd, env, mode: "fix" });
+
+    expect(result.action).toBe("none");
+    expect(env.AGENTBRIDGE_STATE_DIR).toBe("/tmp/manual");
+  });
+
+  test.each(["warn", "strict"] as EnvGuardMode[])("%s mode leaves stale env intact", (mode) => {
+    const cwd = tempCwd(mode);
+    const oldCwd = tempCwd(`${mode}-old`);
+    const stalePairId = derivePairId(oldCwd, "work");
+    const env = {
+      AGENTBRIDGE_PAIR_ID: stalePairId,
+      AGENTBRIDGE_PAIR_NAME: "work",
+      AGENTBRIDGE_STATE_DIR: `/tmp/stale-base/pairs/${stalePairId}`,
+    } as NodeJS.ProcessEnv;
+
+    if (mode === "strict") {
+      expect(() => guardAgentBridgeEnv({ cwd, env, mode })).toThrow(/stale AgentBridge environment/i);
+    } else {
+      expect(guardAgentBridgeEnv({ cwd, env, mode }).action).toBe("warned");
+    }
+
+    expect(env.AGENTBRIDGE_PAIR_ID).toBe(stalePairId);
+  });
+});

--- a/src/unit-test/install-global-script.test.ts
+++ b/src/unit-test/install-global-script.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SCRIPT = join(process.cwd(), "scripts/install-global.mjs");
+const PACKAGE_NAME = "@raysonmeng/agentbridge";
+
+function runDry(mode: string): { status: number | null; stdout: string; stderr: string } {
+  const res = Bun.spawnSync(["node", SCRIPT, mode, "--dry-run"], {
+    env: process.env,
+  });
+  return {
+    status: res.exitCode,
+    stdout: res.stdout.toString(),
+    stderr: res.stderr.toString(),
+  };
+}
+
+function dryRunCommands(mode: string): string[] {
+  const res = runDry(mode);
+  expect(res.status).toBe(0);
+  return res.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("$ "));
+}
+
+describe("scripts/install-global.mjs", () => {
+  test("local mode builds and packs before replacing the global install", () => {
+    const commands = dryRunCommands("local");
+    expect(commands).toEqual([
+      "$ bun run prepublishOnly",
+      "$ npm pack --pack-destination <temp>",
+      `$ npm uninstall -g ${PACKAGE_NAME}  # ignored if not installed`,
+      "$ npm install -g --force <packed-tarball>",
+    ]);
+  });
+
+  test("npm mode verifies the registry package before replacing the global install", () => {
+    const commands = dryRunCommands("npm");
+    expect(commands).toEqual([
+      `$ npm view ${PACKAGE_NAME}@latest version`,
+      `$ npm uninstall -g ${PACKAGE_NAME}  # ignored if not installed`,
+      `$ npm install -g --force ${PACKAGE_NAME}@latest`,
+    ]);
+  });
+
+  test("package.json exposes one-line local and npm install commands", () => {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8"));
+    expect(pkg.scripts["install:global"]).toBe("node scripts/install-global.mjs local");
+    expect(pkg.scripts["install:global:local"]).toBe("node scripts/install-global.mjs local");
+    expect(pkg.scripts["install:global:npm"]).toBe("node scripts/install-global.mjs npm");
+  });
+
+  test("unknown mode fails with usage", () => {
+    const res = runDry("elsewhere");
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("Usage:");
+  });
+});

--- a/src/unit-test/install-global-script.test.ts
+++ b/src/unit-test/install-global-script.test.ts
@@ -29,8 +29,11 @@ describe("scripts/install-global.mjs", () => {
   test("local mode builds and packs before replacing the global install", () => {
     const commands = dryRunCommands("local");
     expect(commands).toEqual([
+      "$ node scripts/install-safety.cjs stop-running --dry-run",
       "$ bun run prepublishOnly",
+      "$ node scripts/install-safety.cjs verify-built",
       "$ npm pack --pack-destination <temp>",
+      "$ node scripts/install-safety.cjs verify-tarball <packed-tarball>",
       `$ npm uninstall -g ${PACKAGE_NAME}  # ignored if not installed`,
       "$ npm install -g --force <packed-tarball>",
     ]);
@@ -39,6 +42,7 @@ describe("scripts/install-global.mjs", () => {
   test("npm mode verifies the registry package before replacing the global install", () => {
     const commands = dryRunCommands("npm");
     expect(commands).toEqual([
+      "$ node scripts/install-safety.cjs stop-running --dry-run",
       `$ npm view ${PACKAGE_NAME}@latest version`,
       `$ npm uninstall -g ${PACKAGE_NAME}  # ignored if not installed`,
       `$ npm install -g --force ${PACKAGE_NAME}@latest`,
@@ -50,11 +54,110 @@ describe("scripts/install-global.mjs", () => {
     expect(pkg.scripts["install:global"]).toBe("node scripts/install-global.mjs local");
     expect(pkg.scripts["install:global:local"]).toBe("node scripts/install-global.mjs local");
     expect(pkg.scripts["install:global:npm"]).toBe("node scripts/install-global.mjs npm");
+    expect(pkg.files).toContain("scripts/install-safety.cjs");
+  });
+
+  test("install safety stop command is dry-runnable and scoped to all pairs", () => {
+    const res = Bun.spawnSync(["node", "scripts/install-safety.cjs", "stop-running", "--dry-run"], {
+      env: {
+        ...process.env,
+        AGENTBRIDGE_PAIR_ID: "stale-pair",
+        AGENTBRIDGE_STATE_DIR: "/tmp/stale-agentbridge-state",
+        AGENTBRIDGE_CONTROL_PORT: "4999",
+      },
+    });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout.toString().trim()).toBe(
+      "$ bun run src/cli.ts kill --all  # stop running AgentBridge daemons/TUIs",
+    );
+  });
+
+  test("install safety strips pair-specific environment from child commands", () => {
+    const res = Bun.spawnSync([
+      "node",
+      "-e",
+      `
+        const { agentBridgeInstallEnv } = require("./scripts/install-safety.cjs");
+        const env = agentBridgeInstallEnv({
+          PATH: "/bin",
+          AGENTBRIDGE_BASE_DIR: "/stale/base",
+          AGENTBRIDGE_DAEMON_ENTRY: "/tmp/fake-daemon.js",
+          AGENTBRIDGE_MODE: "pull",
+          AGENTBRIDGE_PAIR_ID: "stale",
+          AGENTBRIDGE_PAIR_NAME: "main",
+          AGENTBRIDGE_STATE_DIR: "/tmp/stale",
+          AGENTBRIDGE_CONTROL_PORT: "4999",
+          CODEX_WS_PORT: "4997",
+          CODEX_PROXY_PORT: "4998",
+        });
+        console.log(JSON.stringify(env));
+      `,
+    ]);
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout.toString());
+    expect(env.PATH).toBe("/bin");
+    expect(env.AGENTBRIDGE_BASE_DIR).toBeUndefined();
+    expect(env.AGENTBRIDGE_DAEMON_ENTRY).toBeUndefined();
+    expect(env.AGENTBRIDGE_MODE).toBeUndefined();
+    expect(env.AGENTBRIDGE_PAIR_ID).toBeUndefined();
+    expect(env.AGENTBRIDGE_PAIR_NAME).toBeUndefined();
+    expect(env.AGENTBRIDGE_STATE_DIR).toBeUndefined();
+    expect(env.AGENTBRIDGE_CONTROL_PORT).toBeUndefined();
+    expect(env.CODEX_WS_PORT).toBeUndefined();
+    expect(env.CODEX_PROXY_PORT).toBeUndefined();
+  });
+
+  test("postinstall dry-run stops running daemons before plugin registration", () => {
+    const res = Bun.spawnSync(["node", "scripts/postinstall.cjs", "--dry-run"], {
+      env: process.env,
+    });
+    expect(res.exitCode).toBe(0);
+    expect(
+      res.stdout
+        .toString()
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean),
+    ).toEqual([
+      "$ bun run src/cli.ts kill --all  # stop running AgentBridge daemons/TUIs",
+      "$ claude --version",
+      `$ claude plugin marketplace add ${process.cwd()}`,
+      "$ claude plugin install agentbridge@agentbridge",
+    ]);
   });
 
   test("unknown mode fails with usage", () => {
     const res = runDry("elsewhere");
     expect(res.status).not.toBe(0);
     expect(res.stderr).toContain("Usage:");
+  });
+});
+
+describe("scripts/postinstall.cjs shouldStopRunningDaemons", () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { shouldStopRunningDaemons } = require(join(process.cwd(), "scripts/postinstall.cjs"));
+
+  test("packed install with no global env does NOT stop running daemons", () => {
+    expect(shouldStopRunningDaemons({ env: {}, hasSourceCli: false })).toBe(false);
+  });
+
+  test("npm_config_global=true triggers stop-the-world", () => {
+    expect(shouldStopRunningDaemons({ env: { npm_config_global: "true" } })).toBe(true);
+  });
+
+  test("npm_config_location=global triggers stop-the-world", () => {
+    expect(shouldStopRunningDaemons({ env: { npm_config_location: "global" } })).toBe(true);
+  });
+
+  test("AGENTBRIDGE_POSTINSTALL_STOP=1 forces stop", () => {
+    expect(shouldStopRunningDaemons({ env: { AGENTBRIDGE_POSTINSTALL_STOP: "1" } })).toBe(true);
+  });
+
+  test("AGENTBRIDGE_POSTINSTALL_STOP=0 opt-out wins over npm_config_global", () => {
+    expect(
+      shouldStopRunningDaemons({
+        env: { AGENTBRIDGE_POSTINSTALL_STOP: "0", npm_config_global: "true" },
+      }),
+    ).toBe(false);
   });
 });

--- a/src/unit-test/liveness-probe.test.ts
+++ b/src/unit-test/liveness-probe.test.ts
@@ -5,12 +5,9 @@ const OPEN = 1;
 const CLOSED = 3;
 
 function makeTarget(initial: Partial<ProbeTarget> = {}): ProbeTarget & { pingCount: number } {
-  // Seed lastPongAt at "now - 1s" so the defensive baseline (max(lastPongAt, now()))
-  // resolves to now() rather than a synthetic-stale value — preserves the assertion
-  // semantics for tests that simulate a real-time pong arriving during the probe.
   return {
     readyState: OPEN,
-    lastPongAt: Date.now() - 1_000,
+    pongCount: 0,
     pingCount: 0,
     ping() { this.pingCount++; },
     ...initial,
@@ -18,20 +15,16 @@ function makeTarget(initial: Partial<ProbeTarget> = {}): ProbeTarget & { pingCou
 }
 
 describe("probeLiveness", () => {
-  test("returns true when pong observed before timeout", async () => {
+  test("returns true when a pong (counter advances) is observed before timeout", async () => {
     const target = makeTarget();
-
     const promise = probeLiveness(target, { timeoutMs: 500, pollMs: 10 });
-    // Simulate a pong landing after the first poll tick. The timestamp must
-    // exceed Date.now() at the moment the probe takes its baseline; using
-    // `Date.now() + 60_000` is safely far enough in the future for the assertion.
-    setTimeout(() => { target.lastPongAt = Date.now() + 60_000; }, 30);
-
+    // Simulate a pong landing after the first poll tick.
+    setTimeout(() => { target.pongCount++; }, 30);
     expect(await promise).toBe(true);
     expect(target.pingCount).toBe(1);
   });
 
-  test("returns false when no pong within timeout", async () => {
+  test("returns false when no pong (counter never advances) within timeout", async () => {
     const target = makeTarget();
     const result = await probeLiveness(target, { timeoutMs: 120, pollMs: 20 });
     expect(result).toBe(false);
@@ -60,15 +53,25 @@ describe("probeLiveness", () => {
     expect(result).toBe(false);
   });
 
-  test("treats pong received before ping (baseline = same value) as NOT alive", async () => {
-    // Critical: a stale pong that landed before the probe started must not
-    // be interpreted as proof of liveness. Only pongs arriving AFTER the
-    // ping count. The defensive baseline takes max(lastPongAt, now()) so a
-    // recent-but-pre-probe pong is also filtered out — see the dedicated
-    // defensive-baseline tests below for that case.
-    const target = makeTarget({ lastPongAt: Date.now() - 500 });
+  test("a pong observed BEFORE the probe (already in baseline) is NOT proof of liveness", async () => {
+    // pongCount is non-zero at probe start (a prior keepalive pong). The probe
+    // snapshots it as the baseline; with no NEW pong during the probe, it must
+    // return false — a stale pre-probe pong can't be mistaken for fresh liveness.
+    const target = makeTarget({ pongCount: 7 });
     const result = await probeLiveness(target, { timeoutMs: 80, pollMs: 20 });
     expect(result).toBe(false);
+  });
+
+  test("REGRESSION: a pong landing in the SAME tick/ms as the probe start still registers", async () => {
+    // The old implementation compared `lastPongAt(ms) > max(lastPongAt, now())`,
+    // which false-negatived whenever the localhost round-trip completed within the
+    // probe's start millisecond. With a counter, a synchronous same-tick pong
+    // (incremented inside ping()) is unambiguously counted → alive.
+    const target = makeTarget();
+    target.ping = () => { target.pingCount++; target.pongCount++; };
+    const result = await probeLiveness(target, { timeoutMs: 100, pollMs: 25 });
+    expect(result).toBe(true);
+    expect(target.pingCount).toBe(1);
   });
 
   test("uses injected clock and sleep for deterministic timeout", async () => {
@@ -87,33 +90,10 @@ describe("probeLiveness", () => {
     expect(sleeps.every((s) => s === 25)).toBe(true);
   });
 
-  test("defensive baseline: pongs older than probe start are ignored even if newer than lastPongAt seed", async () => {
-    // Regression for Bun's sendPings: true. Without max(lastPongAt, now()),
-    // a recent-but-pre-probe pong (e.g. from Bun's background heartbeat that
-    // landed during the same JS tick before our ping() ran) would falsely
-    // satisfy `lastPongAt > baseline`. Use an injected clock so we can stage
-    // the timestamp ordering deterministically.
+  test("a counter advance DURING the probe (after ping) is accepted with injected clock", async () => {
     let fakeNow = 10_000;
-    const target = makeTarget({ lastPongAt: 9_500 });
-    const result = await probeLiveness(target, {
-      timeoutMs: 100,
-      pollMs: 25,
-      now: () => fakeNow,
-      sleep: async (ms) => { fakeNow += ms; },
-    });
-    expect(result).toBe(false);
-  });
-
-  test("defensive baseline: pong arriving DURING probe (after now()) is accepted", async () => {
-    let fakeNow = 10_000;
-    // lastPongAt seeded BELOW now() — proves we anchor baseline to now(), not lastPongAt.
-    const target = makeTarget({ lastPongAt: 9_500 });
-    let pingCalls = 0;
-    target.ping = () => {
-      pingCalls++;
-      // Simulate peer responding with a pong AFTER the probe started.
-      target.lastPongAt = fakeNow + 1; // strictly greater than baseline (=fakeNow)
-    };
+    const target = makeTarget({ pongCount: 3 });
+    target.ping = () => { target.pingCount++; target.pongCount++; }; // peer pongs in response
     const result = await probeLiveness(target, {
       timeoutMs: 100,
       pollMs: 25,
@@ -121,6 +101,5 @@ describe("probeLiveness", () => {
       sleep: async (ms) => { fakeNow += ms; },
     });
     expect(result).toBe(true);
-    expect(pingCalls).toBe(1);
   });
 });

--- a/src/unit-test/message-filter.test.ts
+++ b/src/unit-test/message-filter.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import {
-  BRIDGE_CONTRACT_REMINDER,
   StatusBuffer,
   classifyMessage,
   parseMarker,
@@ -186,11 +185,4 @@ describe("StatusBuffer pause/resume", () => {
     buf.dispose();
   });
 });
-
-describe("BRIDGE_CONTRACT_REMINDER", () => {
-  test("contains marker instructions", () => {
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("[IMPORTANT]");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("[STATUS]");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("[FYI]");
-  });
-});
+// (The bridge-contract marker spec moved to AGENTS_MD_SECTION; see role-patterns.test.ts.)

--- a/src/unit-test/pair-command.test.ts
+++ b/src/unit-test/pair-command.test.ts
@@ -1,20 +1,41 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { pairScopedCommand } from "../pair-command";
+import { writeRegistry } from "../pair-registry";
 
 describe("pairScopedCommand", () => {
   let savedId: string | undefined;
   let savedName: string | undefined;
+  let savedBase: string | undefined;
+  let savedState: string | undefined;
+  let base: string;
+
   beforeEach(() => {
     savedId = process.env.AGENTBRIDGE_PAIR_ID;
     savedName = process.env.AGENTBRIDGE_PAIR_NAME;
+    savedBase = process.env.AGENTBRIDGE_BASE_DIR;
+    savedState = process.env.AGENTBRIDGE_STATE_DIR;
     delete process.env.AGENTBRIDGE_PAIR_ID;
     delete process.env.AGENTBRIDGE_PAIR_NAME;
+    // Isolate the registry the conservative-C name recovery reads from, so a real
+    // dev-machine registry never leaks into these assertions.
+    base = mkdtempSync(join(tmpdir(), "abg-paircmd-test-"));
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+    delete process.env.AGENTBRIDGE_STATE_DIR;
   });
+
   afterEach(() => {
-    if (savedId === undefined) delete process.env.AGENTBRIDGE_PAIR_ID;
-    else process.env.AGENTBRIDGE_PAIR_ID = savedId;
-    if (savedName === undefined) delete process.env.AGENTBRIDGE_PAIR_NAME;
-    else process.env.AGENTBRIDGE_PAIR_NAME = savedName;
+    const restore = (key: string, val: string | undefined) => {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    };
+    restore("AGENTBRIDGE_PAIR_ID", savedId);
+    restore("AGENTBRIDGE_PAIR_NAME", savedName);
+    restore("AGENTBRIDGE_BASE_DIR", savedBase);
+    restore("AGENTBRIDGE_STATE_DIR", savedState);
+    rmSync(base, { recursive: true, force: true });
   });
 
   test("legacy/manual mode (no AGENTBRIDGE_PAIR_ID) → bare command", () => {
@@ -48,8 +69,34 @@ describe("pairScopedCommand", () => {
     expect(pairScopedCommand("codex")).toBe("agentbridge codex");
   });
 
-  test("falls back to the composite pairId when no friendly name is set", () => {
+  // Conservative C: when AGENTBRIDGE_PAIR_NAME is missing (e.g. an OLD bridge
+  // process started before the NAME env shipped), recover the friendly name from
+  // the registry by pairId instead of exposing the raw composite id in the hint.
+  test("recovers the friendly name from the registry when PAIR_NAME is unset", () => {
     process.env.AGENTBRIDGE_PAIR_ID = "myproj-1a2b3c4d";
+    writeRegistry(base, {
+      version: 1,
+      pairs: [
+        { pairId: "myproj-1a2b3c4d", slot: 3, cwd: "/some/dir", name: "myproj", source: "cwd", createdAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    });
+    expect(pairScopedCommand("codex")).toBe("agentbridge --pair myproj codex");
+  });
+
+  test("falls back to the composite pairId when PAIR_NAME unset AND no registry match", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "myproj-1a2b3c4d";
+    writeRegistry(base, { version: 1, pairs: [] });
     expect(pairScopedCommand("codex")).toBe("agentbridge --pair myproj-1a2b3c4d codex");
+  });
+
+  // best-effort: a corrupt/unreadable registry must NOT throw while rendering a
+  // hint — it falls back to the pairId. (readRegistry throws PAIR_REGISTRY_CORRUPT
+  // on unparseable JSON; pairScopedCommand swallows it.)
+  test("a corrupt registry does not throw, falls back to the pairId", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "ghost-deadbeef";
+    mkdirSync(join(base, "pairs"), { recursive: true });
+    writeFileSync(join(base, "pairs", "registry.json"), "{ this is not valid json", "utf-8");
+    expect(() => pairScopedCommand("codex")).not.toThrow();
+    expect(pairScopedCommand("codex")).toBe("agentbridge --pair ghost-deadbeef codex");
   });
 });

--- a/src/unit-test/pair-command.test.ts
+++ b/src/unit-test/pair-command.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { pairScopedCommand } from "../pair-command";
+
+describe("pairScopedCommand", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env.AGENTBRIDGE_PAIR_ID;
+    delete process.env.AGENTBRIDGE_PAIR_ID;
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.AGENTBRIDGE_PAIR_ID;
+    else process.env.AGENTBRIDGE_PAIR_ID = saved;
+  });
+
+  test("legacy/manual mode (no AGENTBRIDGE_PAIR_ID) → bare command", () => {
+    expect(pairScopedCommand("codex")).toBe("agentbridge codex");
+    expect(pairScopedCommand("claude")).toBe("agentbridge claude");
+    expect(pairScopedCommand("kill")).toBe("agentbridge kill");
+  });
+
+  test("pair mode → injects --pair <id> right after the subcommand", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "work";
+    expect(pairScopedCommand("codex")).toBe("agentbridge codex --pair work");
+    expect(pairScopedCommand("claude")).toBe("agentbridge claude --pair work");
+    expect(pairScopedCommand("kill")).toBe("agentbridge kill --pair work");
+  });
+
+  test("--pair is placed before the subcommand's own extra args", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "review";
+    expect(pairScopedCommand("claude --resume")).toBe("agentbridge claude --pair review --resume");
+  });
+
+  test("an empty-string AGENTBRIDGE_PAIR_ID is treated as unset (no --pair)", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "";
+    expect(pairScopedCommand("codex")).toBe("agentbridge codex");
+  });
+
+  test("a cwd-derived id (with a hash suffix) renders verbatim", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "myproj-1a2b3c4d";
+    expect(pairScopedCommand("codex")).toBe("agentbridge codex --pair myproj-1a2b3c4d");
+  });
+});

--- a/src/unit-test/pair-command.test.ts
+++ b/src/unit-test/pair-command.test.ts
@@ -2,14 +2,19 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { pairScopedCommand } from "../pair-command";
 
 describe("pairScopedCommand", () => {
-  let saved: string | undefined;
+  let savedId: string | undefined;
+  let savedName: string | undefined;
   beforeEach(() => {
-    saved = process.env.AGENTBRIDGE_PAIR_ID;
+    savedId = process.env.AGENTBRIDGE_PAIR_ID;
+    savedName = process.env.AGENTBRIDGE_PAIR_NAME;
     delete process.env.AGENTBRIDGE_PAIR_ID;
+    delete process.env.AGENTBRIDGE_PAIR_NAME;
   });
   afterEach(() => {
-    if (saved === undefined) delete process.env.AGENTBRIDGE_PAIR_ID;
-    else process.env.AGENTBRIDGE_PAIR_ID = saved;
+    if (savedId === undefined) delete process.env.AGENTBRIDGE_PAIR_ID;
+    else process.env.AGENTBRIDGE_PAIR_ID = savedId;
+    if (savedName === undefined) delete process.env.AGENTBRIDGE_PAIR_NAME;
+    else process.env.AGENTBRIDGE_PAIR_NAME = savedName;
   });
 
   test("legacy/manual mode (no AGENTBRIDGE_PAIR_ID) → bare command", () => {
@@ -18,16 +23,24 @@ describe("pairScopedCommand", () => {
     expect(pairScopedCommand("kill")).toBe("agentbridge kill");
   });
 
-  test("pair mode → injects --pair <id> right after the subcommand", () => {
-    process.env.AGENTBRIDGE_PAIR_ID = "work";
-    expect(pairScopedCommand("codex")).toBe("agentbridge codex --pair work");
-    expect(pairScopedCommand("claude")).toBe("agentbridge claude --pair work");
-    expect(pairScopedCommand("kill")).toBe("agentbridge kill --pair work");
+  test("pair mode → puts --pair <selector> BEFORE the subcommand", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "work-1a2b3c4d";
+    process.env.AGENTBRIDGE_PAIR_NAME = "work";
+    expect(pairScopedCommand("codex")).toBe("agentbridge --pair work codex");
+    expect(pairScopedCommand("claude")).toBe("agentbridge --pair work claude");
+    expect(pairScopedCommand("kill")).toBe("agentbridge --pair work kill");
   });
 
-  test("--pair is placed before the subcommand's own extra args", () => {
-    process.env.AGENTBRIDGE_PAIR_ID = "review";
-    expect(pairScopedCommand("claude --resume")).toBe("agentbridge claude --pair review --resume");
+  test("prefers the friendly name over the composite pairId", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "main-deadbeef";
+    process.env.AGENTBRIDGE_PAIR_NAME = "main";
+    expect(pairScopedCommand("codex")).toBe("agentbridge --pair main codex");
+  });
+
+  test("--pair precedes the subcommand's own extra args", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "review-1a2b3c4d";
+    process.env.AGENTBRIDGE_PAIR_NAME = "review";
+    expect(pairScopedCommand("claude --resume")).toBe("agentbridge --pair review claude --resume");
   });
 
   test("an empty-string AGENTBRIDGE_PAIR_ID is treated as unset (no --pair)", () => {
@@ -35,8 +48,8 @@ describe("pairScopedCommand", () => {
     expect(pairScopedCommand("codex")).toBe("agentbridge codex");
   });
 
-  test("a cwd-derived id (with a hash suffix) renders verbatim", () => {
+  test("falls back to the composite pairId when no friendly name is set", () => {
     process.env.AGENTBRIDGE_PAIR_ID = "myproj-1a2b3c4d";
-    expect(pairScopedCommand("codex")).toBe("agentbridge codex --pair myproj-1a2b3c4d");
+    expect(pairScopedCommand("codex")).toBe("agentbridge --pair myproj-1a2b3c4d codex");
   });
 });

--- a/src/unit-test/pair-registry.concurrency.test.ts
+++ b/src/unit-test/pair-registry.concurrency.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { readRegistry, resolvePair } from "../pair-registry";
+import { derivePairId, readRegistry, resolvePair } from "../pair-registry";
 
 // Absolute path to the module under test, so the throwaway child script can
 // import it regardless of where the OS drops the temp dir.
@@ -256,12 +256,13 @@ describe("pair-registry concurrency", () => {
 
     const resolved = await resolvePair(base, { pairFlag: "x", cwd, probePorts: false });
 
-    expect(resolved.pairId).toBe("x");
+    const expectedId = derivePairId(cwd, "x");
+    expect(resolved.pairId).toBe(expectedId);
     expect(resolved.slot).toBe(0);
     expect(resolved.ports.appPort).toBe(4500);
     // The lock must be released after the call returns.
     expect(existsSync(lockFile)).toBe(false);
-    expect(readRegistry(base).pairs.map((p) => p.pairId)).toContain("x");
+    expect(readRegistry(base).pairs.map((p) => p.pairId)).toContain(expectedId);
   });
 
   // A corrupt lock with pid:0 must be treated as dead (process.kill(0,0) targets
@@ -276,7 +277,7 @@ describe("pair-registry concurrency", () => {
     mkdirSync(cwd, { recursive: true });
 
     const resolved = await resolvePair(base, { pairFlag: "y", cwd, probePorts: false });
-    expect(resolved.pairId).toBe("y");
+    expect(resolved.pairId).toBe(derivePairId(cwd, "y"));
     expect(existsSync(join(pairsDir, ".registry.lock"))).toBe(false);
   });
 

--- a/src/unit-test/pair-registry.concurrency.test.ts
+++ b/src/unit-test/pair-registry.concurrency.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readRegistry, resolvePair } from "../pair-registry";
+
+// Absolute path to the module under test, so the throwaway child script can
+// import it regardless of where the OS drops the temp dir.
+const PAIR_REGISTRY_PATH = fileURLToPath(new URL("../pair-registry.ts", import.meta.url));
+
+const tempBases: string[] = [];
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "agentbridge-pair-conc-"));
+  tempBases.push(base);
+  return base;
+}
+
+afterEach(() => {
+  while (tempBases.length > 0) {
+    const base = tempBases.pop();
+    if (base) {
+      rmSync(base, { recursive: true, force: true });
+    }
+  }
+});
+
+interface ChildResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function waitForChild(child: ChildProcess, timeoutMs: number): Promise<ChildResult> {
+  return new Promise((resolve, reject) => {
+    const out: string[] = [];
+    const err: string[] = [];
+    let settled = false;
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {}
+    }, timeoutMs);
+
+    child.stdout?.on("data", (chunk) => out.push(chunk.toString()));
+    child.stderr?.on("data", (chunk) => err.push(chunk.toString()));
+
+    child.once("error", (e) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(e);
+    });
+
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (timedOut) {
+        reject(new Error(`Child timed out after ${timeoutMs}ms\nstdout: ${out.join("")}\nstderr: ${err.join("")}`));
+        return;
+      }
+      resolve({ code, stdout: out.join(""), stderr: err.join("") });
+    });
+  });
+}
+
+/**
+ * Throwaway script run by an independent `bun` process. It calls resolvePair
+ * against the shared base and prints the resolved slot. A port-probe failure
+ * (PAIR_PORTS_BUSY) is caught and reported with the slot that *was* allocated
+ * in the registry, so the test can distinguish "allocation collided" (a real
+ * bug) from "a real daemon already squats the probed port" (environmental).
+ */
+function buildChildScript(): string {
+  // JSON.stringify the import path so backslashes / quotes survive embedding.
+  const importPath = JSON.stringify(PAIR_REGISTRY_PATH);
+  return `import { resolvePair, PairError } from ${importPath};
+
+const base = process.env.PAIR_BASE;
+const pairFlag = process.argv[2];
+const cwd = process.argv[3];
+
+if (!base) {
+  console.error("PAIR_BASE env is required");
+  process.exit(2);
+}
+
+try {
+  // probePorts:false — this test exercises pure slot-allocation mutual
+  // exclusion, not port binding, so it must not depend on which ports happen
+  // to be free on the host (a real local daemon may squat 4500-4502).
+  const resolved = await resolvePair(base, { pairFlag, cwd, probePorts: false });
+  process.stdout.write(JSON.stringify({ slot: resolved.slot, pairId: resolved.pairId }));
+  process.exit(0);
+} catch (err) {
+  if (err instanceof PairError) {
+    const slot = typeof err.details?.slot === "number" ? err.details.slot : null;
+    process.stdout.write(JSON.stringify({ slot, error: err.code }));
+    // Exit 0 even on PairError: the test inspects parsed stdout, and the
+    // registry (read by the parent) is the source of truth for allocation.
+    process.exit(0);
+  }
+  console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+  process.exit(3);
+}
+`;
+}
+
+interface ChildOutput {
+  slot: number | null;
+  pairId?: string;
+  error?: string;
+}
+
+describe("pair-registry concurrency", () => {
+  test(
+    "parallel independent processes never collide on a slot",
+    async () => {
+      const base = makeBase();
+      const scriptPath = join(base, "resolve-pair-child.ts");
+      writeFileSync(scriptPath, buildChildScript(), "utf-8");
+
+      const CHILD_COUNT = 8;
+      // Distinct deterministic pair ids => each child is a distinct pair and
+      // must therefore receive a distinct slot.
+      const children: ChildProcess[] = [];
+      for (let i = 0; i < CHILD_COUNT; i++) {
+        const childCwd = join(base, `proj-${i}`);
+        mkdirSync(childCwd, { recursive: true });
+        // Spawn ALL at once — do NOT await between spawns — to actually
+        // exercise the cross-process lock under contention.
+        children.push(
+          spawn(process.execPath, ["run", scriptPath, `p${i}`, childCwd], {
+            cwd: base,
+            env: { ...process.env, PAIR_BASE: base },
+            stdio: ["ignore", "pipe", "pipe"],
+          }),
+        );
+      }
+
+      const results = await Promise.all(children.map((c) => waitForChild(c, 25000)));
+
+      // All children exited cleanly (PairError is caught and exits 0 in the script).
+      for (let i = 0; i < results.length; i++) {
+        const r = results[i]!;
+        expect(r.code, `child p${i} exit code (stderr: ${r.stderr})`).toBe(0);
+      }
+
+      const outputs: ChildOutput[] = results.map((r, i) => {
+        try {
+          return JSON.parse(r.stdout.trim()) as ChildOutput;
+        } catch {
+          throw new Error(`child p${i} produced unparseable stdout: ${JSON.stringify(r.stdout)}`);
+        }
+      });
+
+      // Only PAIR_PORTS_BUSY is environmentally tolerated (a real daemon may
+      // already squat slot-0's ports 4500-4502 on a dev machine). Any other
+      // PairError code is a real failure — surface it loudly.
+      const errored = outputs.filter((o) => o.error !== undefined);
+      for (let i = 0; i < outputs.length; i++) {
+        const o = outputs[i]!;
+        if (o.error !== undefined) {
+          expect(
+            o.error,
+            `child p${i} returned an unexpected error code: ${JSON.stringify(o)}`,
+          ).toBe("PAIR_PORTS_BUSY");
+        }
+      }
+
+      // ===== THE CRITICAL CORRECTNESS PROPERTY =====
+      // Each child's *returned* slot is the authoritative record of what the
+      // allocator assigned it (captured at return, before any later writer can
+      // clobber the on-disk registry). 8 distinct pairs MUST receive 8 DISTINCT
+      // slots. Two children sharing a slot means two pairs would bind the same
+      // port triple — a real cross-process-lock failure. We assert on the child
+      // return values (not the on-disk registry) because a lost-write race can
+      // hide a duplicate-allocation by clobbering one of the colliding entries,
+      // making the registry *look* clean while the collision really happened.
+      const childSlots = outputs
+        .map((o) => o.slot)
+        .filter((s): s is number => typeof s === "number");
+
+      // Every child resolved to a numeric slot (busy children still report the
+      // slot they were allocated via PairError.details.slot).
+      expect(
+        childSlots.length,
+        `every child must report an allocated slot. outputs: ${JSON.stringify(outputs)}`,
+      ).toBe(CHILD_COUNT);
+
+      const sortedChildSlots = [...childSlots].sort((a, b) => a - b);
+      expect(
+        new Set(childSlots).size,
+        `SLOT COLLISION — two independent processes were assigned the SAME slot. ` +
+          `This is a real cross-process-lock bug (mutual exclusion failed). ` +
+          `assigned slots: ${JSON.stringify(sortedChildSlots)}`,
+      ).toBe(CHILD_COUNT);
+
+      // With no collision, the 8 distinct slots are exactly {0..7}.
+      expect(
+        sortedChildSlots,
+        `assigned slots must be exactly 0..7. got: ${JSON.stringify(sortedChildSlots)}`,
+      ).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+
+      // ===== Registry consistency (secondary) =====
+      // The on-disk registry is the persisted view of allocation. In the
+      // absence of any lock race it should hold all 8 entries with slots
+      // {0..7}. We assert NO DUPLICATE slot in the registry (a duplicate here
+      // would be an even more severe corruption than a lost write). The exact
+      // entry count is verified above via child return values; if the registry
+      // holds fewer than CHILD_COUNT entries that indicates a lost-write race
+      // (entries silently clobbered), so we surface it as an explicit failure
+      // rather than masking it.
+      const reg = readRegistry(base);
+      const registrySlots = reg.pairs.map((p) => p.slot);
+      expect(
+        new Set(registrySlots).size,
+        `DUPLICATE SLOT persisted in registry — registry corruption. ` +
+          `pairs: ${JSON.stringify(reg.pairs)}`,
+      ).toBe(registrySlots.length);
+      expect(
+        reg.pairs.length,
+        `registry lost entries (lost-write race under the registry lock). ` +
+          `expected ${CHILD_COUNT}, got ${reg.pairs.length}. pairs: ${JSON.stringify(reg.pairs)}`,
+      ).toBe(CHILD_COUNT);
+
+      // Sanity: errored children, if any, were only the slot-0 port squatter.
+      for (const e of errored) {
+        expect(e.slot === null || typeof e.slot === "number").toBe(true);
+      }
+    },
+    30000,
+  );
+
+  // The lock is a FILE (created via temp + linkSync), not a directory. Seeding a
+  // file with a DEAD owner pid exercises the dead-pid reclaim branch specifically
+  // (not the orphan-grace fallback).
+  test("reclaims a stale lock held by a DEAD owner pid and succeeds", async () => {
+    const base = makeBase();
+    const pairsDir = join(base, "pairs");
+    mkdirSync(pairsDir, { recursive: true });
+    const lockFile = join(pairsDir, ".registry.lock");
+    // 2147483646 is effectively never a live pid → dead-pid reclaim.
+    writeFileSync(lockFile, JSON.stringify({ pid: 2147483646, createdAt: 0, nonce: "stale-owner" }), "utf-8");
+
+    const cwd = join(base, "stale-proj");
+    mkdirSync(cwd, { recursive: true });
+
+    const resolved = await resolvePair(base, { pairFlag: "x", cwd, probePorts: false });
+
+    expect(resolved.pairId).toBe("x");
+    expect(resolved.slot).toBe(0);
+    expect(resolved.ports.appPort).toBe(4500);
+    // The lock must be released after the call returns.
+    expect(existsSync(lockFile)).toBe(false);
+    expect(readRegistry(base).pairs.map((p) => p.pairId)).toContain("x");
+  });
+
+  // A corrupt lock with pid:0 must be treated as dead (process.kill(0,0) targets
+  // the process GROUP and would otherwise falsely look "alive" → deadlock).
+  test("reclaims a corrupt lock with pid:0 instead of deadlocking", async () => {
+    const base = makeBase();
+    const pairsDir = join(base, "pairs");
+    mkdirSync(pairsDir, { recursive: true });
+    writeFileSync(join(pairsDir, ".registry.lock"), JSON.stringify({ pid: 0, createdAt: 0, nonce: "bad" }), "utf-8");
+
+    const cwd = join(base, "pid0-proj");
+    mkdirSync(cwd, { recursive: true });
+
+    const resolved = await resolvePair(base, { pairFlag: "y", cwd, probePorts: false });
+    expect(resolved.pairId).toBe("y");
+    expect(existsSync(join(pairsDir, ".registry.lock"))).toBe(false);
+  });
+
+  test("same cwd resolves idempotently to one slot / one registry entry", async () => {
+    const base = makeBase();
+    const cwd = join(base, "same-proj");
+    mkdirSync(cwd, { recursive: true });
+
+    const first = await resolvePair(base, { cwd, probePorts: false });
+    const second = await resolvePair(base, { cwd, probePorts: false });
+
+    expect(second.slot).toBe(first.slot);
+    expect(second.pairId).toBe(first.pairId);
+
+    const reg = readRegistry(base);
+    expect(reg.pairs.length).toBe(1);
+    expect(reg.pairs[0]?.pairId).toBe(first.pairId);
+  });
+
+  // Regression for the round-2 finding: a PRE-EXISTING dead lock + many concurrent
+  // acquirers previously let two reclaimers evict each other's fresh lock and enter
+  // the critical section together (duplicate slot). The serialized reclaim lock must
+  // make the dead lock reclaimed exactly once with NO slot collision.
+  test(
+    "concurrent acquirers with a seeded DEAD lock never collide on a slot",
+    async () => {
+      const base = makeBase();
+      const pairsDir = join(base, "pairs");
+      mkdirSync(pairsDir, { recursive: true });
+      // Seed a stale primary lock held by a dead pid — forces the reclaim path.
+      writeFileSync(
+        join(pairsDir, ".registry.lock"),
+        JSON.stringify({ pid: 2147483646, createdAt: 0, nonce: "dead-seed" }),
+        "utf-8",
+      );
+
+      const scriptPath = join(base, "resolve-pair-child.ts");
+      writeFileSync(scriptPath, buildChildScript(), "utf-8");
+
+      const CHILD_COUNT = 8;
+      const children: ChildProcess[] = [];
+      for (let i = 0; i < CHILD_COUNT; i++) {
+        const childCwd = join(base, `dproj-${i}`);
+        mkdirSync(childCwd, { recursive: true });
+        children.push(
+          spawn(process.execPath, ["run", scriptPath, `d${i}`, childCwd], {
+            cwd: base,
+            env: { ...process.env, PAIR_BASE: base },
+            stdio: ["ignore", "pipe", "pipe"],
+          }),
+        );
+      }
+
+      const results = await Promise.all(children.map((c) => waitForChild(c, 25000)));
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i]!.code, `child d${i} (stderr: ${results[i]!.stderr})`).toBe(0);
+      }
+
+      const slots = results
+        .map((r) => (JSON.parse(r.stdout.trim()) as ChildOutput).slot)
+        .filter((s): s is number => typeof s === "number");
+
+      expect(slots.length, `outputs: ${JSON.stringify(results.map((r) => r.stdout))}`).toBe(CHILD_COUNT);
+      expect(
+        new Set(slots).size,
+        `SLOT COLLISION under dead-lock reclaim — got ${JSON.stringify([...slots].sort((a, b) => a - b))}`,
+      ).toBe(CHILD_COUNT);
+
+      // Registry is the persisted truth: 8 entries, no duplicate slot, dead lock gone.
+      const reg = readRegistry(base);
+      expect(reg.pairs.length).toBe(CHILD_COUNT);
+      expect(new Set(reg.pairs.map((p) => p.slot)).size).toBe(CHILD_COUNT);
+      expect(existsSync(join(pairsDir, ".registry.lock"))).toBe(false);
+    },
+    30000,
+  );
+});

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -437,6 +437,107 @@ describe("resolvePair", () => {
       rmSync(tmpB, { recursive: true, force: true });
     }
   });
+
+  // --- raw-pairId fallback: the double-hash strand fix ---
+  // A launch must reuse a pair when the flag IS an already-registered pairId,
+  // mirroring findPairForFlag() (used by kill/pairs). All these resolves hit an
+  // existing entry (no probe) or pass probePorts:false, so they never flake on
+  // ports. Reuse/precedence cases seed non-zero slots; the one allocation case
+  // seeds slot 0 so the new pair lands on slot 1, avoiding the slot-0
+  // detectLegacyRootDaemon path on a dev machine.
+
+  test("--pair <an already-registered pairId> reuses that pair, no double-hash allocation", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-raw-A-"));
+    try {
+      const pairId = derivePairId(tmpA, DEFAULT_PAIR_NAME); // e.g. "main-<hashA>"
+      writeRegistry(base, {
+        version: 1,
+        pairs: [{ pairId, slot: 5, cwd: tmpA, name: DEFAULT_PAIR_NAME, source: "cwd", createdAt: "2026-01-01T00:00:00.000Z" }],
+      });
+      const resolved = await resolvePair(base, { pairFlag: pairId, cwd: tmpA, probePorts: false });
+
+      expect(readRegistry(base).pairs).toHaveLength(1); // NO second double-hashed entry
+      expect(resolved.pairId).toBe(pairId);
+      expect(resolved.slot).toBe(5);
+      expect(resolved.warning).toBeUndefined(); // same cwd → unremarkable reuse
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
+
+  test("a current-cwd scoped name wins over a same-string raw pairId", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-prec-A-"));
+    try {
+      const flag = "foo-1a2b3c4d"; // itself shaped like a pairId
+      const scopedId = derivePairId(tmpA, flag); // "foo-1a2b3c4d-<hash>"
+      expect(scopedId).not.toBe(flag);
+      writeRegistry(base, {
+        version: 1,
+        pairs: [
+          { pairId: scopedId, slot: 2, cwd: tmpA, name: flag, source: "flag", createdAt: "2026-01-01T00:00:00.000Z" },
+          { pairId: flag, slot: 7, cwd: tmpA, name: "foo", source: "cwd", createdAt: "2026-01-01T00:00:00.000Z" },
+        ],
+      });
+      const resolved = await resolvePair(base, { pairFlag: flag, cwd: tmpA, probePorts: false });
+      // Scoped (name+cwd) match has priority over the raw pairId entry.
+      expect(resolved.pairId).toBe(scopedId);
+      expect(resolved.slot).toBe(2);
+      expect(readRegistry(base).pairs).toHaveLength(2); // nothing allocated
+      expect(resolved.warning).toBeUndefined();
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
+
+  test("a cross-cwd raw pairId match reuses the pair AND warns", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-xcwd-A-"));
+    const tmpB = mkdtempSync(join(tmpdir(), "abg-pair-xcwd-B-"));
+    try {
+      const pairId = derivePairId(tmpA, DEFAULT_PAIR_NAME);
+      writeRegistry(base, {
+        version: 1,
+        pairs: [{ pairId, slot: 6, cwd: tmpA, name: DEFAULT_PAIR_NAME, source: "cwd", createdAt: "2026-01-01T00:00:00.000Z" }],
+      });
+      // Resolve the SAME pairId from a DIFFERENT directory.
+      const resolved = await resolvePair(base, { pairFlag: pairId, cwd: tmpB, probePorts: false });
+
+      expect(resolved.pairId).toBe(pairId);
+      expect(resolved.slot).toBe(6); // reused, not reallocated
+      expect(readRegistry(base).pairs).toHaveLength(1);
+      expect(resolved.warning).toBeDefined();
+      expect(resolved.warning!).toContain(tmpA); // the pair's home cwd
+      expect(resolved.warning!).toContain(tmpB); // where the user actually is
+      // Guard the flag→text spacing (a replace_all once ate this space).
+      expect(resolved.warning!).toContain(`--pair ${pairId} matched`);
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+      rmSync(tmpB, { recursive: true, force: true });
+    }
+  });
+
+  test("a pairId-shaped flag matching nothing allocates a new pair WITH a warning", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-ghost-A-"));
+    try {
+      // Seed slot 0 so the new pair lands on slot 1 (skips the slot-0 legacy probe).
+      writeRegistry(base, {
+        version: 1,
+        pairs: [{ pairId: "occupied-00000000", slot: 0, cwd: "/occupied", name: "occupied", source: "cwd", createdAt: "2026-01-01T00:00:00.000Z" }],
+      });
+      const flag = "ghost-1a2b3c4d"; // looks like a pairId, but unregistered
+      const resolved = await resolvePair(base, { pairFlag: flag, cwd: tmpA, probePorts: false });
+
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(2); // occupied + the newly created pair
+      const created = reg.pairs.find((p) => p.pairId === derivePairId(tmpA, flag));
+      expect(created).toBeDefined();
+      expect(created!.slot).toBe(1);
+      expect(resolved.warning).toBeDefined();
+      // Assert the full flag→text fragment incl. the space, to catch spacing regressions.
+      expect(resolved.warning!).toContain(`--pair ${flag} looks like a full pair id`);
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("removePairEntry", () => {

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -13,6 +13,8 @@ import { createServer, type Server } from "node:net";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  DEFAULT_PAIR_NAME,
+  derivePairId,
   derivePairIdFromCwd,
   detectLegacyRootDaemon,
   MAX_PAIR_SLOT,
@@ -322,10 +324,11 @@ describe("resolvePair", () => {
     }
   }
 
-  test("fresh base + cwd -> slot 0, ports 4500/4501/4502, stateDir ends with pairId, 1 entry", async () => {
+  test("fresh base + cwd -> slot 0, default name 'main', stateDir ends with pairId, 1 entry", async () => {
     const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
     try {
-      const expectedId = derivePairIdFromCwd(tmpA);
+      // No flag → default name "main", scoped to this cwd.
+      const expectedId = derivePairId(tmpA, DEFAULT_PAIR_NAME);
       const r = await resolveTolerant(tmpA);
 
       // Allocation must have happened regardless of probe result.
@@ -333,11 +336,13 @@ describe("resolvePair", () => {
       expect(reg.pairs).toHaveLength(1);
       expect(reg.pairs[0]!.slot).toBe(0);
       expect(reg.pairs[0]!.pairId).toBe(expectedId);
+      expect(reg.pairs[0]!.name).toBe(DEFAULT_PAIR_NAME);
       expect(reg.pairs[0]!.source).toBe("cwd");
 
       if (r.ok) {
         expect(r.resolved.slot).toBe(0);
         expect(r.resolved.pairId).toBe(expectedId);
+        expect(r.resolved.name).toBe(DEFAULT_PAIR_NAME);
         expect(r.resolved.ports).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
         expect(r.resolved.stateDir.endsWith(expectedId)).toBe(true);
       } else {
@@ -352,7 +357,7 @@ describe("resolvePair", () => {
   test("calling again with the SAME cwd is idempotent (same pairId/slot, still 1 entry)", async () => {
     const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
     try {
-      const expectedId = derivePairIdFromCwd(tmpA);
+      const expectedId = derivePairId(tmpA, DEFAULT_PAIR_NAME);
       await resolveTolerant(tmpA);
       await resolveTolerant(tmpA);
 
@@ -365,12 +370,14 @@ describe("resolvePair", () => {
     }
   });
 
-  test("a second distinct cwd allocates slot 1", async () => {
+  test("a second distinct cwd allocates slot 1 (same default name, different dir = different pair)", async () => {
     const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
     const tmpB = mkdtempSync(join(tmpdir(), "abg-pair-cwd-B-"));
     try {
-      const idA = derivePairIdFromCwd(tmpA);
-      const idB = derivePairIdFromCwd(tmpB);
+      const idA = derivePairId(tmpA, DEFAULT_PAIR_NAME);
+      const idB = derivePairId(tmpB, DEFAULT_PAIR_NAME);
+      // Same friendly name "main", different directories → distinct ids.
+      expect(idA).not.toBe(idB);
       await resolveTolerant(tmpA);
       const rB = await resolveTolerant(tmpB);
 
@@ -395,19 +402,39 @@ describe("resolvePair", () => {
     }
   });
 
-  test("explicit pairFlag uses that name verbatim", async () => {
+  test("explicit pairFlag scopes the name to the cwd (id = name + cwd hash)", async () => {
     const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
     try {
+      const expectedId = derivePairId(tmpA, "myname");
       const r = await resolveTolerant(tmpA, "myname");
       const reg = readRegistry(base);
       expect(reg.pairs).toHaveLength(1);
-      expect(reg.pairs[0]!.pairId).toBe("myname");
+      expect(reg.pairs[0]!.pairId).toBe(expectedId);
+      expect(reg.pairs[0]!.name).toBe("myname");
       expect(reg.pairs[0]!.source).toBe("flag");
       if (r.ok) {
-        expect(r.resolved.pairId).toBe("myname");
+        expect(r.resolved.pairId).toBe(expectedId);
+        expect(r.resolved.name).toBe("myname");
       }
     } finally {
       rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
+
+  test("the same name in two directories resolves to two distinct pairs", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-same-A-"));
+    const tmpB = mkdtempSync(join(tmpdir(), "abg-pair-same-B-"));
+    try {
+      await resolveTolerant(tmpA, "work");
+      await resolveTolerant(tmpB, "work");
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(2);
+      expect(reg.pairs[0]!.pairId).not.toBe(reg.pairs[1]!.pairId);
+      // Both carry the same friendly name though.
+      expect(reg.pairs.every((p) => p.name === "work")).toBe(true);
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+      rmSync(tmpB, { recursive: true, force: true });
     }
   });
 });
@@ -471,12 +498,16 @@ describe("cross-review regression fixes", () => {
 
   test("#3 case-insensitive match returns the registry's canonical pairId/state dir", async () => {
     const base = tmpBase();
-    writeRegistry(base, { version: 1, pairs: [entry(0, "Foo")] });
-    // Resolve with different casing — must canonicalize to "Foo", not "foo".
+    // The composite id is name-scoped to the cwd; seed the canonical (mixed-case)
+    // id for name "Foo" in /tmp/x, then resolve --pair foo from the SAME cwd.
+    const canonicalId = derivePairId("/tmp/x", "Foo");
+    writeRegistry(base, { version: 1, pairs: [entry(0, canonicalId)] });
+    // Resolve with different casing — must canonicalize to the seeded id, not the
+    // lowercased "foo-<hash>" variant.
     const r = await resolvePair(base, { pairFlag: "foo", cwd: "/tmp/x", probePorts: false });
-    expect(r.pairId).toBe("Foo");
+    expect(r.pairId).toBe(canonicalId);
     expect(r.slot).toBe(0);
-    expect(r.stateDir).toBe(join(base, "pairs", "Foo"));
+    expect(r.stateDir).toBe(join(base, "pairs", canonicalId));
   });
 
   test("#5 slot exhaustion throws WITHOUT persisting an invalid entry", async () => {

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -1,0 +1,540 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, type Server } from "node:net";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  derivePairIdFromCwd,
+  detectLegacyRootDaemon,
+  MAX_PAIR_SLOT,
+  PairError,
+  pickLowestFreeSlot,
+  portsForSlot,
+  probePortFree,
+  readRegistry,
+  removePairEntry,
+  resolvePair,
+  validatePairId,
+  writeRegistry,
+  type PairEntry,
+  type RegistryFile,
+} from "../pair-registry";
+
+// Helper: build a minimal PairEntry with a given slot (other fields are
+// irrelevant for slot-allocation logic).
+function entry(slot: number, pairId = `p${slot}`): PairEntry {
+  return {
+    pairId,
+    slot,
+    cwd: `/tmp/${pairId}`,
+    source: "cwd",
+    createdAt: new Date().toISOString(),
+  };
+}
+
+// Helper: bind a TCP port on 127.0.0.1 and resolve once listening.
+function bindPort(port: number): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("portsForSlot", () => {
+  test("slot 0 maps to the classic 4500/4501/4502 triple", () => {
+    expect(portsForSlot(0)).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
+  });
+
+  test("slot 1 maps to 4510/4511/4512", () => {
+    expect(portsForSlot(1)).toEqual({ appPort: 4510, proxyPort: 4511, controlPort: 4512 });
+  });
+
+  test("slot 3 maps to 4530/4531/4532", () => {
+    expect(portsForSlot(3)).toEqual({ appPort: 4530, proxyPort: 4531, controlPort: 4532 });
+  });
+
+  test("negative slot throws PairError", () => {
+    expect(() => portsForSlot(-1)).toThrow(PairError);
+  });
+
+  test("non-integer slot throws PairError", () => {
+    expect(() => portsForSlot(1.5)).toThrow(PairError);
+  });
+
+  test("the thrown error is a PairError (slot guard reuses PAIR_ID_INVALID code)", () => {
+    try {
+      portsForSlot(-1);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      // NOTE: the source reuses code "PAIR_ID_INVALID" for invalid slots
+      // (there is no dedicated slot code). Asserting the actual behavior.
+      expect((err as PairError).code).toBe("PAIR_ID_INVALID");
+    }
+  });
+});
+
+describe("pickLowestFreeSlot", () => {
+  test("empty set returns 0", () => {
+    expect(pickLowestFreeSlot([])).toBe(0);
+  });
+
+  test("slot 0 used returns 1", () => {
+    expect(pickLowestFreeSlot([entry(0)])).toBe(1);
+  });
+
+  test("slots {0,2} used fills the gap -> 1 (not 3)", () => {
+    expect(pickLowestFreeSlot([entry(0), entry(2)])).toBe(1);
+  });
+
+  test("slots {1,2} used returns 0", () => {
+    expect(pickLowestFreeSlot([entry(1), entry(2)])).toBe(0);
+  });
+});
+
+describe("validatePairId", () => {
+  test.each(["foo", "foo-bar_1.2", "A1"])("accepts valid id %p", (id) => {
+    expect(validatePairId(id)).toBe(id);
+  });
+
+  test.each(["..", ".", "a/b", "a b", "", "foo/../bar"])(
+    "throws PAIR_ID_INVALID for %p",
+    (bad) => {
+      try {
+        validatePairId(bad);
+        throw new Error(`expected throw for ${JSON.stringify(bad)}`);
+      } catch (err) {
+        expect(err).toBeInstanceOf(PairError);
+        expect((err as PairError).code).toBe("PAIR_ID_INVALID");
+      }
+    },
+  );
+
+  test("throws PAIR_ID_INVALID for a 65-char string", () => {
+    const tooLong = "a".repeat(65);
+    try {
+      validatePairId(tooLong);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      expect((err as PairError).code).toBe("PAIR_ID_INVALID");
+    }
+  });
+
+  test("accepts a 64-char string (boundary)", () => {
+    const ok = "a".repeat(64);
+    expect(validatePairId(ok)).toBe(ok);
+  });
+});
+
+describe("derivePairIdFromCwd", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("is stable for the same path (two calls are equal)", () => {
+    const a = derivePairIdFromCwd(base);
+    const b = derivePairIdFromCwd(base);
+    expect(a).toBe(b);
+  });
+
+  test("two different paths produce different ids", () => {
+    const dirA = mkdtempSync(join(tmpdir(), "abg-pair-test-A-"));
+    const dirB = mkdtempSync(join(tmpdir(), "abg-pair-test-B-"));
+    try {
+      expect(derivePairIdFromCwd(dirA)).not.toBe(derivePairIdFromCwd(dirB));
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  test("result always passes validatePairId without throwing", () => {
+    const id = derivePairIdFromCwd(base);
+    expect(() => validatePairId(id)).not.toThrow();
+    expect(validatePairId(id)).toBe(id);
+  });
+
+  test("resolves symlinks: a symlink to a dir yields the same id as the real dir", () => {
+    const realDir = mkdtempSync(join(tmpdir(), "abg-pair-test-real-"));
+    const linkPath = join(base, "link-to-real");
+    try {
+      symlinkSync(realDir, linkPath);
+      // Confirm the symlink actually points at the real dir.
+      expect(realpathSync(linkPath)).toBe(realpathSync(realDir));
+      expect(derivePairIdFromCwd(linkPath)).toBe(derivePairIdFromCwd(realDir));
+    } finally {
+      rmSync(realDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("readRegistry / writeRegistry", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("missing file returns an empty registry", () => {
+    expect(readRegistry(base)).toEqual({ version: 1, pairs: [] });
+  });
+
+  test("round-trips a registry with 2 entries", () => {
+    const reg: RegistryFile = { version: 1, pairs: [entry(0, "alpha"), entry(1, "beta")] };
+    writeRegistry(base, reg);
+    expect(readRegistry(base)).toEqual(reg);
+  });
+
+  test("corrupt JSON throws PAIR_REGISTRY_CORRUPT", () => {
+    // Seed a valid registry first so the pairs dir exists, then clobber the file.
+    writeRegistry(base, { version: 1, pairs: [] });
+    const regPath = join(base, "pairs", "registry.json");
+    writeFileSync(regPath, "{ not valid json ");
+    try {
+      readRegistry(base);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      expect((err as PairError).code).toBe("PAIR_REGISTRY_CORRUPT");
+    }
+  });
+
+  test("wrong shape ({version:2}) throws PAIR_REGISTRY_CORRUPT", () => {
+    writeRegistry(base, { version: 1, pairs: [] });
+    const regPath = join(base, "pairs", "registry.json");
+    writeFileSync(regPath, JSON.stringify({ version: 2 }));
+    try {
+      readRegistry(base);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      expect((err as PairError).code).toBe("PAIR_REGISTRY_CORRUPT");
+    }
+  });
+
+  test("no leftover *.tmp.* files remain after writeRegistry", () => {
+    writeRegistry(base, { version: 1, pairs: [entry(0)] });
+    const files = readdirSync(join(base, "pairs"));
+    const tmpFiles = files.filter((f) => f.includes(".tmp."));
+    expect(tmpFiles).toEqual([]);
+  });
+});
+
+describe("probePortFree", () => {
+  // Use a high port unlikely to collide; bind it to confirm busy detection.
+  const probePort = 47213;
+
+  test("a freshly chosen high port is free", async () => {
+    expect(await probePortFree(probePort)).toBe(true);
+  });
+
+  test("a bound port reports as not free, and frees up after close", async () => {
+    const server = await bindPort(probePort);
+    try {
+      expect(await probePortFree(probePort)).toBe(false);
+    } finally {
+      await closeServer(server);
+    }
+    // After close the port is free again.
+    expect(await probePortFree(probePort)).toBe(true);
+  });
+});
+
+describe("detectLegacyRootDaemon", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("empty base returns null", () => {
+    expect(detectLegacyRootDaemon(base)).toBeNull();
+  });
+
+  test("daemon.pid with a definitely-dead pid returns null", () => {
+    writeFileSync(join(base, "daemon.pid"), "2147483646");
+    expect(detectLegacyRootDaemon(base)).toBeNull();
+  });
+});
+
+describe("resolvePair", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  // resolvePair probes the slot's ports AFTER releasing the lock. Slot 0 maps
+  // to 4500/4501/4502, which may be occupied by a real dev-machine daemon — in
+  // that case resolvePair throws PAIR_PORTS_BUSY. The registry/slot allocation
+  // happens under the lock BEFORE probing, so allocation is durable regardless
+  // of the probe outcome. These helpers assert allocation via the registry and
+  // tolerate a PAIR_PORTS_BUSY thrown by the port probe.
+
+  // Run resolvePair, returning either the resolved pair or the PairError it
+  // threw. Re-throws anything that is not a PAIR_PORTS_BUSY PairError so real
+  // failures still surface.
+  async function resolveTolerant(
+    cwd: string,
+    pairFlag?: string,
+  ): Promise<{ ok: true; resolved: Awaited<ReturnType<typeof resolvePair>> } | { ok: false; busy: PairError }> {
+    try {
+      const resolved = await resolvePair(base, pairFlag ? { pairFlag, cwd } : { cwd });
+      return { ok: true, resolved };
+    } catch (err) {
+      if (err instanceof PairError && err.code === "PAIR_PORTS_BUSY") {
+        return { ok: false, busy: err };
+      }
+      throw err;
+    }
+  }
+
+  test("fresh base + cwd -> slot 0, ports 4500/4501/4502, stateDir ends with pairId, 1 entry", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
+    try {
+      const expectedId = derivePairIdFromCwd(tmpA);
+      const r = await resolveTolerant(tmpA);
+
+      // Allocation must have happened regardless of probe result.
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(1);
+      expect(reg.pairs[0]!.slot).toBe(0);
+      expect(reg.pairs[0]!.pairId).toBe(expectedId);
+      expect(reg.pairs[0]!.source).toBe("cwd");
+
+      if (r.ok) {
+        expect(r.resolved.slot).toBe(0);
+        expect(r.resolved.pairId).toBe(expectedId);
+        expect(r.resolved.ports).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
+        expect(r.resolved.stateDir.endsWith(expectedId)).toBe(true);
+      } else {
+        // Ports 4500-4502 busy on this machine; allocation still correct.
+        expect(r.busy.details?.slot).toBe(0);
+      }
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
+
+  test("calling again with the SAME cwd is idempotent (same pairId/slot, still 1 entry)", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
+    try {
+      const expectedId = derivePairIdFromCwd(tmpA);
+      await resolveTolerant(tmpA);
+      await resolveTolerant(tmpA);
+
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(1);
+      expect(reg.pairs[0]!.slot).toBe(0);
+      expect(reg.pairs[0]!.pairId).toBe(expectedId);
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
+
+  test("a second distinct cwd allocates slot 1", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
+    const tmpB = mkdtempSync(join(tmpdir(), "abg-pair-cwd-B-"));
+    try {
+      const idA = derivePairIdFromCwd(tmpA);
+      const idB = derivePairIdFromCwd(tmpB);
+      await resolveTolerant(tmpA);
+      const rB = await resolveTolerant(tmpB);
+
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(2);
+      const entryA = reg.pairs.find((p) => p.pairId === idA)!;
+      const entryB = reg.pairs.find((p) => p.pairId === idB)!;
+      expect(entryA.slot).toBe(0);
+      expect(entryB.slot).toBe(1);
+
+      // Slot 1 ports are 4510-4512, almost certainly free on a dev machine, so
+      // this resolve normally succeeds — but stay tolerant just in case.
+      if (rB.ok) {
+        expect(rB.resolved.slot).toBe(1);
+        expect(rB.resolved.ports).toEqual({ appPort: 4510, proxyPort: 4511, controlPort: 4512 });
+      } else {
+        expect(rB.busy.details?.slot).toBe(1);
+      }
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+      rmSync(tmpB, { recursive: true, force: true });
+    }
+  });
+
+  test("explicit pairFlag uses that name verbatim", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-cwd-A-"));
+    try {
+      const r = await resolveTolerant(tmpA, "myname");
+      const reg = readRegistry(base);
+      expect(reg.pairs).toHaveLength(1);
+      expect(reg.pairs[0]!.pairId).toBe("myname");
+      expect(reg.pairs[0]!.source).toBe("flag");
+      if (r.ok) {
+        expect(r.resolved.pairId).toBe("myname");
+      }
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("removePairEntry", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  // Drive allocation through the registry directly (writeRegistry) so the test
+  // is independent of port-probe outcome for slot 0. removePairEntry only
+  // touches the registry under the lock, never probes ports.
+  test("removes the slot-0 entry and returns it; a new cwd then reuses slot 0", async () => {
+    const idA = derivePairIdFromCwd("/tmp/projectA");
+    const idB = derivePairIdFromCwd("/tmp/projectB");
+    writeRegistry(base, {
+      version: 1,
+      pairs: [
+        { pairId: idA, slot: 0, cwd: "/tmp/projectA", source: "cwd", createdAt: new Date().toISOString() },
+        { pairId: idB, slot: 1, cwd: "/tmp/projectB", source: "cwd", createdAt: new Date().toISOString() },
+      ],
+    });
+
+    const removed = await removePairEntry(base, idA);
+    expect(removed).not.toBeNull();
+    expect(removed!.slot).toBe(0);
+    expect(removed!.pairId).toBe(idA);
+
+    // Slot 0 is now free; the lowest-free-slot logic should hand it to a new pair.
+    const reg = readRegistry(base);
+    expect(reg.pairs.map((p) => p.slot).sort()).toEqual([1]);
+    expect(pickLowestFreeSlot(reg.pairs)).toBe(0);
+  });
+
+  test("removing a non-existent pair returns null", async () => {
+    writeRegistry(base, { version: 1, pairs: [] });
+    expect(await removePairEntry(base, "nope")).toBeNull();
+  });
+});
+
+// Regression coverage for the cross-review round-1 fixes.
+describe("cross-review regression fixes", () => {
+  const bases: string[] = [];
+  afterEach(() => {
+    while (bases.length > 0) {
+      const b = bases.pop();
+      if (b) rmSync(b, { recursive: true, force: true });
+    }
+  });
+  function tmpBase(): string {
+    const b = mkdtempSync(join(tmpdir(), "abg-rgr-"));
+    bases.push(b);
+    return b;
+  }
+
+  test("#3 case-insensitive match returns the registry's canonical pairId/state dir", async () => {
+    const base = tmpBase();
+    writeRegistry(base, { version: 1, pairs: [entry(0, "Foo")] });
+    // Resolve with different casing — must canonicalize to "Foo", not "foo".
+    const r = await resolvePair(base, { pairFlag: "foo", cwd: "/tmp/x", probePorts: false });
+    expect(r.pairId).toBe("Foo");
+    expect(r.slot).toBe(0);
+    expect(r.stateDir).toBe(join(base, "pairs", "Foo"));
+  });
+
+  test("#5 slot exhaustion throws WITHOUT persisting an invalid entry", async () => {
+    const base = tmpBase();
+    const full: PairEntry[] = [];
+    for (let s = 0; s <= MAX_PAIR_SLOT; s++) full.push(entry(s, `p${s}`));
+    writeRegistry(base, { version: 1, pairs: full });
+    const before = readRegistry(base).pairs.length;
+    await expect(resolvePair(base, { pairFlag: "overflow", cwd: "/tmp/x", probePorts: false })).rejects.toThrow();
+    // The failed allocation must not leave an out-of-range slot in the registry.
+    expect(readRegistry(base).pairs.length).toBe(before);
+    expect(readRegistry(base).pairs.some((p) => p.slot > MAX_PAIR_SLOT)).toBe(false);
+  });
+
+  test("#6 validatePairId rejects Windows reserved device names with extensions", () => {
+    expect(() => validatePairId("CON.txt")).toThrow(PairError);
+    expect(() => validatePairId("NUL.log")).toThrow(PairError);
+    expect(() => validatePairId("com1.x")).toThrow(PairError);
+    // Not reserved: the device-base check only matches exact device words.
+    expect(validatePairId("conduit")).toBe("conduit");
+    expect(validatePairId("console")).toBe("console");
+  });
+
+  test("#7 readRegistry rejects a tampered pairId that could escape the pairs dir", () => {
+    const base = tmpBase();
+    const pairsDir = join(base, "pairs");
+    mkdirSync(pairsDir, { recursive: true });
+    writeFileSync(
+      join(pairsDir, "registry.json"),
+      JSON.stringify({ version: 1, pairs: [{ pairId: "../../etc", slot: 0, cwd: "/", source: "flag", createdAt: "x" }] }),
+      "utf-8",
+    );
+    expect(() => readRegistry(base)).toThrow(PairError);
+    try {
+      readRegistry(base);
+    } catch (e) {
+      expect((e as PairError).code).toBe("PAIR_REGISTRY_CORRUPT");
+    }
+  });
+
+  test("a brand-new pair whose port is squatted reports PAIR_PORTS_BUSY (deterministic)", async () => {
+    const base = tmpBase();
+    // Occupy slots 0 and 1 so the new pair deterministically lands on slot 2.
+    writeRegistry(base, { version: 1, pairs: [entry(0, "a"), entry(1, "b")] });
+    const slot2 = portsForSlot(2);
+    const server = await bindPort(slot2.appPort); // squat 4520
+    try {
+      let caught: unknown;
+      try {
+        await resolvePair(base, { pairFlag: "c", cwd: "/tmp/x" }); // probePorts defaults true
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(PairError);
+      expect((caught as PairError).code).toBe("PAIR_PORTS_BUSY");
+      expect((caught as PairError).details?.port).toBe(slot2.appPort);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -56,6 +56,18 @@ function closeServer(server: Server): Promise<void> {
   return new Promise((resolve) => server.close(() => resolve()));
 }
 
+async function bindFirstAvailableAppPortSlot(): Promise<{ slot: number; server: Server }> {
+  for (let slot = 0; slot <= MAX_PAIR_SLOT; slot++) {
+    try {
+      return { slot, server: await bindPort(portsForSlot(slot).appPort) };
+    } catch (err: any) {
+      if (err?.code === "EADDRINUSE" || err?.code === "EACCES") continue;
+      throw err;
+    }
+  }
+  throw new Error("No bindable AgentBridge app port slot found for test");
+}
+
 describe("portsForSlot", () => {
   test("slot 0 maps to the classic 4500/4501/4502 triple", () => {
     expect(portsForSlot(0)).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
@@ -299,22 +311,16 @@ describe("resolvePair", () => {
     rmSync(base, { recursive: true, force: true });
   });
 
-  // resolvePair probes the slot's ports AFTER releasing the lock. Slot 0 maps
-  // to 4500/4501/4502, which may be occupied by a real dev-machine daemon — in
-  // that case resolvePair throws PAIR_PORTS_BUSY. The registry/slot allocation
-  // happens under the lock BEFORE probing, so allocation is durable regardless
-  // of the probe outcome. These helpers assert allocation via the registry and
-  // tolerate a PAIR_PORTS_BUSY thrown by the port probe.
+  // These tests exercise pure pair/slot allocation. Disable port probing so
+  // they do not depend on whether a developer-machine daemon currently owns
+  // the classic 4500/4501/4502 ports; port conflicts are covered separately.
 
-  // Run resolvePair, returning either the resolved pair or the PairError it
-  // threw. Re-throws anything that is not a PAIR_PORTS_BUSY PairError so real
-  // failures still surface.
   async function resolveTolerant(
     cwd: string,
     pairFlag?: string,
   ): Promise<{ ok: true; resolved: Awaited<ReturnType<typeof resolvePair>> } | { ok: false; busy: PairError }> {
     try {
-      const resolved = await resolvePair(base, pairFlag ? { pairFlag, cwd } : { cwd });
+      const resolved = await resolvePair(base, pairFlag ? { pairFlag, cwd, probePorts: false } : { cwd, probePorts: false });
       return { ok: true, resolved };
     } catch (err) {
       if (err instanceof PairError && err.code === "PAIR_PORTS_BUSY") {
@@ -331,7 +337,6 @@ describe("resolvePair", () => {
       const expectedId = derivePairId(tmpA, DEFAULT_PAIR_NAME);
       const r = await resolveTolerant(tmpA);
 
-      // Allocation must have happened regardless of probe result.
       const reg = readRegistry(base);
       expect(reg.pairs).toHaveLength(1);
       expect(reg.pairs[0]!.slot).toBe(0);
@@ -489,7 +494,7 @@ describe("resolvePair", () => {
     }
   });
 
-  test("a cross-cwd raw pairId match reuses the pair AND warns", async () => {
+  test("a cross-cwd raw pairId match THROWS PAIR_CROSS_CWD (a pair is scoped to its directory)", async () => {
     const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-xcwd-A-"));
     const tmpB = mkdtempSync(join(tmpdir(), "abg-pair-xcwd-B-"));
     try {
@@ -498,20 +503,48 @@ describe("resolvePair", () => {
         version: 1,
         pairs: [{ pairId, slot: 6, cwd: tmpA, name: DEFAULT_PAIR_NAME, source: "cwd", createdAt: "2026-01-01T00:00:00.000Z" }],
       });
-      // Resolve the SAME pairId from a DIFFERENT directory.
-      const resolved = await resolvePair(base, { pairFlag: pairId, cwd: tmpB, probePorts: false });
-
-      expect(resolved.pairId).toBe(pairId);
-      expect(resolved.slot).toBe(6); // reused, not reallocated
-      expect(readRegistry(base).pairs).toHaveLength(1);
-      expect(resolved.warning).toBeDefined();
-      expect(resolved.warning!).toContain(tmpA); // the pair's home cwd
-      expect(resolved.warning!).toContain(tmpB); // where the user actually is
+      // Resolve the SAME pairId from a DIFFERENT directory: must be an error, not a
+      // silent reuse — the identity layer would reject a cross-cwd attach anyway.
+      let err: unknown;
+      try {
+        await resolvePair(base, { pairFlag: pairId, cwd: tmpB, probePorts: false });
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(PairError);
+      expect((err as PairError).code).toBe("PAIR_CROSS_CWD");
+      const message = (err as PairError).message;
+      expect(message).toContain(tmpA); // the pair's home cwd
+      expect(message).toContain(tmpB); // where the user actually is
       // Guard the flag→text spacing (a replace_all once ate this space).
-      expect(resolved.warning!).toContain(`--pair ${pairId} matched`);
+      expect(message).toContain(`--pair ${pairId} refers to`);
+      // Nothing reused, nothing reallocated, registry untouched.
+      expect(readRegistry(base).pairs).toHaveLength(1);
+      expect((err as PairError).details).toMatchObject({ pairId, registeredCwd: tmpA, cwd: tmpB });
     } finally {
       rmSync(tmpA, { recursive: true, force: true });
       rmSync(tmpB, { recursive: true, force: true });
+    }
+  });
+
+  test("a same-cwd full pairId recovers (reuses) the entry without a warning", async () => {
+    const tmpA = mkdtempSync(join(tmpdir(), "abg-pair-samecwd-A-"));
+    try {
+      // The pairId-shaped flag IS the registered pair's id AND we are in its dir:
+      // this is the `abg --pair <pairId>` same-dir recovery path (commit 400b737).
+      const pairId = derivePairId(tmpA, DEFAULT_PAIR_NAME);
+      writeRegistry(base, {
+        version: 1,
+        pairs: [{ pairId, slot: 5, cwd: tmpA, name: DEFAULT_PAIR_NAME, source: "cwd", createdAt: "2026-01-01T00:00:00.000Z" }],
+      });
+      const resolved = await resolvePair(base, { pairFlag: pairId, cwd: tmpA, probePorts: false });
+
+      expect(resolved.pairId).toBe(pairId);
+      expect(resolved.slot).toBe(5); // reused, not reallocated
+      expect(readRegistry(base).pairs).toHaveLength(1); // nothing allocated
+      expect(resolved.warning).toBeUndefined(); // same-cwd recovery is silent
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
     }
   });
 
@@ -651,10 +684,15 @@ describe("cross-review regression fixes", () => {
 
   test("a brand-new pair whose port is squatted reports PAIR_PORTS_BUSY (deterministic)", async () => {
     const base = tmpBase();
-    // Occupy slots 0 and 1 so the new pair deterministically lands on slot 2.
-    writeRegistry(base, { version: 1, pairs: [entry(0, "a"), entry(1, "b")] });
-    const slot2 = portsForSlot(2);
-    const server = await bindPort(slot2.appPort); // squat 4520
+    const { slot, server } = await bindFirstAvailableAppPortSlot();
+    const ports = portsForSlot(slot);
+    // Occupy all lower slots in the registry so the new pair deterministically
+    // lands on the app port we are squatting, without assuming any fixed port is
+    // free on the developer machine.
+    writeRegistry(base, {
+      version: 1,
+      pairs: Array.from({ length: slot }, (_, s) => entry(s, `occupied-${s}`)),
+    });
     try {
       let caught: unknown;
       try {
@@ -664,7 +702,10 @@ describe("cross-review regression fixes", () => {
       }
       expect(caught).toBeInstanceOf(PairError);
       expect((caught as PairError).code).toBe("PAIR_PORTS_BUSY");
-      expect((caught as PairError).details?.port).toBe(slot2.appPort);
+      expect((caught as PairError).details?.port).toBe(ports.appPort);
+      const registryAfterFailure = readRegistry(base);
+      expect(registryAfterFailure.pairs.some((pair) => pair.name === "c")).toBe(false);
+      expect(registryAfterFailure.pairs.some((pair) => pair.slot === slot)).toBe(false);
     } finally {
       await closeServer(server);
     }

--- a/src/unit-test/pair-resolver.test.ts
+++ b/src/unit-test/pair-resolver.test.ts
@@ -3,11 +3,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { writeRegistry, type PairEntry } from "../pair-registry";
+import { derivePairId, writeRegistry, type PairEntry } from "../pair-registry";
 import {
   applyPairEnv,
   computeBaseDir,
   findPair,
+  findPairForFlag,
   listPairs,
   parseKillArgs,
   parsePairFlag,
@@ -23,6 +24,7 @@ const ENV_KEYS = [
   "AGENTBRIDGE_STATE_DIR",
   "AGENTBRIDGE_CONTROL_PORT",
   "AGENTBRIDGE_PAIR_ID",
+  "AGENTBRIDGE_PAIR_NAME",
   "CODEX_WS_PORT",
   "CODEX_PROXY_PORT",
 ] as const;
@@ -140,24 +142,31 @@ describe("applyPairEnv — pair mode env injection", () => {
   test("an existing pair injects its slot's ports + state dir + pair id (no port probe)", async () => {
     const base = makeBase();
     process.env.AGENTBRIDGE_STATE_DIR = base;
-    // Seed the pair as already-registered at slot 3 so resolvePair takes the
-    // existing branch (no port probe → deterministic regardless of host ports).
-    writeRegistry(base, { version: 1, pairs: [entry("work", 3)] });
+    // The friendly name "work" is scoped to the cwd; seed the composite id that
+    // applyPairEnv (cwd = process.cwd()) will derive, at slot 3, so resolvePair
+    // takes the existing branch (no port probe → deterministic regardless of host).
+    const pairId = derivePairId(process.cwd(), "work");
+    writeRegistry(base, {
+      version: 1,
+      pairs: [{ pairId, slot: 3, cwd: process.cwd(), name: "work", source: "flag", createdAt: "2026-01-01T00:00:00.000Z" }],
+    });
 
     const res = await applyPairEnv({ pairFlag: "work" });
 
     expect(res.manual).toBe(false);
-    expect(res.pairId).toBe("work");
+    expect(res.pairId).toBe(pairId);
+    expect(res.name).toBe("work");
     expect(res.slot).toBe(3);
     expect(res.ports).toEqual({ appPort: 4530, proxyPort: 4531, controlPort: 4532 });
 
-    // The env vars + pair id are injected for downstream / spawned children.
-    expect(process.env.AGENTBRIDGE_PAIR_ID).toBe("work");
+    // The env vars + pair id/name are injected for downstream / spawned children.
+    expect(process.env.AGENTBRIDGE_PAIR_ID).toBe(pairId);
+    expect(process.env.AGENTBRIDGE_PAIR_NAME).toBe("work");
     expect(process.env.AGENTBRIDGE_CONTROL_PORT).toBe("4532");
     expect(process.env.CODEX_WS_PORT).toBe("4530");
     expect(process.env.CODEX_PROXY_PORT).toBe("4531");
-    expect(process.env.AGENTBRIDGE_STATE_DIR).toBe(join(base, "pairs", "work"));
-    expect(res.stateDir.dir).toBe(join(base, "pairs", "work"));
+    expect(process.env.AGENTBRIDGE_STATE_DIR).toBe(join(base, "pairs", pairId));
+    expect(res.stateDir.dir).toBe(join(base, "pairs", pairId));
     // BASE_DIR is pinned to the registry base (NOT the per-pair state dir) so a
     // child `abg pairs`/`abg kill` resolves the same registry.
     expect(process.env.AGENTBRIDGE_BASE_DIR).toBe(base);
@@ -204,5 +213,49 @@ describe("registry helpers", () => {
     const removed = await removePair(base, "a");
     expect(removed?.pairId).toBe("a");
     expect(listPairs(base).map((p) => p.pairId)).toEqual(["b"]);
+  });
+});
+
+describe("findPairForFlag — cwd-scoped name resolution (used by kill / pairs rm)", () => {
+  function seed(base: string, cwd: string, name: string, slot = 0) {
+    const pairId = derivePairId(cwd, name);
+    writeRegistry(base, {
+      version: 1,
+      pairs: [{ pairId, slot, cwd, name, source: "flag", createdAt: "2026-01-01T00:00:00.000Z" }],
+    });
+    return pairId;
+  }
+
+  test("matches a friendly name scoped to the cwd", () => {
+    const base = makeBase();
+    const cwd = "/tmp/projX";
+    const pairId = seed(base, cwd, "work");
+    expect(findPairForFlag(base, cwd, "work")?.pairId).toBe(pairId);
+  });
+
+  test("the same name from a DIFFERENT cwd does not match (different pair)", () => {
+    const base = makeBase();
+    const cwd = "/tmp/projX";
+    seed(base, cwd, "work");
+    expect(findPairForFlag(base, "/tmp/projY", "work")).toBeNull();
+  });
+
+  test("falls back to a raw composite pairId regardless of cwd", () => {
+    const base = makeBase();
+    const cwd = "/tmp/projX";
+    const pairId = seed(base, cwd, "work");
+    // From an unrelated cwd the friendly name won't resolve, but the raw id does.
+    expect(findPairForFlag(base, "/tmp/unrelated", pairId)?.pairId).toBe(pairId);
+  });
+
+  test("reaches an OLD verbatim-id entry (no name field) via the raw fallback", () => {
+    const base = makeBase();
+    writeRegistry(base, { version: 1, pairs: [entry("work", 0)] }); // legacy shape
+    expect(findPairForFlag(base, "/tmp/anything", "work")?.pairId).toBe("work");
+  });
+
+  test("throws PAIR_ID_INVALID for a malformed flag", () => {
+    const base = makeBase();
+    expect(() => findPairForFlag(base, "/tmp/x", "../escape")).toThrow();
   });
 });

--- a/src/unit-test/pair-resolver.test.ts
+++ b/src/unit-test/pair-resolver.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { writeRegistry, type PairEntry } from "../pair-registry";
+import {
+  applyPairEnv,
+  computeBaseDir,
+  findPair,
+  listPairs,
+  parseKillArgs,
+  parsePairFlag,
+  portsForEntry,
+  removePair,
+} from "../pair-resolver";
+
+// ---------------------------------------------------------------------------
+// Env isolation: pair env vars leak across tests otherwise.
+// ---------------------------------------------------------------------------
+const ENV_KEYS = [
+  "AGENTBRIDGE_BASE_DIR",
+  "AGENTBRIDGE_STATE_DIR",
+  "AGENTBRIDGE_CONTROL_PORT",
+  "AGENTBRIDGE_PAIR_ID",
+  "CODEX_WS_PORT",
+  "CODEX_PROXY_PORT",
+] as const;
+
+let savedEnv: Record<string, string | undefined> = {};
+const tempBases: string[] = [];
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  while (tempBases.length > 0) {
+    const base = tempBases.pop();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "agentbridge-resolver-"));
+  tempBases.push(base);
+  return base;
+}
+
+function entry(pairId: string, slot: number): PairEntry {
+  return { pairId, slot, cwd: `/tmp/${pairId}`, source: "flag", createdAt: "2026-01-01T00:00:00.000Z" };
+}
+
+describe("parsePairFlag", () => {
+  test("extracts --pair <name> and leaves the rest in order", () => {
+    const { pairFlag, rest } = parsePairFlag(["--pair", "work", "--resume", "-x"]);
+    expect(pairFlag).toBe("work");
+    expect(rest).toEqual(["--resume", "-x"]);
+  });
+
+  test("extracts --pair=<name>", () => {
+    const { pairFlag, rest } = parsePairFlag(["--model", "o3", "--pair=review"]);
+    expect(pairFlag).toBe("review");
+    expect(rest).toEqual(["--model", "o3"]);
+  });
+
+  test("no flag → undefined, rest untouched", () => {
+    const { pairFlag, rest } = parsePairFlag(["--resume", "foo"]);
+    expect(pairFlag).toBeUndefined();
+    expect(rest).toEqual(["--resume", "foo"]);
+  });
+
+  test("--pair with a missing value → empty string (forces a clear error downstream)", () => {
+    const { pairFlag, rest } = parsePairFlag(["--pair"]);
+    expect(pairFlag).toBe("");
+    expect(rest).toEqual([]);
+  });
+
+  test("--pair followed by another flag does not consume the flag as a value", () => {
+    const { pairFlag, rest } = parsePairFlag(["--pair", "--resume"]);
+    expect(pairFlag).toBe("");
+    expect(rest).toEqual(["--resume"]);
+  });
+});
+
+describe("parseKillArgs", () => {
+  test("no args → all:false, no pair (router treats as kill-all)", () => {
+    expect(parseKillArgs([])).toEqual({ all: false, pairFlag: undefined });
+  });
+  test("--all", () => {
+    expect(parseKillArgs(["--all"])).toEqual({ all: true, pairFlag: undefined });
+  });
+  test("--pair X", () => {
+    expect(parseKillArgs(["--pair", "work"])).toEqual({ all: false, pairFlag: "work" });
+  });
+  test("--pair=X", () => {
+    expect(parseKillArgs(["--pair=review"])).toEqual({ all: false, pairFlag: "review" });
+  });
+});
+
+describe("computeBaseDir", () => {
+  test("honours AGENTBRIDGE_STATE_DIR", () => {
+    process.env.AGENTBRIDGE_STATE_DIR = "/tmp/custom-base";
+    expect(computeBaseDir()).toBe("/tmp/custom-base");
+  });
+  test("falls back to the platform base dir when unset", () => {
+    // Platform base ends in AgentBridge (macOS) or agentbridge (linux).
+    expect(computeBaseDir().toLowerCase()).toContain("agentbridge");
+  });
+});
+
+describe("applyPairEnv — manual/legacy mode", () => {
+  test("explicit port env + no --pair → manual, ports from env, registry untouched", async () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    process.env.AGENTBRIDGE_CONTROL_PORT = "4502";
+    process.env.CODEX_WS_PORT = "4500";
+    process.env.CODEX_PROXY_PORT = "4501";
+
+    const res = await applyPairEnv({});
+
+    expect(res.manual).toBe(true);
+    expect(res.pairId).toBe("(manual)");
+    expect(res.slot).toBeNull();
+    expect(res.ports).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
+    // Manual mode does not allocate a slot: no registry written under the base.
+    expect(listPairs(base)).toEqual([]);
+  });
+});
+
+describe("applyPairEnv — pair mode env injection", () => {
+  test("an existing pair injects its slot's ports + state dir + pair id (no port probe)", async () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    // Seed the pair as already-registered at slot 3 so resolvePair takes the
+    // existing branch (no port probe → deterministic regardless of host ports).
+    writeRegistry(base, { version: 1, pairs: [entry("work", 3)] });
+
+    const res = await applyPairEnv({ pairFlag: "work" });
+
+    expect(res.manual).toBe(false);
+    expect(res.pairId).toBe("work");
+    expect(res.slot).toBe(3);
+    expect(res.ports).toEqual({ appPort: 4530, proxyPort: 4531, controlPort: 4532 });
+
+    // The env vars + pair id are injected for downstream / spawned children.
+    expect(process.env.AGENTBRIDGE_PAIR_ID).toBe("work");
+    expect(process.env.AGENTBRIDGE_CONTROL_PORT).toBe("4532");
+    expect(process.env.CODEX_WS_PORT).toBe("4530");
+    expect(process.env.CODEX_PROXY_PORT).toBe("4531");
+    expect(process.env.AGENTBRIDGE_STATE_DIR).toBe(join(base, "pairs", "work"));
+    expect(res.stateDir.dir).toBe(join(base, "pairs", "work"));
+    // BASE_DIR is pinned to the registry base (NOT the per-pair state dir) so a
+    // child `abg pairs`/`abg kill` resolves the same registry.
+    expect(process.env.AGENTBRIDGE_BASE_DIR).toBe(base);
+  });
+
+  test("a child inheriting the pair env still resolves the registry base", async () => {
+    // Simulate a child of `abg claude --pair work`: BASE_DIR=base, STATE_DIR=pair dir.
+    const base = makeBase();
+    writeRegistry(base, { version: 1, pairs: [entry("work", 0)] });
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+    process.env.AGENTBRIDGE_STATE_DIR = join(base, "pairs", "work");
+    // computeBaseDir must prefer BASE_DIR over the (per-pair) STATE_DIR.
+    expect(computeBaseDir()).toBe(base);
+    expect(findPair(computeBaseDir(), "work")?.pairId).toBe("work");
+  });
+
+  test("an invalid --pair name is rejected", async () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    await expect(applyPairEnv({ pairFlag: "../escape" })).rejects.toThrow();
+  });
+
+  test("an explicit-but-empty --pair (missing value) is rejected, not cwd-derived", async () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    await expect(applyPairEnv({ pairFlag: "" })).rejects.toThrow();
+  });
+});
+
+describe("registry helpers", () => {
+  test("listPairs / findPair / portsForEntry / removePair", async () => {
+    const base = makeBase();
+    writeRegistry(base, { version: 1, pairs: [entry("a", 0), entry("b", 1)] });
+
+    expect(listPairs(base).map((p) => p.pairId).sort()).toEqual(["a", "b"]);
+
+    const b = findPair(base, "B"); // case-insensitive
+    expect(b?.pairId).toBe("b");
+    expect(b?.slot).toBe(1);
+    expect(portsForEntry(b!)).toEqual({ appPort: 4510, proxyPort: 4511, controlPort: 4512 });
+
+    expect(findPair(base, "missing")).toBeNull();
+
+    const removed = await removePair(base, "a");
+    expect(removed?.pairId).toBe("a");
+    expect(listPairs(base).map((p) => p.pairId)).toEqual(["b"]);
+  });
+});

--- a/src/unit-test/pair-resolver.test.ts
+++ b/src/unit-test/pair-resolver.test.ts
@@ -248,6 +248,15 @@ describe("findPairForFlag — cwd-scoped name resolution (used by kill / pairs r
     expect(findPairForFlag(base, "/tmp/unrelated", pairId)?.pairId).toBe(pairId);
   });
 
+  test("trims a raw composite pairId flag (kill/pairs aligns with launch on whitespace)", () => {
+    const base = makeBase();
+    const cwd = "/tmp/projX";
+    const pairId = seed(base, cwd, "work");
+    // A flag with surrounding whitespace must resolve to the same pair as the trimmed
+    // form — matching resolvePair (launch), which validates/trims before the raw match.
+    expect(findPairForFlag(base, "/tmp/unrelated", `  ${pairId}  `)?.pairId).toBe(pairId);
+  });
+
   test("reaches an OLD verbatim-id entry (no name field) via the raw fallback", () => {
     const base = makeBase();
     writeRegistry(base, { version: 1, pairs: [entry("work", 0)] }); // legacy shape

--- a/src/unit-test/pair-resolver.test.ts
+++ b/src/unit-test/pair-resolver.test.ts
@@ -25,6 +25,7 @@ const ENV_KEYS = [
   "AGENTBRIDGE_CONTROL_PORT",
   "AGENTBRIDGE_PAIR_ID",
   "AGENTBRIDGE_PAIR_NAME",
+  "AGENTBRIDGE_MANUAL",
   "CODEX_WS_PORT",
   "CODEX_PROXY_PORT",
 ] as const;
@@ -120,8 +121,9 @@ describe("computeBaseDir", () => {
 });
 
 describe("applyPairEnv — manual/legacy mode", () => {
-  test("explicit port env + no --pair → manual, ports from env, registry untouched", async () => {
+  test("explicit port env + AGENTBRIDGE_MANUAL=1 + no --pair → manual, ports from env, registry untouched", async () => {
     const base = makeBase();
+    process.env.AGENTBRIDGE_MANUAL = "1";
     process.env.AGENTBRIDGE_STATE_DIR = base;
     process.env.AGENTBRIDGE_CONTROL_PORT = "4502";
     process.env.CODEX_WS_PORT = "4500";
@@ -135,6 +137,26 @@ describe("applyPairEnv — manual/legacy mode", () => {
     expect(res.ports).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
     // Manual mode does not allocate a slot: no registry written under the base.
     expect(listPairs(base)).toEqual([]);
+  });
+
+  test("explicit port env without AGENTBRIDGE_MANUAL no longer enters implicit manual mode", async () => {
+    const base = makeBase();
+    const pairId = derivePairId(process.cwd(), "main");
+    writeRegistry(base, {
+      version: 1,
+      pairs: [{ pairId, slot: 4, cwd: process.cwd(), name: "main", source: "cwd", createdAt: "2026-01-01T00:00:00.000Z" }],
+    });
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    process.env.AGENTBRIDGE_CONTROL_PORT = "4502";
+    process.env.CODEX_WS_PORT = "4500";
+    process.env.CODEX_PROXY_PORT = "4501";
+
+    const res = await applyPairEnv({});
+
+    expect(res.manual).toBe(false);
+    expect(res.pairId).toBe(pairId);
+    expect(process.env.AGENTBRIDGE_STATE_DIR).toContain(join(base, "pairs"));
+    expect(process.env.AGENTBRIDGE_CONTROL_PORT).toBe("4542");
   });
 });
 
@@ -240,27 +262,33 @@ describe("findPairForFlag — cwd-scoped name resolution (used by kill / pairs r
     expect(findPairForFlag(base, "/tmp/projY", "work")).toBeNull();
   });
 
-  test("falls back to a raw composite pairId regardless of cwd", () => {
+  test("falls back to a raw composite pairId only in the same cwd", () => {
     const base = makeBase();
     const cwd = "/tmp/projX";
     const pairId = seed(base, cwd, "work");
-    // From an unrelated cwd the friendly name won't resolve, but the raw id does.
-    expect(findPairForFlag(base, "/tmp/unrelated", pairId)?.pairId).toBe(pairId);
+    expect(findPairForFlag(base, cwd, pairId)?.pairId).toBe(pairId);
+    expect(findPairForFlag(base, "/tmp/unrelated", pairId)).toBeNull();
   });
 
-  test("trims a raw composite pairId flag (kill/pairs aligns with launch on whitespace)", () => {
+  test("trims a raw composite pairId flag for the same cwd (kill/pairs aligns with launch on whitespace)", () => {
     const base = makeBase();
     const cwd = "/tmp/projX";
     const pairId = seed(base, cwd, "work");
     // A flag with surrounding whitespace must resolve to the same pair as the trimmed
     // form — matching resolvePair (launch), which validates/trims before the raw match.
-    expect(findPairForFlag(base, "/tmp/unrelated", `  ${pairId}  `)?.pairId).toBe(pairId);
+    expect(findPairForFlag(base, cwd, `  ${pairId}  `)?.pairId).toBe(pairId);
+    expect(findPairForFlag(base, "/tmp/unrelated", `  ${pairId}  `)).toBeNull();
   });
 
-  test("reaches an OLD verbatim-id entry (no name field) via the raw fallback", () => {
+  test("reaches an OLD verbatim-id entry (no name field) via the raw fallback only in the same cwd", () => {
     const base = makeBase();
-    writeRegistry(base, { version: 1, pairs: [entry("work", 0)] }); // legacy shape
-    expect(findPairForFlag(base, "/tmp/anything", "work")?.pairId).toBe("work");
+    const cwd = "/tmp/anything";
+    writeRegistry(base, {
+      version: 1,
+      pairs: [{ pairId: "work", slot: 0, cwd, source: "flag", createdAt: "2026-01-01T00:00:00.000Z" }],
+    }); // legacy shape
+    expect(findPairForFlag(base, cwd, "work")?.pairId).toBe("work");
+    expect(findPairForFlag(base, "/tmp/other", "work")).toBeNull();
   });
 
   test("throws PAIR_ID_INVALID for a malformed flag", () => {

--- a/src/unit-test/plugin-update-notice.test.ts
+++ b/src/unit-test/plugin-update-notice.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Integration test for the shipped plugin-side reminder script that the
+// SessionStart hook invokes. It reads the update cache (written by the CLI
+// notifier) and compares to the installed plugin version.
+const SCRIPT = join(process.cwd(), "plugins/agentbridge/scripts/plugin-update-notice.mjs");
+
+const dirs: string[] = [];
+function setup(latest: string | null, pluginVersion: string): { stateDir: string; pluginJson: string } {
+  const base = mkdtempSync(join(tmpdir(), "abg-pcn-"));
+  dirs.push(base);
+  const stateDir = join(base, "state");
+  mkdirSync(stateDir, { recursive: true });
+  if (latest !== null) {
+    writeFileSync(join(stateDir, "update-check.json"), JSON.stringify({ lastCheckMs: 1, latest }));
+  }
+  const pluginJson = join(base, "plugin.json");
+  writeFileSync(pluginJson, JSON.stringify({ name: "agentbridge", version: pluginVersion }));
+  return { stateDir, pluginJson };
+}
+function run(stateDir: string, pluginJson: string, extraEnv: Record<string, string> = {}): string {
+  const res = Bun.spawnSync(["bun", SCRIPT, pluginJson], {
+    env: { ...process.env, AGENTBRIDGE_STATE_DIR: stateDir, ...extraEnv },
+  });
+  return res.stdout.toString();
+}
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe("plugin-update-notice.mjs", () => {
+  test("prints a reminder when npm latest is newer than the installed plugin", () => {
+    const { stateDir, pluginJson } = setup("0.1.9", "0.1.6");
+    const out = run(stateDir, pluginJson);
+    expect(out).toContain("plugin update available");
+    expect(out).toContain("0.1.6 -> 0.1.9");
+    expect(out).toContain("/plugin marketplace update agentbridge");
+    expect(out).toContain("/reload-plugins");
+  });
+
+  test("prints nothing when the plugin is already at the latest version", () => {
+    const { stateDir, pluginJson } = setup("0.1.6", "0.1.6");
+    expect(run(stateDir, pluginJson).trim()).toBe("");
+  });
+
+  test("prints nothing for a prerelease latest (no beta nag)", () => {
+    const { stateDir, pluginJson } = setup("0.2.0-beta.1", "0.1.6");
+    expect(run(stateDir, pluginJson).trim()).toBe("");
+  });
+
+  test("prints nothing (silent) when no cache exists yet", () => {
+    const { stateDir, pluginJson } = setup(null, "0.1.6");
+    expect(run(stateDir, pluginJson).trim()).toBe("");
+  });
+
+  test("respects the NO_UPDATE_NOTIFIER opt-out even when an upgrade is available", () => {
+    const { stateDir, pluginJson } = setup("0.1.9", "0.1.6");
+    expect(run(stateDir, pluginJson, { NO_UPDATE_NOTIFIER: "1" }).trim()).toBe("");
+    expect(run(stateDir, pluginJson, { AGENTBRIDGE_NO_UPDATE_NOTIFIER: "1" }).trim()).toBe("");
+    // sanity: without the opt-out it DOES remind (proves the opt-out is what silenced it)
+    expect(run(stateDir, pluginJson)).toContain("plugin update available");
+  });
+});

--- a/src/unit-test/reply-required-tracker.test.ts
+++ b/src/unit-test/reply-required-tracker.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { ReplyRequiredTracker } from "../reply-required-tracker";
+
+describe("ReplyRequiredTracker", () => {
+  test("a fresh tracker is not armed", () => {
+    expect(new ReplyRequiredTracker().isArmed).toBe(false);
+  });
+
+  test("arm() activates force-forward", () => {
+    const t = new ReplyRequiredTracker();
+    t.arm();
+    expect(t.isArmed).toBe(true);
+  });
+
+  test("B1 regression: a require_reply turn that never injected must stay unarmed", () => {
+    // The daemon arms ONLY after a successful injection. When injection is
+    // rejected (Codex busy), arm() is never called, so an unrelated in-flight
+    // turn's chatter is NOT force-forwarded and the real request is not lost.
+    const t = new ReplyRequiredTracker();
+    // (no arm())
+    t.noteForwarded(); // unrelated traffic must not flip any state while unarmed
+    expect(t.isArmed).toBe(false);
+    expect(t.consumeOnTurnComplete()).toEqual({ warnReplyMissing: false });
+  });
+
+  test("armed turn with no forwarded reply warns at completion, then resets", () => {
+    const t = new ReplyRequiredTracker();
+    t.arm();
+    expect(t.consumeOnTurnComplete()).toEqual({ warnReplyMissing: true });
+    expect(t.isArmed).toBe(false);
+  });
+
+  test("armed turn with a forwarded reply does not warn, then resets", () => {
+    const t = new ReplyRequiredTracker();
+    t.arm();
+    t.noteForwarded();
+    expect(t.consumeOnTurnComplete()).toEqual({ warnReplyMissing: false });
+    expect(t.isArmed).toBe(false);
+  });
+
+  test("noteForwarded() is a no-op while unarmed", () => {
+    const t = new ReplyRequiredTracker();
+    t.noteForwarded();
+    t.arm();
+    // The pre-arm noteForwarded must not count toward THIS turn.
+    expect(t.consumeOnTurnComplete()).toEqual({ warnReplyMissing: true });
+  });
+
+  test("reset() clears armed state without warning", () => {
+    const t = new ReplyRequiredTracker();
+    t.arm();
+    t.reset();
+    expect(t.isArmed).toBe(false);
+    expect(t.consumeOnTurnComplete()).toEqual({ warnReplyMissing: false });
+  });
+
+  test("re-arming after completion starts a fresh turn", () => {
+    const t = new ReplyRequiredTracker();
+    t.arm();
+    t.noteForwarded();
+    t.consumeOnTurnComplete();
+    t.arm(); // next require_reply turn
+    expect(t.isArmed).toBe(true);
+    expect(t.consumeOnTurnComplete()).toEqual({ warnReplyMissing: true });
+  });
+});

--- a/src/unit-test/resume-pollution.test.ts
+++ b/src/unit-test/resume-pollution.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  extractFirstRealUserMessage,
+  isKickoffText,
+  scanResumePollution,
+} from "../resume-pollution";
+
+const KICKOFF = `Claude Code has connected via AgentBridge.
+You are now in a multi-agent collaboration session.
+When you receive a complex task, propose a division of labor to Claude.`;
+
+function setupDb(root: string) {
+  const codexHome = join(root, "codex-home");
+  mkdirSync(codexHome, { recursive: true });
+  const dbPath = join(codexHome, "state_5.sqlite");
+  const db = new Database(dbPath);
+  db.run(`
+    create table threads (
+      id text primary key,
+      rollout_path text not null,
+      created_at integer not null,
+      updated_at integer not null,
+      cwd text not null,
+      title text not null,
+      first_user_message text not null default '',
+      preview text not null default '',
+      archived integer not null default 0
+    )
+  `);
+  db.close();
+  return { codexHome, dbPath };
+}
+
+function writeRollout(path: string, realMessage: string) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "AGENTS.md instructions for /tmp/x" }],
+        },
+      }),
+      JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: KICKOFF } }),
+      JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: realMessage } }),
+    ].join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function writeKickoffOnlyRollout(path: string) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "AGENTS.md instructions for /tmp/x" }],
+        },
+      }),
+      JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: KICKOFF } }),
+    ].join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function insertThread(dbPath: string, id: string, rollout: string) {
+  const db = new Database(dbPath);
+  db.run(
+    `insert into threads (id, rollout_path, created_at, updated_at, cwd, title, first_user_message, preview, archived)
+     values (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+    [id, rollout, 1, 1, "/repo", KICKOFF, KICKOFF, KICKOFF],
+  );
+  db.close();
+}
+
+describe("resume pollution scanner", () => {
+  test("detects kickoff text", () => {
+    expect(isKickoffText(KICKOFF)).toBe(true);
+    expect(isKickoffText("real task")).toBe(false);
+  });
+
+  test("extracts first real user message from rollout", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-pollution-"));
+    try {
+      const rollout = join(root, "rollout-thread.jsonl");
+      writeRollout(rollout, "Please fix the real bug");
+      expect(extractFirstRealUserMessage(rollout)).toBe("Please fix the real bug");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("dry-run reports polluted metadata and apply updates after backup", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-pollution-"));
+    try {
+      const { codexHome, dbPath } = setupDb(root);
+      const rollout = join(codexHome, "sessions", "2026", "06", "02", "rollout-thread-1.jsonl");
+      writeRollout(rollout, "Fix the current AgentBridge bugs");
+
+      const db = new Database(dbPath);
+      db.run(
+        `insert into threads (id, rollout_path, created_at, updated_at, cwd, title, first_user_message, preview, archived)
+         values (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+        ["thread-1", rollout, 1, 1, "/repo", KICKOFF, KICKOFF, KICKOFF],
+      );
+      db.close();
+
+      const dry = scanResumePollution({ codexHome });
+      expect(dry.candidates).toHaveLength(1);
+      expect(dry.candidates[0]!.replacementFirstUserMessage).toBe("Fix the current AgentBridge bugs");
+      expect(dry.applied).toBe(0);
+
+      const applied = scanResumePollution({ codexHome, apply: true, now: "2026-06-02T00:00:00.000Z" });
+      expect(applied.applied).toBe(1);
+      expect(applied.backupDir).toContain("agentbridge-backups");
+
+      const verify = new Database(dbPath, { readonly: true });
+      const row = verify.query("select title, first_user_message, preview from threads where id = ?")
+        .get("thread-1") as { title: string; first_user_message: string; preview: string };
+      verify.close();
+      expect(row.first_user_message).toBe("Fix the current AgentBridge bugs");
+      expect(row.title).toContain("Fix the current AgentBridge bugs");
+      expect(row.preview).toContain("Fix the current AgentBridge bugs");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("thread with real work is classified rename and apply relabels it", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-pollution-"));
+    try {
+      const { codexHome, dbPath } = setupDb(root);
+      const rollout = join(codexHome, "sessions", "2026", "06", "02", "rollout-real.jsonl");
+      writeRollout(rollout, "Implement the parser fix");
+      insertThread(dbPath, "thread-real", rollout);
+
+      const dry = scanResumePollution({ codexHome });
+      expect(dry.candidates).toHaveLength(1);
+      expect(dry.candidates[0]!.action).toBe("rename");
+
+      const applied = scanResumePollution({ codexHome, apply: true, now: "2026-06-02T00:00:00.000Z" });
+      expect(applied.renamed).toBe(1);
+      expect(applied.deleted).toBe(0);
+      expect(applied.applied).toBe(1);
+
+      const verify = new Database(dbPath, { readonly: true });
+      const row = verify.query("select title, first_user_message from threads where id = ?")
+        .get("thread-real") as { title: string; first_user_message: string } | null;
+      verify.close();
+      expect(row).not.toBeNull();
+      expect(row!.first_user_message).toBe("Implement the parser fix");
+      expect(row!.title).toContain("Implement the parser fix");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("kickoff-only thread is classified delete and apply removes the row with backup", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-pollution-"));
+    try {
+      const { codexHome, dbPath } = setupDb(root);
+      const rollout = join(codexHome, "sessions", "2026", "06", "02", "rollout-kickoff.jsonl");
+      writeKickoffOnlyRollout(rollout);
+      insertThread(dbPath, "thread-kickoff", rollout);
+
+      const dry = scanResumePollution({ codexHome });
+      expect(dry.candidates).toHaveLength(1);
+      expect(dry.candidates[0]!.action).toBe("delete");
+      expect(dry.applied).toBe(0);
+
+      const applied = scanResumePollution({ codexHome, apply: true, now: "2026-06-02T00:00:00.000Z" });
+      expect(applied.deleted).toBe(1);
+      expect(applied.renamed).toBe(0);
+      expect(applied.applied).toBe(1);
+      expect(applied.backupDir).toContain("agentbridge-backups");
+      expect(existsSync(applied.backupDir!)).toBe(true);
+
+      const verify = new Database(dbPath, { readonly: true });
+      const row = verify.query("select id from threads where id = ?").get("thread-kickoff");
+      verify.close();
+      expect(row).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("dry-run applies nothing (no delete, no update)", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-pollution-"));
+    try {
+      const { codexHome, dbPath } = setupDb(root);
+      const renameRollout = join(codexHome, "sessions", "2026", "06", "02", "rollout-rn.jsonl");
+      const deleteRollout = join(codexHome, "sessions", "2026", "06", "02", "rollout-del.jsonl");
+      writeRollout(renameRollout, "Real task to keep");
+      writeKickoffOnlyRollout(deleteRollout);
+      insertThread(dbPath, "thread-keep", renameRollout);
+      insertThread(dbPath, "thread-drop", deleteRollout);
+
+      const dry = scanResumePollution({ codexHome });
+      expect(dry.candidates).toHaveLength(2);
+      expect(dry.applied).toBe(0);
+      expect(dry.renamed).toBe(0);
+      expect(dry.deleted).toBe(0);
+      expect(dry.backupDir).toBeUndefined();
+
+      // No write happened: both rows still present and unchanged (still polluted).
+      const verify = new Database(dbPath, { readonly: true });
+      const rows = verify.query("select id, title from threads order by id").all() as Array<{
+        id: string;
+        title: string;
+      }>;
+      verify.close();
+      expect(rows.map((r) => r.id).sort()).toEqual(["thread-drop", "thread-keep"]);
+      expect(rows.every((r) => r.title === KICKOFF)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/unit-test/role-patterns.test.ts
+++ b/src/unit-test/role-patterns.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { ClaudeAdapter, CLAUDE_INSTRUCTIONS } from "../claude-adapter";
-import { BRIDGE_CONTRACT_REMINDER } from "../message-filter";
+import { AGENTS_MD_SECTION } from "../collaboration-content";
 
 describe("role-aware collaboration guidance", () => {
   test("claude instructions include role keywords and thinking patterns", () => {
@@ -21,25 +21,32 @@ describe("role-aware collaboration guidance", () => {
     expect(CLAUDE_INSTRUCTIONS).toContain("busy error");
   });
 
-  test("bridge contract reminder includes codex role guidance", () => {
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("Your default role: Implementer, Executor, Verifier");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("Independent Analysis & Convergence");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("Architect -> Builder -> Critic");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("Hypothesis -> Experiment -> Interpretation");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("Do not blindly follow Claude");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("My independent view is:");
+  // The Codex-side bridge contract (message markers / git-forbidden / role
+  // guidance) now lives in AGENTS.md (injected once by `abg init`), instead of
+  // being appended to every claude→codex message. These assertions guard that the
+  // contract semantics survive that move — Codex still learns them on startup.
+  test("AGENTS.md collaboration section carries codex role guidance", () => {
+    expect(AGENTS_MD_SECTION).toContain("Implementer, Executor, Verifier");
+    expect(AGENTS_MD_SECTION).toContain("Independent Analysis & Convergence");
+    expect(AGENTS_MD_SECTION).toContain("Architect → Builder → Critic");
+    expect(AGENTS_MD_SECTION).toContain("Hypothesis → Experiment → Interpretation");
+    expect(AGENTS_MD_SECTION).toContain("Do not blindly follow Claude");
+    expect(AGENTS_MD_SECTION).toContain("My independent view is:");
   });
 
-  test("bridge contract reminder specifies marker must be at start", () => {
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("at the very start");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("MUST be the first text");
+  test("AGENTS.md collaboration section requires the marker at the very start", () => {
+    expect(AGENTS_MD_SECTION).toContain("very start");
+    expect(AGENTS_MD_SECTION).toContain("must be the first text");
+    expect(AGENTS_MD_SECTION).toContain("[IMPORTANT]");
+    expect(AGENTS_MD_SECTION).toContain("[STATUS]");
+    expect(AGENTS_MD_SECTION).toContain("[FYI]");
   });
 
-  test("bridge contract reminder forbids git write operations", () => {
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("Git Operations — FORBIDDEN");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("MUST NOT execute any git write commands");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("hang indefinitely");
-    expect(BRIDGE_CONTRACT_REMINDER).toContain("delegated to Claude Code");
+  test("AGENTS.md collaboration section forbids git write operations", () => {
+    expect(AGENTS_MD_SECTION).toContain("Git operations — FORBIDDEN");
+    expect(AGENTS_MD_SECTION).toContain("MUST NOT run git **write** commands");
+    expect(AGENTS_MD_SECTION).toContain("hang your session");
+    expect(AGENTS_MD_SECTION).toContain("Delegate **all** git writes to Claude");
   });
 
   test("CLAUDE_INSTRUCTIONS is wired into MCP Server", () => {

--- a/src/unit-test/rotating-log.test.ts
+++ b/src/unit-test/rotating-log.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendRotatingLog } from "../rotating-log";
+
+describe("appendRotatingLog", () => {
+  test("rotates when appending would exceed max bytes", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-log-"));
+    try {
+      const path = join(root, "agentbridge.log");
+      appendRotatingLog(path, "aaaa\n", { maxBytes: 8, keep: 2 });
+      appendRotatingLog(path, "bbbb\n", { maxBytes: 8, keep: 2 });
+
+      expect(readFileSync(path, "utf-8")).toBe("bbbb\n");
+      expect(readFileSync(`${path}.1`, "utf-8")).toBe("aaaa\n");
+      expect(existsSync(`${path}.2`)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/unit-test/state-dir.test.ts
+++ b/src/unit-test/state-dir.test.ts
@@ -28,6 +28,7 @@ describe("StateDirResolver", () => {
     expect(resolver.statusFile).toBe(join(tempDir, "status.json"));
     expect(resolver.portsFile).toBe(join(tempDir, "ports.json"));
     expect(resolver.logFile).toBe(join(tempDir, "agentbridge.log"));
+    expect(resolver.updateCheckFile).toBe(join(tempDir, "update-check.json"));
   });
 
   test("ensure() creates directory if it does not exist", () => {

--- a/src/unit-test/thread-state.test.ts
+++ b/src/unit-test/thread-state.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { StateDirResolver } from "../state-dir";
+import {
+  findCodexRolloutFile,
+  persistCurrentThreadWithRolloutRetry,
+  promoteCurrentThreadIfRolloutExists,
+  readRawCurrentThread,
+  readUsableCurrentThread,
+  writePendingCurrentThread,
+} from "../thread-state";
+
+function tempDir(prefix: string) {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function identity(root: string, codexHome: string) {
+  return {
+    stateDir: new StateDirResolver(join(root, "pair-state")),
+    pairId: "main-12345678",
+    pairName: "main",
+    cwd: root,
+    env: { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+  };
+}
+
+describe("thread-state", () => {
+  test("pending current thread is not usable for resume", () => {
+    const root = tempDir("agentbridge-thread-state-");
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      const id = identity(root, codexHome);
+      writePendingCurrentThread(id, "thread-pending", "test");
+
+      expect(readUsableCurrentThread(id, id.env)).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("rollout-backed current thread is usable", () => {
+    const root = tempDir("agentbridge-thread-state-");
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      const sessionsDir = join(codexHome, "sessions", "2026", "06", "02");
+      mkdirSync(sessionsDir, { recursive: true });
+      const rolloutPath = join(sessionsDir, "rollout-thread-current.jsonl");
+      writeFileSync(rolloutPath, "{}\n", "utf-8");
+
+      const id = identity(root, codexHome);
+      const state = promoteCurrentThreadIfRolloutExists(id, "thread-current", "test", id.env);
+
+      expect(state.status).toBe("current");
+      expect(state.rolloutPath).toBe(rolloutPath);
+      expect(readUsableCurrentThread(id, id.env)?.threadId).toBe("thread-current");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("persistCurrentThreadWithRolloutRetry promotes to current once the rollout appears", async () => {
+    const root = tempDir("agentbridge-thread-state-");
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      const sessionsDir = join(codexHome, "sessions", "2026", "06", "02");
+      mkdirSync(sessionsDir, { recursive: true });
+      writeFileSync(join(sessionsDir, "rollout-thread-X.jsonl"), "{}\n", "utf-8");
+      const id = identity(root, codexHome);
+
+      const state = await persistCurrentThreadWithRolloutRetry(id, "thread-X", "test", {
+        env: id.env,
+        attempts: 2,
+        delayMs: 1,
+      });
+
+      expect(state?.status).toBe("current");
+      expect(readUsableCurrentThread(id, id.env)?.threadId).toBe("thread-X");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("a superseded persistence loop abandons and does not clobber the active thread's mapping", async () => {
+    const root = tempDir("agentbridge-thread-state-");
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      const id = identity(root, codexHome);
+      // "thread-B" is the active, newer thread already on disk.
+      writePendingCurrentThread(id, "thread-B", "newer");
+
+      // A stale loop for "thread-A" whose guard reports it is already superseded
+      // must write nothing and return null — current-thread.json stays thread-B.
+      const result = await persistCurrentThreadWithRolloutRetry(id, "thread-A", "stale", {
+        env: id.env,
+        attempts: 5,
+        delayMs: 1,
+        shouldContinue: () => false,
+      });
+
+      expect(result).toBeNull();
+      expect(readRawCurrentThread(id.stateDir)?.threadId).toBe("thread-B");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("findCodexRolloutFile returns null when sessions are absent", () => {
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      expect(findCodexRolloutFile("missing", { CODEX_HOME: codexHome } as NodeJS.ProcessEnv)).toBeNull();
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/unit-test/trace-log.test.ts
+++ b/src/unit-test/trace-log.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  appendTraceEvent,
+  pickRelevantEnv,
+  redactArgv,
+  redactEnv,
+} from "../trace-log";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempCwd() {
+  const dir = mkdtempSync(join(tmpdir(), "agentbridge-trace-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("trace log", () => {
+  test("redacts env and argv secrets", () => {
+    expect(redactEnv({
+      PATH: "/bin",
+      OPENAI_API_KEY: "sk-secret",
+      AGENTBRIDGE_PAIR_ID: "pair",
+      SESSION_TOKEN: "session-secret",
+    })).toEqual({
+      PATH: "/bin",
+      OPENAI_API_KEY: "<redacted>",
+      AGENTBRIDGE_PAIR_ID: "pair",
+      SESSION_TOKEN: "<redacted>",
+    });
+
+    expect(redactArgv(["codex", "--api-key", "sk-secret", "--model=o3", "--token=abc"])).toEqual([
+      "codex",
+      "--api-key",
+      "<redacted>",
+      "--model=o3",
+      "--token=<redacted>",
+    ]);
+  });
+
+  test("redacts the no-separator --apikey variant in argv", () => {
+    expect(redactArgv(["codex", "--apikey=secret"])).toEqual([
+      "codex",
+      "--apikey=<redacted>",
+    ]);
+    expect(redactArgv(["codex", "--apikey", "secret", "--model=o3"])).toEqual([
+      "codex",
+      "--apikey",
+      "<redacted>",
+      "--model=o3",
+    ]);
+  });
+
+  test("pickRelevantEnv keeps only AGENTBRIDGE_/CODEX_ keys", () => {
+    expect(pickRelevantEnv({
+      PATH: "/bin",
+      DATABASE_URL: "postgres://user:pw@host/db",
+      HOME: "/home/user",
+      AGENTBRIDGE_PAIR_ID: "pair",
+      CODEX_WS_PORT: "4500",
+      OPENAI_API_KEY: "sk-secret",
+    })).toEqual({
+      AGENTBRIDGE_PAIR_ID: "pair",
+      CODEX_WS_PORT: "4500",
+    });
+  });
+
+  test("pickRelevantEnv still redacts secret-shaped allowlisted keys", () => {
+    expect(pickRelevantEnv({
+      AGENTBRIDGE_PAIR_ID: "pair",
+      CODEX_API_KEY: "sk-secret",
+      AGENTBRIDGE_SESSION_TOKEN: "tok",
+    })).toEqual({
+      AGENTBRIDGE_PAIR_ID: "pair",
+      CODEX_API_KEY: "<redacted>",
+      AGENTBRIDGE_SESSION_TOKEN: "<redacted>",
+    });
+  });
+
+  test("appendTraceEvent's written env contains no non-allowlisted key", () => {
+    const cwd = tempCwd();
+    const path = appendTraceEvent({
+      cwd,
+      event: "test.event",
+      pid: 123,
+      argv: ["abg", "claude"],
+      env: {
+        PATH: "/bin",
+        DATABASE_URL: "postgres://user:pw@host/db",
+        AGENTBRIDGE_PAIR_ID: "pair",
+        CODEX_WS_PORT: "4500",
+      },
+      timestamp: "2026-06-02T00:00:00.000Z",
+      data: { pairId: "main-abc12345" },
+    });
+
+    expect(path).toBe(join(cwd, ".agentbridge", "logs", "trace-2026-06-02.jsonl"));
+    expect(existsSync(path)).toBe(true);
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const event = JSON.parse(lines[0]!);
+    expect(event).toEqual({
+      timestamp: "2026-06-02T00:00:00.000Z",
+      event: "test.event",
+      cwd,
+      pid: 123,
+      argv: ["abg", "claude"],
+      env: { AGENTBRIDGE_PAIR_ID: "pair", CODEX_WS_PORT: "4500" },
+      data: { pairId: "main-abc12345" },
+    });
+    // Explicitly assert non-allowlisted secrets never reach disk.
+    expect(Object.keys(event.env)).not.toContain("PATH");
+    expect(Object.keys(event.env)).not.toContain("DATABASE_URL");
+  });
+
+  test("a nested env snapshot inside data is allowlisted, never written in full", () => {
+    const cwd = tempCwd();
+    const path = appendTraceEvent({
+      cwd,
+      event: "bridge.start",
+      pid: 7,
+      timestamp: "2026-06-02T00:00:00.000Z",
+      data: {
+        originalEnv: {
+          DATABASE_URL: "postgres://user:SUPERSECRETPW@host/db",
+          SENTRY_DSN: "https://abc@sentry.io/1",
+          AGENTBRIDGE_PAIR_ID: "pair",
+        },
+        effectiveEnv: {
+          PATH: "/bin",
+          CODEX_WS_PORT: "4500",
+        },
+        pairId: "main-abc12345",
+      },
+    });
+
+    const event = JSON.parse(readFileSync(path, "utf-8").trim());
+    // The nested env snapshots are reduced to allowlisted keys only.
+    expect(event.data.originalEnv).toEqual({ AGENTBRIDGE_PAIR_ID: "pair" });
+    expect(event.data.effectiveEnv).toEqual({ CODEX_WS_PORT: "4500" });
+    // The raw connection strings must never reach disk.
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain("SUPERSECRETPW");
+    expect(serialized).not.toContain("sentry.io");
+    expect(serialized).not.toContain("DATABASE_URL");
+  });
+});

--- a/src/unit-test/update-notifier.test.ts
+++ b/src/unit-test/update-notifier.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { StateDirResolver } from "../state-dir";
+import {
+  PACKAGE_NAME,
+  buildUpdateNotice,
+  isUpdateCheckSuppressed,
+  maybeNotifyUpdate,
+  parseLatestFromRegistry,
+  refreshUpdateCache,
+  type UpdateCache,
+} from "../update-notifier";
+
+const tmpDirs: string[] = [];
+function freshStateDir(): StateDirResolver {
+  const d = mkdtempSync(join(tmpdir(), "abg-upd-"));
+  tmpDirs.push(d);
+  return new StateDirResolver(d);
+}
+afterEach(() => {
+  while (tmpDirs.length) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+function writeCacheFile(sd: StateDirResolver, cache: UpdateCache): void {
+  sd.ensure();
+  writeFileSync(sd.updateCheckFile, JSON.stringify(cache), "utf-8");
+}
+function readCacheFile(sd: StateDirResolver): UpdateCache {
+  return JSON.parse(readFileSync(sd.updateCheckFile, "utf-8"));
+}
+/** A fetch that returns a 200 npm body and records call count. */
+function recordingFetch(body: unknown, status = 200): { fn: typeof fetch; calls: () => number } {
+  let n = 0;
+  const fn = (async () => {
+    n++;
+    return new Response(JSON.stringify(body), { status });
+  }) as unknown as typeof fetch;
+  return { fn, calls: () => n };
+}
+const tick = () => new Promise((r) => setTimeout(r, 10));
+const CLEAN_ENV = {} as NodeJS.ProcessEnv; // not suppressed by env
+
+describe("parseLatestFromRegistry", () => {
+  test("extracts a stable dist-tags.latest", () => {
+    expect(parseLatestFromRegistry({ "dist-tags": { latest: "0.2.0" } })).toBe("0.2.0");
+  });
+  test("rejects prerelease / missing / wrong-shape / non-string", () => {
+    expect(parseLatestFromRegistry({ "dist-tags": { latest: "0.2.0-beta.1" } })).toBeNull();
+    expect(parseLatestFromRegistry({ "dist-tags": {} })).toBeNull();
+    expect(parseLatestFromRegistry({ "dist-tags": { latest: 5 } })).toBeNull();
+    expect(parseLatestFromRegistry({})).toBeNull();
+    expect(parseLatestFromRegistry(null)).toBeNull();
+    expect(parseLatestFromRegistry("nope")).toBeNull();
+  });
+});
+
+describe("buildUpdateNotice", () => {
+  test("shows current → latest and both upgrade commands", () => {
+    const msg = buildUpdateNotice("0.1.6", "0.2.0", false);
+    expect(msg).toContain("0.1.6");
+    expect(msg).toContain("0.2.0");
+    expect(msg).toContain(`npm install -g ${PACKAGE_NAME}@latest`);
+    expect(msg).toContain("/plugin marketplace update agentbridge");
+  });
+  test("omits ANSI color when not a TTY, includes it on a TTY", () => {
+    expect(buildUpdateNotice("0.1.6", "0.2.0", false)).not.toContain("\x1b[");
+    expect(buildUpdateNotice("0.1.6", "0.2.0", true)).toContain("\x1b[");
+  });
+});
+
+describe("isUpdateCheckSuppressed", () => {
+  test("suppresses on opt-out env, CI, test, and non-TTY", () => {
+    expect(isUpdateCheckSuppressed({ NO_UPDATE_NOTIFIER: "1" } as any, true)).toBe(true);
+    expect(isUpdateCheckSuppressed({ AGENTBRIDGE_NO_UPDATE_NOTIFIER: "1" } as any, true)).toBe(true);
+    expect(isUpdateCheckSuppressed({ CI: "true" } as any, true)).toBe(true);
+    expect(isUpdateCheckSuppressed({ NODE_ENV: "test" } as any, true)).toBe(true);
+    expect(isUpdateCheckSuppressed({} as any, false)).toBe(true); // non-TTY
+  });
+  test("not suppressed on a clean TTY environment", () => {
+    expect(isUpdateCheckSuppressed({} as any, true)).toBe(false);
+  });
+});
+
+describe("maybeNotifyUpdate — printing", () => {
+  test("prints when cache has a newer stable version", () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1000, latest: "0.2.0" });
+    const out: string[] = [];
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m), now: () => 1000 });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("0.1.6");
+    expect(out[0]).toContain("0.2.0");
+  });
+
+  test("does NOT print when latest is equal/older/prerelease or cache absent", () => {
+    const out: string[] = [];
+    const run = (cache: UpdateCache | null, current = "0.1.6") => {
+      const sd = freshStateDir();
+      if (cache) writeCacheFile(sd, cache);
+      maybeNotifyUpdate({ current, stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m), now: () => 1000 });
+    };
+    run({ lastCheckMs: 1, latest: "0.1.6" }); // equal
+    run({ lastCheckMs: 1, latest: "0.1.5" }); // older
+    run({ lastCheckMs: 1, latest: "0.2.0-beta.1" }); // prerelease
+    run({ lastCheckMs: 1, latest: null }); // unknown
+    run(null); // no cache file
+    expect(out).toHaveLength(0);
+  });
+
+  test("does NOT print when suppressed even if a newer version is cached", () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1, latest: "9.9.9" });
+    const out: string[] = [];
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: { CI: "1" } as any, print: (m) => out.push(m) });
+    expect(out).toHaveLength(0);
+  });
+
+  test("never throws on a corrupt cache file", () => {
+    const sd = freshStateDir();
+    sd.ensure();
+    writeFileSync(sd.updateCheckFile, "{not json", "utf-8");
+    const out: string[] = [];
+    expect(() =>
+      maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m) }),
+    ).not.toThrow();
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe("maybeNotifyUpdate — refresh gating", () => {
+  test("refresh:true with a stale cache fires the network check", () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 0, latest: "0.1.6" }); // very stale
+    const f = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: () => {}, now: () => 10 * 24 * 60 * 60 * 1000, refresh: true, fetchImpl: f.fn });
+    expect(f.calls()).toBe(1);
+  });
+
+  test("refresh:true with a FRESH cache does NOT hit the network", () => {
+    const sd = freshStateDir();
+    const now = 1_000_000_000;
+    writeCacheFile(sd, { lastCheckMs: now - 1000, latest: "0.1.6" }); // checked 1s ago
+    const f = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: () => {}, now: () => now, refresh: true, fetchImpl: f.fn });
+    expect(f.calls()).toBe(0);
+  });
+
+  test("refresh:false never hits the network (one-shot commands)", () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 0, latest: "0.1.6" });
+    const f = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: () => {}, now: () => 10 ** 12, refresh: false, fetchImpl: f.fn });
+    expect(f.calls()).toBe(0);
+  });
+
+  test("honors AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS from the injected env (deps.env DI contract)", () => {
+    // With a 1000ms interval, a cache 2s old IS stale (fetch) but 500ms old is fresh (skip).
+    const now = 1_000_000_000;
+    const env = { AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS: "1000" } as unknown as NodeJS.ProcessEnv;
+
+    const sdStale = freshStateDir();
+    writeCacheFile(sdStale, { lastCheckMs: now - 2000, latest: "0.1.6" });
+    const fStale = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sdStale, isTTY: true, env, print: () => {}, now: () => now, refresh: true, fetchImpl: fStale.fn });
+    expect(fStale.calls()).toBe(1); // 2s > 1s interval → fetch
+
+    const sdFresh = freshStateDir();
+    writeCacheFile(sdFresh, { lastCheckMs: now - 500, latest: "0.1.6" });
+    const fFresh = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sdFresh, isTTY: true, env, print: () => {}, now: () => now, refresh: true, fetchImpl: fFresh.fn });
+    expect(fFresh.calls()).toBe(0); // 500ms < 1s interval → skip
+  });
+});
+
+describe("refreshUpdateCache", () => {
+  test("writes the fetched stable latest + a fresh timestamp", async () => {
+    const sd = freshStateDir();
+    const f = recordingFetch({ "dist-tags": { latest: "0.3.0" } });
+    await refreshUpdateCache({ stateDir: sd, now: () => 12345, fetchImpl: f.fn });
+    const cache = readCacheFile(sd);
+    expect(cache.latest).toBe("0.3.0");
+    expect(cache.lastCheckMs).toBe(12345);
+  });
+
+  test("preserves the previously-known latest on a transient fetch failure", async () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1, latest: "0.2.0" });
+    const failing = (async () => { throw new Error("offline"); }) as unknown as typeof fetch;
+    await refreshUpdateCache({ stateDir: sd, now: () => 99999, fetchImpl: failing });
+    const cache = readCacheFile(sd);
+    expect(cache.latest).toBe("0.2.0"); // preserved
+    expect(cache.lastCheckMs).toBe(99999); // but throttle advanced
+  });
+
+  test("never throws and records the check even with no prior cache on failure", async () => {
+    const sd = freshStateDir();
+    const failing = (async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
+    await refreshUpdateCache({ stateDir: sd, now: () => 7, fetchImpl: failing });
+    const cache = readCacheFile(sd);
+    expect(cache.latest).toBeNull();
+    expect(cache.lastCheckMs).toBe(7);
+  });
+
+  test("end-to-end: a stale refresh writes a cache a later run would notify from", async () => {
+    const sd = freshStateDir();
+    const f = recordingFetch({ "dist-tags": { latest: "0.2.0" } });
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: () => {}, now: () => 10 ** 12, refresh: true, fetchImpl: f.fn });
+    await tick();
+    const out: string[] = [];
+    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m), now: () => 10 ** 12 });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("0.2.0");
+  });
+});

--- a/src/unit-test/version-utils.test.ts
+++ b/src/unit-test/version-utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { compareVersions, isStableVersion, isStableUpgrade } from "../version-utils";
+
+describe("compareVersions", () => {
+  test("orders by major, minor, patch", () => {
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareVersions("2.0.0", "1.9.9")).toBe(1);
+    expect(compareVersions("1.9.9", "2.0.0")).toBe(-1);
+    expect(compareVersions("1.2.0", "1.1.9")).toBe(1);
+    expect(compareVersions("0.1.7", "0.1.6")).toBe(1);
+    expect(compareVersions("0.1.6", "0.1.7")).toBe(-1);
+  });
+
+  test("treats missing trailing segments as 0", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+    expect(compareVersions("1", "1.0.0")).toBe(0);
+    expect(compareVersions("1.2.1", "1.2")).toBe(1);
+  });
+});
+
+describe("isStableVersion", () => {
+  test("accepts exactly three numeric segments", () => {
+    expect(isStableVersion("0.1.6")).toBe(true);
+    expect(isStableVersion("10.20.30")).toBe(true);
+    expect(isStableVersion(" 1.2.3 ")).toBe(true); // trimmed
+  });
+
+  test("rejects prerelease / build / prefixed / partial versions", () => {
+    expect(isStableVersion("0.2.0-beta.1")).toBe(false);
+    expect(isStableVersion("1.2.3+build")).toBe(false);
+    expect(isStableVersion("v1.2.3")).toBe(false);
+    expect(isStableVersion("1.2")).toBe(false);
+    expect(isStableVersion("1.2.3.4")).toBe(false);
+    expect(isStableVersion("latest")).toBe(false);
+    expect(isStableVersion("")).toBe(false);
+  });
+});
+
+describe("isStableUpgrade", () => {
+  test("true only when latest is a stable version strictly greater than current", () => {
+    expect(isStableUpgrade("0.1.6", "0.1.7")).toBe(true);
+    expect(isStableUpgrade("0.1.6", "0.2.0")).toBe(true);
+    expect(isStableUpgrade("0.1.6", "1.0.0")).toBe(true);
+  });
+
+  test("false for equal or older latest (no downgrade nag)", () => {
+    expect(isStableUpgrade("0.1.6", "0.1.6")).toBe(false);
+    expect(isStableUpgrade("0.1.7", "0.1.6")).toBe(false);
+  });
+
+  test("false when either side is prerelease or malformed (no beta nag)", () => {
+    expect(isStableUpgrade("0.1.6", "0.2.0-beta.1")).toBe(false);
+    expect(isStableUpgrade("0.1.6-rc.1", "0.1.7")).toBe(false);
+    expect(isStableUpgrade("0.1.6", "garbage")).toBe(false);
+    expect(isStableUpgrade("", "0.1.7")).toBe(false);
+  });
+});

--- a/src/update-notifier.ts
+++ b/src/update-notifier.ts
@@ -1,0 +1,191 @@
+/**
+ * Update notifier (#auto-update).
+ *
+ * Tells the user when a newer stable AgentBridge is available on npm. Designed to
+ * be correct-by-construction:
+ *   - ZERO network on most runs: a notice is printed from a cached `latest`
+ *     (populated by a prior run); the network is hit at most once per `interval`.
+ *   - NEVER blocks / delays / fails the command: printing is sync from cache; the
+ *     daily refresh is fired un-awaited and only on long-lived launchers (claude/
+ *     codex) whose parent process outlives the fetch — one-shot commands never
+ *     keep a pending fetch alive past their own exit.
+ *   - SILENT on any failure (offline, 404, proxy, malformed JSON, timeout).
+ *   - SUPPRESSED for non-TTY/CI/test and via opt-out env vars.
+ *   - STABLE-only: never nags about prereleases or downgrades (see version-utils).
+ *   - READ-ONLY: it only prints the upgrade command; it never installs anything.
+ *
+ * npm is queried as the single authoritative source: the user running `abg`
+ * installed the CLI from npm, and `scripts/check-plugin-versions.js` keeps the
+ * package/plugin/marketplace versions equal, so npm's `dist-tags.latest` is a
+ * faithful proxy for the plugin version too. The notice still surfaces both the
+ * CLI (`npm i -g`) and plugin (`/plugin marketplace update`) upgrade paths.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { StateDirResolver } from "./state-dir";
+import { isStableUpgrade, isStableVersion } from "./version-utils";
+import { parsePositiveIntEnv } from "./env-utils";
+
+export const PACKAGE_NAME = "@raysonmeng/agentbridge";
+/** Scope must be URL-encoded (`@scope%2Fname`) in the registry path. */
+const REGISTRY_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}`;
+/** Abbreviated metadata — smallest payload that still carries `dist-tags`. */
+const ABBREVIATED_ACCEPT = "application/vnd.npm.install-v1+json";
+const DEFAULT_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // once per day
+const FETCH_TIMEOUT_MS = 2500;
+const CHECK_INTERVAL_ENV = "AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS";
+
+export interface UpdateCache {
+  /** Epoch ms of the last completed network check. */
+  lastCheckMs: number;
+  /** Last-known stable `latest` from npm, or null if never/failed. */
+  latest: string | null;
+}
+
+export interface NotifierDeps {
+  /** Installed version. Defaults to the build-time package version. */
+  current?: string;
+  /** Whether to fire the daily background refresh. Only true for long-lived launchers. */
+  refresh?: boolean;
+  stateDir?: StateDirResolver;
+  now?: () => number;
+  /** Whether output goes to a TTY (defaults to stderr.isTTY). */
+  isTTY?: boolean;
+  env?: NodeJS.ProcessEnv;
+  print?: (msg: string) => void;
+  fetchImpl?: typeof fetch;
+}
+
+/** Installed version, inlined at build time by Bun's bundler (see printVersion). */
+export function getCurrentVersion(): string {
+  try {
+    return (require("../package.json") as { version: string }).version;
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/** Whether the notice should be fully suppressed for this environment. */
+export function isUpdateCheckSuppressed(env: NodeJS.ProcessEnv, isTTY: boolean): boolean {
+  // Ecosystem-standard opt-out + namespaced opt-out (any non-empty value disables).
+  if (env.NO_UPDATE_NOTIFIER) return true;
+  if (env.AGENTBRIDGE_NO_UPDATE_NOTIFIER) return true;
+  if (env.CI) return true; // don't nag in CI
+  if (env.NODE_ENV === "test") return true;
+  if (!isTTY) return true; // piped/redirected — keep output clean
+  return false;
+}
+
+function readCache(stateDir: StateDirResolver): UpdateCache | null {
+  try {
+    const parsed = JSON.parse(readFileSync(stateDir.updateCheckFile, "utf-8")) as Partial<UpdateCache>;
+    if (typeof parsed.lastCheckMs !== "number" || !Number.isFinite(parsed.lastCheckMs)) return null;
+    return {
+      lastCheckMs: parsed.lastCheckMs,
+      latest: typeof parsed.latest === "string" ? parsed.latest : null,
+    };
+  } catch {
+    return null; // missing / corrupt → treat as "no cache, recheck"
+  }
+}
+
+function writeCache(stateDir: StateDirResolver, cache: UpdateCache): void {
+  try {
+    stateDir.ensure();
+    writeFileSync(stateDir.updateCheckFile, JSON.stringify(cache, null, 2) + "\n", "utf-8");
+  } catch {
+    // best-effort; a failed cache write just means we recheck next time
+  }
+}
+
+/** Extract + validate the stable `dist-tags.latest` from an npm registry body. */
+export function parseLatestFromRegistry(body: unknown): string | null {
+  if (typeof body !== "object" || body === null) return null;
+  const distTags = (body as Record<string, unknown>)["dist-tags"];
+  if (typeof distTags !== "object" || distTags === null) return null;
+  const latest = (distTags as Record<string, unknown>).latest;
+  if (typeof latest !== "string" || !isStableVersion(latest)) return null;
+  return latest;
+}
+
+async function fetchLatest(fetchImpl: typeof fetch): Promise<string | null> {
+  try {
+    const res = await fetchImpl(REGISTRY_URL, {
+      headers: { Accept: ABBREVIATED_ACCEPT },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    return parseLatestFromRegistry(await res.json());
+  } catch {
+    return null; // offline / timeout / DNS / 4xx / malformed JSON — all silent
+  }
+}
+
+/**
+ * Refresh the cache from npm. On a transient failure the previously-known
+ * `latest` is preserved (only `lastCheckMs` advances) so we neither lose a good
+ * value nor hammer the registry. Swallows all errors.
+ */
+export async function refreshUpdateCache(deps: NotifierDeps = {}): Promise<void> {
+  const stateDir = deps.stateDir ?? new StateDirResolver();
+  const now = deps.now ?? Date.now;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  try {
+    const latest = await fetchLatest(fetchImpl);
+    const prev = readCache(stateDir);
+    writeCache(stateDir, { lastCheckMs: now(), latest: latest ?? prev?.latest ?? null });
+  } catch {
+    // never throw
+  }
+}
+
+/** The user-facing notice. TTY-aware (color only on a terminal). */
+export function buildUpdateNotice(current: string, latest: string, isTTY: boolean): string {
+  const yellow = isTTY ? "\x1b[33m" : "";
+  const bold = isTTY ? "\x1b[1m" : "";
+  const reset = isTTY ? "\x1b[0m" : "";
+  return [
+    `${yellow}⚠ AgentBridge update available: ${bold}${current}${reset}${yellow} → ${bold}${latest}${reset}`,
+    `  CLI:    npm install -g ${PACKAGE_NAME}@latest`,
+    `  Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)`,
+    `  (silence with NO_UPDATE_NOTIFIER=1)`,
+  ].join("\n");
+}
+
+function checkIntervalMs(env: NodeJS.ProcessEnv): number {
+  // Read from the injected env (not process.env) so the deps.env DI contract
+  // holds end-to-end and the interval is overridable/testable.
+  return parsePositiveIntEnv(CHECK_INTERVAL_ENV, DEFAULT_CHECK_INTERVAL_MS, undefined, env);
+}
+
+/**
+ * Best-effort update notice. Synchronously prints a notice from the cached
+ * `latest` (if a newer stable version exists), then — only when `refresh` is set
+ * — fires an un-awaited daily refresh. NEVER throws, blocks, or changes exit code.
+ */
+export function maybeNotifyUpdate(deps: NotifierDeps = {}): void {
+  try {
+    const env = deps.env ?? process.env;
+    const isTTY = deps.isTTY ?? Boolean(process.stderr.isTTY);
+    if (isUpdateCheckSuppressed(env, isTTY)) return;
+
+    const current = deps.current ?? getCurrentVersion();
+    const stateDir = deps.stateDir ?? new StateDirResolver();
+    const now = deps.now ?? Date.now;
+    const print = deps.print ?? ((m: string) => process.stderr.write(m + "\n"));
+
+    const cache = readCache(stateDir);
+    if (cache?.latest && isStableUpgrade(current, cache.latest)) {
+      print(buildUpdateNotice(current, cache.latest, isTTY));
+    }
+
+    // Daily refresh — only on long-lived launchers (deps.refresh), where the
+    // parent process outlives the fetch. One-shot commands skip this so a
+    // pending fetch can never delay their exit.
+    if (deps.refresh && (!cache || now() - cache.lastCheckMs >= checkIntervalMs(env))) {
+      void refreshUpdateCache({ stateDir, now, fetchImpl: deps.fetchImpl }).catch(() => {});
+    }
+  } catch {
+    // The notifier must never affect the command it precedes.
+  }
+}

--- a/src/version-utils.ts
+++ b/src/version-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared semver helpers. Kept dependency-free (AgentBridge has zero runtime
+ * deps) and deliberately conservative: we only ever reason about plain
+ * `MAJOR.MINOR.PATCH` stable versions. Prerelease/build metadata is treated as
+ * "not a stable version" so the update notifier never nags users about betas.
+ */
+
+/** A strict stable semver: exactly three numeric dot-segments, e.g. `0.1.6`. */
+const STABLE_SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+/** True when `v` is a clean stable `X.Y.Z` (no prerelease/build suffix, no `v` prefix). */
+export function isStableVersion(v: string): boolean {
+  return STABLE_SEMVER_RE.test(v.trim());
+}
+
+/**
+ * Compare two `X.Y.Z` version strings. Returns -1 if a<b, 0 if equal, 1 if a>b.
+ * Missing segments are treated as 0; non-numeric segments collapse to NaN which
+ * compares as neither `<` nor `>` (callers should pass stable versions — see
+ * `isStableVersion`). Matches the original comparator extracted from init.ts.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va < vb) return -1;
+    if (va > vb) return 1;
+  }
+  return 0;
+}
+
+/**
+ * True only when `latest` is a STABLE version strictly greater than a STABLE
+ * `current`. If either side is missing / prerelease / malformed, returns false —
+ * we never surface a downgrade, an equal version, a beta, or a garbage tag.
+ */
+export function isStableUpgrade(current: string, latest: string): boolean {
+  if (!isStableVersion(current) || !isStableVersion(latest)) return false;
+  return compareVersions(latest, current) === 1;
+}


### PR DESCRIPTION
## Scope note / 范围说明

`origin/master` is **15 commits behind** this branch. The local `integration-test` line (multi-pair Route A, Codex transport ws→unix fallback, auto-update notifier, pair-UX redesign, daemon self-heal) was never merged to master, and the new **P0a–P5 install-consistency / reliability hardening** is built on top of it. This PR therefore brings the **entire unmerged integration backlog + the new work** to `master` (16 commits). The headline new commit is `3f6efff`.

> If you'd rather land only the new P0a–P5 work, it cannot be cherry-picked cleanly onto raw `master` (it depends on the multi-pair + reliability commits below) — it would need to go through `integration-test` first.

## What's new in this PR (the P0a–P5 commit `3f6efff`)

On top of `6c24127`, lands the **P0a–P5 install-consistency and multi-pair reliability hardening**, and fixes **11 real bugs** surfaced across a **12-round cross-review gate (R1–R12)**.

### Core (P0a–P5)
- **Install consistency (B3):** stop-the-world before install, dist/tarball artifact verification, postinstall sync (`scripts/install-safety.cjs`)
- **env-guard:** detect/clear stale `AGENTBRIDGE_*` runtime env (kills the "wrong daemon" class)
- **daemon identity (B8):** control connection carries `pairId`/`cwd`; mismatch rejected with `CLOSE_CODE_PAIR_MISMATCH` (4004)
- **build-drift gate (B9):** old-bytes daemon auto-replaced on upgrade (`sameRuntimeContract` keyed on version/commit/contract)
- **explicit manual mode (B1):** `AGENTBRIDGE_MANUAL=1` opt-in; stale pinned env no longer implicitly manual
- **thread-state:** current-thread persistence + rollout verification + auto-resume; turn watchdog emits `turnStalled` instead of faking completion (B12)
- **`abg doctor`:** static diagnostics; `resume-pollution` cleanup of kickoff-polluted sessions (rename/delete, explicit `--apply` + backup-first)
- log rotation, version pinning, managed-TUI guard, opt-in redacted trace

### Real bugs fixed (cross-review)
- **CRITICAL** build-drift replace-war: dist vs plugin daemon each declared the other "drifted" → ping-pong kill → Codex TUI couldn't stay up. `sameRuntimeContract` ignores the `bundle` kind.
- **HIGH** thread-state concurrency clobber: un-serialized persistence retry loops overwrote `current-thread.json`. `shouldContinue` guard.
- **HIGH** require_reply ×3 terminal-path strands (arm-on-failed-send / strand-on-abort / strand-on-rejected-turn-start). New `ReplyRequiredTracker`.
- **HIGH** `bridge.ts` trace full-env leak: off-by-default + `pickRelevantEnv` allowlist + `.agentbridge/` gitignored.
- **HIGH** B11: `abg codex` no longer rewrites `AGENTS.md` on start (read-only nudge).
- over-broad postinstall stop trigger (only explicit global self-install stops daemons now).
- directory-strict pair ops (per user decision): launch throws `PAIR_CROSS_CWD`; `kill`/`pairs rm` resolve a raw id only in the same cwd.
- resume-pollution delete branch; docs sync.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test src` — **502 pass / 0 fail**
- [x] `bun run build:cli` + `bun run build:plugin` + `bun run verify:plugin-sync` — bundles in sync
- [x] `bun scripts/check-plugin-versions.js` — version-aligned at 0.1.6
- [x] `node scripts/install-safety.cjs verify-built` — 16 artifacts verified
- [x] Every fix ships a regression test
- [x] **Cross-review gate:** 12 rounds (dual reviewer + adversarial verification), converged on two consecutive clean rounds; Codex independently re-verified green
- [ ] Deploy (`install:global:local` stop-the-world) — pending: run after stopping other live pairs

## Known non-blocking follow-up
- A pair whose registered cwd is deleted/renamed can't release its slot via `pairs rm` (now cwd-strict). Mitigated: the slot is skipped by `pickLowestFreeSlot`, the orphan is still listed by `abg pairs` and stopped by `abg kill --all`, and `<base>/pairs/registry.json` can be edited manually. Optional escape hatch (allow rm of an orphan whose cwd no longer exists) tracked as backlog.
