### PR TITLE
fix(security): WS upgrade 加 Origin 校验防 CSWSH / WS Origin guard against CSWSH

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14254,7 +14254,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("bbdc792", "source"),
+  commit: defineString("a2eb5fa", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("bbdc792", "source"),
+  commit: defineString("a2eb5fa", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -625,6 +625,25 @@ function buildTurnAbortedNotice(reason, replyWasRequired) {
   return `\u26A0\uFE0F Codex's current turn ended without completing (${reason}). ` + "This usually means Codex hit an error (e.g. a rate limit / 429), the app-server connection dropped, or the turn was interrupted." + tail;
 }
 
+// src/ws-origin-guard.ts
+var ALLOWED_ORIGINS_ENV = "AGENTBRIDGE_WS_ALLOWED_ORIGINS";
+function parseAllowedWsOrigins(env = process.env) {
+  const raw = env[ALLOWED_ORIGINS_ENV];
+  if (raw == null || raw === "")
+    return new Set;
+  const origins = raw.split(",").map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+  return new Set(origins);
+}
+function isAllowedWsUpgrade(req, allowedOrigins = parseAllowedWsOrigins()) {
+  const origin = req.headers.get("origin");
+  if (origin == null || origin === "")
+    return true;
+  return allowedOrigins.has(origin);
+}
+function wsOriginRejectedResponse() {
+  return new Response("Forbidden: WebSocket Origin not allowed", { status: 403 });
+}
+
 // src/codex-adapter.ts
 class CodexAdapter extends EventEmitter {
   static RESPONSE_TRACKING_TTL_MS = 30000;
@@ -1173,6 +1192,10 @@ class CodexAdapter extends EventEmitter {
             return new Response(up ? "ok" : "upstream not connected", { status: up ? 200 : 503 });
           }
           return fetch(`http://127.0.0.1:${self.appPort}${url.pathname}`);
+        }
+        if (isUpgrade && !isAllowedWsUpgrade(req)) {
+          self.log("Rejected WS upgrade on proxy port: Origin header present (possible CSWSH)");
+          return wsOriginRejectedResponse();
         }
         if (server.upgrade(req, { data: { connId: 0 } }))
           return;
@@ -4297,8 +4320,14 @@ function startControlServer() {
       if (url.pathname === "/readyz") {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: [] } })) {
-        return;
+      if (url.pathname === "/ws") {
+        if (!isAllowedWsUpgrade(req)) {
+          log("Rejected WS upgrade on control port: Origin header present (possible CSWSH)");
+          return wsOriginRejectedResponse();
+        }
+        if (server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: [] } })) {
+          return;
+        }
       }
       return new Response("AgentBridge daemon");
     },

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -47,6 +47,7 @@ import {
   ADAPTER_DISCONNECT_REASON,
   APP_SERVER_RECONNECT_NEW_TUI_REASON,
 } from "./turn-notices";
+import { isAllowedWsUpgrade, wsOriginRejectedResponse } from "./ws-origin-guard";
 
 interface TuiSocketData {
   connId: number;
@@ -920,6 +921,15 @@ export class CodexAdapter extends EventEmitter {
             return new Response(up ? "ok" : "upstream not connected", { status: up ? 200 : 503 });
           }
           return fetch(`http://127.0.0.1:${self.appPort}${url.pathname}`);
+        }
+        // CSWSH guard: reject any WS upgrade carrying an Origin header (browser
+        // page) before upgrading. The legitimate Codex TUI proxy client uses the
+        // Bun global WebSocket and sends no Origin — empirically verified, see
+        // ws-origin-guard.ts. The /healthz and /readyz GET endpoints above are
+        // not gated (they are plain HTTP, not upgrades).
+        if (isUpgrade && !isAllowedWsUpgrade(req)) {
+          self.log("Rejected WS upgrade on proxy port: Origin header present (possible CSWSH)");
+          return wsOriginRejectedResponse();
         }
         if (server.upgrade(req, { data: { connId: 0 } })) return undefined;
         self.log(`WARNING: non-upgrade HTTP request not handled: ${req.method} ${url.pathname}`);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -22,6 +22,7 @@ import {
   CLOSE_CODE_PROBE_IN_PROGRESS,
 } from "./control-protocol";
 import { parsePositiveIntEnv } from "./env-utils";
+import { isAllowedWsUpgrade, wsOriginRejectedResponse } from "./ws-origin-guard";
 import { ReplyRequiredTracker } from "./reply-required-tracker";
 import { persistCurrentThreadWithRolloutRetry } from "./thread-state";
 import { createProcessLogger } from "./process-log";
@@ -471,8 +472,18 @@ function startControlServer() {
         return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
       }
 
-      if (url.pathname === "/ws" && server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: [] } })) {
-        return undefined;
+      if (url.pathname === "/ws") {
+        // CSWSH guard: reject any WS upgrade carrying an Origin header (browser
+        // page) before upgrading. The legitimate CLI client (daemon-client.ts)
+        // uses the Bun global WebSocket and sends no Origin — empirically
+        // verified, see ws-origin-guard.ts. GET endpoints above are not gated.
+        if (!isAllowedWsUpgrade(req)) {
+          log("Rejected WS upgrade on control port: Origin header present (possible CSWSH)");
+          return wsOriginRejectedResponse();
+        }
+        if (server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: [] } })) {
+          return undefined;
+        }
       }
 
       return new Response("AgentBridge daemon");

--- a/src/unit-test/daemon-wiring.test.ts
+++ b/src/unit-test/daemon-wiring.test.ts
@@ -12,7 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createServer } from "node:net";
+import { createServer, connect, type Socket } from "node:net";
 import type { BridgeMessage } from "../types";
 import type { ControlServerMessage, DaemonStatus } from "../control-protocol";
 import { portsForSlot, type PairPorts } from "../pair-registry";
@@ -57,6 +57,32 @@ describe("daemon wiring", () => {
       await harness.close();
     }
   });
+
+  test("CSWSH guard: a WS upgrade carrying an Origin header is 403'd on BOTH the control and proxy ports, while no-Origin clients still connect", async () => {
+    const harness = await startHarness({ pairId: "main-cswshabcd", pairName: "main" });
+
+    // The no-Origin legit path must still work: attachClaude uses the Bun global
+    // WebSocket (control /ws) and connectTui uses it against the proxy. Both send
+    // no Origin and must succeed through the guard.
+    await harness.attachClaude();
+    await harness.connectTui();
+    expect(harness.controlWs?.readyState).toBe(WebSocket.OPEN);
+
+    // A browser-style upgrade (Origin present) must be rejected with 403 — never
+    // upgraded — on the control port (CSWSH against turn injection + readback)…
+    const controlStatus = await rawUpgradeStatus(harness.controlPort, "/ws", "http://evil.example");
+    expect(controlStatus).toContain("403");
+    expect(controlStatus).not.toContain("101");
+
+    // …and on the Codex proxy port (CSWSH against the Codex TUI relay).
+    const proxyStatus = await rawUpgradeStatus(harness.proxyPort, "/", "http://evil.example");
+    expect(proxyStatus).toContain("403");
+    expect(proxyStatus).not.toContain("101");
+
+    // /healthz is a plain GET, not an upgrade — the guard must not break it.
+    const healthz = await fetch(`http://127.0.0.1:${harness.controlPort}/healthz`);
+    expect(healthz.status).toBe(200);
+  }, 25000);
 
   test("waiting notice uses pair-aware waiting message formatting", async () => {
     const harness = await startHarness({ pairId: "main-testabcd", pairName: "main" });
@@ -698,6 +724,45 @@ async function startHarness(opts: {
   });
 
   return harness;
+}
+
+/**
+ * Drive a raw HTTP WS-upgrade handshake against a port with an explicit Origin
+ * header and return the response status line. A raw socket is the only way to
+ * attach an arbitrary Origin to the upgrade — the JS WebSocket constructor does
+ * not let us set it, but a browser always sends one.
+ */
+function rawUpgradeStatus(port: number, path: string, origin: string): Promise<string> {
+  const handshake =
+    `GET ${path} HTTP/1.1\r\n` +
+    "Host: 127.0.0.1\r\n" +
+    "Upgrade: websocket\r\n" +
+    "Connection: Upgrade\r\n" +
+    "Sec-WebSocket-Version: 13\r\n" +
+    "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+    `Origin: ${origin}\r\n` +
+    "\r\n";
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(port, "127.0.0.1", () => sock.write(handshake));
+    let buf = "";
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error("raw upgrade timeout"));
+    }, 5000);
+    sock.on("data", (d: Buffer) => {
+      buf += d.toString("utf8");
+      const nl = buf.indexOf("\r\n");
+      if (nl !== -1) {
+        clearTimeout(timer);
+        sock.destroy();
+        resolve(buf.slice(0, nl));
+      }
+    });
+    sock.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
 }
 
 function fakeCodexScript(): string {

--- a/src/unit-test/ws-origin-guard.test.ts
+++ b/src/unit-test/ws-origin-guard.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { connect, type Socket } from "node:net";
+import {
+  isAllowedWsUpgrade,
+  parseAllowedWsOrigins,
+  wsOriginRejectedResponse,
+} from "../ws-origin-guard";
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function reqWithHeaders(headers: Record<string, string>): Request {
+  return new Request("http://127.0.0.1/ws", { headers });
+}
+
+const WS_KEY = "dGhlIHNhbXBsZSBub25jZQ==";
+
+function upgradeHandshake(origin: string | null): string {
+  const originLine = origin === null ? "" : `Origin: ${origin}\r\n`;
+  return (
+    "GET /ws HTTP/1.1\r\n" +
+    "Host: 127.0.0.1\r\n" +
+    "Upgrade: websocket\r\n" +
+    "Connection: Upgrade\r\n" +
+    "Sec-WebSocket-Version: 13\r\n" +
+    `Sec-WebSocket-Key: ${WS_KEY}\r\n` +
+    originLine +
+    "\r\n"
+  );
+}
+
+/**
+ * Drive a raw HTTP WS-upgrade handshake against a port and return the first
+ * status line of the response. Sending a raw socket (not `new WebSocket`) is
+ * the only way to attach an arbitrary Origin header to the upgrade — a browser
+ * always sends one, but the JS WebSocket constructor does not let us set it.
+ */
+function rawUpgradeStatus(port: number, origin: string | null): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(port, "127.0.0.1", () => {
+      sock.write(upgradeHandshake(origin));
+    });
+    let buf = "";
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error("raw upgrade timeout"));
+    }, 5000);
+    sock.on("data", (d: Buffer) => {
+      buf += d.toString("utf8");
+      const nl = buf.indexOf("\r\n");
+      if (nl !== -1) {
+        clearTimeout(timer);
+        sock.destroy();
+        resolve(buf.slice(0, nl));
+      }
+    });
+    sock.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+}
+
+// ── pure-function policy unit tests ─────────────────────────────────────────
+
+describe("isAllowedWsUpgrade — default strict policy", () => {
+  test("absent Origin header → allowed (legitimate CLI / Bun WebSocket)", () => {
+    expect(isAllowedWsUpgrade(reqWithHeaders({}))).toBe(true);
+  });
+
+  test("empty-string Origin → allowed (Bun may surface '')", () => {
+    expect(isAllowedWsUpgrade(reqWithHeaders({ Origin: "" }))).toBe(true);
+  });
+
+  test("present non-empty Origin → rejected (browser CSWSH)", () => {
+    expect(isAllowedWsUpgrade(reqWithHeaders({ Origin: "http://evil.example" }))).toBe(false);
+  });
+
+  test("present Origin from a real browser localhost page → rejected by default", () => {
+    // Even a localhost page is rejected when no allowlist is configured: a
+    // malicious page served from any localhost port must not be trusted.
+    expect(isAllowedWsUpgrade(reqWithHeaders({ Origin: "http://localhost:3000" }))).toBe(false);
+  });
+});
+
+describe("isAllowedWsUpgrade — explicit allowlist", () => {
+  test("a listed Origin is permitted, an unlisted one still rejected", () => {
+    const allow = new Set(["app://agentbridge"]);
+    expect(isAllowedWsUpgrade(reqWithHeaders({ Origin: "app://agentbridge" }), allow)).toBe(true);
+    expect(isAllowedWsUpgrade(reqWithHeaders({ Origin: "http://evil.example" }), allow)).toBe(false);
+  });
+
+  test("allowlist never blocks the no-Origin path", () => {
+    const allow = new Set(["app://agentbridge"]);
+    expect(isAllowedWsUpgrade(reqWithHeaders({}), allow)).toBe(true);
+  });
+
+  test("exact-match only — a near-miss Origin is rejected", () => {
+    const allow = new Set(["https://app.example"]);
+    expect(isAllowedWsUpgrade(reqWithHeaders({ Origin: "https://app.example.evil.com" }), allow)).toBe(false);
+    expect(isAllowedWsUpgrade(reqWithHeaders({ Origin: "http://app.example" }), allow)).toBe(false);
+  });
+});
+
+describe("parseAllowedWsOrigins", () => {
+  test("absent env → empty allowlist (strict no-Origin-only default)", () => {
+    expect(parseAllowedWsOrigins({}).size).toBe(0);
+    expect(parseAllowedWsOrigins({ AGENTBRIDGE_WS_ALLOWED_ORIGINS: "" }).size).toBe(0);
+  });
+
+  test("comma-separated env is parsed, trimmed, and empties dropped", () => {
+    const set = parseAllowedWsOrigins({
+      AGENTBRIDGE_WS_ALLOWED_ORIGINS: " app://a , https://b.example ,, ",
+    });
+    expect([...set].sort()).toEqual(["app://a", "https://b.example"]);
+  });
+
+  test("env allowlist drives isAllowedWsUpgrade end to end", () => {
+    const allow = parseAllowedWsOrigins({ AGENTBRIDGE_WS_ALLOWED_ORIGINS: "app://ok" });
+    expect(isAllowedWsUpgrade(reqWithHeaders({ Origin: "app://ok" }), allow)).toBe(true);
+    expect(isAllowedWsUpgrade(reqWithHeaders({ Origin: "app://nope" }), allow)).toBe(false);
+  });
+});
+
+describe("wsOriginRejectedResponse", () => {
+  test("is an HTTP 403", () => {
+    expect(wsOriginRejectedResponse().status).toBe(403);
+  });
+});
+
+// ── integration: a Bun.serve wired exactly like production gates the upgrade ──
+
+const servers: Array<ReturnType<typeof Bun.serve>> = [];
+afterEach(() => {
+  while (servers.length) {
+    try {
+      servers.pop()!.stop(true);
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+/**
+ * Stand up a Bun.serve whose fetch handler mirrors BOTH production WS servers:
+ * a plain GET /healthz that must keep working, and a /ws upgrade that is gated
+ * by the shared guard. This is the structural contract both daemon.ts and
+ * codex-adapter.ts now share, exercised with real sockets.
+ */
+function startGuardedServer(): { server: ReturnType<typeof Bun.serve>; port: number } {
+  const server = Bun.serve<{ ok: true }>({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req, srv) {
+      const url = new URL(req.url);
+      if (url.pathname === "/healthz") {
+        return new Response("ok");
+      }
+      if (url.pathname === "/ws") {
+        if (!isAllowedWsUpgrade(req)) {
+          return wsOriginRejectedResponse();
+        }
+        if (srv.upgrade(req, { data: { ok: true } })) return undefined;
+      }
+      return new Response("fallback");
+    },
+    websocket: {
+      open() {},
+      message() {},
+    },
+  });
+  servers.push(server);
+  // server.port is always a concrete number once Bun.serve returns.
+  return { server, port: server.port as number };
+}
+
+describe("WS upgrade gating over a real socket", () => {
+  test("upgrade WITHOUT Origin completes the 101 handshake (legit CLI path)", async () => {
+    const server = startGuardedServer();
+    const status = await rawUpgradeStatus(server.port, null);
+    expect(status).toContain("101");
+  });
+
+  test("upgrade WITH a browser Origin is rejected 403, not upgraded", async () => {
+    const server = startGuardedServer();
+    const status = await rawUpgradeStatus(server.port, "http://evil.example");
+    expect(status).toContain("403");
+    expect(status).not.toContain("101");
+  });
+
+  test("GET /healthz is never gated (plain HTTP, not an upgrade)", async () => {
+    const server = startGuardedServer();
+    const res = await fetch(`http://127.0.0.1:${server.port}/healthz`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+
+  test("the legit global `new WebSocket` connects (sends no Origin)", async () => {
+    const server = startGuardedServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/ws`);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("ws connect timeout")), 5000);
+      ws.onopen = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        reject(new Error("ws connection rejected"));
+      };
+    });
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+});

--- a/src/ws-origin-guard.ts
+++ b/src/ws-origin-guard.ts
@@ -1,0 +1,99 @@
+/**
+ * CSWSH (cross-site WebSocket hijacking) Origin guard.
+ *
+ * Both Bun.serve WebSocket servers (daemon control port and the Codex proxy
+ * port) bind 127.0.0.1 but otherwise accept ANY WS upgrade. WebSocket
+ * handshakes are NOT subject to the browser same-origin policy, so a malicious
+ * web page open in the user's browser can `new WebSocket('ws://127.0.0.1:4502/ws')`,
+ * connect to the control port, inject turns AND read back Codex's
+ * agentMessages. This module gates the upgrade to block that vector.
+ *
+ * ── Policy ──────────────────────────────────────────────────────────────────
+ * A legitimate CLI client connects via the Bun/Node global `new WebSocket(url)`
+ * (see src/daemon-client.ts:58), which by default sends NO `Origin` request
+ * header. A browser page ALWAYS sends one. Therefore the default policy is:
+ *
+ *   - Origin header ABSENT (or empty string) → ALLOW.
+ *   - Origin header PRESENT (non-empty)      → REJECT (HTTP 403, do NOT upgrade),
+ *                                              unless it is in the allowlist.
+ *
+ * The allowlist exists for a future legitimate Origin-sending client (e.g. an
+ * Electron renderer) that can be permitted via env without a code change:
+ *   AGENTBRIDGE_WS_ALLOWED_ORIGINS  (comma-separated exact origins).
+ * Absent/empty env = strict no-Origin-only (the secure default). Setting the
+ * env permits the listed origins IN ADDITION to the no-Origin case; it never
+ * loosens the no-Origin path.
+ *
+ * ── Empirical verification (the "never assume protocol behavior" rule) ───────
+ * The whole policy rests on "Bun/Node `new WebSocket()` does NOT send an Origin
+ * header." This was verified empirically against Bun 1.3.11 in this worktree:
+ * a Bun.serve WS server logged `req.headers.get("origin")` while a client
+ * connected with the SAME global `new WebSocket(url)` class that
+ * daemon-client.ts uses — the received Origin was `null`
+ * (`hasHeader === false`). The OTHER production consumer is the real Codex TUI
+ * Rust binary connecting to the proxy port via `--remote`; PTY-launching the
+ * actual codex-cli 0.139.0 against a raw-socket logger captured its WS upgrade
+ * carrying NO Origin header either (confirmed in cross-review — the proxy
+ * consumer most likely to drift on a codex upgrade). So the no-Origin allow
+ * path keeps both legitimate clients — CLI reconnect AND Codex TUI proxy —
+ * working. If a future Bun/codex version starts sending an Origin, this guard
+ * would reject those legit clients and the fix is to add that exact Origin to
+ * AGENTBRIDGE_WS_ALLOWED_ORIGINS (or switch to a capability token —
+ * codex-rs already exposes `--remote-auth-token-env`) — re-run the probe
+ * before trusting it.
+ */
+
+const ALLOWED_ORIGINS_ENV = "AGENTBRIDGE_WS_ALLOWED_ORIGINS";
+
+/**
+ * Parse the comma-separated allowlist from an env map into a Set of exact
+ * origin strings. Entries are trimmed; empty entries are dropped. The result is
+ * an exact-match allowlist (no wildcards, no scheme/host normalization) — an
+ * attacker-controlled page cannot match unless its Origin string is byte-for-byte
+ * present, which the operator must opt into explicitly.
+ */
+export function parseAllowedWsOrigins(
+  env: NodeJS.ProcessEnv = process.env,
+): ReadonlySet<string> {
+  const raw = env[ALLOWED_ORIGINS_ENV];
+  if (raw == null || raw === "") return new Set();
+  const origins = raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return new Set(origins);
+}
+
+/**
+ * Decide whether a WS upgrade request is allowed by the Origin policy.
+ *
+ * @param req           The incoming upgrade Request.
+ * @param allowedOrigins Exact-match allowlist of Origins that may send a
+ *                       non-empty Origin header (defaults to the env allowlist).
+ * @returns `true` if the upgrade may proceed, `false` if it must be rejected.
+ */
+export function isAllowedWsUpgrade(
+  req: Request,
+  allowedOrigins: ReadonlySet<string> = parseAllowedWsOrigins(),
+): boolean {
+  const origin = req.headers.get("origin");
+
+  // No Origin header at all → a non-browser client (CLI / Bun WebSocket).
+  // Empty-string Origin → treat the same as absent: some clients/proxies may
+  // surface "" and it carries no cross-site identity. The secure default
+  // allows both, matching the empirically-verified legitimate CLI path.
+  if (origin == null || origin === "") return true;
+
+  // A non-empty Origin means a browser (or browser-like) client. Reject unless
+  // the operator explicitly allowlisted this exact Origin.
+  return allowedOrigins.has(origin);
+}
+
+/**
+ * Build the HTTP 403 Response returned when a WS upgrade is rejected by the
+ * Origin policy. Returned in the fetch handler INSTEAD of calling
+ * `server.upgrade`, so the socket is never upgraded.
+ */
+export function wsOriginRejectedResponse(): Response {
+  return new Response("Forbidden: WebSocket Origin not allowed", { status: 403 });
+}


### PR DESCRIPTION
## 摘要 / Summary

**架构审视 P1（high · security）**：daemon 控制端口与 codex-adapter 代理端口的两个 `Bun.serve` 都只绑 127.0.0.1，但对 WS upgrade **不做任何 Origin 校验**。WebSocket 握手不受同源策略约束 → 用户浏览器里任意恶意页面可 `new WebSocket('ws://127.0.0.1:4502/ws')` 连上控制端口，**双向注入 turn 并读回 Codex 的 agentMessage**（CSWSH，跨站 WebSocket 劫持）。

## 修复 / Fix

共享 `src/ws-origin-guard.ts`（`isAllowedWsUpgrade`），两个 server 在 `server.upgrade` 前复用:Origin 头**存在即 403 拒绝**(浏览器必发;CLI 的 Bun/Node `new WebSocket()` 不发)。可选 `AGENTBRIDGE_WS_ALLOWED_ORIGINS` 白名单留给未来会发 Origin 的合法客户端。GET `/healthz`/`/readyz` 永不被 gate。

**关键假设已实证(steer-expectedTurnId 教训:绝不假设协议行为)**:
- Bun 1.3.11 global `new WebSocket` → `Origin: null`
- **PTY 启动真实 codex-cli 0.139.0 `--remote`** upgrade → 无 Origin 头(代理端口最可能漂移的生产消费者,cross-review 中实证)

## 测试 / Test plan

- [x] typecheck 清洁;全量 `bun run ci:local` **759 pass / 0 fail**(+16)
- [x] 新增 16 个:纯策略 + env 白名单 + raw-socket 集成(带 Origin 的 upgrade 在**两个端口**都得 403 而非 101;无 Origin 仍连通;`/healthz` GET 仍 200);e2e-reconnect 保持 8/8
- [x] Cross-review 第一轮**双 reviewer 0 REAL**:各自独立重跑 ci:local、PTY 探测真实 codex TUI、确认无绕过(Origin 是浏览器 forbidden header JS 无法抑制;大小写不敏感匹配;两个 upgrade 入口都 gate;无合法路径被破坏)

## Backlog（reviewer 标注，本 PR 范围外）

- `/healthz`/`/readyz` 仍向本机页面泄漏 currentStatus（GET，非 WS）
- WS 能力令牌(codex-rs 已暴露 `--remote-auth-token-env`)作为 Origin 之上的纵深防御