### PR TITLE
feat: wrapper 退出可观测性（turn 三态分类 + native pid + sqlite 日志尾固化）/ wrapper exit observability (closes #102)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14209,7 +14209,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("7f27707", "source"),
+  commit: defineString("935ca23", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.6", "0.0.0-source"),
-  commit: defineString("7f27707", "source"),
+  commit: defineString("935ca23", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -3901,8 +3901,16 @@ var tuiConnectionState = new TuiConnectionState({
   }
 });
 var statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
+function tryWriteStatusFile(reason) {
+  try {
+    writeStatusFile();
+  } catch (err) {
+    log(`status file write failed (${reason}): ${err?.message ?? err}`);
+  }
+}
 codex.on("turnStarted", () => {
   log("Codex turn started");
+  tryWriteStatusFile("turnStarted");
   emitToClaude(systemMessage("system_turn_started", "\u23F3 Codex is working on the current task. Wait for completion before sending a reply."));
 });
 codex.on("agentMessage", (msg) => {
@@ -3943,6 +3951,7 @@ codex.on("agentMessage", (msg) => {
 });
 codex.on("turnCompleted", () => {
   log("Codex turn completed");
+  tryWriteStatusFile("turnCompleted");
   statusBuffer.flush("turn completed");
   const { warnReplyMissing } = replyTracker.consumeOnTurnComplete();
   if (warnReplyMissing) {
@@ -3954,6 +3963,7 @@ codex.on("turnCompleted", () => {
 });
 codex.on("turnAborted", (reason) => {
   log(`Codex turn aborted (${reason}) \u2014 clearing reply-required state`);
+  tryWriteStatusFile("turnAborted");
   const replyWasRequired = replyTracker.isArmed;
   replyTracker.reset();
   const notice = buildTurnAbortedNotice(reason, replyWasRequired);
@@ -4433,7 +4443,8 @@ function currentStatus() {
     cwd: process.cwd(),
     stateDir: stateDir.dir,
     build: daemonStatusBuildInfo(),
-    budget: budgetCoordinator?.getSnapshot() ?? undefined
+    budget: budgetCoordinator?.getSnapshot() ?? undefined,
+    turnInProgress: codex.turnInProgress
   };
 }
 function currentWaitingMessage() {
@@ -4475,7 +4486,8 @@ function writeStatusFile() {
     pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
     cwd: process.cwd(),
     stateDir: stateDir.dir,
-    build: daemonStatusBuildInfo()
+    build: daemonStatusBuildInfo(),
+    turnInProgress: codex.turnInProgress
   });
 }
 function removeStatusFile() {

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -1,4 +1,4 @@
-import { spawn, execSync } from "node:child_process";
+import { spawn, execSync, execFileSync } from "node:child_process";
 import {
   openSync,
   writeSync,
@@ -9,8 +9,15 @@ import {
   existsSync,
   mkdirSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { checkAgentsMdContract } from "../agents-contract";
+import {
+  captureTuiLogTail,
+  discoverNativeChildPid,
+  readTurnInProgress,
+  refineCleanExitClassification,
+} from "../wrapper-exit-observability";
 import { ConfigService } from "../config-service";
 import { BUILD_INFO } from "../build-info";
 import { DaemonLifecycle } from "../daemon-lifecycle";
@@ -422,6 +429,32 @@ export async function runCodex(args: string[]) {
     appendWrapperLog(wrapperLogPath, `child pid=${child.pid}`);
   }
 
+  // The spawned `codex` is an npm launcher; the real TUI is ITS child, and
+  // the structured logs in ~/.codex/logs_*.sqlite are keyed by that native
+  // pid. Discover it shortly after spawn (retry: the launcher needs a moment
+  // to fork) so the exit block can freeze the right log tail (issue #102).
+  let nativeChildPid: number | null = null;
+  if (typeof child.pid === "number") {
+    const launcherPid = child.pid;
+    let attempts = 0;
+    const discover = () => {
+      attempts += 1;
+      nativeChildPid = discoverNativeChildPid(launcherPid, (cmd, args) =>
+        execFileSync(cmd, args, { encoding: "utf-8", timeout: 2000 }),
+      );
+      if (nativeChildPid !== null) {
+        appendWrapperLog(wrapperLogPath, `native child pid=${nativeChildPid} (launcher pid=${launcherPid})`);
+        return;
+      }
+      if (attempts < 5 && !childExited) {
+        const retry = setTimeout(discover, 500);
+        retry.unref();
+      }
+    };
+    const first = setTimeout(discover, 300);
+    first.unref();
+  }
+
   // Tee stderr: pass through to user's terminal, tail into ring buffer.
   if (child.stderr) {
     child.stderr.on("data", (chunk: Buffer) => {
@@ -536,15 +569,35 @@ export async function runCodex(args: string[]) {
     else if (/Error: .* failed:/.test(tail)) classification = "rpc_error_exit";
     else if (signal) classification = `signal:${signal}`;
     else if (typeof code === "number" && code !== 0) classification = `nonzero_exit:${code}`;
-    else if (code === 0 && tail.trim().length === 0) classification = "exit_0_empty_stderr";
+    else if (code === 0 && tail.trim().length === 0) {
+      // Refine the historically-opaque exit_0_empty_stderr via the daemon's
+      // turn state (status.json, refreshed on every turn transition). A clean
+      // exit DURING a turn is the alarming one — the user sees "Codex died"
+      // while the agent loop usually finishes app-server-side (issue #102).
+      classification = refineCleanExitClassification(readTurnInProgress(stateDir.statusFile));
+    }
+
+    // Freeze the native TUI's structured-log tail into the exit block — the
+    // sqlite db outlives the process, but correlating it manually cost a
+    // two-agent triage last time. Best-effort and bounded by design: worst
+    // case adds 2s (execFileSync timeout) to every exit path including
+    // Ctrl-C — accepted diagnostics cost, cannot hang.
+    const tuiLogTail = captureTuiLogTail({
+      codexHome: join(homedir(), ".codex"),
+      nativePid: nativeChildPid,
+      run: (cmd, args) => execFileSync(cmd, args, { encoding: "utf-8", timeout: 2000 }),
+    });
 
     appendWrapperLog(
       wrapperLogPath,
       [
-        `exit: code=${code ?? "null"} signal=${signal ?? "null"} runtime_ms=${runtimeMs} pid=${child.pid ?? "unknown"} classification=${classification}`,
+        `exit: code=${code ?? "null"} signal=${signal ?? "null"} runtime_ms=${runtimeMs} pid=${child.pid ?? "unknown"} native_pid=${nativeChildPid ?? "unknown"} classification=${classification}`,
         `--- last stderr (${stderrTail.byteLength} bytes) ---`,
         tailLines,
         `--- end stderr ---`,
+        `--- last tui log (native pid ${nativeChildPid ?? "unknown"}) ---`,
+        tuiLogTail,
+        `--- end tui log ---`,
       ].join("\n"),
     );
 

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -27,6 +27,13 @@ export interface DaemonStatus {
   build?: AgentBridgeBuildInfo;
   /** Latest budget coordination snapshot; absent when budget sensing is unavailable/disabled. */
   budget?: BudgetSnapshot;
+  /**
+   * Whether a Codex turn is currently executing. Exposed on BOTH /healthz and
+   * status.json (kept in sync so the two payloads don't drift) so the TUI
+   * wrapper can classify a clean exit as exit_0_during_turn vs exit_0_idle at
+   * the moment the TUI dies (issue #102).
+   */
+  turnInProgress?: boolean;
 }
 
 export type ControlClientMessage =

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -226,8 +226,22 @@ const tuiConnectionState = new TuiConnectionState({
 
 const statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
 
+// Turn-transition status refreshes are OBSERVABILITY writes (issue #102) —
+// a disk/permission failure there must never break core turn handling, so
+// they go through this catcher (boot-path writes keep strict semantics).
+function tryWriteStatusFile(reason: string) {
+  try {
+    writeStatusFile();
+  } catch (err: any) {
+    log(`status file write failed (${reason}): ${err?.message ?? err}`);
+  }
+}
+
 codex.on("turnStarted", () => {
   log("Codex turn started");
+  // Keep status.json's turnInProgress current — the TUI wrapper reads it at
+  // exit time to classify exit_0_during_turn vs exit_0_idle (issue #102).
+  tryWriteStatusFile("turnStarted");
   emitToClaude(
     systemMessage(
       "system_turn_started",
@@ -280,6 +294,7 @@ codex.on("agentMessage", (msg: BridgeMessage) => {
 
 codex.on("turnCompleted", () => {
   log("Codex turn completed");
+  tryWriteStatusFile("turnCompleted"); // turnInProgress flipped (#102)
   statusBuffer.flush("turn completed");
 
   // Check if reply was required but Codex didn't send any agentMessage, then
@@ -309,6 +324,7 @@ codex.on("turnAborted", (reason: string) => {
   // stop). Clear the require_reply tracker so its armed state cannot be inherited
   // by a later, unrelated turn (force-forward leak + misattributed warning).
   log(`Codex turn aborted (${reason}) — clearing reply-required state`);
+  tryWriteStatusFile("turnAborted"); // turnInProgress flipped (#102)
   const replyWasRequired = replyTracker.isArmed;
   replyTracker.reset();
 
@@ -999,6 +1015,7 @@ function currentStatus(): DaemonStatus {
     stateDir: stateDir.dir,
     build: daemonStatusBuildInfo(),
     budget: budgetCoordinator?.getSnapshot() ?? undefined,
+    turnInProgress: codex.turnInProgress,
   };
 }
 
@@ -1054,6 +1071,10 @@ function writeStatusFile() {
     cwd: process.cwd(),
     stateDir: stateDir.dir,
     build: daemonStatusBuildInfo(),
+    // Refreshed on every turn transition (turnStarted/turnCompleted/turnAborted
+    // handlers call writeStatusFile) so the TUI wrapper reads an up-to-date
+    // value at exit time: exit_0_during_turn vs exit_0_idle (issue #102).
+    turnInProgress: codex.turnInProgress,
   });
 }
 

--- a/src/unit-test/wrapper-exit-observability.test.ts
+++ b/src/unit-test/wrapper-exit-observability.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  captureTuiLogTail,
+  codexSqliteTailCommand,
+  discoverNativeChildPid,
+  findCodexSqliteLog,
+  readTurnInProgress,
+  refineCleanExitClassification,
+} from "../wrapper-exit-observability";
+
+describe("discoverNativeChildPid", () => {
+  test("parses the first child pid from pgrep output", () => {
+    expect(discoverNativeChildPid(100, () => "61880\n61999\n")).toBe(61880);
+    expect(discoverNativeChildPid(100, () => "  61880  \n")).toBe(61880);
+  });
+
+  test("returns null when pgrep finds nothing or fails", () => {
+    // pgrep exits 1 on no match → runner throws
+    expect(discoverNativeChildPid(100, () => { throw new Error("exit 1"); })).toBeNull();
+    expect(discoverNativeChildPid(100, () => "")).toBeNull();
+    expect(discoverNativeChildPid(100, () => "garbage\n")).toBeNull();
+  });
+});
+
+describe("readTurnInProgress", () => {
+  test("reads the boolean field from status.json", () => {
+    expect(readTurnInProgress("/x", () => JSON.stringify({ turnInProgress: true }))).toBe(true);
+    expect(readTurnInProgress("/x", () => JSON.stringify({ turnInProgress: false }))).toBe(false);
+  });
+
+  test("unknown when field missing, file unreadable, or json invalid", () => {
+    // Old daemon builds don't write the field — must be unknown, NOT idle.
+    expect(readTurnInProgress("/x", () => JSON.stringify({ pid: 1 }))).toBeNull();
+    expect(readTurnInProgress("/x", () => { throw new Error("ENOENT"); })).toBeNull();
+    expect(readTurnInProgress("/x", () => "not-json")).toBeNull();
+    expect(readTurnInProgress("/x", () => JSON.stringify({ turnInProgress: "yes" }))).toBeNull();
+  });
+
+  test("stale file from a dead daemon degrades to unknown, not during_turn", () => {
+    // A daemon killed MID-TURN leaves turnInProgress:true behind; trusting it
+    // would label a later idle TUI quit as the alarming exit_0_during_turn.
+    const staleTrue = JSON.stringify({ turnInProgress: true, pid: 4242 });
+    expect(readTurnInProgress("/x", () => staleTrue, () => false)).toBeNull();
+    expect(readTurnInProgress("/x", () => staleTrue, () => true)).toBe(true);
+    // No pid recorded (legacy file) → field taken at face value.
+    expect(readTurnInProgress("/x", () => JSON.stringify({ turnInProgress: false }), () => false)).toBe(false);
+  });
+});
+
+describe("refineCleanExitClassification", () => {
+  test("maps daemon turn state onto the three clean-exit classes", () => {
+    expect(refineCleanExitClassification(true)).toBe("exit_0_during_turn");
+    expect(refineCleanExitClassification(false)).toBe("exit_0_idle");
+    expect(refineCleanExitClassification(null)).toBe("exit_0_turn_unknown");
+  });
+});
+
+describe("findCodexSqliteLog", () => {
+  test("picks the newest logs*.sqlite and ignores other files", () => {
+    const home = mkdtempSync(join(tmpdir(), "codex-home-"));
+    try {
+      writeFileSync(join(home, "logs_1.sqlite"), "");
+      writeFileSync(join(home, "logs_2.sqlite"), "");
+      writeFileSync(join(home, "config.toml"), "");
+      const old = new Date(Date.now() - 86_400_000);
+      utimesSync(join(home, "logs_1.sqlite"), old, old);
+
+      expect(findCodexSqliteLog(home)).toBe(join(home, "logs_2.sqlite"));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("null when the directory or matches are absent", () => {
+    expect(findCodexSqliteLog("/nonexistent-dir-xyz")).toBeNull();
+    const home = mkdtempSync(join(tmpdir(), "codex-home-empty-"));
+    try {
+      expect(findCodexSqliteLog(home)).toBeNull();
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("codexSqliteTailCommand", () => {
+  test("builds a read-only, pid-scoped, bounded query", () => {
+    const { cmd, args } = codexSqliteTailCommand("/db.sqlite", 61880, 50);
+    expect(cmd).toBe("sqlite3");
+    expect(args[0]).toBe("-readonly");
+    expect(args[1]).toBe("/db.sqlite");
+    expect(args[2]).toContain("like 'pid:61880:%'");
+    expect(args[2]).toContain("limit 50");
+    expect(args[2]).toContain("substr(feedback_log_body,1,300)");
+  });
+});
+
+describe("captureTuiLogTail", () => {
+  test("degrades gracefully at every failure point — never throws", () => {
+    expect(captureTuiLogTail({ codexHome: "/none", nativePid: null, run: () => "x" }))
+      .toContain("native child pid unknown");
+    expect(captureTuiLogTail({ codexHome: "/nonexistent-dir-xyz", nativePid: 1, run: () => "x" }))
+      .toContain("no codex sqlite log database");
+
+    const home = mkdtempSync(join(tmpdir(), "codex-home-tail-"));
+    try {
+      writeFileSync(join(home, "logs_2.sqlite"), "");
+      expect(captureTuiLogTail({ codexHome: home, nativePid: 1, run: () => { throw new Error("sqlite3 missing"); } }))
+        .toContain("capture failed: sqlite3 missing");
+      expect(captureTuiLogTail({ codexHome: home, nativePid: 1, run: () => "" }))
+        .toContain("no log rows for pid 1");
+      expect(captureTuiLogTail({ codexHome: home, nativePid: 1, run: () => "row1|INFO|target|body\n" }))
+        .toBe("row1|INFO|target|body");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/wrapper-exit-observability.ts
+++ b/src/wrapper-exit-observability.ts
@@ -1,0 +1,155 @@
+/**
+ * TUI-wrapper exit observability (issue #102).
+ *
+ * A real outage triage showed every TUI exit in codex-wrapper.log classified
+ * as the same `exit_0_empty_stderr` — indistinguishable user-quit vs
+ * unexpected clean death, and the structured TUI logs (which live in
+ * ~/.codex/logs_*.sqlite, NOT the empty ~/.codex/log/ decoy directory) were
+ * keyed by the NATIVE child pid, which the wrapper never recorded.
+ *
+ * This module holds the pure/injectable pieces the wrapper exit hook uses:
+ *  - native-child pid discovery (the spawned `codex` is an npm launcher whose
+ *    child is the real TUI binary);
+ *  - clean-exit refinement via the daemon's status.json turnInProgress field
+ *    (refreshed by the daemon on every turn transition);
+ *  - the sqlite tail query that freezes the TUI's last structured log lines
+ *    into the wrapper log at exit time.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export type RunCommand = (cmd: string, args: string[]) => string;
+
+/**
+ * Discover the native TUI child of the npm launcher process. Returns the
+ * first child pid, or null when none is visible (already exited, or the
+ * launcher IS the native binary).
+ */
+export function discoverNativeChildPid(launcherPid: number, run: RunCommand): number | null {
+  try {
+    const out = run("pgrep", ["-P", String(launcherPid)]);
+    const first = out
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => /^\d+$/.test(line));
+    return first ? Number(first) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the daemon's turnInProgress from status.json. Returns null when the
+ * file/field is unavailable (old daemon build, daemon gone) — callers must
+ * treat null as "unknown", never as idle.
+ *
+ * Trust gate: status.json outlives a killed daemon, and a daemon killed
+ * MID-TURN leaves `turnInProgress: true` behind — a later idle TUI exit would
+ * misclassify as exit_0_during_turn. So the field is only trusted when the
+ * writing daemon (status.pid) is still alive; a stale file degrades to
+ * unknown.
+ */
+export function readTurnInProgress(
+  statusFilePath: string,
+  read: (p: string) => string = (p) => readFileSync(p, "utf-8"),
+  isPidAlive: (pid: number) => boolean = defaultIsPidAlive,
+): boolean | null {
+  try {
+    const status = JSON.parse(read(statusFilePath)) as Record<string, unknown>;
+    if (typeof status.turnInProgress !== "boolean") return null;
+    if (typeof status.pid === "number" && !isPidAlive(status.pid)) return null;
+    return status.turnInProgress;
+  } catch {
+    return null;
+  }
+}
+
+function defaultIsPidAlive(pid: number): boolean {
+  if (pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM = exists but not ours (not the case for our own daemon, but err
+    // on the side of "alive" like pair-registry's pidLooksAlive).
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Refine the clean-exit classification using the daemon-side turn state.
+ * `exit_0_during_turn` is the alarming one: the user sees "Codex died", but
+ * the agent loop lives app-server-side and the task usually completes.
+ */
+export function refineCleanExitClassification(turnInProgress: boolean | null): string {
+  if (turnInProgress === true) return "exit_0_during_turn";
+  if (turnInProgress === false) return "exit_0_idle";
+  return "exit_0_turn_unknown";
+}
+
+/**
+ * Locate the newest codex structured-log sqlite database. The filename is
+ * versioned (logs_2.sqlite today) — pick the most recently modified match so
+ * a future logs_3 keeps working. Returns null when none exist.
+ */
+export function findCodexSqliteLog(codexHome: string, fs: { readdir: typeof readdirSync; stat: typeof statSync } = { readdir: readdirSync, stat: statSync }): string | null {
+  try {
+    const entries = fs.readdir(codexHome).filter((name) => /^logs.*\.sqlite$/.test(String(name)));
+    let best: { path: string; mtime: number } | null = null;
+    for (const name of entries) {
+      const path = join(codexHome, String(name));
+      try {
+        const mtime = fs.stat(path).mtimeMs;
+        if (!best || mtime > best.mtime) best = { path, mtime };
+      } catch {
+        // Race with deletion — skip.
+      }
+    }
+    return best?.path ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The sqlite tail query for one native pid's structured log records.
+ * `process_uuid` is `pid:<pid>:<uuid>`; body is truncated per row and the row
+ * count bounded so a wrapper exit appends a bounded block, not a dump.
+ */
+export function codexSqliteTailCommand(dbPath: string, nativePid: number, limit = 80): { cmd: string; args: string[] } {
+  // Both interpolations are numbers by type, but NaN/Infinity are valid JS
+  // numbers sqlite would reject — clamp to a sane integer before embedding.
+  const rows = Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : 80;
+  const pid = Math.max(0, Math.floor(nativePid));
+  const sql =
+    `select ts, level, target, substr(feedback_log_body,1,300) from logs ` +
+    `where process_uuid like 'pid:${pid}:%' order by id desc limit ${rows};`;
+  return { cmd: "sqlite3", args: ["-readonly", dbPath, sql] };
+}
+
+/**
+ * Capture the TUI log tail for the exit block. Best-effort: any failure
+ * (sqlite3 missing, db locked, no rows) degrades to a one-line explanation —
+ * the wrapper exit path must never throw or block on this.
+ */
+export function captureTuiLogTail(options: {
+  codexHome: string;
+  nativePid: number | null;
+  run: RunCommand;
+}): string {
+  if (options.nativePid === null) {
+    return "(native child pid unknown — tui log tail unavailable)";
+  }
+  const db = findCodexSqliteLog(options.codexHome);
+  if (!db) {
+    return "(no codex sqlite log database found)";
+  }
+  try {
+    const { cmd, args } = codexSqliteTailCommand(db, options.nativePid);
+    const out = options.run(cmd, args).trim();
+    return out.length > 0 ? out : `(no log rows for pid ${options.nativePid} in ${db})`;
+  } catch (err) {
+    return `(tui log tail capture failed: ${err instanceof Error ? err.message : String(err)})`;
+  }
+}


### PR DESCRIPTION
issue #102 完整落地（关键事实与设计经 Codex 两轮确认：status.json 原无 turn 字段、sqlite 真机 schema/锁验证）。详见提交信息。2 轮 cross-review 收敛 0 REAL。723 tests 全绿。

Closes #102