### PR TITLE
feat: 协作协议 v2 B0——on_busy=steer 把消息喂进运行中的 Codex turn / protocol v2 B0: steer-on-busy

### DIFF
--- a/docs/collaboration-protocol-v2.md
+++ b/docs/collaboration-protocol-v2.md
@@ -36,6 +36,25 @@ observable, correlatable contract.
   control `status` 三个 payload 字段一致；turn 转移与 attention 转移
   都会刷新 status.json（经 tryWriteStatusFile，观测写失败不阻断核心路径）。
 
+### PR B0 — busy 转向注入 / steer-on-busy（已实施）
+
+- `reply` 工具新增 `on_busy: "reject" | "steer"`，**默认 `reject`，旧调用行为
+  不变**；`steer` 仅在 Codex turn 运行中生效，经 app-server `turn/steer`
+  把消息喂进**当前 turn**（不新开 turn、不打断、不丢已有工作）。
+- daemon 侧统一加 `[STEER from Claude]` 前缀 framing，让 Codex 能区分
+  mid-turn 更新与原始任务指令。
+- steer 被 app-server 拒绝（`ActiveTurnNotSteerable`（Review/Plan turn）、
+  `NoActiveTurn` race 等）**不是 turn 终结**：不发 `turnAborted`、不改
+  `turnPhase`；以 `system_steer_failed` 系统消息显式告知 Claude
+  「消息没送进去，原 turn 不受影响」。
+- `require_reply × steer` 在 B0 **显式不支持**（tool 层 + daemon 层双重
+  loud reject）——steer 加入的是正在运行的 turn，reply 追踪语义需要
+  PR B 的幂等状态机（"steer-accept 之后、terminal 之前的新 agentMessage"）。
+- race 退化：发送时 turn 已结束 → 自动退化为普通 `turn/start` 注入
+  （无 `[STEER]` 前缀）；caller 侧的判别能力由 PR B 的
+  `turn_started` ACK 补足。
+- `turn/interrupt`（打断入口）**不在 B0**，与 ACK/幂等机制一起进 PR B。
+
 ### PR B — 核心协议：ACK + 幂等 / core protocol: ACK + idempotency（未实施）
 
 - `claude_to_codex_result` 维持即时返回，语义收窄为 **accepted** =

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13947,7 +13947,7 @@ var CLAUDE_INSTRUCTIONS = [
   "## Turn coordination",
   "- When you see '\u23F3 Codex is working', do NOT call the reply tool \u2014 wait for '\u2705 Codex finished'.",
   "- After Codex finishes a turn, you have an attention window to review and respond before new messages arrive.",
-  "- If the reply tool returns a busy error, Codex is still executing \u2014 wait and try again later.",
+  '- If the reply tool returns a busy error, Codex is still executing. You decide: wait and retry later, or resend with on_busy="steer" to feed the message INTO the running turn (good for mid-course corrections; it does not interrupt or restart the work).',
   "",
   "## Budget awareness",
   "- Use the get_budget tool to check both agents' subscription quota (5h/weekly windows, drift, pause state).",
@@ -14099,6 +14099,11 @@ ${formatted}`
               require_reply: {
                 type: "boolean",
                 description: "When true, Codex is required to send a reply. All Codex messages from this turn will be forwarded immediately (bypassing STATUS buffering). Use this when you need a direct answer from Codex."
+              },
+              on_busy: {
+                type: "string",
+                enum: ["reject", "steer"],
+                description: `What to do when Codex is mid-turn. "reject" (default): fail with a busy error \u2014 wait and retry. "steer": feed this message INTO the running turn \u2014 Codex sees it immediately and integrates it without losing work. Use steer for mid-course corrections, added constraints, or updated acceptance criteria; it does NOT start a new turn, so don't combine it with require_reply. If you need Codex to STOP and do something else, wait for the turn to finish (interrupt support is coming separately).`
               }
             },
             required: ["text"]
@@ -14157,6 +14162,20 @@ ${formatted}`
       };
     }
     const requireReply = args?.require_reply === true;
+    const onBusyRaw = args?.on_busy;
+    const onBusy = onBusyRaw === "steer" ? "steer" : "reject";
+    if (onBusyRaw !== undefined && onBusyRaw !== "reject" && onBusyRaw !== "steer") {
+      return {
+        content: [{ type: "text", text: `Error: invalid on_busy value ${JSON.stringify(onBusyRaw)} \u2014 use "reject" or "steer".` }],
+        isError: true
+      };
+    }
+    if (onBusy === "steer" && requireReply) {
+      return {
+        content: [{ type: "text", text: 'Error: require_reply cannot be combined with on_busy="steer" yet \u2014 a steer joins the RUNNING turn instead of starting a new one, so reply tracking would mis-arm. Send the steer without require_reply.' }],
+        isError: true
+      };
+    }
     const bridgeMsg = {
       id: args?.chat_id ?? `reply_${Date.now()}`,
       source: "claude",
@@ -14170,7 +14189,7 @@ ${formatted}`
         isError: true
       };
     }
-    const result = await this.replySender(bridgeMsg, requireReply);
+    const result = await this.replySender(bridgeMsg, requireReply, onBusy);
     if (!result.success) {
       this.log(`Reply delivery failed: ${result.error}`);
       return {
@@ -14179,7 +14198,7 @@ ${formatted}`
       };
     }
     const pending = this.pendingMessages.length;
-    let responseText = "Reply sent to Codex.";
+    let responseText = onBusy === "steer" ? "Reply sent to Codex (will be steered into the running turn if one is active; watch for a system_steer_failed notice if the app-server rejects it)." : "Reply sent to Codex.";
     if (pending > 0) {
       responseText += ` Note: ${pending} unread Codex message${pending > 1 ? "s" : ""} already waiting \u2014 call get_messages to read them.`;
     }
@@ -14209,7 +14228,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.7", "0.0.0-source"),
-  commit: defineString("ec1ab68", "source"),
+  commit: defineString("1df8b91", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14381,7 +14400,7 @@ class DaemonClient extends EventEmitter2 {
     this.ws = null;
     this.rejectPendingReplies("Daemon connection closed");
   }
-  async sendReply(message, requireReply) {
+  async sendReply(message, requireReply, onBusy) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return { success: false, error: "AgentBridge daemon is not connected." };
     }
@@ -14396,7 +14415,8 @@ class DaemonClient extends EventEmitter2 {
         type: "claude_to_codex",
         requestId,
         message,
-        ...requireReply ? { requireReply: true } : {}
+        ...requireReply ? { requireReply: true } : {},
+        ...onBusy && onBusy !== "reject" ? { onBusy } : {}
       });
     });
   }
@@ -15416,7 +15436,7 @@ if (process.env.AGENTBRIDGE_TRACE === "1") {
     });
   } catch {}
 }
-claude.setReplySender(async (msg, requireReply) => {
+claude.setReplySender(async (msg, requireReply, onBusy) => {
   if (msg.source !== "claude") {
     return { success: false, error: "Invalid message source" };
   }
@@ -15426,7 +15446,7 @@ claude.setReplySender(async (msg, requireReply) => {
       error: disabledReplyError(daemonDisabledReason ?? "killed")
     };
   }
-  return daemonClient.sendReply(msg, requireReply);
+  return daemonClient.sendReply(msg, requireReply, onBusy);
 });
 daemonClient.on("codexMessage", (message) => {
   log(`Forwarding daemon \u2192 Claude (${message.content.length} chars)`);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.7", "0.0.0-source"),
-  commit: defineString("ec1ab68", "source"),
+  commit: defineString("1df8b91", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -639,6 +639,7 @@ class CodexAdapter extends EventEmitter {
   pendingServerResponses = new Map;
   staleProxyIds = new Map;
   bridgeRequestIds = new Map;
+  bridgeRequestKinds = new Map;
   intentionalDisconnect = false;
   pendingTuiMessages = [];
   reconnectingForNewSession = false;
@@ -794,6 +795,36 @@ class CodexAdapter extends EventEmitter {
     } catch (err) {
       this.untrackBridgeRequestId(requestId);
       this.log(`Injection send failed: ${err.message}`);
+      return false;
+    }
+  }
+  steerMessage(text) {
+    if (!this.threadId) {
+      this.log("Cannot steer: no active thread");
+      return false;
+    }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      this.log("Cannot steer: app-server WebSocket not connected");
+      return false;
+    }
+    if (!this.turnInProgress) {
+      this.log("Cannot steer: no turn in progress (use injectMessage)");
+      return false;
+    }
+    this.log(`Steering message into active Codex turn (${text.length} chars)`);
+    const requestId = this.nextInjectionId--;
+    this.trackBridgeRequestId(requestId, "steer");
+    const params = { threadId: this.threadId, input: [{ type: "text", text }] };
+    try {
+      this.appServerWs.send(JSON.stringify({
+        method: "turn/steer",
+        id: requestId,
+        params
+      }));
+      return true;
+    } catch (err) {
+      this.untrackBridgeRequestId(requestId);
+      this.log(`Steer send failed: ${err.message}`);
       return false;
     }
   }
@@ -1519,14 +1550,22 @@ class CodexAdapter extends EventEmitter {
       this.interceptServerMessage(parsed, mapping.connId);
       return forwarded;
     }
-    if (!isNaN(numericId) && this.consumeBridgeRequestId(numericId)) {
+    const bridgeKind = !isNaN(numericId) ? this.consumeBridgeRequestId(numericId) : null;
+    if (bridgeKind) {
       if (parsed.error) {
-        this.log(`Bridge-originated request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
-        this.lastTurnEndedAbnormally = true;
-        this.emit("turnAborted", `injected turn/start rejected: ${parsed.error.message ?? "unknown error"}`);
-        this.notifyPhaseIfChanged();
+        this.log(`Bridge-originated ${bridgeKind} request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
+        if (bridgeKind === "steer") {
+          this.emit("steerFailed", parsed.error.message ?? "unknown error");
+        } else {
+          this.lastTurnEndedAbnormally = true;
+          this.emit("turnAborted", `injected turn/start rejected: ${parsed.error.message ?? "unknown error"}`);
+          this.notifyPhaseIfChanged();
+        }
       } else {
-        this.log(`Bridge-originated request completed (id ${responseId})`);
+        this.log(`Bridge-originated ${bridgeKind} request completed (id ${responseId})`);
+        if (bridgeKind === "steer") {
+          this.emit("steerAccepted");
+        }
       }
       return null;
     }
@@ -1877,18 +1916,23 @@ class CodexAdapter extends EventEmitter {
   consumeStaleProxyId(proxyId) {
     return this.clearTrackedId(this.staleProxyIds, proxyId);
   }
-  trackBridgeRequestId(requestId) {
+  trackBridgeRequestId(requestId, kind = "turn-start") {
     this.clearTrackedId(this.bridgeRequestIds, requestId);
     const timer = setTimeout(() => {
       this.bridgeRequestIds.delete(requestId);
+      this.bridgeRequestKinds.delete(requestId);
     }, CodexAdapter.RESPONSE_TRACKING_TTL_MS);
     timer.unref?.();
     this.bridgeRequestIds.set(requestId, timer);
+    this.bridgeRequestKinds.set(requestId, kind);
   }
   consumeBridgeRequestId(requestId) {
-    return this.clearTrackedId(this.bridgeRequestIds, requestId);
+    const kind = this.bridgeRequestKinds.get(requestId) ?? "turn-start";
+    this.bridgeRequestKinds.delete(requestId);
+    return this.clearTrackedId(this.bridgeRequestIds, requestId) ? kind : null;
   }
   untrackBridgeRequestId(requestId) {
+    this.bridgeRequestKinds.delete(requestId);
     this.clearTrackedId(this.bridgeRequestIds, requestId);
   }
   clearTrackedId(store, id) {
@@ -1910,6 +1954,7 @@ class CodexAdapter extends EventEmitter {
       clearTimeout(timer);
     }
     this.bridgeRequestIds.clear();
+    this.bridgeRequestKinds.clear();
   }
   clearResponseTrackingState() {
     this.clearTransientResponseTrackingState();
@@ -3947,6 +3992,13 @@ codex.on("turnPhaseChanged", ({ phase, previous }) => {
   tryWriteStatusFile(`turnPhase:${phase}`);
   broadcastStatus();
 });
+codex.on("steerFailed", (reason) => {
+  log(`Steer rejected by app-server: ${reason}`);
+  emitToClaude(systemMessage("system_steer_failed", `\u26A0\uFE0F Your steer message did NOT reach Codex (${reason}). The original turn continues unaffected \u2014 wait for it to finish, or resend as a normal reply.`));
+});
+codex.on("steerAccepted", () => {
+  log("Steer accepted by app-server");
+});
 codex.on("turnStarted", () => {
   log("Codex turn started");
   emitToClaude(systemMessage("system_turn_started", "\u23F3 Codex is working on the current task. Wait for completion before sending a reply."));
@@ -4184,9 +4236,36 @@ function handleControlMessage(ws, raw) {
       }
       log(`Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
       const tierOverrides = BUDGET_CONFIG.codexTierControl ? budgetCoordinator?.getCodexTurnOverrides() ?? undefined : undefined;
+      if (codex.turnInProgress && message.onBusy === "steer") {
+        if (requireReply) {
+          sendProtocolMessage(ws, {
+            type: "claude_to_codex_result",
+            requestId: message.requestId,
+            success: false,
+            error: 'require_reply is not supported together with on_busy="steer" yet. Send the steer without require_reply, or wait for the turn to finish.'
+          });
+          return;
+        }
+        const steerContent = `[STEER from Claude]
+` + `Mid-turn update for the current Codex turn. Integrate if relevant; do not restart work unless explicitly requested.
+
+` + message.message.content;
+        const steered = codex.steerMessage(steerContent);
+        log(`Steer ${steered ? "transport-accepted" : "failed"} (${message.message.content.length} chars)`);
+        if (steered) {
+          clearAttentionWindow();
+        }
+        sendProtocolMessage(ws, {
+          type: "claude_to_codex_result",
+          requestId: message.requestId,
+          success: steered,
+          error: steered ? undefined : "Steer failed: the turn may have just ended or the connection dropped \u2014 retry as a normal reply."
+        });
+        return;
+      }
       const injected = codex.injectMessage(contentToSend, tierOverrides);
       if (!injected) {
-        const reason = codex.turnInProgress ? "Codex is busy executing a turn. Wait for it to finish before sending another message." : "Injection failed: no active thread or WebSocket not connected.";
+        const reason = codex.turnInProgress ? 'Codex is busy executing a turn. Options: wait for it to finish, or retry with on_busy="steer" to feed this message into the running turn without interrupting it.' : "Injection failed: no active thread or WebSocket not connected.";
         log(`Injection rejected: ${reason}`);
         sendProtocolMessage(ws, {
           type: "claude_to_codex_result",

--- a/src/app-server-protocol.ts
+++ b/src/app-server-protocol.ts
@@ -6,6 +6,7 @@ const APP_SERVER_REQUEST_METHODS = [
   "thread/list",
   "review/start",
   "turn/start",
+  "turn/steer",
   "turn/interrupt",
 ] as const;
 
@@ -71,6 +72,18 @@ export type AppServerUserInput =
   | { type: string; [key: string]: unknown };
 
 export interface TurnStartParams {
+  threadId: string;
+  input: AppServerUserInput[];
+  [key: string]: unknown;
+}
+
+/**
+ * turn/steer — feed additional input into the CURRENTLY RUNNING turn without
+ * interrupting it (available since codex app-server v0.100; the TUI uses it
+ * when the user types mid-turn). Fails with NoActiveTurn / ExpectedTurnMismatch
+ * / ActiveTurnNotSteerable (Review/Plan turns) / EmptyInput.
+ */
+export interface TurnSteerParams {
   threadId: string;
   input: AppServerUserInput[];
   [key: string]: unknown;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -90,7 +90,7 @@ if (process.env.AGENTBRIDGE_TRACE === "1") {
   }
 }
 
-claude.setReplySender(async (msg: BridgeMessage, requireReply?: boolean) => {
+claude.setReplySender(async (msg: BridgeMessage, requireReply?: boolean, onBusy?: "reject" | "steer") => {
   if (msg.source !== "claude") {
     return { success: false, error: "Invalid message source" };
   }
@@ -102,7 +102,7 @@ claude.setReplySender(async (msg: BridgeMessage, requireReply?: boolean) => {
     };
   }
 
-  return daemonClient.sendReply(msg, requireReply);
+  return daemonClient.sendReply(msg, requireReply, onBusy);
 });
 
 daemonClient.on("codexMessage", (message) => {

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -26,7 +26,7 @@ import type { BridgeMessage } from "./types";
 import type { BudgetSnapshot } from "./budget/types";
 import { renderBudgetSnapshot, BUDGET_UNAVAILABLE_TEXT } from "./budget/render";
 
-export type ReplySender = (msg: BridgeMessage, requireReply?: boolean) => Promise<{ success: boolean; error?: string }>;
+export type ReplySender = (msg: BridgeMessage, requireReply?: boolean, onBusy?: "reject" | "steer") => Promise<{ success: boolean; error?: string }>;
 
 export const CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
@@ -58,7 +58,7 @@ export const CLAUDE_INSTRUCTIONS = [
   "## Turn coordination",
   "- When you see '⏳ Codex is working', do NOT call the reply tool — wait for '✅ Codex finished'.",
   "- After Codex finishes a turn, you have an attention window to review and respond before new messages arrive.",
-  "- If the reply tool returns a busy error, Codex is still executing — wait and try again later.",
+  "- If the reply tool returns a busy error, Codex is still executing. You decide: wait and retry later, or resend with on_busy=\"steer\" to feed the message INTO the running turn (good for mid-course corrections; it does not interrupt or restart the work).",
   "",
   "## Budget awareness",
   "- Use the get_budget tool to check both agents' subscription quota (5h/weekly windows, drift, pause state).",
@@ -249,6 +249,11 @@ export class ClaudeAdapter extends EventEmitter {
                 type: "boolean",
                 description: "When true, Codex is required to send a reply. All Codex messages from this turn will be forwarded immediately (bypassing STATUS buffering). Use this when you need a direct answer from Codex.",
               },
+              on_busy: {
+                type: "string",
+                enum: ["reject", "steer"],
+                description: "What to do when Codex is mid-turn. \"reject\" (default): fail with a busy error — wait and retry. \"steer\": feed this message INTO the running turn — Codex sees it immediately and integrates it without losing work. Use steer for mid-course corrections, added constraints, or updated acceptance criteria; it does NOT start a new turn, so don't combine it with require_reply. If you need Codex to STOP and do something else, wait for the turn to finish (interrupt support is coming separately).",
+              },
             },
             required: ["text"],
           },
@@ -318,6 +323,20 @@ export class ClaudeAdapter extends EventEmitter {
     }
 
     const requireReply = args?.require_reply === true;
+    const onBusyRaw = args?.on_busy;
+    const onBusy: "reject" | "steer" = onBusyRaw === "steer" ? "steer" : "reject";
+    if (onBusyRaw !== undefined && onBusyRaw !== "reject" && onBusyRaw !== "steer") {
+      return {
+        content: [{ type: "text" as const, text: `Error: invalid on_busy value ${JSON.stringify(onBusyRaw)} — use "reject" or "steer".` }],
+        isError: true,
+      };
+    }
+    if (onBusy === "steer" && requireReply) {
+      return {
+        content: [{ type: "text" as const, text: "Error: require_reply cannot be combined with on_busy=\"steer\" yet — a steer joins the RUNNING turn instead of starting a new one, so reply tracking would mis-arm. Send the steer without require_reply." }],
+        isError: true,
+      };
+    }
 
     const bridgeMsg: BridgeMessage = {
       id: (args?.chat_id as string) ?? `reply_${Date.now()}`,
@@ -334,7 +353,7 @@ export class ClaudeAdapter extends EventEmitter {
       };
     }
 
-    const result = await this.replySender(bridgeMsg, requireReply);
+    const result = await this.replySender(bridgeMsg, requireReply, onBusy);
     if (!result.success) {
       this.log(`Reply delivery failed: ${result.error}`);
       return {
@@ -345,7 +364,9 @@ export class ClaudeAdapter extends EventEmitter {
 
     // Include pending message hint
     const pending = this.pendingMessages.length;
-    let responseText = "Reply sent to Codex.";
+    let responseText = onBusy === "steer"
+      ? "Reply sent to Codex (will be steered into the running turn if one is active; watch for a system_steer_failed notice if the app-server rejects it)."
+      : "Reply sent to Codex.";
     if (pending > 0) {
       responseText += ` Note: ${pending} unread Codex message${pending > 1 ? "s" : ""} already waiting \u2014 call get_messages to read them.`;
     }

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -29,6 +29,7 @@ import {
   type AppServerServerRequestMethod,
   type AppServerTrackedRequestMethod,
   type TurnStartParams,
+  type TurnSteerParams,
 } from "./app-server-protocol";
 import {
   CODEX_TRANSPORT_ENV,
@@ -164,6 +165,11 @@ export class CodexAdapter extends EventEmitter {
   private pendingServerResponses = new Map<number, PendingServerResponse>();
   private staleProxyIds = new Map<number, ReturnType<typeof setTimeout>>();
   private bridgeRequestIds = new Map<number, ReturnType<typeof setTimeout>>();
+  // What each bridge-originated request was (turn/start injection vs
+  // turn/steer) — error handling differs: a rejected injection emits
+  // turnAborted, a rejected steer must NOT (the original turn is still
+  // running) and surfaces steerFailed instead.
+  private bridgeRequestKinds = new Map<number, "turn-start" | "steer">();
   private intentionalDisconnect = false;
   // Fresh-session reconnection: buffer TUI messages while reconnecting app-server
   private pendingTuiMessages: string[] = [];
@@ -405,6 +411,44 @@ export class CodexAdapter extends EventEmitter {
     } catch (err: any) {
       this.untrackBridgeRequestId(requestId);
       this.log(`Injection send failed: ${err.message}`);
+      return false;
+    }
+  }
+
+  /**
+   * Feed additional input into the CURRENTLY RUNNING turn via turn/steer —
+   * Codex sees it mid-turn and adjusts without losing work (protocol v2 B0,
+   * design consensus: explicit [STEER] framing is the CALLER's job).
+   * Returns true when transport-accepted; a later JSON-RPC error surfaces as
+   * a "steerFailed" event (NOT turnAborted — the original turn keeps running).
+   */
+  steerMessage(text: string): boolean {
+    if (!this.threadId) {
+      this.log("Cannot steer: no active thread");
+      return false;
+    }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      this.log("Cannot steer: app-server WebSocket not connected");
+      return false;
+    }
+    if (!this.turnInProgress) {
+      this.log("Cannot steer: no turn in progress (use injectMessage)");
+      return false;
+    }
+    this.log(`Steering message into active Codex turn (${text.length} chars)`);
+    const requestId = this.nextInjectionId--;
+    this.trackBridgeRequestId(requestId, "steer");
+    const params: TurnSteerParams = { threadId: this.threadId, input: [{ type: "text", text }] };
+    try {
+      this.appServerWs.send(JSON.stringify({
+        method: "turn/steer",
+        id: requestId,
+        params,
+      } satisfies AppServerRequest<"turn/steer", TurnSteerParams>));
+      return true;
+    } catch (err: any) {
+      this.untrackBridgeRequestId(requestId);
+      this.log(`Steer send failed: ${err.message}`);
       return false;
     }
   }
@@ -1443,23 +1487,33 @@ export class CodexAdapter extends EventEmitter {
       return forwarded;
     }
 
-    if (!isNaN(numericId) && this.consumeBridgeRequestId(numericId)) {
+    const bridgeKind = !isNaN(numericId) ? this.consumeBridgeRequestId(numericId) : null;
+    if (bridgeKind) {
       if (parsed.error) {
-        this.log(`Bridge-originated request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
-        // A bridge-originated request is always an injected turn/start. If Codex
-        // REJECTS it (error response) before any turn/started, no turn ever goes
-        // in-progress, so resetTurnState's wasInProgress-gated turnAborted never
-        // fires. Signal the abort here so daemon-level per-turn state (the
-        // require_reply tracker) is not stranded on a turn that never started.
-        // turnPhase must agree with the emitted event: an observer seeing
-        // turnAborted while the phase reads "idle" violates the PR A contract
-        // ("aborted" = the last turn ended abnormally, no new turn since).
-        // The richer "rejected" terminal classification is PR B territory.
-        this.lastTurnEndedAbnormally = true;
-        this.emit("turnAborted", `injected turn/start rejected: ${parsed.error.message ?? "unknown error"}`);
-        this.notifyPhaseIfChanged();
+        this.log(`Bridge-originated ${bridgeKind} request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
+        if (bridgeKind === "steer") {
+          // A rejected steer leaves the ORIGINAL turn running untouched —
+          // no abort, no phase change. Surface it so the daemon can tell
+          // Claude the mid-turn message did NOT reach Codex (e.g.
+          // ActiveTurnNotSteerable on Review/Plan turns, or the turn ended
+          // in the NoActiveTurn race window).
+          this.emit("steerFailed", parsed.error.message ?? "unknown error");
+        } else {
+          // An injected turn/start was REJECTED before any turn/started — no
+          // turn ever goes in-progress, so resetTurnState's wasInProgress-gated
+          // turnAborted never fires. Signal the abort here so daemon-level
+          // per-turn state (the require_reply tracker) is not stranded.
+          // turnPhase must agree with the emitted event (PR A contract); the
+          // richer "rejected" terminal classification is PR B territory.
+          this.lastTurnEndedAbnormally = true;
+          this.emit("turnAborted", `injected turn/start rejected: ${parsed.error.message ?? "unknown error"}`);
+          this.notifyPhaseIfChanged();
+        }
       } else {
-        this.log(`Bridge-originated request completed (id ${responseId})`);
+        this.log(`Bridge-originated ${bridgeKind} request completed (id ${responseId})`);
+        if (bridgeKind === "steer") {
+          this.emit("steerAccepted");
+        }
       }
       return null;
     }
@@ -1923,21 +1977,27 @@ export class CodexAdapter extends EventEmitter {
     return this.clearTrackedId(this.staleProxyIds, proxyId);
   }
 
-  private trackBridgeRequestId(requestId: number) {
+  private trackBridgeRequestId(requestId: number, kind: "turn-start" | "steer" = "turn-start") {
     this.clearTrackedId(this.bridgeRequestIds, requestId);
 
     const timer = setTimeout(() => {
       this.bridgeRequestIds.delete(requestId);
+      this.bridgeRequestKinds.delete(requestId);
     }, CodexAdapter.RESPONSE_TRACKING_TTL_MS);
     timer.unref?.();
     this.bridgeRequestIds.set(requestId, timer);
+    this.bridgeRequestKinds.set(requestId, kind);
   }
 
-  private consumeBridgeRequestId(requestId: number) {
-    return this.clearTrackedId(this.bridgeRequestIds, requestId);
+  /** Returns the request kind when this id was bridge-originated, else null. */
+  private consumeBridgeRequestId(requestId: number): "turn-start" | "steer" | null {
+    const kind = this.bridgeRequestKinds.get(requestId) ?? "turn-start";
+    this.bridgeRequestKinds.delete(requestId);
+    return this.clearTrackedId(this.bridgeRequestIds, requestId) ? kind : null;
   }
 
   private untrackBridgeRequestId(requestId: number) {
+    this.bridgeRequestKinds.delete(requestId);
     this.clearTrackedId(this.bridgeRequestIds, requestId);
   }
 
@@ -1962,6 +2022,10 @@ export class CodexAdapter extends EventEmitter {
       clearTimeout(timer);
     }
     this.bridgeRequestIds.clear();
+    // The kinds map shares its lifecycle with bridgeRequestIds — clearing one
+    // without the other leaks kind entries forever, because the TTL timer that
+    // would have deleted them was just cancelled above.
+    this.bridgeRequestKinds.clear();
   }
 
   private clearResponseTrackingState() {

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -58,7 +58,19 @@ export interface DaemonStatus {
 export type ControlClientMessage =
   | { type: "claude_connect"; identity?: ControlClientIdentity }
   | { type: "claude_disconnect" }
-  | { type: "claude_to_codex"; requestId: string; message: BridgeMessage; requireReply?: boolean }
+  | {
+      type: "claude_to_codex";
+      requestId: string;
+      message: BridgeMessage;
+      requireReply?: boolean;
+      /**
+       * Busy-turn policy (protocol v2 B0). "reject" (default): fail with the
+       * busy error when a Codex turn is running. "steer": feed the message
+       * into the RUNNING turn via turn/steer — Codex sees it mid-turn without
+       * losing work. ("interrupt" lands with PR B's ACK/idempotency machinery.)
+       */
+      onBusy?: "reject" | "steer";
+    }
   | { type: "status" }
   // Non-attaching probe: ask the daemon whether it already has a LIVE Claude
   // frontend attached, WITHOUT contesting/attaching this socket. Used by the

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -195,7 +195,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     this.rejectPendingReplies("Daemon connection closed");
   }
 
-  async sendReply(message: BridgeMessage, requireReply?: boolean): Promise<{ success: boolean; error?: string }> {
+  async sendReply(message: BridgeMessage, requireReply?: boolean, onBusy?: "reject" | "steer"): Promise<{ success: boolean; error?: string }> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return { success: false, error: "AgentBridge daemon is not connected." };
     }
@@ -213,6 +213,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
         requestId,
         message,
         ...(requireReply ? { requireReply: true } : {}),
+        ...(onBusy && onBusy !== "reject" ? { onBusy } : {}),
       });
     });
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -247,6 +247,24 @@ codex.on("turnPhaseChanged", ({ phase, previous }: { phase: string; previous: st
   broadcastStatus();
 });
 
+// A steer is transport-accepted at send time; a later JSON-RPC rejection
+// (Review/Plan turns are not steerable; the turn may have ended in the race
+// window) means Claude's mid-turn message did NOT reach Codex — say so
+// explicitly instead of letting Claude assume it landed.
+codex.on("steerFailed", (reason: string) => {
+  log(`Steer rejected by app-server: ${reason}`);
+  emitToClaude(
+    systemMessage(
+      "system_steer_failed",
+      `⚠️ Your steer message did NOT reach Codex (${reason}). The original turn continues unaffected — wait for it to finish, or resend as a normal reply.`,
+    ),
+  );
+});
+
+codex.on("steerAccepted", () => {
+  log("Steer accepted by app-server");
+});
+
 codex.on("turnStarted", () => {
   log("Codex turn started");
   emitToClaude(
@@ -589,10 +607,52 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
       const tierOverrides = BUDGET_CONFIG.codexTierControl
         ? budgetCoordinator?.getCodexTurnOverrides() ?? undefined
         : undefined;
+      // Busy-turn policy (protocol v2 B0): when a turn is running and the
+      // caller opted into "steer", feed the message INTO the running turn via
+      // turn/steer instead of rejecting — Codex integrates it mid-turn without
+      // losing work. Framed explicitly so Codex can distinguish it from the
+      // original task instructions (design consensus with Codex).
+      if (codex.turnInProgress && message.onBusy === "steer") {
+        if (requireReply) {
+          // B0 limitation (explicit, not silent): require_reply semantics for
+          // steer ("a NEW agentMessage after steer-accept, before terminal")
+          // need the PR B state machine. Reject loudly instead of mis-arming
+          // the tracker on the already-running turn.
+          sendProtocolMessage(ws, {
+            type: "claude_to_codex_result",
+            requestId: message.requestId,
+            success: false,
+            error: "require_reply is not supported together with on_busy=\"steer\" yet. Send the steer without require_reply, or wait for the turn to finish.",
+          });
+          return;
+        }
+        const steerContent =
+          "[STEER from Claude]\n" +
+          "Mid-turn update for the current Codex turn. Integrate if relevant; do not restart work unless explicitly requested.\n\n" +
+          message.message.content;
+        const steered = codex.steerMessage(steerContent);
+        log(`Steer ${steered ? "transport-accepted" : "failed"} (${message.message.content.length} chars)`);
+        if (steered) {
+          // An IMPORTANT message forwarded mid-turn opens an attention window;
+          // a steer is exactly Claude responding to it — close the window like
+          // the inject path does, so status buffering resumes promptly.
+          clearAttentionWindow();
+        }
+        sendProtocolMessage(ws, {
+          type: "claude_to_codex_result",
+          requestId: message.requestId,
+          success: steered,
+          error: steered
+            ? undefined
+            : "Steer failed: the turn may have just ended or the connection dropped — retry as a normal reply.",
+        });
+        return;
+      }
+
       const injected = codex.injectMessage(contentToSend, tierOverrides);
       if (!injected) {
         const reason = codex.turnInProgress
-          ? "Codex is busy executing a turn. Wait for it to finish before sending another message."
+          ? "Codex is busy executing a turn. Options: wait for it to finish, or retry with on_busy=\"steer\" to feed this message into the running turn without interrupting it."
           : "Injection failed: no active thread or WebSocket not connected.";
         log(`Injection rejected: ${reason}`);
         sendProtocolMessage(ws, {

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -2269,3 +2269,159 @@ describe("CodexAdapter.forceKillAppServerSync", () => {
     expect(() => adapter.forceKillAppServerSync()).not.toThrow();
   });
 });
+
+describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
+  function createSteerableAdapter() {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.threadId = "thread-steer";
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    return { adapter, appSent };
+  }
+
+  test("steerMessage rejects when no thread is active", () => {
+    const adapter = createAdapter();
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    expect(adapter.steerMessage("hello")).toBe(false);
+  });
+
+  test("steerMessage rejects when the app-server WebSocket is not connected", () => {
+    const adapter = createAdapter();
+    adapter.threadId = "thread-steer";
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    adapter.appServerWs = null;
+    expect(adapter.steerMessage("hello")).toBe(false);
+  });
+
+  test("steerMessage rejects when NO turn is in progress (injectMessage territory)", () => {
+    const adapter = createAdapter();
+    adapter.threadId = "thread-steer";
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+    expect(adapter.turnInProgress).toBe(false);
+    expect(adapter.steerMessage("hello")).toBe(false);
+  });
+
+  test("steerMessage sends turn/steer with a tracked negative id and text input", () => {
+    const { adapter, appSent } = createSteerableAdapter();
+
+    expect(adapter.steerMessage("mid-turn correction")).toBe(true);
+    expect(appSent).toHaveLength(1);
+
+    const sent = JSON.parse(appSent[0]);
+    expect(sent.method).toBe("turn/steer");
+    expect(typeof sent.id).toBe("number");
+    expect(sent.id).toBeLessThan(0);
+    expect(sent.params).toEqual({
+      threadId: "thread-steer",
+      input: [{ type: "text", text: "mid-turn correction" }],
+    });
+    expect(adapter.bridgeRequestIds.has(sent.id)).toBe(true);
+    expect(adapter.bridgeRequestKinds.get(sent.id)).toBe("steer");
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("a rejected steer emits steerFailed, NOT turnAborted, and leaves the turn running", () => {
+    // Core B0 invariant: ActiveTurnNotSteerable / NoActiveTurn-race rejections
+    // must not be confused with a turn abort — the ORIGINAL turn is untouched.
+    const { adapter, appSent } = createSteerableAdapter();
+    const failures: string[] = [];
+    const aborts: string[] = [];
+    adapter.on("steerFailed", (reason: string) => failures.push(reason));
+    adapter.on("turnAborted", (reason: string) => aborts.push(reason));
+
+    adapter.steerMessage("mid-turn correction");
+    const steerId = JSON.parse(appSent[0]).id;
+
+    const forwarded = adapter.handleAppServerPayload(JSON.stringify({
+      id: steerId,
+      error: { message: "ActiveTurnNotSteerable" },
+    }));
+
+    expect(forwarded).toBeNull(); // swallowed, never forwarded to the TUI
+    expect(failures).toEqual(["ActiveTurnNotSteerable"]);
+    expect(aborts).toEqual([]);
+    expect(adapter.turnInProgress).toBe(true);
+    expect(adapter.turnPhase).toBe("running");
+    expect(adapter.bridgeRequestIds.has(steerId)).toBe(false); // consumed
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("an accepted steer emits steerAccepted and nothing else", () => {
+    const { adapter, appSent } = createSteerableAdapter();
+    const events: string[] = [];
+    adapter.on("steerAccepted", () => events.push("accepted"));
+    adapter.on("steerFailed", () => events.push("failed"));
+    adapter.on("turnAborted", () => events.push("aborted"));
+
+    adapter.steerMessage("mid-turn correction");
+    const steerId = JSON.parse(appSent[0]).id;
+
+    adapter.handleAppServerPayload(JSON.stringify({ id: steerId, result: {} }));
+
+    expect(events).toEqual(["accepted"]);
+    expect(adapter.turnInProgress).toBe(true);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("a rejected injected turn/start still emits turnAborted (kind default unchanged)", () => {
+    // Regression guard for the kind-aware tracking refactor: the pre-existing
+    // turn-start error path must keep its abort semantics.
+    const { adapter } = createSteerableAdapter();
+    const aborts: string[] = [];
+    const failures: string[] = [];
+    adapter.on("turnAborted", (reason: string) => aborts.push(reason));
+    adapter.on("steerFailed", (reason: string) => failures.push(reason));
+
+    adapter.trackBridgeRequestId(-77); // default kind: "turn-start"
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: -77,
+      error: { message: "turn/start rejected" },
+    }));
+
+    expect(aborts).toHaveLength(1);
+    expect(aborts[0]).toContain("turn/start rejected");
+    expect(failures).toEqual([]);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("clearResponseTrackingState clears in-flight steer kinds (no leak across reconnects)", () => {
+    // Regression: clearTransientResponseTrackingState cancelled the TTL timers
+    // (the only other deletion path for bridgeRequestKinds) but cleared only
+    // bridgeRequestIds — every in-flight request at an app-server disconnect
+    // leaked its kind entry forever.
+    const { adapter } = createSteerableAdapter();
+
+    adapter.steerMessage("in flight at disconnect");
+    adapter.trackBridgeRequestId(-88); // an in-flight turn-start, same lifecycle
+    expect(adapter.bridgeRequestIds.size).toBe(2);
+    expect(adapter.bridgeRequestKinds.size).toBe(2);
+
+    adapter.clearResponseTrackingState();
+
+    expect(adapter.bridgeRequestIds.size).toBe(0);
+    expect(adapter.bridgeRequestKinds.size).toBe(0);
+  });
+
+  test("a failed send untracks the steer id so a late response is unmatched", () => {
+    const { adapter } = createSteerableAdapter();
+    adapter.appServerWs = {
+      readyState: WebSocket.OPEN,
+      send: () => { throw new Error("socket write failed"); },
+    } as any;
+    const failures: string[] = [];
+    adapter.on("steerFailed", (reason: string) => failures.push(reason));
+
+    expect(adapter.steerMessage("doomed")).toBe(false);
+    expect(adapter.bridgeRequestIds.size).toBe(0);
+    expect(adapter.bridgeRequestKinds.size).toBe(0);
+    expect(failures).toEqual([]); // send failure is the return value's job, not the event's
+
+    adapter.clearResponseTrackingState();
+  });
+});

--- a/src/unit-test/daemon-wiring.test.ts
+++ b/src/unit-test/daemon-wiring.test.ts
@@ -41,7 +41,11 @@ interface Harness {
   controlWs: WebSocket | null;
   /** Connect a fake Codex TUI to the proxy and complete the thread/start handshake. */
   connectTui: () => Promise<void>;
-  sendClaudeToCodex: (requestId: string, text: string) => void;
+  sendClaudeToCodex: (
+    requestId: string,
+    text: string,
+    opts?: { onBusy?: "reject" | "steer"; requireReply?: boolean },
+  ) => void;
 }
 
 const harnesses: Harness[] = [];
@@ -451,6 +455,81 @@ describe("daemon wiring", () => {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
   }, 60000);
+
+  test("on_busy=steer feeds the message into a running turn via turn/steer (protocol v2 B0)", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-steer-fixture-"));
+    const steerLog = join(fixtureRoot, "turnsteer.jsonl");
+    const readSteers = (): Array<{ threadId: string; input: Array<{ type: string; text: string }> }> =>
+      existsSync(steerLog)
+        ? readFileSync(steerLog, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+        : [];
+    const resultFor = (requestId: string) =>
+      harness.statusMessages.find(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === requestId,
+      ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }> | undefined;
+    const waitForResult = async (requestId: string) => {
+      await waitFor(() => resultFor(requestId) !== undefined, `claude_to_codex_result for ${requestId}`);
+      return resultFor(requestId)!;
+    };
+
+    const harness = await startHarness({
+      pairId: "main-steerabcd",
+      pairName: "main",
+      extraEnv: { FAKE_APP_TURNSTEER_LOG: steerLog },
+    });
+
+    try {
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      // Drive the adapter into a running turn so the busy path is active.
+      harness.sendAppCommand("start-turn");
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_turn_started"),
+        "system_turn_started",
+      );
+
+      // Default policy unchanged: a plain reply during the turn is rejected,
+      // and the busy error now advertises the steer escape hatch.
+      harness.sendClaudeToCodex("req-steer-0", "plain message during turn");
+      const rejected = await waitForResult("req-steer-0");
+      expect(rejected.success).toBe(false);
+      expect(rejected.error).toContain('on_busy="steer"');
+
+      // B0 limitation is loud, not silent: require_reply×steer is refused.
+      harness.sendClaudeToCodex("req-steer-rr", "needs ack", { onBusy: "steer", requireReply: true });
+      const refused = await waitForResult("req-steer-rr");
+      expect(refused.success).toBe(false);
+      expect(refused.error).toContain("require_reply is not supported");
+
+      // The steer path: message reaches the app-server as turn/steer with the
+      // explicit [STEER from Claude] framing, on the live thread.
+      harness.sendClaudeToCodex("req-steer-1", "course correction: use approach B", { onBusy: "steer" });
+      const accepted = await waitForResult("req-steer-1");
+      expect(accepted.success).toBe(true);
+      await waitFor(() => readSteers().length >= 1, "recorded turn/steer", 100, 100);
+      const steer = readSteers()[0]!;
+      expect(steer.threadId).toBe("thread-fake-1");
+      expect(steer.input[0]!.type).toBe("text");
+      expect(steer.input[0]!.text.startsWith("[STEER from Claude]\n")).toBe(true);
+      expect(steer.input[0]!.text).toContain("course correction: use approach B");
+
+      // An app-server rejection after transport-accept surfaces as
+      // system_steer_failed (the original turn is NOT reported aborted).
+      harness.sendClaudeToCodex("req-steer-2", "[force-steer-error] doomed", { onBusy: "steer" });
+      const failedNotice = await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_steer_failed"),
+        "system_steer_failed",
+      );
+      expect(failedNotice.content).toContain("did NOT reach Codex");
+      expect(failedNotice.content).toContain("ActiveTurnNotSteerable");
+      expect(harness.messages.some((m) => m.id.startsWith("system_turn_aborted"))).toBe(false);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 60000);
 });
 
 async function startHarness(opts: {
@@ -592,11 +671,13 @@ async function startHarness(opts: {
         }
       }, "bridge ready after TUI handshake", 100, 100);
     },
-    sendClaudeToCodex: (requestId: string, text: string) => {
+    sendClaudeToCodex: (requestId: string, text: string, sendOpts?: { onBusy?: "reject" | "steer"; requireReply?: boolean }) => {
       harness.controlWs?.send(JSON.stringify({
         type: "claude_to_codex",
         requestId,
         message: { id: requestId, source: "claude", content: text, timestamp: Date.now() },
+        ...(sendOpts?.requireReply ? { requireReply: true } : {}),
+        ...(sendOpts?.onBusy && sendOpts.onBusy !== "reject" ? { onBusy: sendOpts.onBusy } : {}),
       }));
     },
   };
@@ -660,6 +741,19 @@ const server = Bun.serve({
         // Record received turn/start params (tier-override assertions).
         if (msg.method === "turn/start" && process.env.FAKE_APP_TURNSTART_LOG) {
           appendFileSync(process.env.FAKE_APP_TURNSTART_LOG, JSON.stringify(msg.params) + "\\n");
+        }
+        // turn/steer: record params, then ack — or reject when the text carries
+        // the [force-steer-error] marker (drives the steerFailed wiring test).
+        if (msg.method === "turn/steer") {
+          if (process.env.FAKE_APP_TURNSTEER_LOG) {
+            appendFileSync(process.env.FAKE_APP_TURNSTEER_LOG, JSON.stringify(msg.params) + "\\n");
+          }
+          const steerText = msg.params?.input?.[0]?.text ?? "";
+          if (steerText.includes("[force-steer-error]")) {
+            ws.send(JSON.stringify({ id: msg.id, error: { message: "ActiveTurnNotSteerable" } }));
+          } else {
+            ws.send(JSON.stringify({ id: msg.id, result: {} }));
+          }
         }
       } catch {}
     },

--- a/src/unit-test/message-delivery.test.ts
+++ b/src/unit-test/message-delivery.test.ts
@@ -256,6 +256,77 @@ describe("Message delivery: reply pending hint", () => {
   });
 });
 
+describe("Reply on_busy option (protocol v2 B0)", () => {
+  function withCapturingSender(adapter: any) {
+    const calls: Array<{ content: string; requireReply?: boolean; onBusy?: string }> = [];
+    adapter.replySender = async (msg: any, requireReply?: boolean, onBusy?: string) => {
+      calls.push({ content: msg.content, requireReply, onBusy });
+      return { success: true };
+    };
+    return calls;
+  }
+
+  test("on_busy defaults to reject when omitted", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello codex" });
+
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].onBusy).toBe("reject");
+    expect(result.content[0].text).toBe("Reply sent to Codex.");
+  });
+
+  test("on_busy=steer is passed through and the result text says so", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "mid-course fix", on_busy: "steer" });
+
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].onBusy).toBe("steer");
+    expect(result.content[0].text).toContain("steered into the running turn");
+    expect(result.content[0].text).toContain("system_steer_failed");
+  });
+
+  test("invalid on_busy value errors before sending anything", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello", on_busy: "interrupt" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("invalid on_busy value");
+    expect(result.content[0].text).toContain('"interrupt"');
+    expect(calls).toHaveLength(0);
+  });
+
+  test("on_busy=steer combined with require_reply errors before sending (B0 limitation)", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello", on_busy: "steer", require_reply: true });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("require_reply cannot be combined");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("on_busy=reject explicit value behaves like the default", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello", on_busy: "reject", require_reply: true });
+
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].onBusy).toBe("reject");
+    expect(calls[0].requireReply).toBe(true);
+  });
+});
+
 describe("get_budget tool (handleGetBudget)", () => {
   const snapshot = {
     phase: "normal" as const,


### PR DESCRIPTION
## 摘要 / Summary

**中文**：Claude 给 Codex 发消息时撞上 active turn，之前唯一选项是收到 busy 错误后干等。本 PR 落地协作协议 v2 的 B0 阶段：`reply` 工具新增 `on_busy` 入口（默认 `reject`，旧行为零变化），`on_busy="steer"` 经 Codex app-server 的 `turn/steer`（codex ≥0.100）把消息以 `[STEER from Claude]` framing 喂进**当前运行中的 turn**——不打断、不重启、不丢已有工作。要不要用 steer 由 Claude 自行判断（busy 错误文案会提示该入口）。

**English**: When Codex is mid-turn, Claude's only option used to be waiting out the busy error. This lands protocol v2 phase B0: the `reply` tool gains an `on_busy` option (default `reject`, zero behavior change for existing callers); `on_busy="steer"` feeds the message INTO the running turn via the app-server `turn/steer` method with explicit `[STEER from Claude]` framing — no interrupt, no restart, no lost work.

## 设计共识 / Design consensus (Claude × Codex, 2026-06-10)

- 默认仍 `reject`，steer 按调用显式 opt-in
- steer 拒绝（`ActiveTurnNotSteerable`（Review/Plan turn）、`NoActiveTurn` race）**不是 turn 终结**：不发 `turnAborted`、不改 `turnPhase`，以 `system_steer_failed` 显式告知「消息没送进去，原 turn 不受影响」
- `require_reply × steer` B0 显式不支持（tool 层 + daemon 层双重 loud reject），语义需要 PR B 幂等状态机
- race 退化：turn 已结束 → 自动退化为普通 `turn/start`（caller 判别由 PR B 的 `turn_started` ACK 补足）
- `turn/interrupt`（打断入口）按共识并入 PR B

## 变更 / Changes

| 层 | 内容 |
|---|---|
| claude-adapter | `on_busy` enum + 校验（非法值 / steer×require_reply 发送前报错）；steer 结果文案指向 `system_steer_failed`；CLAUDE_INSTRUCTIONS 更新 |
| control-protocol / daemon-client / bridge | `onBusy` 字段透传 |
| daemon | steer 分支仅在 `turnInProgress && opt-in`；tier overrides 不消费；requireReply 不武装；steer 成功清 attention window（与 inject 路径对齐） |
| codex-adapter | `steerMessage()`；kind-aware bridge-request 追踪（`bridgeRequestKinds`）；steer JSON-RPC error → `steerFailed` 事件；断连时 kinds 与 ids 同步清理（review 修复） |
| app-server-protocol | `TurnSteerParams` + 方法表补 `turn/steer` |
| docs | collaboration-protocol-v2.md 新增 B0 节 |

## 测试 / Test plan

- [x] typecheck 清洁；全量 `bun test src` **740 pass / 0 fail**
- [x] `bun run ci:local` 全绿（check + smoke:built + smoke:pack）
- [x] 新增 14 个测试：codex-adapter steer 套件（发送形状、3 个前置条件、error→steerFailed-非-turnAborted+phase 断言、success→steerAccepted、kind 默认回归、send-throw 清理、断连 kind 泄漏回归）；reply on_busy 套件（默认/透传/非法值/steer×require_reply/显式 reject）；daemon-wiring e2e（fake app-server 记录 turn/steer：busy 文案提示、requireReply×steer 拒绝、[STEER] 前缀上线、强制 steer 失败 → system_steer_failed 送达、无 system_turn_aborted）
- [x] Cross-review：round 1 报 1 REAL（bridgeRequestKinds 断连泄漏）已修；round 2 两位全新 reviewer 一致 **0 REAL**；Codex 终审逐项核验五条 B0 验收（含「未偷带 interrupt」）

## 后续 / Follow-ups

- PR B：`turn/interrupt` + `turn_started` ACK + 幂等 tombstone 状态机 + require_reply×steer 严格语义
- PR C：预算指令降噪分层