### PR TITLE
fix: 探针数据分层消费——降级记录展示可见、决策层滴水不漏 / layered probe-data consumption (closes #103)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14209,7 +14209,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("1650804", "source"),
+  commit: defineString("7f27707", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("1650804", "source"),
+  commit: defineString("7f27707", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2910,8 +2910,8 @@ function parallelDirective(claude, codex, parallel) {
   ].join(`
 `);
 }
-function codexTierFor(codex) {
-  if (!codex)
+function codexTierFor(codex, now) {
+  if (!codex || !isDecisionGrade(codex, now))
     return "full";
   if (codex.warnUtil >= CODEX_ECO_WARN_UTIL)
     return "eco";
@@ -2919,8 +2919,10 @@ function codexTierFor(codex) {
     return "balanced";
   return "full";
 }
-function claudeAdviceFor(claude) {
-  if (!claude || claude.warnUtil < CLAUDE_ADVICE_WARN_UTIL)
+function claudeAdviceFor(claude, now) {
+  if (!claude || !isDecisionGrade(claude, now))
+    return null;
+  if (claude.warnUtil < CLAUDE_ADVICE_WARN_UTIL)
     return null;
   return `Claude warnUtil ${pct(claude.warnUtil)} \u5DF2\u504F\u9AD8\uFF1B\u540E\u7EED\u53EF\u62C6\u5206 subagent \u5EFA\u8BAE\u964D\u6863\u5230 haiku/sonnet\uFF0C\u5E76\u4FDD\u7559\u9AD8\u96BE\u5EA6\u4E3B\u7EBF\u7ED9\u5F53\u524D\u4F1A\u8BDD\u3002`;
 }
@@ -2967,7 +2969,7 @@ function computeBudgetState(claude, codex, cfg, now) {
       resetEpochs
     },
     parallel,
-    effort: { claudeAdvice: claudeAdviceFor(claude), codexTier: codexTierFor(codex) },
+    effort: { claudeAdvice: claudeAdviceFor(claude, now), codexTier: codexTierFor(codex, now) },
     directiveToClaude
   };
 }
@@ -3268,7 +3270,7 @@ class BudgetCoordinator {
       if (!this.activeSides.has(agent))
         return false;
       const usage = state.perAgent[agent];
-      return usage === null || usage.rateLimitedUntil > state.now;
+      return usage === null || usage.rateLimitedUntil > state.now || !isDecisionGrade(usage, state.now);
     });
   }
   activeSideReason(agent, usage, now) {
@@ -3407,8 +3409,6 @@ function normalizeTopLevelBucket(record, util, fetchedAt) {
   if (resetEpoch <= 0 && resetAfter !== null && fetchedAt > 0) {
     resetEpoch = fetchedAt + resetAfter;
   }
-  if (resetEpoch <= 0 && resetAfter === null)
-    return null;
   return {
     id: "top_level",
     util: clamp(util, 0, 100),
@@ -3462,11 +3462,12 @@ function normalizeProbeResult(raw) {
   if (!record)
     return null;
   const fetchedAt = numberOr(record.fetched_at ?? record.fetchedAt ?? record.now_epoch ?? record.nowEpoch, 0);
+  const hasFiniteUtil = asFiniteNumber(record.util ?? record.hard_util ?? record.hardUtil) !== null || asFiniteNumber(record.warn_util ?? record.warnUtil) !== null;
   const gateUtil = clamp(numberOr(record.util ?? record.hard_util ?? record.hardUtil, 0), 0, 100);
   const warnUtil = clamp(numberOr(record.warn_util ?? record.warnUtil, gateUtil), 0, 100);
   const rawBuckets = Array.isArray(record.buckets) ? record.buckets : [];
   const buckets = rawBuckets.map((bucket) => normalizeBucket(bucket, fetchedAt)).filter((bucket) => bucket !== null);
-  if (buckets.length === 0) {
+  if (buckets.length === 0 && hasFiniteUtil) {
     const topLevelBucket = normalizeTopLevelBucket(record, gateUtil, fetchedAt);
     if (topLevelBucket)
       buckets.push(topLevelBucket);
@@ -3476,7 +3477,7 @@ function normalizeProbeResult(raw) {
   if (!ok && rateLimitedUntil <= 0 && buckets.length === 0)
     return null;
   const { fiveHour, weekly } = identifyWindows(buckets);
-  if (!fiveHour && !weekly && rateLimitedUntil === 0)
+  if (!fiveHour && !weekly && rateLimitedUntil === 0 && !hasFiniteUtil)
     return null;
   return {
     ok,
@@ -3500,6 +3501,12 @@ function withTimeout(promise, timeoutMs) {
       clearTimeout(timer);
   });
 }
+function isDegradedUsage(usage, now = Math.floor(Date.now() / 1000)) {
+  if (usage.stale || !usage.ok)
+    return true;
+  const hasFreshWindow = usage.fiveHour !== null && usage.fiveHour.resetEpoch > now || usage.weekly !== null && usage.weekly.resetEpoch > now;
+  return !hasFreshWindow;
+}
 
 class QuotaSource {
   env;
@@ -3507,12 +3514,15 @@ class QuotaSource {
   timeoutMs;
   runner;
   log;
+  now;
+  degradedLogged = new Map;
   constructor(options = {}) {
     this.env = options.env ?? process.env;
     this.homeDir = options.homeDir ?? homedir2();
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.runner = options.runner ?? defaultRunner;
     this.log = options.log ?? (() => {});
+    this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
   }
   async fetchBoth() {
     const candidates = this.findProbeCandidates();
@@ -3560,15 +3570,35 @@ class QuotaSource {
         const text = String(result.stdout).trim();
         if (!text)
           continue;
-        const usage = normalizeProbeResult(JSON.parse(text));
-        if (usage)
+        let parsed;
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          this.log(`budget probe output unparseable for ${agent}: ${candidate.command} \u2014 raw: ${text.slice(0, 200)}`);
+          continue;
+        }
+        const usage = normalizeProbeResult(parsed);
+        if (usage) {
+          this.noteDegradation(agent, usage);
           return usage;
-        this.log(`budget probe returned no usable data for ${agent}: ${candidate.command}`);
+        }
+        this.log(`budget probe returned no usable data for ${agent}: ${candidate.command} \u2014 raw: ${text.slice(0, 200)}`);
       } catch (error) {
         this.log(`budget probe failed for ${agent}: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
     return null;
+  }
+  noteDegradation(agent, usage) {
+    const degraded = isDegradedUsage(usage, this.now());
+    const wasDegraded = this.degradedLogged.get(agent) === true;
+    if (degraded && !wasDegraded) {
+      const gate = usage.rateLimitedUntil > 0 ? `, rate-limit gated until ${usage.rateLimitedUntil}` : "";
+      this.log(`budget probe degraded data accepted for ${agent} (stale=${usage.stale}, ok=${usage.ok}${gate}) \u2014 display only, decisions hold`);
+    } else if (!degraded && wasDegraded) {
+      this.log(`budget probe recovered to fresh data for ${agent}`);
+    }
+    this.degradedLogged.set(agent, degraded);
   }
 }
 function createQuotaSource(options) {

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -409,7 +409,12 @@ export class BudgetCoordinator {
     return (["claude", "codex"] as const).some((agent) => {
       if (!this.activeSides.has(agent)) return false;
       const usage = state.perAgent[agent];
-      return usage === null || usage.rateLimitedUntil > state.now;
+      // Non-decision-grade covers every degraded shape (#103 lets stale /
+      // unknown-reset records through as display data): mid-pause they must
+      // hold the directive fingerprint, not recompute it against a phantom
+      // reset bucket — recomputing re-emitted the pause directive on each
+      // data-quality flap, the exact regression e7a66fc guarded against.
+      return usage === null || usage.rateLimitedUntil > state.now || !isDecisionGrade(usage, state.now);
     });
   }
 

--- a/src/budget/budget-state.ts
+++ b/src/budget/budget-state.ts
@@ -204,15 +204,21 @@ function parallelDirective(
   ].join("\n");
 }
 
-function codexTierFor(codex: AgentUsage | null): CodexTier {
-  if (!codex) return "full";
+// Tier/advice are decision OUTPUTS (they queue turn overrides and inject
+// advice), so they require decision-grade data exactly like pause/advice
+// directives — a degraded display-only record (stale cache, unknown-reset
+// window, see agent-bridge#103) must not flip the Codex tier. Non-decision-
+// grade falls back to the same outputs a probe miss produces.
+function codexTierFor(codex: AgentUsage | null, now: number): CodexTier {
+  if (!codex || !isDecisionGrade(codex, now)) return "full";
   if (codex.warnUtil >= CODEX_ECO_WARN_UTIL) return "eco";
   if (codex.warnUtil >= CODEX_BALANCED_WARN_UTIL) return "balanced";
   return "full";
 }
 
-function claudeAdviceFor(claude: AgentUsage | null): string | null {
-  if (!claude || claude.warnUtil < CLAUDE_ADVICE_WARN_UTIL) return null;
+function claudeAdviceFor(claude: AgentUsage | null, now: number): string | null {
+  if (!claude || !isDecisionGrade(claude, now)) return null;
+  if (claude.warnUtil < CLAUDE_ADVICE_WARN_UTIL) return null;
   return `Claude warnUtil ${pct(claude.warnUtil)} 已偏高；后续可拆分 subagent 建议降档到 haiku/sonnet，并保留高难度主线给当前会话。`;
 }
 
@@ -276,7 +282,7 @@ export function computeBudgetState(
       resetEpochs,
     },
     parallel,
-    effort: { claudeAdvice: claudeAdviceFor(claude), codexTier: codexTierFor(codex) },
+    effort: { claudeAdvice: claudeAdviceFor(claude, now), codexTier: codexTierFor(codex, now) },
     directiveToClaude,
   };
 }

--- a/src/budget/quota-source.ts
+++ b/src/budget/quota-source.ts
@@ -26,6 +26,8 @@ export interface QuotaSourceOptions {
   timeoutMs?: number;
   runner?: ProbeRunner;
   log?: (message: string) => void;
+  /** Unix-seconds clock, injectable for tests (degradation freshness checks). */
+  now?: () => number;
 }
 
 interface ProbeCandidate {
@@ -128,7 +130,12 @@ function normalizeTopLevelBucket(record: Record<string, unknown>, util: number, 
   if (resetEpoch <= 0 && resetAfter !== null && fetchedAt > 0) {
     resetEpoch = fetchedAt + resetAfter;
   }
-  if (resetEpoch <= 0 && resetAfter === null) return null;
+  // Unknown reset (claude's non-resettable bucket shape emits reset_epoch:null,
+  // see agent-bridge#103) is still a DISPLAYABLE reading: keep the window with
+  // resetEpoch=0 — render shows 重置 未知, and isDecisionGrade() rejects it for
+  // interventions (no fresh window), so the degraded record is display-only.
+  // The information floor against fabricated readings lives in the caller: a
+  // record with no actual util field never reaches this point.
   return {
     id: "top_level",
     util: clamp(util, 0, 100),
@@ -193,13 +200,19 @@ export function normalizeProbeResult(raw: unknown): AgentUsage | null {
   if (!record) return null;
 
   const fetchedAt = numberOr(record.fetched_at ?? record.fetchedAt ?? record.now_epoch ?? record.nowEpoch, 0);
+  // Information floor: a record that carries no actual util reading at all
+  // (e.g. a transient `{ok:true}` shell) must stay a probe miss — its
+  // defaulted 0% would be a fabricated reading, not a degraded one.
+  const hasFiniteUtil =
+    asFiniteNumber(record.util ?? record.hard_util ?? record.hardUtil) !== null ||
+    asFiniteNumber(record.warn_util ?? record.warnUtil) !== null;
   const gateUtil = clamp(numberOr(record.util ?? record.hard_util ?? record.hardUtil, 0), 0, 100);
   const warnUtil = clamp(numberOr(record.warn_util ?? record.warnUtil, gateUtil), 0, 100);
   const rawBuckets = Array.isArray(record.buckets) ? record.buckets : [];
   const buckets = rawBuckets
     .map((bucket) => normalizeBucket(bucket, fetchedAt))
     .filter((bucket): bucket is RawBucket => bucket !== null);
-  if (buckets.length === 0) {
+  if (buckets.length === 0 && hasFiniteUtil) {
     const topLevelBucket = normalizeTopLevelBucket(record, gateUtil, fetchedAt);
     if (topLevelBucket) buckets.push(topLevelBucket);
   }
@@ -212,9 +225,12 @@ export function normalizeProbeResult(raw: unknown): AgentUsage | null {
   if (!ok && rateLimitedUntil <= 0 && buckets.length === 0) return null;
 
   const { fiveHour, weekly } = identifyWindows(buckets);
-  // A successful response with no resettable windows is not actionable budget
-  // data. Treat it like a transient probe miss instead of trusting fake 0% util.
-  if (!fiveHour && !weekly && rateLimitedUntil === 0) return null;
+  // Truly unusable = no windows, no rate-limit gate AND no actual util
+  // reading. Degraded-but-usable records (stale cache during a 429 gate,
+  // unknown-reset buckets) flow through for DISPLAY — the decision layer
+  // (isDecisionGrade) independently rejects anything without a fresh window,
+  // so accepting them here cannot flip interventions. (agent-bridge#103)
+  if (!fiveHour && !weekly && rateLimitedUntil === 0 && !hasFiniteUtil) return null;
 
   return {
     ok,
@@ -239,12 +255,29 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   });
 }
 
+/**
+ * Is this usage record degraded (usable for display, not for decisions)?
+ * Freshness uses `resetEpoch > now` — the same standard as isDecisionGrade —
+ * so an expired-window record cannot log a premature "recovered" transition.
+ */
+export function isDegradedUsage(usage: AgentUsage, now: number = Math.floor(Date.now() / 1000)): boolean {
+  if (usage.stale || !usage.ok) return true;
+  const hasFreshWindow =
+    (usage.fiveHour !== null && usage.fiveHour.resetEpoch > now) ||
+    (usage.weekly !== null && usage.weekly.resetEpoch > now);
+  return !hasFreshWindow;
+}
+
 export class QuotaSource {
   private readonly env: Record<string, string | undefined>;
   private readonly homeDir: string;
   private readonly timeoutMs: number;
   private readonly runner: ProbeRunner;
   private readonly log: (message: string) => void;
+  private readonly now: () => number;
+  /** Last degraded-state per agent — degradation is logged on TRANSITIONS only
+   *  (a stale period spans many 60s polls; per-poll lines are log spam). */
+  private readonly degradedLogged = new Map<AgentName, boolean>();
 
   constructor(options: QuotaSourceOptions = {}) {
     this.env = options.env ?? process.env;
@@ -252,6 +285,7 @@ export class QuotaSource {
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.runner = options.runner ?? defaultRunner;
     this.log = options.log ?? (() => {});
+    this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
   }
 
   async fetchBoth(): Promise<{ claude: AgentUsage | null; codex: AgentUsage | null } | null> {
@@ -304,14 +338,44 @@ export class QuotaSource {
         );
         const text = String(result.stdout).trim();
         if (!text) continue;
-        const usage = normalizeProbeResult(JSON.parse(text));
-        if (usage) return usage;
-        this.log(`budget probe returned no usable data for ${agent}: ${candidate.command}`);
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          // Unparseable output gets the same triage snippet as unusable data —
+          // the outer catch only sees the parse error message otherwise.
+          this.log(`budget probe output unparseable for ${agent}: ${candidate.command} — raw: ${text.slice(0, 200)}`);
+          continue;
+        }
+        const usage = normalizeProbeResult(parsed);
+        if (usage) {
+          this.noteDegradation(agent, usage);
+          return usage;
+        }
+        // Genuinely unusable (no windows, no rate-limit gate, no util reading)
+        // — include a raw snippet so the next triage doesn't have to guess
+        // which output shape the daemon actually saw. Degraded-but-usable
+        // records no longer land here; they return above. (agent-bridge#103)
+        this.log(
+          `budget probe returned no usable data for ${agent}: ${candidate.command} — raw: ${text.slice(0, 200)}`,
+        );
       } catch (error) {
         this.log(`budget probe failed for ${agent}: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
     return null;
+  }
+
+  private noteDegradation(agent: AgentName, usage: AgentUsage): void {
+    const degraded = isDegradedUsage(usage, this.now());
+    const wasDegraded = this.degradedLogged.get(agent) === true;
+    if (degraded && !wasDegraded) {
+      const gate = usage.rateLimitedUntil > 0 ? `, rate-limit gated until ${usage.rateLimitedUntil}` : "";
+      this.log(`budget probe degraded data accepted for ${agent} (stale=${usage.stale}, ok=${usage.ok}${gate}) — display only, decisions hold`);
+    } else if (!degraded && wasDegraded) {
+      this.log(`budget probe recovered to fresh data for ${agent}`);
+    }
+    this.degradedLogged.set(agent, degraded);
   }
 }
 

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -211,6 +211,68 @@ describe("BudgetCoordinator", () => {
     expect(emitted.filter((event) => event.id.startsWith("system_budget_balance"))).toHaveLength(1);
   });
 
+  test("degraded display-only record must not queue a codex tier override (#103)", async () => {
+    // warnUtil 85 would select "eco" — but the record's only window has an
+    // unknown reset (resetEpoch 0, the #103 degraded shape), so the tier
+    // decision must fall back to "full" / no override, exactly like a probe
+    // miss. Display-layer acceptance must never reach the override queue.
+    const tierConfig = { ...CONFIG, codexTierControl: true };
+
+    // Positive control first: the same warnUtil on DECISION-GRADE data does
+    // queue the eco override — proving the mechanism is live, so the degraded
+    // case below blocks specifically on data quality, not on configuration.
+    const freshSource = new FakeSource([
+      { claude: usage(), codex: usage({ gateUtil: 85, warnUtil: 85 }) },
+    ]);
+    const fresh = makeCoordinator(freshSource, tierConfig);
+    await fresh.coordinator.start();
+    await waitFor(() => freshSource.calls >= 1);
+    fresh.coordinator.stop();
+    expect(fresh.coordinator.getCodexTurnOverrides()).toEqual({ effort: "low" });
+
+    const source = new FakeSource([
+      {
+        claude: usage(),
+        codex: usage({ gateUtil: 85, warnUtil: 85, stale: true, fiveHour: { util: 85, resetEpoch: 0 }, weekly: null }),
+      },
+    ]);
+    const { coordinator } = makeCoordinator(source, tierConfig);
+
+    await coordinator.start();
+    await waitFor(() => source.calls >= 1);
+    coordinator.stop();
+
+    expect(coordinator.getCodexTurnOverrides()).toBeNull();
+    expect(coordinator.getSnapshot()?.codexTier).toBe("full");
+  });
+
+  test("mid-pause degraded record holds the pause directive fingerprint (#103)", async () => {
+    // Pause entered on decision-grade data; the next poll returns a degraded
+    // stale windowless record WITHOUT a rate-limit gate (the shape that
+    // previously normalized to null and was held by the probe-uncertain
+    // check). It must still hold — not recompute the fingerprint against a
+    // phantom reset bucket and re-emit the pause directive.
+    const source = new FakeSource([
+      { claude: usage(), codex: usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }) },
+      {
+        claude: usage(),
+        codex: usage({ gateUtil: 0, warnUtil: 0, stale: true, fiveHour: { util: 0, resetEpoch: 0 }, weekly: null }),
+      },
+      {
+        claude: usage(),
+        codex: usage({ gateUtil: 0, warnUtil: 0, stale: true, fiveHour: { util: 0, resetEpoch: 0 }, weekly: null }),
+      },
+    ]);
+    const { coordinator, emitted } = makeCoordinator(source);
+
+    await coordinator.start();
+    await waitFor(() => source.calls >= 3);
+    coordinator.stop();
+
+    expect(coordinator.isPaused()).toBe(true);
+    expect(emitted.filter((event) => event.id.startsWith("system_budget_pause"))).toHaveLength(1);
+  });
+
   test("re-emits balance directive when the lighter side enters a new five-hour window", async () => {
     const source = new FakeSource([
       {

--- a/src/unit-test/quota-source.test.ts
+++ b/src/unit-test/quota-source.test.ts
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { QuotaSource, normalizeProbeResult } from "../budget/quota-source";
+import { QuotaSource, isDegradedUsage, normalizeProbeResult } from "../budget/quota-source";
+import { isDecisionGrade } from "../budget/budget-state";
 
 const NOW = 1_700_000_000;
 
@@ -64,19 +65,66 @@ describe("quota-source normalization", () => {
     expect(usage).not.toBeNull();
     expect(usage!.ok).toBe(false);
     expect(usage!.gateUtil).toBe(0);
-    expect(usage!.fiveHour).toBeNull();
+    // util:0 is an actual (finite) reading — it surfaces as a display-only
+    // window with unknown reset (resetEpoch 0 is rejected by isDecisionGrade).
+    expect(usage!.fiveHour).toEqual({ util: 0, resetEpoch: 0 });
     expect(usage!.weekly).toBeNull();
     expect(usage!.rateLimitedUntil).toBe(NOW + 900);
   });
 
-  test("returns null for empty successful probe responses with no windows or rate limit", () => {
-    expect(normalizeProbeResult({
+  test("accepts windowless util readings as display-only degraded data (#103)", () => {
+    // Layered consumption: the display layer accepts any finite util reading;
+    // the decision layer (isDecisionGrade) independently rejects records
+    // without a fresh window, so this cannot flip interventions.
+    const usage = normalizeProbeResult({
       ok: true,
       util: 0,
       warn_util: 0,
       fetched_at: NOW,
       buckets: [],
+    });
+    expect(usage).not.toBeNull();
+    expect(usage!.fiveHour).toEqual({ util: 0, resetEpoch: 0 });
+    expect(isDecisionGrade(usage, NOW)).toBe(false);
+  });
+
+  test("returns null when the record carries no util reading at all (information floor)", () => {
+    expect(normalizeProbeResult({
+      ok: true,
+      fetched_at: NOW,
+      buckets: [],
     })).toBeNull();
+  });
+
+  test("keeps reset_epoch:null buckets as unknown-reset windows (#103)", () => {
+    const usage = normalizeProbeResult({
+      ok: true,
+      util: 55,
+      warn_util: 55,
+      fetched_at: NOW,
+      buckets: [{ id: "seven_day", util: 55, reset_epoch: null }],
+    });
+    expect(usage).not.toBeNull();
+    expect(usage!.weekly).toEqual({ util: 55, resetEpoch: 0 });
+    expect(isDecisionGrade(usage, NOW)).toBe(false);
+  });
+
+  test("accepts the live 429-gate stale cache shape from agent-bridge#103", () => {
+    const usage = normalizeProbeResult({
+      ok: true,
+      agent: "claude",
+      util: 0,
+      warn_util: 0,
+      hard_util: 0,
+      source: "cache",
+      stale: true,
+      fetched_at: NOW - 120,
+      rate_limited_until: NOW + 300,
+    });
+    expect(usage).not.toBeNull();
+    expect(usage!.stale).toBe(true);
+    expect(usage!.rateLimitedUntil).toBe(NOW + 300);
+    expect(isDegradedUsage(usage!, NOW)).toBe(true);
   });
 
   test("keeps cache fallback results when bucket windows are still present", () => {
@@ -191,6 +239,85 @@ describe("QuotaSource", () => {
       { command: "/tmp/fake-budget-probe", args: ["--agent", "claude"] },
       { command: "/tmp/fake-budget-probe", args: ["--agent", "codex"] },
     ]);
+  });
+
+  test("unusable probe output is logged with a raw snippet for triage (#103)", async () => {
+    const logs: string[] = [];
+    const source = new QuotaSource({
+      env: { AGENTBRIDGE_QUOTA_PROBE: "/tmp/fake-budget-probe" },
+      homeDir: "/unused",
+      log: (m) => logs.push(m),
+      runner: async () => ({
+        stdout: JSON.stringify({ ok: true, source: "cache", note: "no util fields at all" }),
+      }),
+    });
+
+    await source.fetchBoth();
+    const line = logs.find((l) => l.includes("no usable data"));
+    expect(line).toBeDefined();
+    expect(line).toContain("raw: ");
+    expect(line).toContain("no util fields at all");
+  });
+
+  test("unparseable probe output is logged with a raw snippet (#103 MEDIUM)", async () => {
+    const logs: string[] = [];
+    const source = new QuotaSource({
+      env: { AGENTBRIDGE_QUOTA_PROBE: "/tmp/fake-budget-probe" },
+      homeDir: "/unused",
+      log: (m) => logs.push(m),
+      runner: async () => ({ stdout: "Error: keychain locked\npartial{json" }),
+    });
+
+    await source.fetchBoth();
+    const line = logs.find((l) => l.includes("unparseable"));
+    expect(line).toBeDefined();
+    expect(line).toContain("raw: Error: keychain locked");
+  });
+
+  test("expired-window records stay degraded — no premature recovery log", () => {
+    const expired = normalizeProbeResult({
+      ok: true,
+      util: 30,
+      warn_util: 30,
+      fetched_at: NOW,
+      buckets: [{ id: "five_hour", util: 30, reset_epoch: NOW - 100 }],
+    });
+    expect(expired).not.toBeNull();
+    // resetEpoch > 0 but in the past: fresh by the OLD (>0) standard, degraded
+    // by the isDecisionGrade-aligned (>now) standard.
+    expect(isDegradedUsage(expired!, NOW)).toBe(true);
+  });
+
+  test("degraded acceptance is logged on transitions only, with recovery (#103)", async () => {
+    const logs: string[] = [];
+    let stale = true;
+    const source = new QuotaSource({
+      env: { AGENTBRIDGE_QUOTA_PROBE: "/tmp/fake-budget-probe" },
+      homeDir: "/unused",
+      log: (m) => logs.push(m),
+      now: () => NOW,
+      runner: async () => ({
+        stdout: JSON.stringify({
+          ok: true,
+          util: 30,
+          warn_util: 30,
+          stale,
+          fetched_at: NOW,
+          buckets: [{ id: "five_hour", util: 30, reset_epoch: NOW + 3600 }],
+        }),
+      }),
+    });
+
+    await source.fetchBoth(); // degraded (stale) — logs once per agent
+    await source.fetchBoth(); // still degraded — no new logs
+    const degradedLines = logs.filter((l) => l.includes("degraded data accepted"));
+    expect(degradedLines.length).toBe(2); // one per agent (claude + codex)
+
+    stale = false;
+    await source.fetchBoth(); // recovery — logs once per agent
+    const recoveredLines = logs.filter((l) => l.includes("recovered to fresh data"));
+    expect(recoveredLines.length).toBe(2);
+    expect(logs.filter((l) => l.includes("degraded data accepted")).length).toBe(2);
   });
 
   test("uses installed budget-probe when env probes are unset", async () => {


### PR DESCRIPTION
issue #103 + 架构审视「探针数据质量」三方共识（Codex 强主张 #7 ⟷ Claude 扫描 ⟷ #103 实锤）的落地。详见提交信息。2 轮 cross-review 收敛（轮 1 双 reviewer 各抓 1 REAL：tier override 走漏 + mid-pause 指纹翻动，均修复带正反对照回归测试）。713 tests + typecheck + plugin sync 全绿。

Closes #103