### PR TITLE
fix: steer 缺必填 expectedTurnId 致 B0 全部弹回（真机 E2E 发现）/ steer missing required expectedTurnId

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,8 @@
   "workspaces": {
     "": {
       "name": "agentbridge",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
-      },
       "devDependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/bun": "^1.3.11",
         "typescript": "^5.8.0",
       },

--- a/docs/collaboration-protocol-v2.md
+++ b/docs/collaboration-protocol-v2.md
@@ -43,7 +43,14 @@ observable, correlatable contract.
   把消息喂进**当前 turn**（不新开 turn、不打断、不丢已有工作）。
 - daemon 侧统一加 `[STEER from Claude]` 前缀 framing，让 Codex 能区分
   mid-turn 更新与原始任务指令。
-- steer 被 app-server 拒绝（`ActiveTurnNotSteerable`（Review/Plan turn）、
+- wire 前置条件：`turn/steer` 自引入（rust-v0.99）起即要求必填
+  `expectedTurnId`（当前活跃 turn id，缺失/不匹配即拒）。bridge 侧由
+  codex-adapter 从 turn/started 跟踪的活跃 turn id 自动填充；若活跃 turn
+  无可寻址 id（防御分支，真实 codex 的 turn id 为 UUID 不会触发），steer
+  在本地 transport-reject、不发往 app-server，错误文案按 turn 是否仍在
+  运行分叉（防「改发普通 reply」↔ busy guard 的建议乒乓）。
+- steer 被 app-server 拒绝（`missing field expectedTurnId`、
+  `ExpectedTurnMismatch`、`ActiveTurnNotSteerable`（Review/Compact turn）、
   `NoActiveTurn` race 等）**不是 turn 终结**：不发 `turnAborted`、不改
   `turnPhase`；以 `system_steer_failed` 系统消息显式告知 Claude
   「消息没送进去，原 turn 不受影响」。

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14228,7 +14228,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.8", "0.0.0-source"),
-  commit: defineString("1df8b91", "source"),
+  commit: defineString("c80a7fd", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.8", "0.0.0-source"),
-  commit: defineString("1df8b91", "source"),
+  commit: defineString("c80a7fd", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -811,10 +811,19 @@ class CodexAdapter extends EventEmitter {
       this.log("Cannot steer: no turn in progress (use injectMessage)");
       return false;
     }
-    this.log(`Steering message into active Codex turn (${text.length} chars)`);
+    const expectedTurnId = this.currentSteerableTurnId();
+    if (!expectedTurnId) {
+      this.log("Cannot steer: no addressable active turn id (turn/started carried no id)");
+      return false;
+    }
+    this.log(`Steering message into active Codex turn ${expectedTurnId} (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
     this.trackBridgeRequestId(requestId, "steer");
-    const params = { threadId: this.threadId, input: [{ type: "text", text }] };
+    const params = {
+      threadId: this.threadId,
+      expectedTurnId,
+      input: [{ type: "text", text }]
+    };
     try {
       this.appServerWs.send(JSON.stringify({
         method: "turn/steer",
@@ -1758,6 +1767,14 @@ class CodexAdapter extends EventEmitter {
     this.log(`Thread detected: ${threadId} (${reason})`);
     this.emit("ready", threadId);
   }
+  currentSteerableTurnId() {
+    let newest = null;
+    for (const id of this.activeTurnIds) {
+      if (!id.startsWith("unknown:"))
+        newest = id;
+    }
+    return newest;
+  }
   get turnPhase() {
     if (this.activeTurnIds.size > 0) {
       const allStalled = [...this.activeTurnIds].every((id) => this.currentlyStalledTurnIds.has(id));
@@ -1776,6 +1793,7 @@ class CodexAdapter extends EventEmitter {
   markTurnStarted(turnId) {
     const wasInProgress = this.turnInProgress;
     const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
+    this.activeTurnIds.delete(turnKey);
     this.activeTurnIds.add(turnKey);
     this.stalledTurnIds.delete(turnKey);
     this.currentlyStalledTurnIds.delete(turnKey);
@@ -3994,7 +4012,8 @@ codex.on("turnPhaseChanged", ({ phase, previous }) => {
 });
 codex.on("steerFailed", (reason) => {
   log(`Steer rejected by app-server: ${reason}`);
-  emitToClaude(systemMessage("system_steer_failed", `\u26A0\uFE0F Your steer message did NOT reach Codex (${reason}). The original turn continues unaffected \u2014 wait for it to finish, or resend as a normal reply.`));
+  const advice = codex.turnInProgress ? "wait for it to finish (\u2705), then send normally" : "the turn has ended \u2014 resend as a normal reply";
+  emitToClaude(systemMessage("system_steer_failed", `\u26A0\uFE0F Your steer message did NOT reach Codex (${reason}). The original turn continues unaffected \u2014 ${advice}.`));
 });
 codex.on("steerAccepted", () => {
   log("Steer accepted by app-server");
@@ -4255,11 +4274,12 @@ function handleControlMessage(ws, raw) {
         if (steered) {
           clearAttentionWindow();
         }
+        const steerFailureAdvice = codex.turnInProgress ? "Steer failed: the running turn cannot be steered right now \u2014 wait for it to finish (\u2705), then send normally." : "Steer failed: the turn may have just ended or the connection dropped \u2014 retry as a normal reply.";
         sendProtocolMessage(ws, {
           type: "claude_to_codex_result",
           requestId: message.requestId,
           success: steered,
-          error: steered ? undefined : "Steer failed: the turn may have just ended or the connection dropped \u2014 retry as a normal reply."
+          error: steered ? undefined : steerFailureAdvice
         });
         return;
       }

--- a/src/app-server-protocol.ts
+++ b/src/app-server-protocol.ts
@@ -79,12 +79,18 @@ export interface TurnStartParams {
 
 /**
  * turn/steer — feed additional input into the CURRENTLY RUNNING turn without
- * interrupting it (available since codex app-server v0.100; the TUI uses it
- * when the user types mid-turn). Fails with NoActiveTurn / ExpectedTurnMismatch
- * / ActiveTurnNotSteerable (Review/Plan turns) / EmptyInput.
+ * interrupting it (introduced in codex rust-v0.99; the TUI uses it when the
+ * user types mid-turn). Fails with NoActiveTurn / ExpectedTurnMismatch /
+ * ActiveTurnNotSteerable (Review/Compact turns) / EmptyInput.
+ *
+ * expectedTurnId is a REQUIRED active-turn precondition since the API was
+ * introduced (every codex release that has turn/steer requires it). B0
+ * shipped without it, so every real steer bounced with "missing field
+ * `expectedTurnId`" — found by live E2E against codex 0.139.
  */
 export interface TurnSteerParams {
   threadId: string;
+  expectedTurnId: string;
   input: AppServerUserInput[];
   [key: string]: unknown;
 }

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -435,10 +435,24 @@ export class CodexAdapter extends EventEmitter {
       this.log("Cannot steer: no turn in progress (use injectMessage)");
       return false;
     }
-    this.log(`Steering message into active Codex turn (${text.length} chars)`);
+    // turn/steer requires the active turn id as a precondition (expectedTurnId
+    // — REQUIRED on every codex release that has turn/steer; omitting it gets
+    // "missing field `expectedTurnId`", which is how the live E2E caught B0
+    // sending steers that could never land). A turn tracked only under an
+    // `unknown:` fallback key has no addressable id and cannot be steered.
+    const expectedTurnId = this.currentSteerableTurnId();
+    if (!expectedTurnId) {
+      this.log("Cannot steer: no addressable active turn id (turn/started carried no id)");
+      return false;
+    }
+    this.log(`Steering message into active Codex turn ${expectedTurnId} (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
     this.trackBridgeRequestId(requestId, "steer");
-    const params: TurnSteerParams = { threadId: this.threadId, input: [{ type: "text", text }] };
+    const params: TurnSteerParams = {
+      threadId: this.threadId,
+      expectedTurnId,
+      input: [{ type: "text", text }],
+    };
     try {
       this.appServerWs.send(JSON.stringify({
         method: "turn/steer",
@@ -1495,7 +1509,7 @@ export class CodexAdapter extends EventEmitter {
           // A rejected steer leaves the ORIGINAL turn running untouched —
           // no abort, no phase change. Surface it so the daemon can tell
           // Claude the mid-turn message did NOT reach Codex (e.g.
-          // ActiveTurnNotSteerable on Review/Plan turns, or the turn ended
+          // ActiveTurnNotSteerable on Review/Compact turns, or the turn ended
           // in the NoActiveTurn race window).
           this.emit("steerFailed", parsed.error.message ?? "unknown error");
         } else {
@@ -1764,6 +1778,20 @@ export class CodexAdapter extends EventEmitter {
   }
 
   /**
+   * The most recently started REAL active turn id — the value turn/steer must
+   * pass as expectedTurnId. `unknown:` fallback keys (turn/started without an
+   * id) are not addressable and are skipped. Insertion order of the Set makes
+   * the last real entry the newest turn.
+   */
+  private currentSteerableTurnId(): string | null {
+    let newest: string | null = null;
+    for (const id of this.activeTurnIds) {
+      if (!id.startsWith("unknown:")) newest = id;
+    }
+    return newest;
+  }
+
+  /**
    * Turn lifecycle phase (protocol v2 PR A). Strictly the turn axis — the
    * bridge's attention/routing window is reported separately by the daemon.
    */
@@ -1790,6 +1818,10 @@ export class CodexAdapter extends EventEmitter {
     // Compute the key ONCE and use it for both the set and the watchdog so the
     // two never diverge (incl. the no-turn-id `unknown:` fallback).
     const turnKey = typeof turnId === "string" && turnId.length > 0 ? turnId : `unknown:${Date.now()}`;
+    // delete-before-add keeps Set insertion order = recency even if the
+    // app-server re-emits turn/started for an already-active id —
+    // currentSteerableTurnId relies on "last entry = newest turn".
+    this.activeTurnIds.delete(turnKey);
     this.activeTurnIds.add(turnKey);
     // A new turn must be eligible to notify on stall even if a prior turn
     // reused the same id (e.g. the `unknown:` fallback is time-stamped, but

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -248,15 +248,22 @@ codex.on("turnPhaseChanged", ({ phase, previous }: { phase: string; previous: st
 });
 
 // A steer is transport-accepted at send time; a later JSON-RPC rejection
-// (Review/Plan turns are not steerable; the turn may have ended in the race
+// (Review/Compact turns are not steerable; the turn may have ended in the race
 // window) means Claude's mid-turn message did NOT reach Codex — say so
 // explicitly instead of letting Claude assume it landed.
 codex.on("steerFailed", (reason: string) => {
   log(`Steer rejected by app-server: ${reason}`);
+  // Branch the advice on the live turn state (same reasoning as the sync
+  // steer-failure path): while the turn still runs (e.g. ActiveTurnNotSteerable
+  // on a Review/Compact turn), "resend as a normal reply" just bounces off the
+  // busy guard, whose error suggests steer again — an advice ping-pong.
+  const advice = codex.turnInProgress
+    ? "wait for it to finish (✅), then send normally"
+    : "the turn has ended — resend as a normal reply";
   emitToClaude(
     systemMessage(
       "system_steer_failed",
-      `⚠️ Your steer message did NOT reach Codex (${reason}). The original turn continues unaffected — wait for it to finish, or resend as a normal reply.`,
+      `⚠️ Your steer message did NOT reach Codex (${reason}). The original turn continues unaffected — ${advice}.`,
     ),
   );
 });
@@ -638,13 +645,20 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
           // the inject path does, so status buffering resumes promptly.
           clearAttentionWindow();
         }
+        // "Retry as a normal reply" is only good advice when the turn actually
+        // ended — while it is still running, a normal reply just bounces off
+        // the busy guard, whose error suggests steer again: an advice
+        // ping-pong. Branch on the live turn state. (The "ended" branch is
+        // defensive: in the current synchronous flow turnInProgress was true
+        // at dispatch and nothing async runs before this re-read.)
+        const steerFailureAdvice = codex.turnInProgress
+          ? "Steer failed: the running turn cannot be steered right now — wait for it to finish (✅), then send normally."
+          : "Steer failed: the turn may have just ended or the connection dropped — retry as a normal reply.";
         sendProtocolMessage(ws, {
           type: "claude_to_codex_result",
           requestId: message.requestId,
           success: steered,
-          error: steered
-            ? undefined
-            : "Steer failed: the turn may have just ended or the connection dropped — retry as a normal reply.",
+          error: steered ? undefined : steerFailureAdvice,
         });
         return;
       }

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -2303,7 +2303,7 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     expect(adapter.steerMessage("hello")).toBe(false);
   });
 
-  test("steerMessage sends turn/steer with a tracked negative id and text input", () => {
+  test("steerMessage sends turn/steer with a tracked negative id, expectedTurnId and text input", () => {
     const { adapter, appSent } = createSteerableAdapter();
 
     expect(adapter.steerMessage("mid-turn correction")).toBe(true);
@@ -2315,10 +2315,47 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     expect(sent.id).toBeLessThan(0);
     expect(sent.params).toEqual({
       threadId: "thread-steer",
+      // REQUIRED on every codex release with turn/steer — omitting it gets the
+      // steer rejected with "missing field `expectedTurnId`" (live-E2E regression).
+      expectedTurnId: "t1",
       input: [{ type: "text", text: "mid-turn correction" }],
     });
     expect(adapter.bridgeRequestIds.has(sent.id)).toBe(true);
     expect(adapter.bridgeRequestKinds.get(sent.id)).toBe("steer");
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("steerMessage rejects when the only active turn has no addressable id (unknown: fallback)", () => {
+    const adapter = createAdapter();
+    adapter.threadId = "thread-steer";
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+    // turn/started without a turn id → tracked under an `unknown:<ts>` key.
+    adapter.handleServerNotification({ method: "turn/started", params: {} });
+    expect(adapter.turnInProgress).toBe(true);
+
+    expect(adapter.steerMessage("hello")).toBe(false);
+  });
+
+  test("steerMessage targets the NEWEST real turn id when several are active", () => {
+    const { adapter, appSent } = createSteerableAdapter();
+    // A second (nested/newer) turn starts; insertion order makes it the newest.
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t2" } } });
+
+    expect(adapter.steerMessage("target the newest")).toBe(true);
+    expect(JSON.parse(appSent[0]).params.expectedTurnId).toBe("t2");
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("steerMessage falls back to the remaining turn id after the newest completes", () => {
+    const { adapter, appSent } = createSteerableAdapter();
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t2" } } });
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t2" } } });
+
+    expect(adapter.turnInProgress).toBe(true); // t1 still active
+    expect(adapter.steerMessage("back to t1")).toBe(true);
+    expect(JSON.parse(appSent[0]).params.expectedTurnId).toBe("t1");
 
     adapter.clearResponseTrackingState();
   });

--- a/src/unit-test/daemon-wiring.test.ts
+++ b/src/unit-test/daemon-wiring.test.ts
@@ -459,7 +459,7 @@ describe("daemon wiring", () => {
   test("on_busy=steer feeds the message into a running turn via turn/steer (protocol v2 B0)", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-steer-fixture-"));
     const steerLog = join(fixtureRoot, "turnsteer.jsonl");
-    const readSteers = (): Array<{ threadId: string; input: Array<{ type: string; text: string }> }> =>
+    const readSteers = (): Array<{ threadId: string; expectedTurnId?: string; input: Array<{ type: string; text: string }> }> =>
       existsSync(steerLog)
         ? readFileSync(steerLog, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
         : [];
@@ -511,6 +511,11 @@ describe("daemon wiring", () => {
       await waitFor(() => readSteers().length >= 1, "recorded turn/steer", 100, 100);
       const steer = readSteers()[0]!;
       expect(steer.threadId).toBe("thread-fake-1");
+      // This assertion is the real regression gate: `accepted.success` above is
+      // only the daemon's SYNCHRONOUS transport-accept (sent before the fake's
+      // JSON-RPC verdict arrives), so a strict-fake rejection would NOT flip it
+      // — it would surface later as an async system_steer_failed.
+      expect(steer.expectedTurnId).toBe("turn-1");
       expect(steer.input[0]!.type).toBe("text");
       expect(steer.input[0]!.text.startsWith("[STEER from Claude]\n")).toBe(true);
       expect(steer.input[0]!.text).toContain("course correction: use approach B");
@@ -714,6 +719,7 @@ const listen = process.argv[listenIndex + 1];
 const port = Number(new URL(listen).port);
 const commandFile = process.env.FAKE_APP_COMMAND_FILE;
 let appWs = null;
+let lastStartedTurnId = null;
 
 const server = Bun.serve({
   hostname: "127.0.0.1",
@@ -744,15 +750,23 @@ const server = Bun.serve({
         }
         // turn/steer: record params, then ack — or reject when the text carries
         // the [force-steer-error] marker (drives the steerFailed wiring test).
+        // Strict emulation of the real app-server (expectedTurnId has been
+        // REQUIRED since turn/steer was introduced — live-E2E regression: B0
+        // shipped without the field and every steer bounced): missing field →
+        // serde-style error; wrong value → ExpectedTurnMismatch-style error.
         if (msg.method === "turn/steer") {
           if (process.env.FAKE_APP_TURNSTEER_LOG) {
             appendFileSync(process.env.FAKE_APP_TURNSTEER_LOG, JSON.stringify(msg.params) + "\\n");
           }
           const steerText = msg.params?.input?.[0]?.text ?? "";
-          if (steerText.includes("[force-steer-error]")) {
+          if (typeof msg.params?.expectedTurnId !== "string" || msg.params.expectedTurnId.length === 0) {
+            ws.send(JSON.stringify({ id: msg.id, error: { message: "Invalid request: missing field \`expectedTurnId\`" } }));
+          } else if (lastStartedTurnId && msg.params.expectedTurnId !== lastStartedTurnId) {
+            ws.send(JSON.stringify({ id: msg.id, error: { message: "expected active turn id \`" + msg.params.expectedTurnId + "\` but found \`" + lastStartedTurnId + "\`" } }));
+          } else if (steerText.includes("[force-steer-error]")) {
             ws.send(JSON.stringify({ id: msg.id, error: { message: "ActiveTurnNotSteerable" } }));
           } else {
-            ws.send(JSON.stringify({ id: msg.id, result: {} }));
+            ws.send(JSON.stringify({ id: msg.id, result: { turnId: msg.params.expectedTurnId } }));
           }
         }
       } catch {}
@@ -769,6 +783,7 @@ setInterval(() => {
   try { unlinkSync(commandFile); } catch {}
   if (!appWs) return;
   if (command === "start-turn") {
+    lastStartedTurnId = "turn-1";
     appWs.send(JSON.stringify({ method: "turn/started", params: { turn: { id: "turn-1" } } }));
   }
   if (command === "close-app-server") {


### PR DESCRIPTION
## 摘要 / Summary

**中文**：用户要求的真机 E2E 自测第一发命中：v0.1.8 的 `on_busy="steer"` 实际**从未送达过任何真实 codex**——app-server 全部拒绝 `Invalid request: missing field 'expectedTurnId'`。实证 codex-rs 源码（4 轮 reviewer 独立复证）：该字段自 turn/steer 引入（rust-v0.99，提交 0d8b2b74c4）起就是必填，且从未变为可选。B0 只过了 fake 测试，fake 没仿真这个前置条件。本 PR 修复发送逻辑并把 fake 升级为严格仿真，防止同类回归。

**English**: The user-requested live E2E caught it on the first shot: v0.1.8's steer never landed on any real codex — every request bounced with `missing field 'expectedTurnId'`. Verified against codex-rs source: the field has been REQUIRED since turn/steer was introduced (rust-v0.99) and was never optional. B0 only passed against a fake that didn't emulate the precondition; this PR fixes the send path and upgrades the fake to strict emulation.

亮点：B0 的错误通路在实测中 100% 按设计工作——失败被精确分流为 `system_steer_failed`，Codex 原 turn 无损，无 `turnAborted`、无 phase 污染。

## 变更 / Changes

| 文件 | 内容 |
|---|---|
| codex-adapter | `currentSteerableTurnId()`：取最新可寻址活跃 turn id（Set 插入序；`markTurnStarted` delete-before-add 保证序=新近序）；`steerMessage` 携带 `expectedTurnId`，无可寻址 id 时本地拒绝 |
| daemon | 两处 steer 失败文案（同步 result + 异步 `system_steer_failed`）按实时 `turnInProgress` 分叉——防「改发普通 reply」↔ busy guard 的建议乒乓 |
| app-server-protocol | `TurnSteerParams.expectedTurnId`（必填）+ 方法表 |
| 测试 | fake app-server 严格仿真真实 codex：缺字段 → serde 错误、值不匹配 → ExpectedTurnMismatch（逐字格式）、成功 → `{turnId}`；新增发送形状/新近序/完成回退/unknown-key 拒绝覆盖；e2e 断言活线程上的 expectedTurnId |
| docs | collaboration-protocol-v2.md B0 节补 wire 前置条件 + 失败模式 |
| bun.lock | lockfile 追平 HEAD package.json（无依赖变化，独立说明防 squash 语义混淆）|

## 测试 / Test plan

- [x] typecheck 清洁；全量 `bun run ci:local` **743 pass / 0 fail**（check + smoke:built + smoke:pack + plugin-sync）
- [x] Cross-review 4 轮 / 8 位全新 reviewer 收敛：R1 抓到注释版本史错误（reviewer 实证 tags 0.99–0.137 全必填）；R2 抓到 Review/Plan→Review/Compact（NonSteerableTurnKind 从无 Plan）；R3 抓到 stale bundle + 测试注释失实；R4 双 0 REAL。全部协议论断对照 codex-rs 源码逐项核验
- [ ] 合并 + 本机升级后真机复测：Codex busy 靶标 + steer 送达 + mid-turn 整合验证（follow-up，本 PR 合并后立即执行）

## 后续 / Follow-ups

- 真机 steer 复测（Codex 已确认继续当靶标）
- `abg resume` + 最高权限默认（已完成开发，独立 PR 紧随）
- PR B：turn/interrupt（复用本 PR 的活跃 turn id 跟踪基础设施）