### PR TITLE
fix: abg budget 只读化 + 共享 daemon-status helper / read-only budget observability (audit P0)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14209,7 +14209,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("e3322d0", "source"),
+  commit: defineString("1650804", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14206,7 +14206,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("830d8a3", "source"),
+  commit: defineString("e3322d0", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, 1)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("e3322d0", "source"),
+  commit: defineString("1650804", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -15,7 +15,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("830d8a3", "source"),
+  commit: defineString("e3322d0", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, 1)
 });

--- a/src/cli/budget.ts
+++ b/src/cli/budget.ts
@@ -6,16 +6,37 @@
  * two surfaces to stay consistent).
  */
 
-import { applyPairEnv, parsePairFlag } from "../pair-resolver";
-import type { DaemonStatus } from "../control-protocol";
+import { fetchDaemonStatus } from "../daemon-status";
+import { parsePairFlag, type ReadOnlyPairResolution, resolvePairReadOnly } from "../pair-resolver";
 import { renderBudgetSnapshot, BUDGET_UNAVAILABLE_TEXT } from "../budget/render";
-
-const STATUS_FETCH_TIMEOUT_MS = 1000;
 
 export async function runBudget(args: string[]) {
   const json = args.includes("--json");
   const { pairFlag } = parsePairFlag(args.filter((arg) => arg !== "--json"));
-  const pair = await applyPairEnv({ pairFlag });
+  let resolution: ReadOnlyPairResolution;
+  try {
+    resolution = resolvePairReadOnly(pairFlag);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (json) {
+      console.log(JSON.stringify({ ok: false, error: message }));
+    } else {
+      console.error(`[agentbridge] ${message}`);
+    }
+    process.exit(1);
+    return;
+  }
+  const { pair } = resolution;
+
+  if (!resolution.registered) {
+    if (json) {
+      console.log(JSON.stringify({ ok: false, error: "pair_not_registered" }));
+    } else {
+      console.error("该目录尚无 pair，先运行 abg claude");
+    }
+    process.exit(1);
+    return;
+  }
 
   const status = await fetchDaemonStatus(pair.ports.controlPort);
   if (!status) {
@@ -43,18 +64,4 @@ export async function runBudget(args: string[]) {
 
   console.log(`pair: ${status.pairId ?? pair.pairId}`);
   console.log(status.budget ? renderBudgetSnapshot(status.budget) : BUDGET_UNAVAILABLE_TEXT);
-}
-
-async function fetchDaemonStatus(port: number): Promise<DaemonStatus | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), STATUS_FETCH_TIMEOUT_MS);
-  try {
-    const response = await fetch(`http://127.0.0.1:${port}/healthz`, { signal: controller.signal });
-    if (!response.ok) return null;
-    return (await response.json()) as DaemonStatus;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,16 +2,14 @@ import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "n
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { BUILD_INFO, formatBuildInfo, sameRuntimeContract } from "../build-info";
+import { fetchDaemonStatus } from "../daemon-status";
 import { inspectAgentBridgeEnv } from "../env-guard";
-import { derivePairId } from "../pair-registry";
 import {
-  computeBaseDir,
-  findPairForFlag,
   parsePairFlag,
-  portsForEntry,
   type PairResolution,
+  type ReadOnlyPairResolution,
+  resolvePairReadOnly,
 } from "../pair-resolver";
-import { StateDirResolver } from "../state-dir";
 import { readRawCurrentThread, readUsableCurrentThread } from "../thread-state";
 import { scanResumePollution } from "../resume-pollution";
 import {
@@ -115,74 +113,6 @@ export async function runDoctor(args: string[] = []) {
   printDoctorReport(report);
 }
 
-interface ReadOnlyPairResolution {
-  pair: PairResolution;
-  /** False when no registry entry exists yet (pair would be created on first launch). */
-  registered: boolean;
-}
-
-function resolvePairReadOnly(pairFlag: string | undefined): ReadOnlyPairResolution {
-  // Manual/legacy override: explicit env + AGENTBRIDGE_MANUAL=1 (mirror of
-  // applyPairEnv's manual branch — already read-only there).
-  const explicitEnv =
-    !!process.env.AGENTBRIDGE_STATE_DIR ||
-    !!process.env.AGENTBRIDGE_CONTROL_PORT ||
-    !!process.env.CODEX_WS_PORT ||
-    !!process.env.CODEX_PROXY_PORT;
-  if (pairFlag === undefined && explicitEnv && process.env.AGENTBRIDGE_MANUAL === "1") {
-    return {
-      registered: true,
-      pair: {
-        pairId: "(manual)",
-        slot: null,
-        ports: {
-          appPort: Number.parseInt(process.env.CODEX_WS_PORT ?? "4500", 10),
-          proxyPort: Number.parseInt(process.env.CODEX_PROXY_PORT ?? "4501", 10),
-          controlPort: Number.parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10),
-        },
-        stateDir: new StateDirResolver(),
-        name: "(manual)",
-        manual: true,
-      },
-    };
-  }
-
-  const base = computeBaseDir();
-  const cwd = process.cwd();
-  const name = pairFlag ?? "main";
-  let entry = null;
-  try {
-    entry = findPairForFlag(base, cwd, name);
-  } catch {
-    // Corrupt registry must not stop diagnosis — fall through to derived identity.
-  }
-  if (entry) {
-    return {
-      registered: true,
-      pair: {
-        pairId: entry.pairId,
-        slot: entry.slot,
-        ports: portsForEntry(entry),
-        stateDir: new StateDirResolver(join(base, "pairs", entry.pairId)),
-        name: entry.name ?? name,
-        manual: false,
-      },
-    };
-  }
-  const pairId = derivePairId(cwd, name);
-  return {
-    registered: false,
-    pair: {
-      pairId,
-      slot: null,
-      ports: { appPort: 0, proxyPort: 0, controlPort: 0 },
-      stateDir: new StateDirResolver(join(base, "pairs", pairId)),
-      name,
-      manual: false,
-    },
-  };
-}
-
 function runResumePollution(args: string[]) {
   const json = args.includes("--json");
   const apply = args.includes("--apply");
@@ -227,8 +157,12 @@ function runResumePollution(args: string[]) {
 async function buildDoctorReport(pair: PairResolution, registered: boolean): Promise<DoctorReport> {
   const cwd = process.cwd();
   const env = inspectAgentBridgeEnv({ cwd, env: process.env });
-  const health = registered ? await fetchDaemonStatus(pair.ports.controlPort, "/healthz") : null;
-  const ready = registered ? await fetchDaemonStatus(pair.ports.controlPort, "/readyz") : null;
+  const [health, ready] = registered
+    ? await Promise.all([
+        fetchDaemonStatus(pair.ports.controlPort, "/healthz"),
+        fetchDaemonStatus(pair.ports.controlPort, "/readyz"),
+      ])
+    : [null, null];
   // Drift keys on the runtime contract (version/commit/contractVersion), not the
   // bundle kind — a dist daemon vs a plugin launcher is not real drift.
   // A source-mode launcher (bun src/cli.ts …) is unstamped — "source" never
@@ -492,20 +426,6 @@ function logCheck(name: string, path: string): DoctorCheck {
     };
   }
   return { name, status: "ok", detail: `${path} (${stat.size} bytes)` };
-}
-
-async function fetchDaemonStatus(port: number, path: "/healthz" | "/readyz"): Promise<DaemonStatus | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 500);
-  try {
-    const response = await fetch(`http://127.0.0.1:${port}${path}`, { signal: controller.signal });
-    if (!response.ok) return null;
-    return (await response.json()) as DaemonStatus;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
 }
 
 /** Render the doctor report. Pure (no I/O) so the exact shape is unit-testable. */

--- a/src/daemon-status.ts
+++ b/src/daemon-status.ts
@@ -1,0 +1,23 @@
+import type { DaemonStatus } from "./control-protocol";
+
+export type DaemonStatusPath = "/healthz" | "/readyz";
+
+export const DAEMON_STATUS_FETCH_TIMEOUT_MS = 1000;
+
+export async function fetchDaemonStatus(
+  port: number,
+  path: DaemonStatusPath = "/healthz",
+  timeoutMs = DAEMON_STATUS_FETCH_TIMEOUT_MS,
+): Promise<DaemonStatus | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, { signal: controller.signal });
+    if (!response.ok) return null;
+    return (await response.json()) as DaemonStatus;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/pair-resolver.ts
+++ b/src/pair-resolver.ts
@@ -1,9 +1,10 @@
 import { realpathSync } from "node:fs";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { StateDirResolver } from "./state-dir";
 import {
   type PairEntry,
   type PairPorts,
+  PairError,
   derivePairId,
   portsForSlot,
   readRegistry,
@@ -35,6 +36,12 @@ export interface PairResolution {
   manual: boolean;
   /** Non-blocking advisory (cross-cwd raw match / pairId-looking new alloc); CLI prints to stderr. */
   warning?: string;
+}
+
+export interface ReadOnlyPairResolution {
+  pair: PairResolution;
+  /** False when no registry entry exists yet (pair would be created on first launch). */
+  registered: boolean;
 }
 
 /**
@@ -170,6 +177,69 @@ export async function applyPairEnv(opts: { pairFlag?: string }): Promise<PairRes
     name: resolved.name,
     manual: false,
     warning: resolved.warning,
+  };
+}
+
+export function resolvePairReadOnly(pairFlag: string | undefined): ReadOnlyPairResolution {
+  // Manual/legacy override: explicit env + AGENTBRIDGE_MANUAL=1 (mirror of
+  // applyPairEnv's manual branch — already read-only there).
+  const explicitEnv =
+    !!process.env.AGENTBRIDGE_STATE_DIR ||
+    !!process.env.AGENTBRIDGE_CONTROL_PORT ||
+    !!process.env.CODEX_WS_PORT ||
+    !!process.env.CODEX_PROXY_PORT;
+  if (pairFlag === undefined && explicitEnv && process.env.AGENTBRIDGE_MANUAL === "1") {
+    return {
+      registered: true,
+      pair: {
+        pairId: "(manual)",
+        slot: null,
+        ports: {
+          appPort: Number.parseInt(process.env.CODEX_WS_PORT ?? "4500", 10),
+          proxyPort: Number.parseInt(process.env.CODEX_PROXY_PORT ?? "4501", 10),
+          controlPort: Number.parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10),
+        },
+        stateDir: new StateDirResolver(),
+        name: "(manual)",
+        manual: true,
+      },
+    };
+  }
+
+  const base = computeBaseDir();
+  const cwd = process.cwd();
+  const name = pairFlag ?? "main";
+  let entry: PairEntry | null = null;
+  try {
+    entry = findPairForFlag(base, cwd, name);
+  } catch (err) {
+    if (err instanceof PairError && err.code === "PAIR_ID_INVALID") throw err;
+    // Corrupt/unreadable registry must not stop diagnosis — fall through to derived identity.
+  }
+  if (entry) {
+    return {
+      registered: true,
+      pair: {
+        pairId: entry.pairId,
+        slot: entry.slot,
+        ports: portsForEntry(entry),
+        stateDir: new StateDirResolver(join(base, "pairs", entry.pairId)),
+        name: entry.name ?? name,
+        manual: false,
+      },
+    };
+  }
+  const pairId = derivePairId(cwd, name);
+  return {
+    registered: false,
+    pair: {
+      pairId,
+      slot: null,
+      ports: { appPort: 0, proxyPort: 0, controlPort: 0 },
+      stateDir: new StateDirResolver(join(base, "pairs", pairId)),
+      name,
+      manual: false,
+    },
   };
 }
 

--- a/src/unit-test/budget-cli.test.ts
+++ b/src/unit-test/budget-cli.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runBudget } from "../cli/budget";
+import { listPairs } from "../pair-resolver";
+
+const ENV_KEYS = [
+  "AGENTBRIDGE_BASE_DIR",
+  "AGENTBRIDGE_PAIR_ID",
+  "AGENTBRIDGE_PAIR_NAME",
+  "AGENTBRIDGE_STATE_DIR",
+  "AGENTBRIDGE_CONTROL_PORT",
+  "AGENTBRIDGE_MANUAL",
+  "CODEX_WS_PORT",
+  "CODEX_PROXY_PORT",
+] as const;
+
+const EXIT = Symbol("process.exit");
+
+let savedEnv: Record<string, string | undefined>;
+let previousCwd: string;
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+let originalFetch: typeof fetch;
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  savedEnv = {};
+  previousCwd = process.cwd();
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  originalLog = console.log;
+  originalError = console.error;
+  originalExit = process.exit;
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+  globalThis.fetch = originalFetch;
+  process.chdir(previousCwd);
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function captureBudget(args: string[]) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | undefined;
+  let fetchCalls = 0;
+  console.log = (...parts: unknown[]) => {
+    stdout.push(parts.map(String).join(" "));
+  };
+  console.error = (...parts: unknown[]) => {
+    stderr.push(parts.map(String).join(" "));
+  };
+  process.exit = ((code?: string | number | null | undefined) => {
+    exitCode = typeof code === "number" ? code : Number(code ?? 0);
+    throw EXIT;
+  }) as typeof process.exit;
+  globalThis.fetch = (async () => {
+    fetchCalls++;
+    return new Response("unreachable", { status: 503 });
+  }) as unknown as typeof fetch;
+
+  try {
+    await runBudget(args);
+  } catch (err) {
+    if (err !== EXIT) throw err;
+  }
+  return { stdout: stdout.join("\n"), stderr: stderr.join("\n"), exitCode, fetchCalls };
+}
+
+describe("budget command", () => {
+  test("JSON mode reports an unregistered pair without creating registry state", async () => {
+    const root = makeTempDir("agentbridge-budget-root-");
+    const base = makeTempDir("agentbridge-budget-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    const result = await captureBudget(["--json"]);
+
+    expect(JSON.parse(result.stdout)).toEqual({ ok: false, error: "pair_not_registered" });
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+    expect(result.fetchCalls).toBe(0);
+    expect(listPairs(base)).toEqual([]);
+  });
+
+  test("human mode tells the user to start a pair before reading budget", async () => {
+    const root = makeTempDir("agentbridge-budget-root-");
+    const base = makeTempDir("agentbridge-budget-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    const result = await captureBudget([]);
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("该目录尚无 pair，先运行 abg claude");
+    expect(result.exitCode).toBe(1);
+    expect(result.fetchCalls).toBe(0);
+    expect(listPairs(base)).toEqual([]);
+  });
+
+  test("JSON mode reports invalid pair names as a structured user error", async () => {
+    const root = makeTempDir("agentbridge-budget-root-");
+    const base = makeTempDir("agentbridge-budget-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    const result = await captureBudget(["--json", "--pair", "../escape"]);
+    const payload = JSON.parse(result.stdout);
+
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toContain("Invalid --pair name");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+    expect(result.fetchCalls).toBe(0);
+    expect(listPairs(base)).toEqual([]);
+  });
+
+  test("human mode reports invalid pair names without an unhandled exception", async () => {
+    const root = makeTempDir("agentbridge-budget-root-");
+    const base = makeTempDir("agentbridge-budget-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    const result = await captureBudget(["--pair", "../escape"]);
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Invalid --pair name");
+    expect(result.exitCode).toBe(1);
+    expect(result.fetchCalls).toBe(0);
+    expect(listPairs(base)).toEqual([]);
+  });
+});

--- a/src/unit-test/daemon-status.test.ts
+++ b/src/unit-test/daemon-status.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { fetchDaemonStatus } from "../daemon-status";
+
+let server: ReturnType<typeof Bun.serve> | null = null;
+
+afterEach(() => {
+  if (server) {
+    server.stop(true);
+    server = null;
+  }
+});
+
+describe("fetchDaemonStatus", () => {
+  test("fetches daemon status from /readyz as well as /healthz", async () => {
+    const requestedPaths: string[] = [];
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        requestedPaths.push(url.pathname);
+        return Response.json({
+          bridgeReady: url.pathname === "/readyz",
+          tuiConnected: false,
+          threadId: null,
+          queuedMessageCount: 0,
+          proxyUrl: "ws://127.0.0.1:4501",
+          appServerUrl: "ws://127.0.0.1:4500",
+          pid: 123,
+          pairId: url.pathname,
+        });
+      },
+    });
+
+    const port = server.port;
+    if (port === undefined) throw new Error("expected Bun.serve to assign a port");
+
+    const health = await fetchDaemonStatus(port, "/healthz");
+    const ready = await fetchDaemonStatus(port, "/readyz");
+
+    expect(health?.pairId).toBe("/healthz");
+    expect(ready?.bridgeReady).toBe(true);
+    expect(requestedPaths).toEqual(["/healthz", "/readyz"]);
+  });
+
+  test("returns null for non-2xx daemon status responses", async () => {
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("not ready", { status: 503 });
+      },
+    });
+
+    const port = server.port;
+    if (port === undefined) throw new Error("expected Bun.serve to assign a port");
+
+    expect(await fetchDaemonStatus(port, "/readyz")).toBeNull();
+  });
+
+  test("returns null when the daemon status request times out", async () => {
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Promise<Response>(() => {});
+      },
+    });
+
+    const port = server.port;
+    if (port === undefined) throw new Error("expected Bun.serve to assign a port");
+
+    expect(await fetchDaemonStatus(port, "/healthz", 10)).toBeNull();
+  });
+});

--- a/src/unit-test/doctor.test.ts
+++ b/src/unit-test/doctor.test.ts
@@ -153,4 +153,64 @@ describe("doctor command", () => {
       rmSync(base, { recursive: true, force: true });
     }
   });
+
+  test("checks daemon health and readiness concurrently", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-doctor-"));
+    const base = mkdtempSync(join(tmpdir(), "agentbridge-doctor-base-"));
+    const originalFetch = globalThis.fetch;
+    try {
+      process.chdir(root);
+      process.env.AGENTBRIDGE_BASE_DIR = base;
+      seedPair(root, base);
+
+      const paths: string[] = [];
+      let markReadyRequested: () => void = () => {};
+      const readyRequested = new Promise<void>((resolve) => {
+        markReadyRequested = resolve;
+      });
+      const statusPayload = (path: string) => ({
+        bridgeReady: true,
+        tuiConnected: false,
+        threadId: null,
+        queuedMessageCount: 0,
+        proxyUrl: "ws://127.0.0.1:16841",
+        appServerUrl: "ws://127.0.0.1:16840",
+        pid: 123,
+        pairId: path,
+      });
+
+      globalThis.fetch = ((input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const path = new URL(String(input)).pathname;
+        paths.push(path);
+        if (path === "/healthz") {
+          return new Promise<Response>((resolve, reject) => {
+            const signal = init?.signal;
+            const onAbort = () => reject(new Error("aborted"));
+            signal?.addEventListener("abort", onAbort, { once: true });
+            readyRequested.then(() => {
+              signal?.removeEventListener("abort", onAbort);
+              resolve(Response.json(statusPayload(path)));
+            });
+          });
+        }
+        if (path === "/readyz") {
+          markReadyRequested();
+          return Promise.resolve(Response.json(statusPayload(path)));
+        }
+        return Promise.resolve(new Response("missing", { status: 404 }));
+      }) as unknown as typeof fetch;
+
+      const started = Date.now();
+      const report = await runDoctorJson(["--pair", "main"]);
+
+      expect(Date.now() - started).toBeLessThan(900);
+      expect(paths).toEqual(["/healthz", "/readyz"]);
+      expect(report.daemon.health?.pairId).toBe("/healthz");
+      expect(report.daemon.ready?.pairId).toBe("/readyz");
+    } finally {
+      globalThis.fetch = originalFetch;
+      rmSync(root, { recursive: true, force: true });
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/unit-test/pair-resolver.test.ts
+++ b/src/unit-test/pair-resolver.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,6 +15,7 @@ import {
   parsePairFlag,
   portsForEntry,
   removePair,
+  resolvePairReadOnly,
 } from "../pair-resolver";
 
 // ---------------------------------------------------------------------------
@@ -32,9 +33,11 @@ const ENV_KEYS = [
 ] as const;
 
 let savedEnv: Record<string, string | undefined> = {};
+let previousCwd: string;
 const tempBases: string[] = [];
 
 beforeEach(() => {
+  previousCwd = process.cwd();
   savedEnv = {};
   for (const k of ENV_KEYS) {
     savedEnv[k] = process.env[k];
@@ -43,6 +46,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  process.chdir(previousCwd);
   for (const k of ENV_KEYS) {
     if (savedEnv[k] === undefined) delete process.env[k];
     else process.env[k] = savedEnv[k];
@@ -51,6 +55,82 @@ afterEach(() => {
     const base = tempBases.pop();
     if (base) rmSync(base, { recursive: true, force: true });
   }
+});
+
+describe("resolvePairReadOnly", () => {
+  test("returns an unregistered derived pair without allocating a registry entry", () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+
+    const res = resolvePairReadOnly(undefined);
+
+    expect(res.registered).toBe(false);
+    expect(res.pair.pairId).toBe(derivePairId(process.cwd(), "main"));
+    expect(res.pair.slot).toBeNull();
+    expect(res.pair.ports).toEqual({ appPort: 0, proxyPort: 0, controlPort: 0 });
+    expect(res.pair.stateDir.dir).toBe(join(base, "pairs", res.pair.pairId));
+    expect(listPairs(base)).toEqual([]);
+    expect(process.env.AGENTBRIDGE_PAIR_ID).toBeUndefined();
+    expect(process.env.AGENTBRIDGE_CONTROL_PORT).toBeUndefined();
+  });
+
+  test("resolves an existing pair without injecting child env", () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    const pairId = derivePairId(process.cwd(), "work");
+    writeRegistry(base, {
+      version: 1,
+      pairs: [{ pairId, slot: 2, cwd: process.cwd(), name: "work", source: "flag", createdAt: "2026-01-01T00:00:00.000Z" }],
+    });
+
+    const res = resolvePairReadOnly("work");
+
+    expect(res.registered).toBe(true);
+    expect(res.pair.pairId).toBe(pairId);
+    expect(res.pair.slot).toBe(2);
+    expect(res.pair.ports).toEqual({ appPort: 4520, proxyPort: 4521, controlPort: 4522 });
+    expect(res.pair.stateDir.dir).toBe(join(base, "pairs", pairId));
+    expect(process.env.AGENTBRIDGE_PAIR_ID).toBeUndefined();
+    expect(process.env.AGENTBRIDGE_CONTROL_PORT).toBeUndefined();
+  });
+
+  test("preserves manual legacy mode semantics", () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_MANUAL = "1";
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    process.env.AGENTBRIDGE_CONTROL_PORT = "5502";
+    process.env.CODEX_WS_PORT = "5500";
+    process.env.CODEX_PROXY_PORT = "5501";
+
+    const res = resolvePairReadOnly(undefined);
+
+    expect(res.registered).toBe(true);
+    expect(res.pair.manual).toBe(true);
+    expect(res.pair.pairId).toBe("(manual)");
+    expect(res.pair.ports).toEqual({ appPort: 5500, proxyPort: 5501, controlPort: 5502 });
+    expect(listPairs(base)).toEqual([]);
+  });
+
+  test("falls back to a derived identity when the registry is corrupt", () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+    mkdirSync(join(base, "pairs"), { recursive: true });
+    writeFileSync(join(base, "pairs", "registry.json"), "{not-json", "utf-8");
+
+    const res = resolvePairReadOnly("main");
+
+    expect(res.registered).toBe(false);
+    expect(res.pair.pairId).toBe(derivePairId(process.cwd(), "main"));
+    expect(res.pair.ports).toEqual({ appPort: 0, proxyPort: 0, controlPort: 0 });
+  });
+
+  test("rejects invalid pair names instead of treating them as unregistered pairs", () => {
+    const base = makeBase();
+    process.env.AGENTBRIDGE_STATE_DIR = base;
+
+    expect(() => resolvePairReadOnly("../escape")).toThrow("Invalid --pair name");
+    expect(listPairs(base)).toEqual([]);
+  });
 });
 
 function makeBase(): string {


### PR DESCRIPTION
架构审视 P0：观测命令必须只读（doctor 已确立的原则补齐到 budget）。Codex 按 TDD 实施，Claude 编排/review/git。

- resolvePairReadOnly 外提共享（不吞非法 --pair）
- budget 未注册 pair → pair_not_registered，零 registry 写入（文件系统级断言）
- 新共享 src/daemon-status.ts（统一超时，/healthz+/readyz）；doctor 双探测 Promise.all 并行
- 2 轮 cross-review 收敛 0 REAL（轮1 抓非法 --pair 未处理异常等 3 项，红绿验证修复）

含 master 合入后从合并源码重建的 plugin bundle。704 tests + bun run check 全绿。