### PR TITLE
fix: 修复 CI 一周全红根因（smoke manual 模式声明）+ ci:local 本地镜像 / fix week-long CI red

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "release:bump": "node scripts/bump-version.mjs",
     "typecheck": "tsc --noEmit",
     "validate:plugin-versions": "bun scripts/check-plugin-versions.js",
-    "check": "tsc --noEmit && bun test src && bun run verify:plugin-sync && bun scripts/check-plugin-versions.js"
+    "check": "tsc --noEmit && bun test src && bun run verify:plugin-sync && bun scripts/check-plugin-versions.js",
+    "ci:local": "bun run check && bun run smoke:built && bun run smoke:pack"
   },
   "repository": {
     "type": "git",

--- a/scripts/smoke-built-cli.mjs
+++ b/scripts/smoke-built-cli.mjs
@@ -334,9 +334,24 @@ async function main() {
   let daemonPid = null;
   const statusPath = join(stateDir, "status.json");
 
+  // Two env hazards (both bit us in CI/locally — CI red since 2026-06-03):
+  // 1. The CLI's env-guard treats manual runtime env (STATE_DIR/ports) WITHOUT
+  //    AGENTBRIDGE_PAIR_ID or AGENTBRIDGE_MANUAL=1 as stale and CLEARS it —
+  //    the daemon then boots at the default location while we poll the smoke
+  //    ports ("Unable to connect"). Declare manual mode explicitly.
+  // 2. Ambient AGENTBRIDGE_*/CODEX_* from the invoking shell (a live pair
+  //    session) leaks through ...process.env and trips the guard's pair
+  //    consistency checks. Strip them before applying the smoke's own env.
+  const ambient = { ...process.env };
+  for (const key of Object.keys(ambient)) {
+    if (key.startsWith("AGENTBRIDGE_") || key === "CODEX_WS_PORT" || key === "CODEX_PROXY_PORT") {
+      delete ambient[key];
+    }
+  }
   const env = {
-    ...process.env,
+    ...ambient,
     PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    AGENTBRIDGE_MANUAL: "1",
     AGENTBRIDGE_STATE_DIR: stateDir,
     AGENTBRIDGE_CONTROL_PORT: String(controlPort),
     CODEX_WS_PORT: String(appPort),


### PR DESCRIPTION
CI 自 6 月 3 日 env-guard 引入起全红 → release-on-merge 全失败 → 一周零发布。根因与修复详见提交信息。本 PR 的 CI 运行本身即是修复的实证（应为一周来首绿）。

新增 `bun run ci:local` 与 CI check job 完全镜像——推送前本地跑绿即可保证云端绿。