### PR TITLE
fix: Windows 预检端口清理（平台感知 + windows CI 真机验证）/ platform-aware pre-flight port cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,28 @@ jobs:
 
       - name: Release smoke (npm pack completeness)
         run: bun run smoke:pack
+
+  # Windows is not a fully supported platform yet, but the pre-flight port
+  # cleanup (issue #76) has a dedicated win32 path that no maintainer can
+  # exercise locally — this job runs its unit tests plus a LIVE check of the
+  # real PowerShell commands (Get-NetTCPConnection / Win32_Process) against
+  # an actual listener on the runner.
+  windows-port-cleanup:
+    runs-on: windows-latest
+    # Advisory while the platform job proves itself stable (per the repo's own
+    # audit guidance on new platform jobs); flip to a hard gate after a streak
+    # of green runs.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Port-cleanup unit + live platform tests
+        run: bun test src/unit-test/port-cleanup.test.ts src/unit-test/port-cleanup-live.test.ts

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14206,7 +14206,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("18adc83", "source"),
+  commit: defineString("830d8a3", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, 1)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -15,7 +15,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("18adc83", "source"),
+  commit: defineString("830d8a3", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, 1)
 });
@@ -39,7 +39,7 @@ function formatBuildInfo(build) {
 }
 
 // src/codex-adapter.ts
-import { spawn, execSync } from "child_process";
+import { spawn, execFileSync } from "child_process";
 import { createInterface } from "readline";
 import { EventEmitter } from "events";
 
@@ -98,6 +98,106 @@ class StateDirResolver {
   }
   get updateCheckFile() {
     return join(this.stateDir, "update-check.json");
+  }
+}
+
+// src/port-cleanup.ts
+function portPidsCommand(port, platform2 = process.platform) {
+  if (platform2 === "win32") {
+    return {
+      cmd: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-Command",
+        `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique`
+      ]
+    };
+  }
+  return { cmd: "lsof", args: ["-ti", `tcp:${port}`, "-sTCP:LISTEN"] };
+}
+function processCommandLineCommand(pid, platform2 = process.platform) {
+  if (platform2 === "win32") {
+    return {
+      cmd: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-Command",
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction SilentlyContinue; if ($p -and $p.CommandLine) { $p.CommandLine }`
+      ]
+    };
+  }
+  return { cmd: "ps", args: ["-p", pid, "-o", "args="] };
+}
+function killPidCommand(pid, platform2 = process.platform) {
+  if (platform2 === "win32") {
+    return {
+      cmd: "powershell.exe",
+      args: ["-NoProfile", "-Command", `Stop-Process -Id ${pid} -Force -ErrorAction Stop`]
+    };
+  }
+  return { cmd: "kill", args: [pid] };
+}
+function parsePids(output) {
+  const seen = new Set;
+  const pids = [];
+  for (const line of output.split(/\r?\n/)) {
+    const pid = line.trim();
+    if (!/^\d+$/.test(pid))
+      continue;
+    if (pid === "0")
+      continue;
+    if (seen.has(pid))
+      continue;
+    seen.add(pid);
+    pids.push(pid);
+  }
+  return pids;
+}
+function isCodexAppServerCommandLine(cmdline, platform2 = process.platform) {
+  const s = platform2 === "win32" ? cmdline.toLowerCase() : cmdline;
+  return s.includes("codex") && s.includes("app-server");
+}
+async function cleanupPorts(options) {
+  const platform2 = options.platform ?? process.platform;
+  const listPids = (port) => {
+    try {
+      return parsePids(options.run(portPidsCommand(port, platform2)));
+    } catch {
+      return [];
+    }
+  };
+  for (const { port, envVar } of options.ports) {
+    const pidList = listPids(port);
+    if (pidList.length === 0)
+      continue;
+    const staleCodexPids = [];
+    const foreignPids = [];
+    for (const pid of pidList) {
+      try {
+        const cmdline = options.run(processCommandLineCommand(pid, platform2)).trim();
+        if (isCodexAppServerCommandLine(cmdline, platform2)) {
+          staleCodexPids.push(pid);
+        } else {
+          foreignPids.push(pid);
+        }
+      } catch {}
+    }
+    if (staleCodexPids.length > 0) {
+      options.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
+      for (const pid of staleCodexPids) {
+        try {
+          options.run(killPidCommand(pid, platform2));
+        } catch {}
+      }
+      await options.sleep(500);
+    }
+    if (foreignPids.length > 0) {
+      throw new Error(`Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` + `Please stop the process or set a different port via ${envVar} env var.`);
+    }
+    const remaining = listPids(port);
+    if (remaining.length > 0) {
+      throw new Error(`Port ${port} is still occupied (PID(s): ${remaining.join(", ")}) after cleanup. ` + `Please stop the process or set a different port via ${envVar} env var.`);
+    }
   }
 }
 
@@ -1795,58 +1895,19 @@ class CodexAdapter extends EventEmitter {
     this.pendingServerResponses.clear();
   }
   static buildPortListenLsofCommand(port) {
-    return `lsof -ti tcp:${port} -sTCP:LISTEN`;
+    const { cmd, args } = portPidsCommand(port, "linux");
+    return [cmd, ...args].join(" ");
   }
   async checkPorts() {
-    for (const port of [this.appPort, this.proxyPort]) {
-      try {
-        const pids = execSync(CodexAdapter.buildPortListenLsofCommand(port), {
-          encoding: "utf-8"
-        }).trim();
-        if (!pids)
-          continue;
-        const pidList = pids.split(`
-`).map((p) => p.trim()).filter(Boolean);
-        const staleCodexPids = [];
-        const foreignPids = [];
-        for (const pid of pidList) {
-          try {
-            const cmdline = execSync(`ps -p ${pid} -o args=`, { encoding: "utf-8" }).trim();
-            if (cmdline.includes("codex") && cmdline.includes("app-server")) {
-              staleCodexPids.push(pid);
-            } else {
-              foreignPids.push(pid);
-            }
-          } catch {}
-        }
-        if (staleCodexPids.length > 0) {
-          this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
-          for (const pid of staleCodexPids) {
-            try {
-              execSync(`kill ${pid}`, { encoding: "utf-8" });
-            } catch {}
-          }
-          await new Promise((r) => setTimeout(r, 500));
-        }
-        if (foreignPids.length > 0) {
-          throw new Error(`Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
-        }
-        try {
-          const remaining = execSync(CodexAdapter.buildPortListenLsofCommand(port), {
-            encoding: "utf-8"
-          }).trim();
-          if (remaining) {
-            throw new Error(`Port ${port} is still occupied (PID(s): ${remaining.replace(/\n/g, ", ")}) after cleanup. ` + `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`);
-          }
-        } catch (err) {
-          if (err.message?.includes("Port"))
-            throw err;
-        }
-      } catch (err) {
-        if (err.message?.includes("Port") || err.message?.includes("non-Codex"))
-          throw err;
-      }
-    }
+    await cleanupPorts({
+      ports: [
+        { port: this.appPort, envVar: "CODEX_WS_PORT" },
+        { port: this.proxyPort, envVar: "CODEX_PROXY_PORT" }
+      ],
+      run: ({ cmd, args }) => execFileSync(cmd, args, { encoding: "utf-8" }),
+      log: (message) => this.log(message),
+      sleep: (ms) => new Promise((r) => setTimeout(r, ms))
+    });
   }
   log(msg) {
     this.logger.log(msg);
@@ -2064,7 +2125,7 @@ class TuiConnectionState {
 }
 
 // src/daemon-lifecycle.ts
-import { spawn as spawn2, execFileSync } from "child_process";
+import { spawn as spawn2, execFileSync as execFileSync2 } from "child_process";
 import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync2, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 
@@ -2414,7 +2475,7 @@ class DaemonLifecycle {
   }
   isAgentBridgeProcess(pid) {
     try {
-      const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
+      const cmd = execFileSync2("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
       return cmd.includes("agentbridge") || cmd.includes("agent_bridge");
     } catch {
       return false;
@@ -2467,7 +2528,7 @@ class DaemonLifecycle {
   }
   isDaemonProcess(pid) {
     try {
-      const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
+      const cmd = execFileSync2("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
       const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
       const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
       return hasDaemonEntry && hasAgentbridge;

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -9,10 +9,11 @@
  * disconnect), because TUI rapidly reconnects between bootstrap phases.
  */
 
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, execFileSync, type ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
 import { EventEmitter } from "node:events";
 import { StateDirResolver } from "./state-dir";
+import { cleanupPorts, portPidsCommand } from "./port-cleanup";
 import { createProcessLogger, type ProcessLogger } from "./process-log";
 import type { BridgeMessage } from "./types";
 import type { ServerWebSocket } from "bun";
@@ -1934,85 +1935,37 @@ export class CodexAdapter extends EventEmitter {
 
   /**
    * Build the lsof command used to find LISTENing processes on a TCP port.
+   * Kept as the POSIX single source of truth (delegates to port-cleanup.ts);
+   * see portPidsCommand for why the LISTEN restriction matters.
    *
-   * Restricting to `-sTCP:LISTEN` is critical: a bare `lsof -ti :PORT` also
-   * returns processes that merely have an outbound (client) FD to that port,
-   * including stale CLOSED connections from crashed clients. Those false
-   * positives caused `abg claude` to refuse startup whenever a previous
-   * Codex TUI process lingered with a half-closed connection to port 4501.
+   * Platform is hardcoded to "linux" on purpose: this method exists only for
+   * the POSIX lsof test fixture (string-equality asserted in tests). The
+   * production path is checkPorts(), which uses process.platform.
    */
   static buildPortListenLsofCommand(port: number): string {
-    return `lsof -ti tcp:${port} -sTCP:LISTEN`;
+    const { cmd, args } = portPidsCommand(port, "linux");
+    return [cmd, ...args].join(" ");
   }
 
   /**
    * Clean up stale ports before starting.
    * Only kills `codex app-server` processes (our own spawns). If the port is
    * occupied by something else, throws with a clear message.
+   *
+   * Platform-aware (issue #76): POSIX uses lsof/ps/kill, win32 uses
+   * PowerShell — previously the lsof failure on Windows was swallowed and the
+   * spawn ran straight into "os error 10048".
    */
   private async checkPorts() {
-    for (const port of [this.appPort, this.proxyPort]) {
-      try {
-        const pids = execSync(CodexAdapter.buildPortListenLsofCommand(port), {
-          encoding: "utf-8",
-        }).trim();
-        if (!pids) continue;
-
-        // Check if the occupying process is a codex app-server (our own stale spawn)
-        const pidList = pids.split("\n").map((p) => p.trim()).filter(Boolean);
-        const staleCodexPids: string[] = [];
-        const foreignPids: string[] = [];
-
-        for (const pid of pidList) {
-          try {
-            const cmdline = execSync(`ps -p ${pid} -o args=`, { encoding: "utf-8" }).trim();
-            if (cmdline.includes("codex") && cmdline.includes("app-server")) {
-              staleCodexPids.push(pid);
-            } else {
-              foreignPids.push(pid);
-            }
-          } catch {
-            // Process already gone
-          }
-        }
-
-        // Kill stale codex app-server processes (our own previous spawns)
-        if (staleCodexPids.length > 0) {
-          this.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
-          for (const pid of staleCodexPids) {
-            try { execSync(`kill ${pid}`, { encoding: "utf-8" }); } catch {}
-          }
-          await new Promise((r) => setTimeout(r, 500));
-        }
-
-        // If foreign processes still occupy the port, fail with a clear message
-        if (foreignPids.length > 0) {
-          throw new Error(
-            `Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` +
-            `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
-          );
-        }
-
-        // Verify port is now free
-        try {
-          const remaining = execSync(CodexAdapter.buildPortListenLsofCommand(port), {
-            encoding: "utf-8",
-          }).trim();
-          if (remaining) {
-            throw new Error(
-              `Port ${port} is still occupied (PID(s): ${remaining.replace(/\n/g, ", ")}) after cleanup. ` +
-              `Please stop the process or set a different port via ${port === this.appPort ? "CODEX_WS_PORT" : "CODEX_PROXY_PORT"} env var.`
-            );
-          }
-        } catch (err: any) {
-          if (err.message?.includes("Port")) throw err;
-          // lsof exit 1 = port free, good
-        }
-      } catch (err: any) {
-        // lsof returns exit code 1 if no match — port is free
-        if (err.message?.includes("Port") || err.message?.includes("non-Codex")) throw err;
-      }
-    }
+    await cleanupPorts({
+      ports: [
+        { port: this.appPort, envVar: "CODEX_WS_PORT" },
+        { port: this.proxyPort, envVar: "CODEX_PROXY_PORT" },
+      ],
+      run: ({ cmd, args }) => execFileSync(cmd, args, { encoding: "utf-8" }),
+      log: (message) => this.log(message),
+      sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    });
   }
 
   private log(msg: string) {

--- a/src/port-cleanup.ts
+++ b/src/port-cleanup.ts
@@ -1,0 +1,191 @@
+/**
+ * Platform-aware pre-flight port cleanup.
+ *
+ * Before the daemon spawns `codex app-server`, ports left occupied by a stale
+ * spawn (daemon hard-killed, child survived) must be reclaimed — otherwise the
+ * fresh spawn dies with EADDRINUSE / os error 10048 and the user lands in the
+ * recurring "PARTIAL state" failure that needs a manual `agentbridge kill`.
+ *
+ * The POSIX path uses lsof/ps/kill. The win32 path (issue #76, contributed by
+ * @Tominori666) uses PowerShell: `Get-NetTCPConnection` for port→PID,
+ * `Get-CimInstance Win32_Process` for the command line, `Stop-Process -Force`
+ * to kill — all available on every supported Windows without extra tooling.
+ *
+ * Every command is expressed as argv (no shell interpolation) and the runner
+ * is injectable so the decision logic is unit-testable on any platform.
+ */
+
+export interface PortCommand {
+  cmd: string;
+  args: string[];
+}
+
+export type CommandRunner = (command: PortCommand) => string;
+
+/**
+ * Command that lists PIDs LISTENing on a TCP port, one per line.
+ *
+ * POSIX: restricting to `-sTCP:LISTEN` is critical — a bare `lsof -ti :PORT`
+ * also returns processes that merely have an outbound (client) FD to that
+ * port, including stale CLOSED connections from crashed clients. Those false
+ * positives caused `abg claude` to refuse startup whenever a previous Codex
+ * TUI process lingered with a half-closed connection to port 4501.
+ *
+ * win32: `Get-NetTCPConnection -State Listen` has the LISTEN restriction
+ * built in; `-ErrorAction SilentlyContinue` makes "no match" emit nothing
+ * instead of failing, mirroring lsof's exit-1-on-empty handled by the caller.
+ */
+export function portPidsCommand(port: number, platform: NodeJS.Platform = process.platform): PortCommand {
+  if (platform === "win32") {
+    return {
+      cmd: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-Command",
+        `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique`,
+      ],
+    };
+  }
+  return { cmd: "lsof", args: ["-ti", `tcp:${port}`, "-sTCP:LISTEN"] };
+}
+
+/** Command that prints the full command line of a PID (empty when gone). */
+export function processCommandLineCommand(pid: string, platform: NodeJS.Platform = process.platform): PortCommand {
+  if (platform === "win32") {
+    return {
+      cmd: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-Command",
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction SilentlyContinue; if ($p -and $p.CommandLine) { $p.CommandLine }`,
+      ],
+    };
+  }
+  return { cmd: "ps", args: ["-p", pid, "-o", "args="] };
+}
+
+/**
+ * Command that terminates a PID. POSIX keeps plain SIGTERM (the pre-existing
+ * behavior — stale app-servers exit cleanly on TERM). win32 uses -Force:
+ * there is no TERM equivalent a headless app-server responds to, and the
+ * whole point is reclaiming the port from an already-orphaned process.
+ */
+export function killPidCommand(pid: string, platform: NodeJS.Platform = process.platform): PortCommand {
+  if (platform === "win32") {
+    return {
+      cmd: "powershell.exe",
+      args: ["-NoProfile", "-Command", `Stop-Process -Id ${pid} -Force -ErrorAction Stop`],
+    };
+  }
+  return { cmd: "kill", args: [pid] };
+}
+
+/** Split command output into deduplicated, trimmed, non-empty PID strings. */
+export function parsePids(output: string): string[] {
+  const seen = new Set<string>();
+  const pids: string[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const pid = line.trim();
+    // PIDs only — PowerShell failures can emit error text on stdout in some
+    // hosts; anything non-numeric must not reach kill.
+    if (!/^\d+$/.test(pid)) continue;
+    // PID 0 is never a reclaimable user process: on Windows it's the System
+    // Idle pseudo-process (would classify as foreign and spuriously block
+    // startup); on POSIX `kill 0` signals the whole process group.
+    if (pid === "0") continue;
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    pids.push(pid);
+  }
+  return pids;
+}
+
+/**
+ * Is this command line one of our own `codex app-server` spawns?
+ *
+ * Case-insensitive ONLY on win32 (paths like `C:\...\Codex\codex.exe` are
+ * case-preserving but case-insensitive). POSIX keeps the pre-existing
+ * case-sensitive match — widening it would reclassify a foreign process
+ * with `Codex` in a path component from "refuse startup with a clear error"
+ * to "silently kill".
+ */
+export function isCodexAppServerCommandLine(cmdline: string, platform: NodeJS.Platform = process.platform): boolean {
+  const s = platform === "win32" ? cmdline.toLowerCase() : cmdline;
+  return s.includes("codex") && s.includes("app-server");
+}
+
+export interface CleanupPortsOptions {
+  ports: Array<{ port: number; envVar: string }>;
+  run: CommandRunner;
+  log: (message: string) => void;
+  sleep: (ms: number) => Promise<void>;
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * Reclaim stale `codex app-server` listeners on the given ports.
+ *
+ * Only kills processes whose command line identifies them as codex
+ * app-servers (our own previous spawns). Throws with an actionable message
+ * when a foreign process holds the port, or when the port is still occupied
+ * after cleanup.
+ */
+export async function cleanupPorts(options: CleanupPortsOptions): Promise<void> {
+  const platform = options.platform ?? process.platform;
+
+  const listPids = (port: number): string[] => {
+    try {
+      return parsePids(options.run(portPidsCommand(port, platform)));
+    } catch {
+      // lsof exits 1 when nothing matches — port is free.
+      return [];
+    }
+  };
+
+  for (const { port, envVar } of options.ports) {
+    const pidList = listPids(port);
+    if (pidList.length === 0) continue;
+
+    const staleCodexPids: string[] = [];
+    const foreignPids: string[] = [];
+    for (const pid of pidList) {
+      try {
+        const cmdline = options.run(processCommandLineCommand(pid, platform)).trim();
+        if (isCodexAppServerCommandLine(cmdline, platform)) {
+          staleCodexPids.push(pid);
+        } else {
+          foreignPids.push(pid);
+        }
+      } catch {
+        // Process already gone between the two commands.
+      }
+    }
+
+    if (staleCodexPids.length > 0) {
+      options.log(`Cleaning up stale codex app-server on port ${port}: PID(s) ${staleCodexPids.join(", ")}`);
+      for (const pid of staleCodexPids) {
+        try {
+          options.run(killPidCommand(pid, platform));
+        } catch {
+          // Already exited; the post-cleanup re-check below is the authority.
+        }
+      }
+      await options.sleep(500);
+    }
+
+    if (foreignPids.length > 0) {
+      throw new Error(
+        `Port ${port} is already in use by non-Codex process(es): PID(s) ${foreignPids.join(", ")}. ` +
+          `Please stop the process or set a different port via ${envVar} env var.`,
+      );
+    }
+
+    const remaining = listPids(port);
+    if (remaining.length > 0) {
+      throw new Error(
+        `Port ${port} is still occupied (PID(s): ${remaining.join(", ")}) after cleanup. ` +
+          `Please stop the process or set a different port via ${envVar} env var.`,
+      );
+    }
+  }
+}

--- a/src/unit-test/port-cleanup-live.test.ts
+++ b/src/unit-test/port-cleanup-live.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import type { TCPSocketListener } from "bun";
+import { parsePids, portPidsCommand, processCommandLineCommand } from "../port-cleanup";
+
+/**
+ * Live verification against the REAL platform commands — this is what the
+ * windows-latest CI job exists for (issue #76: no maintainer has a local
+ * Windows box). On POSIX it doubles as a live check of the lsof path.
+ *
+ * The test binds a real TCP listener and asserts the platform command finds
+ * our own PID on that port, then that the command-line lookup returns a
+ * non-empty command line for it.
+ */
+describe("port-cleanup live platform commands", () => {
+  let server: TCPSocketListener | null = null;
+  let port = 0;
+
+  beforeAll(() => {
+    server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: { data() {} },
+    }) as TCPSocketListener;
+    port = server.port;
+  });
+
+  afterAll(() => {
+    server?.stop(true);
+  });
+
+  test("portPidsCommand finds our own listener PID", () => {
+    const { cmd, args } = portPidsCommand(port);
+    const output = execFileSync(cmd, args, { encoding: "utf-8" });
+    const pids = parsePids(output);
+    expect(pids).toContain(String(process.pid));
+  });
+
+  test("processCommandLineCommand returns a command line for our PID", () => {
+    const { cmd, args } = processCommandLineCommand(String(process.pid));
+    const output = execFileSync(cmd, args, { encoding: "utf-8" }).trim();
+    expect(output.length).toBeGreaterThan(0);
+    // Our own process is the bun test runner.
+    expect(output.toLowerCase()).toContain("bun");
+  });
+
+  test("portPidsCommand returns nothing for a free port", () => {
+    const free = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+    const freePort = free.port;
+    free.stop(true);
+    const { cmd, args } = portPidsCommand(freePort);
+    let output = "";
+    try {
+      output = execFileSync(cmd, args, { encoding: "utf-8" });
+    } catch {
+      // lsof exits 1 on no match — that IS the free-port signal on POSIX.
+    }
+    expect(parsePids(output)).toEqual([]);
+  });
+});

--- a/src/unit-test/port-cleanup.test.ts
+++ b/src/unit-test/port-cleanup.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from "bun:test";
+import {
+  cleanupPorts,
+  isCodexAppServerCommandLine,
+  killPidCommand,
+  parsePids,
+  portPidsCommand,
+  processCommandLineCommand,
+  type PortCommand,
+} from "../port-cleanup";
+
+describe("port-cleanup command construction", () => {
+  test("posix port listing keeps the TCP:LISTEN restriction", () => {
+    expect(portPidsCommand(4501, "darwin")).toEqual({
+      cmd: "lsof",
+      args: ["-ti", "tcp:4501", "-sTCP:LISTEN"],
+    });
+    expect(portPidsCommand(4501, "linux")).toEqual(portPidsCommand(4501, "darwin"));
+  });
+
+  test("win32 port listing uses Get-NetTCPConnection with Listen state", () => {
+    const { cmd, args } = portPidsCommand(4500, "win32");
+    expect(cmd).toBe("powershell.exe");
+    expect(args[0]).toBe("-NoProfile");
+    expect(args[2]).toContain("Get-NetTCPConnection -LocalPort 4500 -State Listen");
+    expect(args[2]).toContain("OwningProcess");
+  });
+
+  test("command line lookup per platform", () => {
+    expect(processCommandLineCommand("123", "linux")).toEqual({
+      cmd: "ps",
+      args: ["-p", "123", "-o", "args="],
+    });
+    const win = processCommandLineCommand("123", "win32");
+    expect(win.cmd).toBe("powershell.exe");
+    expect(win.args[2]).toContain("Win32_Process");
+    expect(win.args[2]).toContain("ProcessId = 123");
+  });
+
+  test("kill keeps plain SIGTERM on posix and Stop-Process -Force on win32", () => {
+    expect(killPidCommand("99", "darwin")).toEqual({ cmd: "kill", args: ["99"] });
+    const win = killPidCommand("99", "win32");
+    expect(win.cmd).toBe("powershell.exe");
+    expect(win.args[2]).toContain("Stop-Process -Id 99 -Force");
+  });
+});
+
+describe("parsePids", () => {
+  test("splits, trims, dedupes and drops non-numeric noise", () => {
+    expect(parsePids("123\n456\n123\n")).toEqual(["123", "456"]);
+    // CRLF from PowerShell output
+    expect(parsePids("123\r\n456\r\n")).toEqual(["123", "456"]);
+    // Error text or prompts must never reach kill
+    expect(parsePids("Get-NetTCPConnection : error\n123\n")).toEqual(["123"]);
+    expect(parsePids("")).toEqual([]);
+    expect(parsePids("\n\n")).toEqual([]);
+  });
+});
+
+describe("isCodexAppServerCommandLine", () => {
+  test("matches posix and windows codex app-server command lines", () => {
+    expect(isCodexAppServerCommandLine("/usr/local/bin/codex app-server", "darwin")).toBe(true);
+    expect(isCodexAppServerCommandLine('"C:\\Users\\x\\AppData\\Local\\Programs\\Codex\\codex.exe" app-server', "win32")).toBe(true);
+    expect(isCodexAppServerCommandLine("node /srv/other-server.js", "darwin")).toBe(false);
+    // A codex TUI without app-server must NOT be treated as a stale spawn
+    expect(isCodexAppServerCommandLine("codex resume abc --yolo", "darwin")).toBe(false);
+  });
+
+  test("POSIX match stays case-sensitive: foreign Codex-cased paths must refuse startup, not get killed", () => {
+    expect(isCodexAppServerCommandLine("/opt/Codex/app-server-helper", "darwin")).toBe(false);
+    expect(isCodexAppServerCommandLine("/opt/Codex/app-server-helper", "linux")).toBe(false);
+    // win32 is case-insensitive by design (case-preserving filesystem)
+    expect(isCodexAppServerCommandLine("C:\\Tools\\CODEX.EXE APP-SERVER", "win32")).toBe(true);
+  });
+});
+
+describe("parsePids PID 0 guard", () => {
+  test("PID 0 never reaches classification or kill", () => {
+    expect(parsePids("0\n123\n")).toEqual(["123"]);
+    expect(parsePids("0")).toEqual([]);
+  });
+});
+
+interface FakeProcess {
+  cmdline: string;
+}
+
+/**
+ * Simulates the OS surface cleanupPorts talks to: a port→PID table and a
+ * PID→cmdline table; kill removes the process and frees its ports.
+ */
+function fakeRunner(state: {
+  ports: Map<number, string[]>;
+  processes: Map<string, FakeProcess>;
+  killed: string[];
+}) {
+  return ({ cmd, args }: PortCommand): string => {
+    const joined = args.join(" ");
+    if (cmd === "lsof" || (cmd === "powershell.exe" && joined.includes("Get-NetTCPConnection"))) {
+      const port = Number(/(?:tcp:|LocalPort )(\d+)/.exec(joined)?.[1]);
+      const pids = (state.ports.get(port) ?? []).filter((pid) => state.processes.has(pid));
+      if (pids.length === 0 && cmd === "lsof") {
+        // lsof exits 1 on no match
+        throw new Error("lsof: no match");
+      }
+      return pids.join("\n");
+    }
+    if (cmd === "ps" || (cmd === "powershell.exe" && joined.includes("Win32_Process"))) {
+      const pid = cmd === "ps" ? args[1]! : /ProcessId = (\d+)/.exec(joined)![1]!;
+      const proc = state.processes.get(pid);
+      if (!proc) throw new Error("no such process");
+      return proc.cmdline;
+    }
+    if (cmd === "kill" || (cmd === "powershell.exe" && joined.includes("Stop-Process"))) {
+      const pid = cmd === "kill" ? args[0]! : /-Id (\d+)/.exec(joined)![1]!;
+      state.killed.push(pid);
+      state.processes.delete(pid);
+      return "";
+    }
+    throw new Error(`unexpected command: ${cmd} ${joined}`);
+  };
+}
+
+function harness(platform: NodeJS.Platform) {
+  const state = {
+    ports: new Map<number, string[]>(),
+    processes: new Map<string, FakeProcess>(),
+    killed: [] as string[],
+  };
+  const logs: string[] = [];
+  const runCleanup = () =>
+    cleanupPorts({
+      ports: [
+        { port: 4500, envVar: "CODEX_WS_PORT" },
+        { port: 4501, envVar: "CODEX_PROXY_PORT" },
+      ],
+      run: fakeRunner(state),
+      log: (m) => logs.push(m),
+      sleep: async () => {},
+      platform,
+    });
+  return { state, logs, runCleanup };
+}
+
+for (const platform of ["darwin", "win32"] as const) {
+  describe(`cleanupPorts decision logic (${platform})`, () => {
+    test("free ports are a no-op", async () => {
+      const { runCleanup, state } = harness(platform);
+      await runCleanup();
+      expect(state.killed).toEqual([]);
+    });
+
+    test("stale codex app-server is killed and the port reclaimed", async () => {
+      const { runCleanup, state, logs } = harness(platform);
+      state.ports.set(4500, ["111"]);
+      state.processes.set("111", { cmdline: platform === "win32" ? "C:\\codex.exe app-server" : "codex app-server" });
+      await runCleanup();
+      expect(state.killed).toEqual(["111"]);
+      expect(logs.some((l) => l.includes("stale codex app-server on port 4500"))).toBe(true);
+    });
+
+    test("foreign process on the port throws with the env var hint", async () => {
+      const { runCleanup, state } = harness(platform);
+      state.ports.set(4501, ["222"]);
+      state.processes.set("222", { cmdline: "nginx -g daemon" });
+      await expect(runCleanup()).rejects.toThrow(/non-Codex process.*222.*CODEX_PROXY_PORT/s);
+      expect(state.killed).toEqual([]);
+    });
+
+    test("mixed stale + foreign: stale is killed, then foreign still fails the start", async () => {
+      const { runCleanup, state } = harness(platform);
+      state.ports.set(4500, ["111", "222"]);
+      state.processes.set("111", { cmdline: "codex app-server" });
+      state.processes.set("222", { cmdline: "some-other-daemon" });
+      await expect(runCleanup()).rejects.toThrow(/non-Codex process/);
+      expect(state.killed).toEqual(["111"]);
+    });
+
+    test("port still occupied after kill throws the post-cleanup error", async () => {
+      const { runCleanup, state } = harness(platform);
+      state.ports.set(4500, ["111"]);
+      const immortal: FakeProcess = { cmdline: "codex app-server" };
+      state.processes.set("111", immortal);
+      const base = fakeRunner(state);
+      // Kill that doesn't actually free the port
+      const run = (c: PortCommand) => {
+        const out = base(c);
+        if (c.cmd === "kill" || c.args.join(" ").includes("Stop-Process")) {
+          state.processes.set("111", immortal);
+        }
+        return out;
+      };
+      await expect(
+        cleanupPorts({
+          ports: [{ port: 4500, envVar: "CODEX_WS_PORT" }],
+          run,
+          log: () => {},
+          sleep: async () => {},
+          platform,
+        }),
+      ).rejects.toThrow(/still occupied.*111/s);
+    });
+
+    test("process vanishing between list and cmdline lookup is tolerated", async () => {
+      const { runCleanup, state } = harness(platform);
+      state.ports.set(4500, ["333"]);
+      // Simulate the race with a one-shot listing: the PID appears on the
+      // port once, but is gone by the time the cmdline lookup runs.
+      let listed = false;
+      const base = fakeRunner(state);
+      const run = (c: PortCommand) => {
+        const joined = c.args.join(" ");
+        if ((c.cmd === "lsof" || joined.includes("Get-NetTCPConnection")) && !listed) {
+          listed = true;
+          return "333";
+        }
+        return base(c);
+      };
+      await cleanupPorts({
+        ports: [{ port: 4500, envVar: "CODEX_WS_PORT" }],
+        run,
+        log: () => {},
+        sleep: async () => {},
+        platform,
+      });
+      expect(state.killed).toEqual([]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adapts external PR #76 (@Tominori666) to the current codebase: on Windows, a hard-killed daemon leaves an orphan `codex.exe` holding the app-server port, so the next spawn dies with `os error 10048` — the old `checkPorts()` was lsof/ps/kill-only and silently swallowed the lsof failure on Windows.

将外部贡献 PR #76 适配到当前代码库：新模块 `src/port-cleanup.ts`（argv 化命令 + 可注入 runner），POSIX 路径行为与原实现逐条等价（lsof -sTCP:LISTEN 限制、报错文案、500ms 复查），win32 走 PowerShell（沿用原作者方案）。

## Verification without a local Windows box

- Fixture-driven decision-matrix unit tests on both platforms (free / stale / foreign / mixed / immortal / vanishing-race)
- **Live test**: binds a real socket and runs the REAL platform commands — runs on macOS/Linux and on the new `windows-latest` CI job
- ⚠️ **The Windows job is advisory (`continue-on-error`) and does not yet exercise a real stale Codex process**: the real `codex app-server` command-line shape under Win32_Process and an actual `Stop-Process -Force` kill remain unproven until someone with Windows + Codex confirms (per Codex's review note).

## Review

- Round 1: two independent reviewers — 1 REAL fixed (POSIX command-line matching stays case-sensitive; lowercase only on win32), PID 0 guard added
- Terminal review by Codex: 0 blocking; POSIX equivalence checked line-by-line against master's `checkPorts()`; Stop-Process semantics analyzed (kills the socket owner → frees the port; tree-kill is out of #76's scope)
- typecheck clean, 681 tests pass (+23 new)

Closes #76 (supersedes — original diff no longer applies after the v0.1.6 merge train; design and credit preserved via Co-authored-by).