### PR TITLE
refactor: 进程身份与存活判定收敛到单一模块 / consolidate process identity + liveness

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14228,7 +14228,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.10", "0.0.0-source"),
-  commit: defineString("10dfd58", "source"),
+  commit: defineString("51a44cb", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14485,7 +14485,7 @@ class DaemonClient extends EventEmitter2 {
 }
 
 // src/daemon-lifecycle.ts
-import { spawn, execFileSync } from "child_process";
+import { spawn } from "child_process";
 import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync2, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 
@@ -14500,6 +14500,41 @@ function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) 
     return fallback;
   }
   return parsed;
+}
+
+// src/process-lifecycle.ts
+import { execFileSync } from "child_process";
+function commandForPid(pid) {
+  try {
+    return execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
+  } catch {
+    return null;
+  }
+}
+function pidLooksAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0)
+    return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === "EPERM";
+  }
+}
+var isProcessAlive = pidLooksAlive;
+function isAgentBridgeDaemon(pid, lookup = commandForPid) {
+  const cmd = lookup(pid);
+  if (cmd === null)
+    return false;
+  const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
+  const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
+  return hasDaemonEntry && hasAgentbridge;
+}
+function isAgentBridgeProcess(pid, lookup = commandForPid) {
+  const cmd = lookup(pid);
+  if (cmd === null)
+    return false;
+  return cmd.includes("agentbridge") || cmd.includes("agent_bridge");
 }
 
 // src/daemon-lifecycle.ts
@@ -14601,7 +14636,7 @@ class DaemonLifecycle {
     const existingPid = this.readPid();
     if (existingPid) {
       if (isProcessAlive(existingPid)) {
-        if (this.isDaemonProcess(existingPid)) {
+        if (isAgentBridgeDaemon(existingPid)) {
           try {
             await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
@@ -14812,7 +14847,7 @@ class DaemonLifecycle {
             this.releaseLock();
             return this.acquireLockStrict(true);
           }
-          if (Number.isFinite(holderPid) && this.lockAgeMs() > LOCK_IDENTITY_GRACE_MS && !this.isAgentBridgeProcess(holderPid)) {
+          if (Number.isFinite(holderPid) && this.lockAgeMs() > LOCK_IDENTITY_GRACE_MS && !isAgentBridgeProcess(holderPid)) {
             this.log(`Startup lock is ${Math.round(this.lockAgeMs() / 1000)}s old and holder pid ${holderPid} ` + `is an unrelated process (pid recycled), reclaiming`);
             this.releaseLock();
             return this.acquireLockStrict(true);
@@ -14833,14 +14868,6 @@ class DaemonLifecycle {
       return 0;
     }
   }
-  isAgentBridgeProcess(pid) {
-    try {
-      const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-      return cmd.includes("agentbridge") || cmd.includes("agent_bridge");
-    } catch {
-      return false;
-    }
-  }
   releaseLock() {
     try {
       unlinkSync2(this.stateDir.lockFile);
@@ -14858,7 +14885,7 @@ class DaemonLifecycle {
       this.cleanup();
       return false;
     }
-    if (!this.isDaemonProcess(pid)) {
+    if (!isAgentBridgeDaemon(pid)) {
       this.log(`Pid ${pid} is alive but is NOT an AgentBridge daemon \u2014 refusing to kill. Cleaning up stale pid file.`);
       this.cleanup();
       return false;
@@ -14886,16 +14913,6 @@ class DaemonLifecycle {
     this.cleanup();
     return true;
   }
-  isDaemonProcess(pid) {
-    try {
-      const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-      const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
-      const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
-      return hasDaemonEntry && hasAgentbridge;
-    } catch {
-      return false;
-    }
-  }
   cleanup() {
     this.removePidFile();
     this.removeStatusFile();
@@ -14908,14 +14925,6 @@ async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
     return await fetch(url, { signal: controller.signal });
   } finally {
     clearTimeout(timer);
-  }
-}
-function isProcessAlive(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
   }
 }
 

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.10", "0.0.0-source"),
-  commit: defineString("10dfd58", "source"),
+  commit: defineString("51a44cb", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2225,7 +2225,7 @@ class TuiConnectionState {
 }
 
 // src/daemon-lifecycle.ts
-import { spawn as spawn2, execFileSync as execFileSync2 } from "child_process";
+import { spawn as spawn2 } from "child_process";
 import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync2, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
 
@@ -2240,6 +2240,41 @@ function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) 
     return fallback;
   }
   return parsed;
+}
+
+// src/process-lifecycle.ts
+import { execFileSync as execFileSync2 } from "child_process";
+function commandForPid(pid) {
+  try {
+    return execFileSync2("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
+  } catch {
+    return null;
+  }
+}
+function pidLooksAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0)
+    return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === "EPERM";
+  }
+}
+var isProcessAlive = pidLooksAlive;
+function isAgentBridgeDaemon(pid, lookup = commandForPid) {
+  const cmd = lookup(pid);
+  if (cmd === null)
+    return false;
+  const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
+  const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
+  return hasDaemonEntry && hasAgentbridge;
+}
+function isAgentBridgeProcess(pid, lookup = commandForPid) {
+  const cmd = lookup(pid);
+  if (cmd === null)
+    return false;
+  return cmd.includes("agentbridge") || cmd.includes("agent_bridge");
 }
 
 // src/daemon-lifecycle.ts
@@ -2341,7 +2376,7 @@ class DaemonLifecycle {
     const existingPid = this.readPid();
     if (existingPid) {
       if (isProcessAlive(existingPid)) {
-        if (this.isDaemonProcess(existingPid)) {
+        if (isAgentBridgeDaemon(existingPid)) {
           try {
             await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
@@ -2552,7 +2587,7 @@ class DaemonLifecycle {
             this.releaseLock();
             return this.acquireLockStrict(true);
           }
-          if (Number.isFinite(holderPid) && this.lockAgeMs() > LOCK_IDENTITY_GRACE_MS && !this.isAgentBridgeProcess(holderPid)) {
+          if (Number.isFinite(holderPid) && this.lockAgeMs() > LOCK_IDENTITY_GRACE_MS && !isAgentBridgeProcess(holderPid)) {
             this.log(`Startup lock is ${Math.round(this.lockAgeMs() / 1000)}s old and holder pid ${holderPid} ` + `is an unrelated process (pid recycled), reclaiming`);
             this.releaseLock();
             return this.acquireLockStrict(true);
@@ -2573,14 +2608,6 @@ class DaemonLifecycle {
       return 0;
     }
   }
-  isAgentBridgeProcess(pid) {
-    try {
-      const cmd = execFileSync2("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-      return cmd.includes("agentbridge") || cmd.includes("agent_bridge");
-    } catch {
-      return false;
-    }
-  }
   releaseLock() {
     try {
       unlinkSync2(this.stateDir.lockFile);
@@ -2598,7 +2625,7 @@ class DaemonLifecycle {
       this.cleanup();
       return false;
     }
-    if (!this.isDaemonProcess(pid)) {
+    if (!isAgentBridgeDaemon(pid)) {
       this.log(`Pid ${pid} is alive but is NOT an AgentBridge daemon \u2014 refusing to kill. Cleaning up stale pid file.`);
       this.cleanup();
       return false;
@@ -2626,16 +2653,6 @@ class DaemonLifecycle {
     this.cleanup();
     return true;
   }
-  isDaemonProcess(pid) {
-    try {
-      const cmd = execFileSync2("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-      const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
-      const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
-      return hasDaemonEntry && hasAgentbridge;
-    } catch {
-      return false;
-    }
-  }
   cleanup() {
     this.removePidFile();
     this.removeStatusFile();
@@ -2648,14 +2665,6 @@ async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
     return await fetch(url, { signal: controller.signal });
   } finally {
     clearTimeout(timer);
-  }
-}
-function isProcessAlive(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
   }
 }
 

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -1,9 +1,10 @@
-import { spawn, execFileSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { BUILD_INFO, compatibleContractVersion, formatBuildInfo, sameRuntimeContract } from "./build-info";
 import { StateDirResolver } from "./state-dir";
 import { parsePositiveIntEnv } from "./env-utils";
+import { isAgentBridgeDaemon, isAgentBridgeProcess, isProcessAlive } from "./process-lifecycle";
 import type { DaemonStatus } from "./control-protocol";
 
 // In source/dev mode this module is loaded from src/*.ts and can launch the
@@ -190,7 +191,7 @@ export class DaemonLifecycle {
     if (existingPid) {
       if (isProcessAlive(existingPid)) {
         // Verify the live process is actually our daemon, not an OS-reused PID
-        if (this.isDaemonProcess(existingPid)) {
+        if (isAgentBridgeDaemon(existingPid)) {
           try {
             await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
@@ -504,7 +505,7 @@ export class DaemonLifecycle {
           if (
             Number.isFinite(holderPid) &&
             this.lockAgeMs() > LOCK_IDENTITY_GRACE_MS &&
-            !this.isAgentBridgeProcess(holderPid)
+            !isAgentBridgeProcess(holderPid)
           ) {
             this.log(
               `Startup lock is ${Math.round(this.lockAgeMs() / 1000)}s old and holder pid ${holderPid} ` +
@@ -533,21 +534,6 @@ export class DaemonLifecycle {
     }
   }
 
-  /**
-   * Loose identity check for lock holders: launchers (CLI / plugin frontend)
-   * and daemons all carry agentbridge markers in their command line. Used only
-   * to detect OS pid recycling — NOT for kill decisions (kill() keeps the
-   * stricter daemon-entry match).
-   */
-  private isAgentBridgeProcess(pid: number): boolean {
-    try {
-      const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-      return cmd.includes("agentbridge") || cmd.includes("agent_bridge");
-    } catch {
-      return false;
-    }
-  }
-
   /** Release the startup lock file. */
   private releaseLock(): void {
     try {
@@ -562,7 +548,7 @@ export class DaemonLifecycle {
   async kill(gracefulTimeoutMs = 3000, pidOverride?: number): Promise<boolean> {
     // pidOverride lets us target a daemon reported via /healthz body whose pid file
     // we don't own (e.g. a foreign daemon squatting our control port). Falls back to
-    // the pid file. The isDaemonProcess() guard below still prevents killing a
+    // the pid file. The isAgentBridgeDaemon() guard below still prevents killing a
     // non-AgentBridge process if the OS reused the pid.
     const pid = pidOverride ?? this.readPid();
     if (!pid) {
@@ -580,7 +566,7 @@ export class DaemonLifecycle {
     // Verify the PID actually belongs to an AgentBridge daemon.
     // If the PID file is stale and the OS has reused the PID,
     // we must NOT kill an unrelated process.
-    if (!this.isDaemonProcess(pid)) {
+    if (!isAgentBridgeDaemon(pid)) {
       this.log(`Pid ${pid} is alive but is NOT an AgentBridge daemon — refusing to kill. Cleaning up stale pid file.`);
       this.cleanup();
       return false;
@@ -617,34 +603,6 @@ export class DaemonLifecycle {
   }
 
   /**
-   * Verify that a live PID actually belongs to an AgentBridge daemon
-   * by checking the process command line. Prevents killing an unrelated
-   * process when the OS has reused a stale PID.
-   */
-  private isDaemonProcess(pid: number): boolean {
-    // Verify via process command line that this PID is actually our daemon, not
-    // an OS-reused PID belonging to some unrelated process. Match on the
-    // executable basename being a daemon-role script (`daemon.{ts,js}` for
-    // production, `*-daemon.{ts,js}` for the e2e harness's fake) — NOT on the
-    // loose substring "daemon", which would also match e.g. a test file named
-    // `daemon-self-heal.test.ts` invoked by an IDE runner.
-    try {
-      const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-      // Match: .../<anything>-daemon.js or .../<anything>-daemon.ts as a runnable
-      // argument (preceded by whitespace/path-sep, followed by whitespace or EOL).
-      // We additionally require the command to mention the agentbridge package OR
-      // the repo dir to avoid matching some unrelated `*-daemon.js` from another
-      // project.
-      const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
-      const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
-      return hasDaemonEntry && hasAgentbridge;
-    } catch {
-      // ps failed — process may have exited between our check and the ps call
-      return false;
-    }
-  }
-
-  /**
    * Clean up daemon state files (pid + status). Does NOT touch the startup lock:
    * kill() runs INSIDE withStartupLockStrict's held section during a replace, and
    * releasing the lock here would let a concurrent launcher grab it mid-replace and
@@ -668,13 +626,6 @@ async function fetchWithTimeout(url: string, timeoutMs = HEALTH_FETCH_TIMEOUT_MS
   }
 }
 
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
+// Re-exported for the existing daemon-lifecycle.test.ts import surface. The
+// implementation now lives in process-lifecycle.ts (single source of truth).
 export { isProcessAlive };

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -20,6 +20,7 @@ import { createServer } from "node:net";
 import { createHash, randomUUID } from "node:crypto";
 import { hostname, userInfo } from "node:os";
 import { basename, join, resolve, sep } from "node:path";
+import { isAgentBridgeDaemon, pidLooksAlive } from "./process-lifecycle";
 
 /**
  * Pair registry — the single shared resource of the multi-pair feature.
@@ -346,21 +347,6 @@ function readLockOwner(lockFile: string): LockOwner | null {
   }
 }
 
-/** `process.kill(pid, 0)` liveness, but treat EPERM (exists, not signalable by us) as ALIVE. */
-function pidLooksAlive(pid: number): boolean {
-  // pid <= 0 is never a real holder: process.kill(0, 0) targets the current
-  // process GROUP and "succeeds", which would wrongly mark a corrupt
-  // `{pid:0}` lock as live and deadlock acquisition. Negatives are signal-broadcast
-  // semantics, not a pid. Treat all of these as dead so the lock is reclaimable.
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err: any) {
-    return err?.code === "EPERM";
-  }
-}
-
 function lockFileAgeMs(lockFile: string): number {
   try {
     return Date.now() - statSync(lockFile).mtimeMs;
@@ -571,19 +557,17 @@ export async function withRegistryLock<T>(base: string, fn: () => Promise<T> | T
 // Legacy-root daemon detection
 // ---------------------------------------------------------------------------
 
-function isDaemonProcess(pid: number): boolean {
-  try {
-    const cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
-    return cmd.includes("daemon") && (cmd.includes("agentbridge") || cmd.includes("agent_bridge"));
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Detect a pre-multi-pair daemon that wrote its pid directly at <base>/daemon.pid
  * (the classic single-pair layout) and is still alive on control port 4502.
  * Returns its pid, or null.
+ *
+ * Identity uses the shared strict {@link isAgentBridgeDaemon} matcher (anchored
+ * on a `daemon.{ts,js}` argv plus an agentbridge marker). This is a TIGHTENING
+ * over the former loose `cmd.includes("daemon")` check: a legacy root daemon was
+ * still spawned as `<bun> run <…>/daemon.{ts,js}` / `<…>/server/daemon.js` whose
+ * path carries an agentbridge marker, so it still matches — while an OS-reused
+ * pid that merely has "daemon" somewhere in its argv no longer false-positives.
  */
 export function detectLegacyRootDaemon(base: string): { pid: number; controlPort: number } | null {
   const rootPidFile = join(base, "daemon.pid");
@@ -595,7 +579,7 @@ export function detectLegacyRootDaemon(base: string): { pid: number; controlPort
   } catch {
     return null;
   }
-  if (!Number.isFinite(pid) || !pidLooksAlive(pid) || !isDaemonProcess(pid)) return null;
+  if (!Number.isFinite(pid) || !pidLooksAlive(pid) || !isAgentBridgeDaemon(pid)) return null;
   return { pid, controlPort: LEGACY_ROOT_CONTROL_PORT };
 }
 

--- a/src/process-lifecycle.ts
+++ b/src/process-lifecycle.ts
@@ -125,21 +125,103 @@ export function listBridgeFrontendProcesses(): ProcessListEntry[] {
   }
 }
 
-export function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export function commandForPid(pid: number): string | null {
   try {
     return execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8" }).trim();
   } catch {
     return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Process identity & liveness — the SINGLE source of truth
+//
+// These three helpers used to be re-implemented (with drifted semantics) in
+// daemon-lifecycle.ts and pair-registry.ts. They are consolidated here, next to
+// the `ps` parsing and the argv[0]-anchored `commandMatchesManagedCodexTui`
+// matcher, which is the project's most rigorous matcher template. All call sites
+// import from this module; do NOT re-add local copies.
+// ---------------------------------------------------------------------------
+
+/** A `ps` command-line lookup for a pid — injectable so the identity matchers are pure/testable. */
+export type CommandLookup = (pid: number) => string | null;
+
+/**
+ * `process.kill(pid, 0)` liveness with two deliberate hardenings, applied
+ * uniformly so every call site agrees:
+ *
+ *  - pid <= 0 (and non-integer) is NEVER a real holder. `process.kill(0, 0)`
+ *    targets the current process GROUP and "succeeds", which would wrongly mark
+ *    a corrupt `{pid:0}` pid file / lock as live and wedge acquisition forever.
+ *    Negatives carry signal-broadcast semantics, not a pid. Treat all as dead so
+ *    the slot/lock/pid file is reclaimable.
+ *  - EPERM (the process exists but we may not signal it) is treated as ALIVE.
+ *    On a single-user machine EPERM is near-unreachable, but if it does occur,
+ *    declaring an existing-but-unsignalable process dead and then stomping its
+ *    state is strictly worse than conservatively keeping it. This adopts
+ *    pair-registry's historical "EPERM = alive" choice; the previous
+ *    daemon-lifecycle/process-lifecycle copies wrongly treated EPERM as dead.
+ */
+export function pidLooksAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: any) {
+    return err?.code === "EPERM";
+  }
+}
+
+/**
+ * Backward-compatible alias for {@link pidLooksAlive}. Kept because many call
+ * sites and tests import `isProcessAlive`. Identical semantics — there is now a
+ * single liveness implementation (incl. the pid<=0 guard and EPERM = alive).
+ */
+export const isProcessAlive = pidLooksAlive;
+
+/**
+ * The SINGLE strict AgentBridge-daemon matcher, shared by daemon-lifecycle
+ * (kill / reuse identity guard) and pair-registry (legacy-root detection).
+ *
+ * Verifies via the process command line that `pid` is actually our daemon, not
+ * an OS-reused pid belonging to an unrelated process. It anchors on the
+ * executable basename being a daemon-role script (`daemon.{ts,js}` in
+ * production, `*-daemon.{ts,js}` for the e2e harness's fake) — NOT on the loose
+ * substring "daemon", which also matches e.g. a test file named
+ * `daemon-self-heal.test.ts` invoked by an IDE runner. It additionally requires
+ * an agentbridge marker so an unrelated `*-daemon.js` from another project is
+ * not matched.
+ *
+ * This is a behaviour TIGHTENING relative to pair-registry's former loose
+ * `cmd.includes("daemon")`. The legacy single-pair-root daemon is still spawned
+ * as `<bun> run <…>/daemon.{ts,js}` (dev) or `<…>/server/daemon.js` (bundled),
+ * whose path carries an `agentbridge`/`agent_bridge` marker, so the anchored
+ * pattern still catches it — see process-lifecycle.test.ts ("isAgentBridgeDaemon" block) for the proof cases.
+ *
+ * `lookup` defaults to a real `ps` call; tests inject a pure function.
+ */
+export function isAgentBridgeDaemon(pid: number, lookup: CommandLookup = commandForPid): boolean {
+  const cmd = lookup(pid);
+  if (cmd === null) return false;
+  // Match .../<anything>-daemon.js or .../<anything>-daemon.ts as a runnable
+  // argument (preceded by whitespace/path-sep, followed by whitespace or EOL).
+  const hasDaemonEntry = /(?:^|[\s/\\])[\w.-]*-?daemon\.(?:ts|js)(?:\s|$)/.test(cmd);
+  const hasAgentbridge = cmd.includes("agentbridge") || cmd.includes("agent_bridge");
+  return hasDaemonEntry && hasAgentbridge;
+}
+
+/**
+ * The general AgentBridge-process matcher (loose by design): launchers (CLI /
+ * plugin frontend) and daemons all carry an agentbridge marker. Used only to
+ * detect OS pid recycling of a STALE lock holder — NOT for kill decisions
+ * (kill paths use the stricter {@link isAgentBridgeDaemon}).
+ *
+ * `lookup` defaults to a real `ps` call; tests inject a pure function.
+ */
+export function isAgentBridgeProcess(pid: number, lookup: CommandLookup = commandForPid): boolean {
+  const cmd = lookup(pid);
+  if (cmd === null) return false;
+  return cmd.includes("agentbridge") || cmd.includes("agent_bridge");
 }
 
 export function terminateProcessSync(pid: number, options: TerminateProcessOptions = {}): boolean {

--- a/src/unit-test/process-lifecycle.test.ts
+++ b/src/unit-test/process-lifecycle.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   commandMatchesManagedCodexTui,
   parsePsProcessList,
   findManagedCodexTuiProcessesFromList,
   listManagedCodexTuiProcessesFromList,
+  pidLooksAlive,
+  isProcessAlive,
+  isAgentBridgeDaemon,
+  isAgentBridgeProcess,
 } from "../process-lifecycle";
 
 describe("process lifecycle helpers", () => {
@@ -101,5 +105,144 @@ describe("process lifecycle helpers", () => {
     const elsewhere = all.filter((t) => !commandMatchesManagedCodexTui(t.command, "ws://127.0.0.1:4501"));
     expect(here.map((t) => t.pid)).toEqual([201]);
     expect(elsewhere.map((t) => t.pid)).toEqual([202]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Consolidated process-identity & liveness (P1 drift fix)
+//
+// These cover the three matchers that previously had drifted copies in
+// daemon-lifecycle.ts and pair-registry.ts. The matchers take an injectable
+// command lookup so they stay pure (no real `ps` / processes).
+// ---------------------------------------------------------------------------
+
+describe("pidLooksAlive / isProcessAlive (unified liveness)", () => {
+  const realKill = process.kill;
+  afterEach(() => {
+    process.kill = realKill;
+  });
+
+  test("isProcessAlive is the same implementation as pidLooksAlive", () => {
+    expect(isProcessAlive).toBe(pidLooksAlive);
+  });
+
+  test("returns true for the current process", () => {
+    expect(pidLooksAlive(process.pid)).toBe(true);
+  });
+
+  test("returns false for a definitely-dead pid", () => {
+    expect(pidLooksAlive(2147483646)).toBe(false);
+  });
+
+  test("guards pid <= 0 — short-circuits BEFORE process.kill (never signals the group)", () => {
+    // process.kill(0, 0) signals the current process GROUP and would "succeed",
+    // so the guard MUST short-circuit before that call. Mock kill to throw EPERM
+    // (= ALIVE) AND record whether it ran: without the guard, pid<=0 would reach
+    // kill and be reported alive, so asserting BOTH returns-false AND kill-never-
+    // called makes a removed guard fail the test (the old plain-Error mock
+    // collapsed to false either way and let the mutation survive).
+    let killCalled = false;
+    process.kill = ((_pid: number, _signal?: string | number) => {
+      killCalled = true;
+      const err = new Error("operation not permitted") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    }) as typeof process.kill;
+    for (const pid of [0, -1, -process.pid]) {
+      killCalled = false;
+      expect(pidLooksAlive(pid)).toBe(false);
+      expect(killCalled).toBe(false);
+    }
+  });
+
+  test("rejects non-integer pids", () => {
+    expect(pidLooksAlive(Number.NaN)).toBe(false);
+    expect(pidLooksAlive(1.5)).toBe(false);
+  });
+
+  test("EPERM (exists but unsignalable) is treated as ALIVE", () => {
+    process.kill = ((_pid: number, _signal?: string | number) => {
+      const err = new Error("operation not permitted") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    }) as typeof process.kill;
+    expect(pidLooksAlive(4242)).toBe(true);
+  });
+
+  test("ESRCH (no such process) is treated as DEAD", () => {
+    process.kill = ((_pid: number, _signal?: string | number) => {
+      const err = new Error("no such process") as NodeJS.ErrnoException;
+      err.code = "ESRCH";
+      throw err;
+    }) as typeof process.kill;
+    expect(pidLooksAlive(4242)).toBe(false);
+  });
+});
+
+describe("isAgentBridgeDaemon (single strict daemon matcher)", () => {
+  const cmd = (command: string | null) => () => command;
+
+  test("matches a dev daemon.ts command line", () => {
+    expect(
+      isAgentBridgeDaemon(1, cmd("/usr/local/bin/bun run /Users/x/repo/agentbridge/src/daemon.ts")),
+    ).toBe(true);
+  });
+
+  test("matches a bundled daemon.js command line (agentbridge path marker)", () => {
+    expect(
+      isAgentBridgeDaemon(1, cmd("bun run /Users/x/.claude/plugins/agentbridge/server/daemon.js")),
+    ).toBe(true);
+  });
+
+  test("matches the legacy single-pair-root daemon shape (agent_bridge repo dir)", () => {
+    // Pre-multi-pair daemon spawned exactly like today: `<bun> run <…>/daemon.{ts,js}`.
+    // The path carries an agent_bridge marker, so the anchored matcher still catches it.
+    expect(
+      isAgentBridgeDaemon(1, cmd("/opt/homebrew/bin/bun run /Users/x/agent_bridge/src/daemon.ts")),
+    ).toBe(true);
+    expect(
+      isAgentBridgeDaemon(1, cmd("bun run /Users/x/agent_bridge/dist/daemon.js --foo")),
+    ).toBe(true);
+  });
+
+  test("matches the e2e harness's *-daemon fake", () => {
+    expect(
+      isAgentBridgeDaemon(1, cmd("bun run /tmp/agentbridge-e2e/fake-daemon.ts")),
+    ).toBe(true);
+  });
+
+  test("REJECTS the loose-substring false positive (a daemon-*.test.ts process)", () => {
+    // The pre-consolidation pair-registry copy used `cmd.includes("daemon")`,
+    // which would have classified this IDE-launched test process as the daemon.
+    // The anchored matcher must reject it: `daemon-self-heal.test.ts` is not a
+    // `*-daemon.{ts,js}` entry.
+    expect(
+      isAgentBridgeDaemon(1, cmd("bun test /Users/x/agentbridge/src/unit-test/daemon-self-heal.test.ts")),
+    ).toBe(false);
+  });
+
+  test("rejects a daemon.js from an unrelated project (no agentbridge marker)", () => {
+    expect(isAgentBridgeDaemon(1, cmd("node /opt/other-app/daemon.js"))).toBe(false);
+  });
+
+  test("rejects when the command lookup fails (process gone / ps error)", () => {
+    expect(isAgentBridgeDaemon(1, cmd(null))).toBe(false);
+  });
+});
+
+describe("isAgentBridgeProcess (general loose matcher)", () => {
+  const cmd = (command: string | null) => () => command;
+
+  test("matches any process carrying an agentbridge marker (launcher OR daemon)", () => {
+    expect(isAgentBridgeProcess(1, cmd("bun run /Users/x/agentbridge/src/cli.ts codex"))).toBe(true);
+    expect(isAgentBridgeProcess(1, cmd("node /Users/x/agent_bridge/bridge-server.js"))).toBe(true);
+  });
+
+  test("does not match an unrelated process", () => {
+    expect(isAgentBridgeProcess(1, cmd("/usr/bin/vim foo.txt"))).toBe(false);
+  });
+
+  test("rejects when the command lookup fails", () => {
+    expect(isAgentBridgeProcess(1, cmd(null))).toBe(false);
   });
 });

--- a/src/wrapper-exit-observability.ts
+++ b/src/wrapper-exit-observability.ts
@@ -18,6 +18,7 @@
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { pidLooksAlive } from "./process-lifecycle";
 
 export type RunCommand = (cmd: string, args: string[]) => string;
 
@@ -65,17 +66,9 @@ export function readTurnInProgress(
   }
 }
 
-function defaultIsPidAlive(pid: number): boolean {
-  if (pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    // EPERM = exists but not ours (not the case for our own daemon, but err
-    // on the side of "alive" like pair-registry's pidLooksAlive).
-    return (err as NodeJS.ErrnoException).code === "EPERM";
-  }
-}
+// Delegates to the consolidated liveness probe (pid<=0 guard + EPERM = alive),
+// the single source of truth in process-lifecycle.ts.
+const defaultIsPidAlive = pidLooksAlive;
 
 /**
  * Refine the clean-exit classification using the daemon-side turn state.


### PR DESCRIPTION
## 摘要 / Summary

架构审视 P1：进程身份与存活判定散在**四处**且语义已漂移。本 PR 收敛到 `process-lifecycle.ts` 单一模块。

| 漂移 | 修复 |
|---|---|
| daemon-lifecycle 用锚定正则 vs pair-registry 用松散 `includes("daemon")`（把 IDE 跑的测试进程误判为 daemon） | 统一 `isAgentBridgeDaemon`（单一锚定匹配器） |
| `pidLooksAlive` 一处 EPERM=alive + pid≤0 防护，另两处 EPERM=dead 无防护 | 统一 EPERM=ALIVE + pid≤0 守卫（文档化理由） |
| 第 4 处变体 wrapper-exit-observability `defaultIsPidAlive` | 改 delegate 到统一实现 |

**Bonus**：统一后修复了一处潜在 pid:0 lock-wedge（旧拷贝缺 pid≤0 守卫）。

松散→锚定的收紧是**故意的行为变化**，已证安全:legacy 单根 daemon 与当前 daemon spawn 方式相同(`<bun> run …/daemon.{ts,js}`),锚定匹配器 + agentbridge marker 仍命中每个真实形态;唯一被丢弃的是 `includes("daemon")` 的误报(daemon-self-heal.test.ts 之类)。

## 测试 / Test plan

- [x] typecheck 清洁；全量 `bun run ci:local` **760 pass / 0 fail**（+17 over master）
- [x] 新增 17 个收敛测试:松散误报现被拒;锚定匹配器仍命中 daemon.ts/bundled daemon.js/legacy/e2e 形态;EPERM=alive、ESRCH=dead;pid≤0 在 process.kill 之前短路(mutation-proof spy 断言)
- [x] Cross-review 第一轮**双 reviewer 0 REAL**:各自独立重跑 ci:local + mutation 测试匹配器 + 对照真机 daemon 与 9 个枚举 spawn 形态验证收紧安全。已应用两个 reviewer recommend(pid≤0 测试非空洞化 + doc 交叉引用修正)

## 风险 / Risk

低——纯重构 + 一处证明安全的故意收紧。EPERM=ALIVE 统一使两个 CLI 调用点(kill/codex)变得**更保守**(EPERM 落到身份检查而非跳过),无调用者被翻转到更差结果。