### PR TITLE
feat: abg resume 一键恢复双侧会话 + 默认最高权限（--safe 可关）/ abg resume + max-permission defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ After modifying AgentBridge source code, re-run `agentbridge dev` to sync change
 | Command | Description |
 |---------|-------------|
 | `abg init` | Install plugin, check dependencies (bun/claude/codex), generate `.agentbridge/config.json` |
-| `abg claude [args...]` | Start Claude Code with push channel enabled. Clears any killed sentinel from a previous `kill`. Pass-through args are forwarded to `claude` |
-| `abg codex [args...]` | Start Codex TUI connected to AgentBridge daemon. **Bare `abg codex` auto-resumes the pair's last thread; use `abg codex --new` for a fresh thread.** Manages TUI process lifecycle (pid tracking, cleanup). Pass-through args forwarded to `codex` |
+| `abg claude [args...]` | Start Claude Code with push channel enabled. **Runs with `--dangerously-skip-permissions` by default** (opt out: `--safe` or `AGENTBRIDGE_SAFE=1`). Clears any killed sentinel from a previous `kill`. Pass-through args are forwarded to `claude` |
+| `abg codex [args...]` | Start Codex TUI connected to AgentBridge daemon. **Bare `abg codex` auto-resumes the pair's last thread; use `abg codex --new` for a fresh thread. TUI launches run with `--yolo` by default** (opt out: `--safe` or `AGENTBRIDGE_SAFE=1`; non-TUI subcommands like `exec` are never touched). Manages TUI process lifecycle (pid tracking, cleanup). Pass-through args forwarded to `codex` |
+| `abg resume [claude\|codex]` | No target: print the resume commands for this directory's last Claude Code session and this pair's current Codex thread. With a target: resume that side directly (delegates to `abg claude --resume <id>` / `abg codex resume-current`) |
 | `abg pairs` | List registered pairs; `abg pairs rm <name\|id>` removes one, `abg pairs prune` deletes orphan state dirs |
 | `abg doctor [--json]` | Read-only diagnosis: env, daemon health/readiness, build drift, artifact alignment, TUI attachment, logs |
 | `abg budget [--json]` | Both agents' subscription quota snapshot (5h/weekly windows, drift, pause state) |
@@ -165,7 +166,7 @@ After modifying AgentBridge source code, re-run `agentbridge dev` to sync change
 | `abg --help` | Show help |
 | `abg --version` | Show version |
 
-The pair-aware commands (`claude`, `codex`, `kill`, `doctor`, `budget`) accept `--pair <name>` to target a specific pair — one pair per project directory by default, with ports allocated per pair in +10 strides from 4500.
+The pair-aware commands (`claude`, `codex`, `resume`, `kill`, `doctor`, `budget`) accept `--pair <name>` to target a specific pair — one pair per project directory by default, with ports allocated per pair in +10 strides from 4500.
 
 ### Owned flags
 
@@ -173,6 +174,7 @@ Some flags are automatically injected and cannot be manually specified:
 
 - `agentbridge claude` owns: `--channels`, `--dangerously-load-development-channels`
 - `agentbridge codex` owns: `--remote`, `--enable tui_app_server`
+- Both launchers consume the wrapper flag `--safe` (it is never forwarded): it disables the max-permission defaults for that launch. The defaults are also auto-suppressed when you pass any explicit permission flag yourself (`-a`/`--ask-for-approval`/`-s`/`--sandbox` for codex; `--permission-mode`/`--allow-dangerously-skip-permissions` for claude) — injecting `--yolo` next to an explicit approval policy is a hard codex CLI conflict.
 
 Passing these flags manually will result in a hard error with guidance to use the native command directly.
 

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14228,7 +14228,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.9", "0.0.0-source"),
-  commit: defineString("c80a7fd", "source"),
+  commit: defineString("10dfd58", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.9", "0.0.0-source"),
-  commit: defineString("c80a7fd", "source"),
+  commit: defineString("10dfd58", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/src/claude-session.ts
+++ b/src/claude-session.ts
@@ -1,0 +1,65 @@
+import { readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Claude Code stores one transcript per session under
+ * `~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`. The directory name
+ * encodes the project cwd with every non-alphanumeric character replaced by
+ * `-` (verified against real installs: `/Users/x/repo/agent_bridge` →
+ * `-Users-x-repo-agent-bridge`).
+ */
+export function encodeClaudeProjectDir(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+export interface ClaudeSessionInfo {
+  sessionId: string;
+  file: string;
+  mtimeMs: number;
+}
+
+const SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The most recently active Claude Code session for a project directory, by
+ * transcript mtime. Returns null when the project has no sessions (or the
+ * projects dir is unreadable). Non-session entries (memory/, subagent dirs,
+ * stray files) are ignored — only uuid-named .jsonl transcripts count.
+ */
+export function findLatestClaudeSession(
+  cwd: string,
+  // Claude Code honors CLAUDE_CONFIG_DIR to relocate its config dir — without
+  // this, a relocated install would get a false "no session found".
+  // `||` (not `??`): empty-string env is treated as unset (codebase convention,
+  // see computeBaseDir).
+  claudeHome: string = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude"),
+): ClaudeSessionInfo | null {
+  const dir = join(claudeHome, "projects", encodeClaudeProjectDir(cwd));
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return null;
+  }
+
+  let best: ClaudeSessionInfo | null = null;
+  for (const name of entries) {
+    if (!name.endsWith(".jsonl")) continue;
+    const sessionId = name.slice(0, -".jsonl".length);
+    if (!SESSION_ID_PATTERN.test(sessionId)) continue;
+    const file = join(dir, name);
+    let mtimeMs: number;
+    try {
+      const st = statSync(file);
+      if (!st.isFile()) continue;
+      mtimeMs = st.mtimeMs;
+    } catch {
+      continue;
+    }
+    if (!best || mtimeMs > best.mtimeMs) {
+      best = { sessionId, file, mtimeMs };
+    }
+  }
+  return best;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,12 +15,12 @@
 export const MARKETPLACE_NAME = "agentbridge";
 export const PLUGIN_NAME = "agentbridge";
 
-/** Commands that print an update notice. claude/codex also trigger the daily refresh. */
-const REFRESH_COMMANDS = new Set(["claude", "codex"]);
-const NOTIFY_COMMANDS = new Set(["claude", "codex", "init", "dev"]);
+/** Commands that print an update notice. claude/codex/resume also trigger the daily refresh. */
+const REFRESH_COMMANDS = new Set(["claude", "codex", "resume"]);
+const NOTIFY_COMMANDS = new Set(["claude", "codex", "init", "dev", "resume"]);
 
 /** Subcommands that accept a `--pair <name>` selector. */
-const PAIR_AWARE_COMMANDS = new Set(["claude", "codex", "kill", "doctor", "budget"]);
+const PAIR_AWARE_COMMANDS = new Set(["claude", "codex", "kill", "doctor", "budget", "resume"]);
 
 /**
  * Split argv into the subcommand and its args, allowing a leading `--pair <name>`
@@ -92,6 +92,10 @@ async function main(command: string | undefined, restArgs: string[]) {
       const { runCodex } = await import("./cli/codex");
       await runCodex(restArgs);
       break;
+    case "resume":
+      const { runResume } = await import("./cli/resume");
+      await runResume(restArgs);
+      break;
     case "kill":
       const { runKill } = await import("./cli/kill");
       await runKill(restArgs);
@@ -138,6 +142,10 @@ Commands:
   claude [args...]   Start Claude Code with push channel enabled
   codex [args...]    Start Codex TUI connected to AgentBridge daemon
                      (bare command auto-resumes the last thread; --new starts fresh)
+  resume [claude|codex]
+                     No target: print resume commands for this directory's last
+                     Claude session + this pair's current Codex thread.
+                     With target: resume that side directly.
   pairs [rm <name|id> | prune [--dry-run]]
                      List pairs; remove one (rm), or delete orphan state dirs (prune)
   doctor [--json]    Diagnose env, daemon, build drift, logs, and current thread
@@ -147,10 +155,17 @@ Commands:
                      Stop this directory's pairs (default), every pair (all/--all), or one (--pair)
 
 Options:
-  --pair <name>      Run claude/codex/kill in a named pair. The name is scoped to
+  --pair <name>      Run claude/codex/resume/kill/doctor/budget in a named pair. The name is scoped to
                      the current directory, so the same name in another directory
                      is a separate pair. Goes BEFORE the command. Without it, the
                      pair name defaults to "main" for the current directory.
+  --safe             Disable the max-permission defaults for this launch.
+                     Goes AFTER the command (abg claude --safe); also auto-
+                     suppressed when you pass any explicit permission flag
+                     (-a/--sandbox for codex, --permission-mode for claude).
+                     (abg claude runs with --dangerously-skip-permissions and
+                     abg codex with --yolo by default; AGENTBRIDGE_SAFE=1 also
+                     disables both.)
   --help, -h         Show this help message
   --version, -v      Show version
 
@@ -164,6 +179,10 @@ Examples:
   abg init                     # First-time setup
   abg claude                   # Start the "main" pair for this directory
   abg codex                    # Connect Codex to this directory's "main" pair
+  abg resume                   # Print resume commands for both sides
+  abg resume claude            # Resume the last Claude Code session here
+  abg resume codex             # Resume this pair's current Codex thread
+  abg claude --safe            # One launch without the max-permission default
   abg --pair work claude       # Start a named pair "work" (this directory)
   abg --pair work codex        # Connect Codex to the "work" pair
   abg --pair review claude     # A second, parallel pair

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -7,6 +7,11 @@ import { guardAgentBridgeEnv, normalizeEnvGuardMode } from "../env-guard";
 import { parsePositiveIntEnv } from "../env-utils";
 import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
 import { appendTraceEvent, pickRelevantEnv } from "../trace-log";
+import {
+  CLAUDE_MAX_PERMISSION_SUPPRESSORS,
+  CLAUDE_MAX_PERMISSION_FLAG,
+  planMaxPermissions,
+} from "./max-permissions";
 
 /** Flags that AgentBridge owns and will inject automatically. */
 const OWNED_FLAGS = ["--channels", "--dangerously-load-development-channels"];
@@ -22,7 +27,13 @@ export async function runClaude(args: string[]) {
   });
 
   // Strip `--pair <name>` before anything else; the rest flows through to claude.
-  const { pairFlag, rest } = parsePairFlag(args);
+  const { pairFlag, rest: pairRest } = parsePairFlag(args);
+
+  // Max-permission default (user request): `abg claude` runs Claude Code with
+  // --dangerously-skip-permissions unless --safe / AGENTBRIDGE_SAFE=1 / the
+  // user already passed it. `--safe` is wrapper-owned and stripped here.
+  const permissionPlan = planMaxPermissions(pairRest, CLAUDE_MAX_PERMISSION_SUPPRESSORS);
+  const rest = permissionPlan.args;
 
   // Check for owned flag conflicts (on the real claude args, not the pair flag).
   checkOwnedFlagConflicts(rest, "agentbridge claude", OWNED_FLAGS);
@@ -76,8 +87,12 @@ export async function runClaude(args: string[]) {
   // --channels checks the approved allowlist (Anthropic-curated) and fails
   // for custom plugins. The dev flag bypasses this per-entry.
   // Once published to the official marketplace, switch to --channels.
+  if (permissionPlan.inject) {
+    console.error(`[agentbridge] running with ${CLAUDE_MAX_PERMISSION_FLAG} (default; opt out with --safe or AGENTBRIDGE_SAFE=1)`);
+  }
   const fullArgs = [
     "--dangerously-load-development-channels", channelEntry,
+    ...(permissionPlan.inject ? [CLAUDE_MAX_PERMISSION_FLAG] : []),
     ...rest,
   ];
 

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -38,6 +38,11 @@ import {
   isProcessAlive,
 } from "../process-lifecycle";
 import { checkOwnedFlagConflicts } from "./claude";
+import {
+  CODEX_MAX_PERMISSION_SUPPRESSORS,
+  CODEX_MAX_PERMISSION_FLAG,
+  planMaxPermissions,
+} from "./max-permissions";
 
 /**
  * Write a timestamped entry to the codex wrapper log.
@@ -209,9 +214,21 @@ export function resolveCodexResumeArgs(
  *   through unchanged; those do not launch a TUI and must not receive `--remote`.
  * - Unknown first token → treat as a bare prompt (TUI mode). Safer than
  *   silently dropping bridge flags for an unrecognized subcommand.
+ *
+ * `yolo` rides along with the bridge flags (same per-subcommand clap
+ * positioning; `--yolo` is accepted on root and resume/fork — verified on
+ * codex 0.139). Non-TUI subcommands never get it: silently changing the
+ * sandboxing of a manual `abg codex exec …` would be a footgun.
  */
-export function buildCodexArgs(userArgs: string[], proxyUrl: string): BuildArgsResult {
-  const bridgeFlags = ["--enable", "tui_app_server", "--remote", proxyUrl];
+export function buildCodexArgs(
+  userArgs: string[],
+  proxyUrl: string,
+  opts: { yolo?: boolean } = {},
+): BuildArgsResult {
+  const bridgeFlags = [
+    "--enable", "tui_app_server", "--remote", proxyUrl,
+    ...(opts.yolo ? [CODEX_MAX_PERMISSION_FLAG] : []),
+  ];
   const first = userArgs[0];
 
   if (!first || first.startsWith("-")) {
@@ -244,7 +261,12 @@ export async function runCodex(args: string[]) {
 
   // Strip `--pair <name>` first; the rest flows through to codex.
   const { pairFlag, rest } = parsePairFlag(args);
-  const wrapperArgs = parseAgentBridgeCodexArgs(rest);
+
+  // Max-permission default (user request): TUI launches get --yolo unless
+  // --safe / AGENTBRIDGE_SAFE=1 / an explicit alias is already present.
+  // `--safe` is wrapper-owned and stripped here, before codex arg parsing.
+  const permissionPlan = planMaxPermissions(rest, CODEX_MAX_PERMISSION_SUPPRESSORS);
+  const wrapperArgs = parseAgentBridgeCodexArgs(permissionPlan.args);
 
   // AGENTS.md is managed exclusively by `abg init`. Startup never writes or
   // blocks on it — only nudge once on stderr if the contract is missing/stale.
@@ -403,7 +425,12 @@ export async function runCodex(args: string[]) {
     console.error(`[agentbridge] Resuming current Codex thread ${resumeArgs.thread!.threadId}`);
   }
 
-  const { fullArgs } = buildCodexArgs(resumeArgs.rest, proxyUrl);
+  const { fullArgs, injectedBridgeFlags } = buildCodexArgs(resumeArgs.rest, proxyUrl, {
+    yolo: permissionPlan.inject,
+  });
+  if (permissionPlan.inject && injectedBridgeFlags) {
+    console.error(`[agentbridge] running with ${CODEX_MAX_PERMISSION_FLAG} (default; opt out with --safe or AGENTBRIDGE_SAFE=1)`);
+  }
 
   // Capture the last 64KB of child stderr so the "ERROR: ..." line from
   // codex-rs on ExitReason::Fatal survives even when stdio is inherited by

--- a/src/cli/max-permissions.ts
+++ b/src/cli/max-permissions.ts
@@ -1,0 +1,85 @@
+/**
+ * Max-permission-by-default for the wrapper launchers (explicit user request:
+ * `abg claude` runs with --dangerously-skip-permissions and `abg codex` with
+ * --yolo, without typing them every time).
+ *
+ * Injection is skipped whenever the user has expressed ANY explicit permission
+ * preference of their own — not only the exact alias (no double-add) but also
+ * approval/sandbox/permission-mode flags: injecting --yolo next to an explicit
+ * `-a never` is a hard clap conflict on codex (verified on 0.139: "the argument
+ * '--ask-for-approval <APPROVAL_POLICY>' cannot be used with
+ * '--dangerously-bypass-approvals-and-sandbox'"), and silently overriding an
+ * explicit `--sandbox read-only` / `--permission-mode plan` would escalate a
+ * deliberately more-restrictive launch.
+ *
+ * Opt-outs, in priority order:
+ *   - `--safe` wrapper flag (consumed here, never forwarded to the child)
+ *   - AGENTBRIDGE_SAFE=1 in the environment
+ *   - any suppressor flag already present (exact token or `flag=value` form)
+ */
+export interface MaxPermissionPlan {
+  /** Launch args with the wrapper-owned `--safe` flag stripped. */
+  args: string[];
+  /** Whether the launcher should append its max-permission flag. */
+  inject: boolean;
+  /** True when --safe / AGENTBRIDGE_SAFE=1 disabled the default. */
+  safeMode: boolean;
+}
+
+export const CLAUDE_MAX_PERMISSION_FLAG = "--dangerously-skip-permissions";
+/** Explicit permission preferences that suppress the claude injection. */
+export const CLAUDE_MAX_PERMISSION_SUPPRESSORS = [
+  CLAUDE_MAX_PERMISSION_FLAG,
+  "--allow-dangerously-skip-permissions",
+  "--permission-mode",
+];
+
+export const CODEX_MAX_PERMISSION_FLAG = "--yolo";
+/** Explicit permission preferences that suppress the codex injection. */
+export const CODEX_MAX_PERMISSION_SUPPRESSORS = [
+  CODEX_MAX_PERMISSION_FLAG,
+  "--dangerously-bypass-approvals-and-sandbox",
+  "-a",
+  "--ask-for-approval",
+  "-s",
+  "--sandbox",
+];
+
+export function planMaxPermissions(
+  args: string[],
+  suppressors: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): MaxPermissionPlan {
+  let safeFlag = false;
+  const rest: string[] = [];
+  for (const a of args) {
+    if (a === "--safe") {
+      safeFlag = true;
+      continue;
+    }
+    rest.push(a);
+  }
+
+  const safeMode = safeFlag || env.AGENTBRIDGE_SAFE === "1";
+  const userExpressedPreference = rest.some((a) =>
+    suppressors.some((s) => matchesSuppressor(a, s)),
+  );
+  return { args: rest, inject: !safeMode && !userExpressedPreference, safeMode };
+}
+
+function matchesSuppressor(token: string, suppressor: string): boolean {
+  if (token === suppressor || token.startsWith(`${suppressor}=`)) return true;
+  // clap value-taking short options also accept the ATTACHED form with no
+  // separator: `-anever` IS `-a never` (verified on codex 0.139 — and
+  // `-anever --yolo` is the same hard conflict as the spaced form). Any
+  // single-dash token starting with the short flag letter is that option.
+  if (
+    /^-[A-Za-z]$/.test(suppressor) &&
+    !token.startsWith("--") &&
+    token.startsWith(suppressor) &&
+    token.length > suppressor.length
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src/cli/resume.ts
+++ b/src/cli/resume.ts
@@ -1,0 +1,114 @@
+import { findLatestClaudeSession } from "../claude-session";
+import { parsePairFlag, resolvePairReadOnly } from "../pair-resolver";
+import { readUsableCurrentThread } from "../thread-state";
+
+/**
+ * `abg resume` — one place to get back to where the pair left off.
+ *
+ *   abg resume          print the resume commands for this directory's last
+ *                       Claude Code session and this pair's current Codex thread
+ *   abg resume claude   resume the last Claude Code session here, directly
+ *   abg resume codex    resume this pair's verified current Codex thread, directly
+ *
+ * Direct modes delegate to the regular launchers, so pair resolution, conflict
+ * guards and the max-permission defaults all apply exactly as for
+ * `abg claude` / `abg codex`.
+ */
+export interface ResumeTargets {
+  pairName: string;
+  claudeSessionId: string | null;
+  codexThreadId: string | null;
+}
+
+export function resolveResumeTargets(opts: {
+  pairFlag?: string;
+  claudeHome?: string;
+  env?: NodeJS.ProcessEnv;
+} = {}): ResumeTargets {
+  // Pair resolution (resolvePairReadOnly) is hard-wired to process.cwd(), so
+  // the thread identity must use the same cwd — a parameterized cwd here would
+  // silently mismatch the pair's recorded thread state.
+  const cwd = process.cwd();
+  const { pair } = resolvePairReadOnly(opts.pairFlag);
+  const claude = findLatestClaudeSession(cwd, opts.claudeHome);
+  const codex = readUsableCurrentThread(
+    {
+      stateDir: pair.stateDir,
+      pairId: pair.manual ? null : pair.pairId,
+      pairName: pair.name,
+      cwd,
+    },
+    opts.env ?? process.env,
+  );
+  return {
+    pairName: pair.name,
+    claudeSessionId: claude?.sessionId ?? null,
+    codexThreadId: codex?.threadId ?? null,
+  };
+}
+
+export async function runResume(args: string[]) {
+  const { pairFlag, rest } = parsePairFlag(args);
+  const target = rest[0];
+  const extra = rest.slice(1);
+  // `!== undefined`, NOT truthiness: parsePairFlag maps a value-less `--pair`
+  // to "" precisely so resolution throws PAIR_ID_INVALID downstream — a
+  // truthy check would silently fall back to the default pair, diverging from
+  // every other launcher.
+  const pairPrefix = pairFlag !== undefined ? ["--pair", pairFlag] : [];
+
+  if (target === "claude") {
+    const session = findLatestClaudeSession(process.cwd());
+    if (!session) {
+      console.error("[agentbridge] No Claude Code session found for this directory.");
+      console.error("[agentbridge] Start one with: abg claude");
+      process.exit(1);
+    }
+    console.error(`[agentbridge] Resuming Claude Code session ${session!.sessionId}`);
+    const { runClaude } = await import("./claude");
+    await runClaude([...pairPrefix, "--resume", session!.sessionId, ...extra]);
+    return;
+  }
+
+  if (target === "codex") {
+    // resume-current verifies the pair's recorded thread (rollout file must
+    // exist) and fails loudly when there is none — exactly the semantics we
+    // want for "get me back to the last Codex session".
+    const { runCodex } = await import("./codex");
+    await runCodex([...pairPrefix, "resume-current", ...extra]);
+    return;
+  }
+
+  if (target !== undefined) {
+    console.error(`Error: unknown resume target "${target}".`);
+    console.error("");
+    console.error("Usage:");
+    console.error("  abg resume           # print resume commands for this directory");
+    console.error("  abg resume claude    # resume the last Claude Code session here");
+    console.error("  abg resume codex     # resume this pair's current Codex thread");
+    process.exit(1);
+  }
+
+  const targets = resolveResumeTargets({ pairFlag });
+  const pairArg = pairFlag ? `--pair ${pairFlag} ` : "";
+
+  const lines: string[] = [];
+  if (targets.claudeSessionId) {
+    lines.push(`abg ${pairArg}claude --resume ${targets.claudeSessionId}`);
+  } else {
+    lines.push(`# no Claude Code session found for this directory (start one: abg ${pairArg}claude)`);
+  }
+  if (targets.codexThreadId) {
+    lines.push(`abg ${pairArg}codex resume ${targets.codexThreadId}`);
+  } else {
+    lines.push(`# no verified Codex thread for pair "${targets.pairName}" (start one: abg ${pairArg}codex --new)`);
+  }
+  console.log(lines.join("\n"));
+  console.error("");
+  console.error("Tip: `abg resume claude` / `abg resume codex` runs these directly.");
+  console.error("(max-permission flags are applied by default; opt out with --safe or AGENTBRIDGE_SAFE=1)");
+
+  if (!targets.claudeSessionId && !targets.codexThreadId) {
+    process.exit(1);
+  }
+}

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -147,6 +147,9 @@ class CliE2EHarness {
       AGENTBRIDGE_BASE_DIR: undefined,
       AGENTBRIDGE_PAIR_ID: undefined,
       AGENTBRIDGE_PAIR_NAME: undefined,
+      // The persistent max-permission opt-out must not leak in from the
+      // developer's shell — the argv assertions expect the injected defaults.
+      AGENTBRIDGE_SAFE: undefined,
       AGENTBRIDGE_MANUAL: "1",
       AGENTBRIDGE_STATE_DIR: stateDir,
       AGENTBRIDGE_CONTROL_PORT: String(controlPort),
@@ -432,6 +435,8 @@ describe("E2E: CLI surface", () => {
       expect(invocations[0]?.args).toEqual([
         "--dangerously-load-development-channels",
         "plugin:agentbridge@agentbridge",
+        // Max-permission default (opt out: --safe / AGENTBRIDGE_SAFE=1).
+        "--dangerously-skip-permissions",
         "--resume",
       ]);
     });
@@ -479,6 +484,8 @@ describe("E2E: CLI surface", () => {
         "tui_app_server",
         "--remote",
         `ws://127.0.0.1:${harness.proxyPort}`,
+        // Max-permission default (opt out: --safe / AGENTBRIDGE_SAFE=1).
+        "--yolo",
         "--model",
         "o3",
       ]);
@@ -522,6 +529,8 @@ describe("E2E: CLI surface", () => {
         "tui_app_server",
         "--remote",
         `ws://127.0.0.1:${harness.proxyPort}`,
+        // Max-permission default (opt out: --safe / AGENTBRIDGE_SAFE=1).
+        "--yolo",
         "--profile",
         "default",
       ]);

--- a/src/unit-test/claude-session.test.ts
+++ b/src/unit-test/claude-session.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { encodeClaudeProjectDir, findLatestClaudeSession } from "../claude-session";
+
+const UUID_A = "11111111-2222-3333-4444-555555555555";
+const UUID_B = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+function makeClaudeHome(cwd: string): { home: string; projectDir: string } {
+  const home = mkdtempSync(join(tmpdir(), "abg-claude-session-test-"));
+  const projectDir = join(home, "projects", encodeClaudeProjectDir(cwd));
+  mkdirSync(projectDir, { recursive: true });
+  return { home, projectDir };
+}
+
+function writeSession(projectDir: string, id: string, mtimeSeconds: number) {
+  const file = join(projectDir, `${id}.jsonl`);
+  writeFileSync(file, "{}\n");
+  utimesSync(file, mtimeSeconds, mtimeSeconds);
+  return file;
+}
+
+describe("encodeClaudeProjectDir", () => {
+  test("replaces every non-alphanumeric character with a dash (incl. underscores)", () => {
+    expect(encodeClaudeProjectDir("/Users/x/repo/agent_bridge")).toBe(
+      "-Users-x-repo-agent-bridge",
+    );
+  });
+
+  test("keeps alphanumerics intact", () => {
+    expect(encodeClaudeProjectDir("/tmp/Abc123")).toBe("-tmp-Abc123");
+  });
+});
+
+describe("findLatestClaudeSession", () => {
+  test("picks the most recently modified uuid-named transcript", () => {
+    const cwd = "/tmp/abg-resume-fixture";
+    const { home, projectDir } = makeClaudeHome(cwd);
+    writeSession(projectDir, UUID_A, 1_000_000);
+    writeSession(projectDir, UUID_B, 2_000_000);
+
+    const found = findLatestClaudeSession(cwd, home);
+    expect(found?.sessionId).toBe(UUID_B);
+  });
+
+  test("ignores non-uuid jsonl files, directories, and non-jsonl entries", () => {
+    const cwd = "/tmp/abg-resume-fixture2";
+    const { home, projectDir } = makeClaudeHome(cwd);
+    writeSession(projectDir, UUID_A, 1_000_000);
+    // Distractors: stray jsonl, memory dir, session-named SUBDIR (subagent layout).
+    writeFileSync(join(projectDir, "notes.jsonl"), "{}\n");
+    utimesSync(join(projectDir, "notes.jsonl"), 9_000_000, 9_000_000);
+    mkdirSync(join(projectDir, "memory"), { recursive: true });
+    mkdirSync(join(projectDir, `${UUID_B}.jsonl.d`), { recursive: true });
+
+    const found = findLatestClaudeSession(cwd, home);
+    expect(found?.sessionId).toBe(UUID_A);
+  });
+
+  test("returns null when the project has no sessions or no directory", () => {
+    const cwd = "/tmp/abg-resume-fixture3";
+    const { home } = makeClaudeHome(cwd);
+    expect(findLatestClaudeSession(cwd, home)).toBeNull();
+    expect(findLatestClaudeSession("/tmp/never-seen-cwd", home)).toBeNull();
+  });
+});

--- a/src/unit-test/cli.test.ts
+++ b/src/unit-test/cli.test.ts
@@ -325,3 +325,97 @@ describe("CLI: AgentBridge Codex resume args", () => {
     }
   });
 });
+
+describe("CLI: buildCodexArgs --yolo positioning (max-permission default)", () => {
+  const PROXY = "ws://127.0.0.1:4501";
+  const BRIDGE_YOLO = ["--enable", "tui_app_server", "--remote", PROXY, "--yolo"];
+
+  test("bare codex: --yolo rides with the bridge flags at front", () => {
+    const r = buildCodexArgs([], PROXY, { yolo: true });
+    expect(r.fullArgs).toEqual(BRIDGE_YOLO);
+  });
+
+  test("resume subcommand: --yolo lands after 'resume' with the bridge flags", () => {
+    const r = buildCodexArgs(["resume", "thread-1"], PROXY, { yolo: true });
+    expect(r.fullArgs).toEqual(["resume", ...BRIDGE_YOLO, "thread-1"]);
+  });
+
+  test("non-TUI subcommand never gets --yolo (exec sandboxing untouched)", () => {
+    const r = buildCodexArgs(["exec", "ls"], PROXY, { yolo: true });
+    expect(r.fullArgs).toEqual(["exec", "ls"]);
+    expect(r.injectedBridgeFlags).toBe(false);
+  });
+
+  test("yolo:false matches the legacy two-arg shape exactly", () => {
+    const withOpt = buildCodexArgs(["resume", "t"], PROXY, { yolo: false });
+    const legacy = buildCodexArgs(["resume", "t"], PROXY);
+    expect(withOpt).toEqual(legacy);
+  });
+});
+
+describe("CLI: resolveResumeTargets (abg resume)", () => {
+  test("returns both sides' ids from the claude transcript dir and the pair thread state", async () => {
+    const { resolveResumeTargets } = await import("../cli/resume");
+    const { encodeClaudeProjectDir } = await import("../claude-session");
+    const { derivePairId } = await import("../pair-registry");
+
+    const root = mkdtempSync(join(tmpdir(), "abg-resume-targets-"));
+    const previousBase = process.env.AGENTBRIDGE_BASE_DIR;
+    process.env.AGENTBRIDGE_BASE_DIR = join(root, "base");
+    try {
+      const cwd = process.cwd();
+
+      // Claude side: one uuid transcript for this cwd.
+      const claudeHome = join(root, "claude-home");
+      const projectDir = join(claudeHome, "projects", encodeClaudeProjectDir(cwd));
+      mkdirSync(projectDir, { recursive: true });
+      const sessionId = "12345678-1234-1234-1234-123456789abc";
+      writeFileSync(join(projectDir, `${sessionId}.jsonl`), "{}\n");
+
+      // Codex side: a verified current-thread file for the derived "main" pair.
+      const pairId = derivePairId(cwd, "main");
+      const pairDir = join(root, "base", "pairs", pairId);
+      mkdirSync(pairDir, { recursive: true });
+      const rolloutPath = join(root, "rollout.jsonl");
+      writeFileSync(rolloutPath, "{}\n");
+      writeFileSync(
+        join(pairDir, "current-thread.json"),
+        JSON.stringify({
+          version: 1,
+          status: "current",
+          pairId,
+          pairName: "main",
+          cwd,
+          threadId: "thread-resume-test",
+          updatedAt: new Date().toISOString(),
+          rolloutPath,
+        }),
+      );
+
+      const targets = resolveResumeTargets({ claudeHome });
+      expect(targets.claudeSessionId).toBe(sessionId);
+      expect(targets.codexThreadId).toBe("thread-resume-test");
+      expect(targets.pairName).toBe("main");
+    } finally {
+      if (previousBase === undefined) delete process.env.AGENTBRIDGE_BASE_DIR;
+      else process.env.AGENTBRIDGE_BASE_DIR = previousBase;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("returns nulls when nothing exists to resume", async () => {
+    const { resolveResumeTargets } = await import("../cli/resume");
+    const root = mkdtempSync(join(tmpdir(), "abg-resume-empty-"));
+    const previousBase = process.env.AGENTBRIDGE_BASE_DIR;
+    process.env.AGENTBRIDGE_BASE_DIR = join(root, "base");
+    try {
+      const targets = resolveResumeTargets({ claudeHome: join(root, "claude-home") });
+      expect(targets.claudeSessionId).toBeNull();
+      expect(targets.codexThreadId).toBeNull();
+    } finally {
+      if (previousBase === undefined) delete process.env.AGENTBRIDGE_BASE_DIR;
+      else process.env.AGENTBRIDGE_BASE_DIR = previousBase;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/unit-test/max-permissions.test.ts
+++ b/src/unit-test/max-permissions.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CLAUDE_MAX_PERMISSION_SUPPRESSORS,
+  CODEX_MAX_PERMISSION_SUPPRESSORS,
+  planMaxPermissions,
+} from "../cli/max-permissions";
+
+describe("planMaxPermissions", () => {
+  test("injects by default and passes args through", () => {
+    const plan = planMaxPermissions(["--resume", "abc"], CLAUDE_MAX_PERMISSION_SUPPRESSORS, {});
+    expect(plan.inject).toBe(true);
+    expect(plan.safeMode).toBe(false);
+    expect(plan.args).toEqual(["--resume", "abc"]);
+  });
+
+  test("--safe disables injection and is stripped from the forwarded args", () => {
+    const plan = planMaxPermissions(["--safe", "--resume", "abc"], CLAUDE_MAX_PERMISSION_SUPPRESSORS, {});
+    expect(plan.inject).toBe(false);
+    expect(plan.safeMode).toBe(true);
+    expect(plan.args).toEqual(["--resume", "abc"]);
+  });
+
+  test("AGENTBRIDGE_SAFE=1 disables injection", () => {
+    const plan = planMaxPermissions([], CLAUDE_MAX_PERMISSION_SUPPRESSORS, { AGENTBRIDGE_SAFE: "1" });
+    expect(plan.inject).toBe(false);
+    expect(plan.safeMode).toBe(true);
+  });
+
+  test("an explicitly passed flag suppresses injection (no double-add) without safe mode", () => {
+    const plan = planMaxPermissions(
+      ["--dangerously-skip-permissions"],
+      CLAUDE_MAX_PERMISSION_SUPPRESSORS,
+      {},
+    );
+    expect(plan.inject).toBe(false);
+    expect(plan.safeMode).toBe(false);
+    expect(plan.args).toEqual(["--dangerously-skip-permissions"]);
+  });
+
+  test("codex aliases: both --yolo and the long form suppress injection", () => {
+    for (const alias of ["--yolo", "--dangerously-bypass-approvals-and-sandbox"]) {
+      const plan = planMaxPermissions([alias], CODEX_MAX_PERMISSION_SUPPRESSORS, {});
+      expect(plan.inject).toBe(false);
+    }
+  });
+
+  test("explicit codex approval/sandbox preferences suppress injection (clap conflict guard)", () => {
+    // `codex -a never --yolo` is a hard clap conflict (verified on 0.139) —
+    // any explicit approval/sandbox flag must suppress the default.
+    for (const args of [
+      ["-a", "never"],
+      ["-a=never"],
+      ["--ask-for-approval", "untrusted"],
+      ["--ask-for-approval=never"],
+      ["-s", "read-only"],
+      ["--sandbox", "read-only"],
+      ["--sandbox=workspace-write"],
+    ]) {
+      const plan = planMaxPermissions(args, CODEX_MAX_PERMISSION_SUPPRESSORS, {});
+      expect(plan.inject).toBe(false);
+      expect(plan.safeMode).toBe(false);
+      expect(plan.args).toEqual(args);
+    }
+  });
+
+  test("explicit claude permission preferences suppress injection", () => {
+    for (const args of [
+      ["--permission-mode", "plan"],
+      ["--permission-mode=plan"],
+      ["--allow-dangerously-skip-permissions"],
+    ]) {
+      const plan = planMaxPermissions(args, CLAUDE_MAX_PERMISSION_SUPPRESSORS, {});
+      expect(plan.inject).toBe(false);
+    }
+  });
+
+  test("clap ATTACHED short-value forms suppress injection (-anever / -sread-only)", () => {
+    // clap parses `-anever` as `-a never` (verified on codex 0.139), so the
+    // attached form must suppress exactly like the spaced/`=` forms — round-2
+    // review caught `abg codex -anever` hard-conflicting with injected --yolo.
+    for (const args of [["-anever"], ["-sread-only"], ["-a=never"]]) {
+      const plan = planMaxPermissions(args, CODEX_MAX_PERMISSION_SUPPRESSORS, {});
+      expect(plan.inject).toBe(false);
+    }
+  });
+
+  test("long flags sharing a short suppressor's prefix do not suppress", () => {
+    // "--ask" / "--sandboxy" are NOT --ask-for-approval/--sandbox (exact or
+    // `=` only for long flags), and double-dash tokens never match the
+    // attached-short rule.
+    const plan = planMaxPermissions(["--ask", "--sandboxy"], CODEX_MAX_PERMISSION_SUPPRESSORS, {});
+    expect(plan.inject).toBe(true);
+  });
+
+  test("AGENTBRIDGE_SAFE values other than '1' do not disable", () => {
+    const plan = planMaxPermissions([], CODEX_MAX_PERMISSION_SUPPRESSORS, { AGENTBRIDGE_SAFE: "0" });
+    expect(plan.inject).toBe(true);
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary

**中文**：落地用户两项需求。① `abg resume`：无参打印本目录两侧恢复命令（Claude Code 最近会话 + 本 pair 已验证 Codex thread），`abg resume claude` / `abg resume codex` 直接执行恢复；② `abg claude` 默认带 `--dangerously-skip-permissions`、`abg codex` TUI 启动默认带 `--yolo`，不用每次手动加。

**English**: ① `abg resume` prints (or directly executes) the resume commands for this directory's last Claude Code session and the pair's verified Codex thread. ② `abg claude`/`abg codex` launch with max-permission flags by default.

## 安全阀 / Opt-outs（三层）

1. `--safe`（wrapper 旗标，剥离不透传）：单次关闭默认注入
2. `AGENTBRIDGE_SAFE=1`：持久关闭
3. **用户已显式表达任何权限偏好 → 自动不注入**：精确旗标 / `=值` / clap 贴附短值形式（`-anever`、`-sread-only`）全覆盖——向显式 `-a never` 注入 `--yolo` 是 codex clap 硬冲突（启动即崩），向显式 `--sandbox read-only` 注入是静默提权，均实测 codex 0.139 验证。非 TUI 子命令（`exec` 等）永不注入。

## 实现 / Implementation

- `src/cli/max-permissions.ts`：注入计划 + suppressor 匹配（precise/=/attached-short）
- `src/cli/resume.ts` + `src/claude-session.ts`：恢复目标解析（read-only pair 解析 + 已验证 thread state；uuid-only .jsonl 过滤；`CLAUDE_CONFIG_DIR` 感知）
- `abg resume claude|codex` 委派常规 launcher：pair 解析、冲突守卫、权限默认全部一致生效；`--pair` 以 `!== undefined` 透传（空串保留 → PAIR_ID_INVALID 与其他命令一致）
- README + help 同步（含 Owned flags 节的 `--safe` 说明）

## 测试 / Test plan

- [x] typecheck 清洁；全量 `bun run ci:local` **764 pass / 0 fail**
- [x] 新增 max-permissions 矩阵（贴附短旗帜正反两极）、claude-session 发现、buildCodexArgs yolo 定位（含非 TUI 排除 + legacy 形状等价）、resolveResumeTargets fixture；e2e harness 隔离 `AGENTBRIDGE_SAFE`；3 个 e2e argv 期望更新
- [x] Cross-review 3 轮 / 6 位全新 reviewer：修 4 个 REAL（harness env 泄漏、--pair truthiness、`-a` 空格形式 clap 冲突、`-anever` 贴附形式残留+错误测试前提）→ 第三轮双 0 REAL。全部旗标解析论断在 codex 0.139 + claude CLI 真机探测验证
- [x] 收敛后落实 2 个一行级 RECOMMEND（`||` 惯例对齐、help 文案），重跑 ci:local 全绿

## Backlog（reviewer RECOMMEND，不阻塞）

- codex 0.139 新子命令 doctor/archive/unarchive 未入 TUI/NON_TUI 集合（先于本 PR 存在的集合漂移）
- `--allowedTools` 灰区是否纳入 claude suppressor
- runResume 分支直接单测