### PR TITLE
feat: 新增 abg logs 命令——故障恢复最后一公里 / add abg logs command

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14231,7 +14231,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("48eb0ed", "source"),
+  commit: defineString("63c4412", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("48eb0ed", "source"),
+  commit: defineString("63c4412", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,11 +16,11 @@ export const MARKETPLACE_NAME = "agentbridge";
 export const PLUGIN_NAME = "agentbridge";
 
 /** Commands that print an update notice. claude/codex/resume also trigger the daily refresh. */
-const REFRESH_COMMANDS = new Set(["claude", "codex", "resume"]);
-const NOTIFY_COMMANDS = new Set(["claude", "codex", "init", "dev", "resume"]);
+export const REFRESH_COMMANDS = new Set(["claude", "codex", "resume"]);
+export const NOTIFY_COMMANDS = new Set(["claude", "codex", "init", "dev", "resume"]);
 
 /** Subcommands that accept a `--pair <name>` selector. */
-const PAIR_AWARE_COMMANDS = new Set(["claude", "codex", "kill", "doctor", "budget", "resume"]);
+export const PAIR_AWARE_COMMANDS = new Set(["claude", "codex", "kill", "doctor", "budget", "resume", "logs"]);
 
 /**
  * Split argv into the subcommand and its args, allowing a leading `--pair <name>`
@@ -112,6 +112,10 @@ async function main(command: string | undefined, restArgs: string[]) {
       const { runBudget } = await import("./cli/budget");
       await runBudget(restArgs);
       break;
+    case "logs":
+      const { runLogs } = await import("./cli/logs");
+      await runLogs(restArgs);
+      break;
     case "--help":
     case "-h":
     case undefined:
@@ -151,6 +155,9 @@ Commands:
   doctor [--json]    Diagnose env, daemon, build drift, logs, and current thread
   doctor resume-pollution [--apply]  Find/fix old AgentBridge kickoff metadata
   budget [--json]    Show both agents' subscription quota snapshot (5h/weekly, drift, pause state)
+  logs [--codex] [-f] [-n N]
+                     Tail this pair's daemon log (or the codex wrapper log with
+                     --codex). -n N: last N lines (default 100). -f: follow/stream.
   kill [all | --all | --pair <name|id>]
                      Stop this directory's pairs (default), every pair (all/--all), or one (--pair)
 
@@ -189,6 +196,10 @@ Examples:
   abg pairs                    # List all pairs and their ports/status
   abg pairs --threads          # Include current thread mapping
   abg doctor --json            # Emit a structured diagnostics report
+  abg logs                     # Tail the last 100 lines of this pair's daemon log
+  abg logs -f -n 200           # Follow the log, starting from the last 200 lines
+  abg logs --codex             # Tail the codex wrapper log instead
+  abg --pair work logs         # Tail the "work" pair's daemon log
   abg pairs rm work            # Stop this directory's "work" pair and free its slot
   abg pairs rm work-1a2b3c4d   # ...or by its full id (from that pair's directory)
   abg pairs prune --dry-run    # Preview orphan pair dirs (no registry entry, not live)

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,0 +1,223 @@
+/**
+ * `abg logs` — tail a pair's daemon log (or the codex wrapper log).
+ *
+ * Read-only and pair-aware: resolves the pair via resolvePairReadOnly (same path
+ * as `abg doctor` / `abg budget`), so it NEVER writes the registry or any state.
+ * It turns doctor's dead-end "check the daemon log below" hint into a one-liner:
+ * instead of printing an absolute path + byte count and leaving the user to
+ * hand-craft a `tail` command (and first figure out which pairId they're in with
+ * multiple pairs), `abg logs` resolves the right log for the current pair and
+ * prints it.
+ *
+ *   abg [--pair <name>] logs [--codex] [-f] [-n N]
+ *
+ *   --codex   read the codex wrapper log (codex-wrapper.log) instead of the
+ *             daemon log (agentbridge.log).
+ *   -n N      print the last N lines (positive integer; default 100).
+ *   -f        follow mode — stream new lines as they are appended.
+ *
+ * Follow mode shells out to `tail -f -n N <path>` (the project is darwin/linux
+ * only, where `tail -f` is universally available). Args are passed as an array —
+ * never a shell string — so the resolved path cannot be interpreted by a shell.
+ * stdio is inherited, so Ctrl-C (SIGINT) reaches the child `tail` directly and
+ * tears it down cleanly; this process exits with the child's status.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { parsePairFlag, type ReadOnlyPairResolution, resolvePairReadOnly } from "../pair-resolver";
+
+const DEFAULT_LINES = 100;
+
+interface LogsOptions {
+  codex: boolean;
+  follow: boolean;
+  lines: number;
+}
+
+/**
+ * Parse `abg logs` flags. `--pair` is stripped upstream (parsePairFlag); this
+ * only sees the command-local flags.
+ *
+ * `-n` requires a strictly positive integer. A missing/garbage value is a user
+ * error (thrown), not a silent fallback, so a typo never tails the wrong amount.
+ */
+export function parseLogsArgs(args: string[]): LogsOptions {
+  let codex = false;
+  let follow = false;
+  let lines = DEFAULT_LINES;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--codex") {
+      codex = true;
+      continue;
+    }
+    if (a === "-f" || a === "--follow") {
+      follow = true;
+      continue;
+    }
+    if (a === "-n" || a === "--lines") {
+      const next = args[i + 1];
+      if (next === undefined) {
+        throw new Error(`${a} requires a positive integer (e.g. ${a} 200)`);
+      }
+      lines = parsePositiveInt(next, a);
+      i++;
+      continue;
+    }
+    if (a.startsWith("-n")) {
+      // `-n200` (attached value).
+      lines = parsePositiveInt(a.slice(2), "-n");
+      continue;
+    }
+    if (a.startsWith("--lines=")) {
+      lines = parsePositiveInt(a.slice("--lines=".length), "--lines");
+      continue;
+    }
+    throw new Error(`Unknown logs flag: ${a}`);
+  }
+
+  return { codex, follow, lines };
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  // Reject non-integers and non-positives. `Number.parseInt("12abc")` would
+  // accept "12", so test the whole token with a strict integer regex first.
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`${flag} must be a positive integer, got "${raw}"`);
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`${flag} must be a positive integer, got "${raw}"`);
+  }
+  return n;
+}
+
+/** Return the last `count` lines of `text`, preserving order. */
+export function tailLines(text: string, count: number): string[] {
+  // Normalise a single trailing newline so it does not produce a spurious
+  // empty final line (a log file almost always ends in "\n").
+  const body = text.endsWith("\n") ? text.slice(0, -1) : text;
+  if (body.length === 0) return [];
+  const all = body.split("\n");
+  return all.length <= count ? all : all.slice(all.length - count);
+}
+
+export async function runLogs(args: string[]) {
+  const { pairFlag } = parsePairFlag(args);
+  const rest = stripPairTokens(args);
+
+  let options: LogsOptions;
+  try {
+    options = parseLogsArgs(rest);
+  } catch (err) {
+    console.error(`[agentbridge] ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+    return;
+  }
+
+  let resolution: ReadOnlyPairResolution;
+  try {
+    resolution = resolvePairReadOnly(pairFlag);
+  } catch (err) {
+    console.error(`[agentbridge] ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+    return;
+  }
+  const { pair } = resolution;
+
+  const logPath = options.codex ? pair.stateDir.codexWrapperLogFile : pair.stateDir.logFile;
+  const logLabel = options.codex ? "codex wrapper log" : "daemon log";
+
+  if (!existsSync(logPath)) {
+    const which = options.codex ? "codex wrapper log" : "daemon log";
+    console.error(
+      `no ${which} for pair ${pair.name} yet — start it with \`abg claude\` (${logPath})`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  if (options.follow) {
+    await followLog(logPath, options.lines);
+    return;
+  }
+
+  printTail(logPath, options.lines, logLabel, pair.name);
+}
+
+function printTail(logPath: string, count: number, label: string, pairName: string) {
+  let text: string;
+  try {
+    text = readFileSync(logPath, "utf8");
+  } catch (err) {
+    console.error(
+      `[agentbridge] failed to read ${label} for pair ${pairName}: ` +
+        `${err instanceof Error ? err.message : String(err)} (${logPath})`,
+    );
+    process.exit(1);
+    return;
+  }
+  // A corrupt/huge log is still safe to read fully here: tailLines only keeps
+  // the last N entries, so the output is bounded regardless of file size.
+  const lines = tailLines(text, count);
+  for (const line of lines) console.log(line);
+}
+
+/**
+ * Stream the log via `tail -f -n N <path>`.
+ *
+ * Resolves only when the child exits. The path is passed as an argv element (no
+ * shell), and stdio is inherited so SIGINT (Ctrl-C) reaches `tail` directly and
+ * this process mirrors the child's exit status.
+ */
+export function followLog(logPath: string, count: number): Promise<void> {
+  return new Promise((resolvePromise) => {
+    const child = spawn("tail", ["-f", "-n", String(count), logPath], {
+      stdio: "inherit",
+    });
+
+    // If `tail` cannot be spawned (missing binary, unlikely on darwin/linux),
+    // fail loudly with a non-zero exit instead of hanging.
+    child.on("error", (err) => {
+      console.error(`[agentbridge] failed to follow log: ${err.message}`);
+      process.exit(1);
+    });
+
+    child.on("exit", (code, signal) => {
+      // Mirror the child's status. SIGINT (Ctrl-C) is the normal way to stop a
+      // follow; treat a clean signal-stop as a successful exit so Ctrl-C does
+      // not look like an error.
+      if (signal === "SIGINT" || signal === "SIGTERM") {
+        resolvePromise();
+        return;
+      }
+      if (code != null && code !== 0) {
+        process.exit(code);
+        return;
+      }
+      resolvePromise();
+    });
+  });
+}
+
+/**
+ * Drop `--pair <name>` / `--pair=<name>` tokens, leaving the logs-local flags.
+ * parsePairFlag already extracts the value; this removes the same tokens from
+ * the arg list so parseLogsArgs never sees them.
+ */
+function stripPairTokens(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--pair") {
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith("-")) i++; // skip the value too
+      continue;
+    }
+    if (a.startsWith("--pair=")) continue;
+    out.push(a);
+  }
+  return out;
+}

--- a/src/unit-test/cli-toplevel.test.ts
+++ b/src/unit-test/cli-toplevel.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { parseTopLevel } from "../cli";
+import {
+  NOTIFY_COMMANDS,
+  PAIR_AWARE_COMMANDS,
+  REFRESH_COMMANDS,
+  parseTopLevel,
+} from "../cli";
 
 describe("parseTopLevel — leading --pair before the subcommand", () => {
   test("no args → undefined command", () => {
@@ -84,5 +89,28 @@ describe("parseTopLevel — budget is pair-aware", () => {
       command: "budget",
       restArgs: ["--json"],
     });
+  });
+});
+
+describe("parseTopLevel — logs is pair-aware", () => {
+  test("leading --pair is re-attached for logs", () => {
+    expect(parseTopLevel(["--pair", "work", "logs", "-f"])).toEqual({
+      command: "logs",
+      restArgs: ["--pair", "work", "-f"],
+    });
+  });
+
+  test("logs without --pair passes args through", () => {
+    expect(parseTopLevel(["logs", "-n", "200", "--codex"])).toEqual({
+      command: "logs",
+      restArgs: ["-n", "200", "--codex"],
+    });
+  });
+
+  test("logs is registered as pair-aware but NOT as a notify/refresh command", () => {
+    // A read-only log tail must never trigger the daily update check/notice.
+    expect(PAIR_AWARE_COMMANDS.has("logs")).toBe(true);
+    expect(NOTIFY_COMMANDS.has("logs")).toBe(false);
+    expect(REFRESH_COMMANDS.has("logs")).toBe(false);
   });
 });

--- a/src/unit-test/logs-cli.test.ts
+++ b/src/unit-test/logs-cli.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseLogsArgs, runLogs, tailLines } from "../cli/logs";
+import { listPairs } from "../pair-resolver";
+import { derivePairId } from "../pair-registry";
+
+const ENV_KEYS = [
+  "AGENTBRIDGE_BASE_DIR",
+  "AGENTBRIDGE_PAIR_ID",
+  "AGENTBRIDGE_PAIR_NAME",
+  "AGENTBRIDGE_STATE_DIR",
+  "AGENTBRIDGE_CONTROL_PORT",
+  "AGENTBRIDGE_MANUAL",
+  "CODEX_WS_PORT",
+  "CODEX_PROXY_PORT",
+] as const;
+
+const EXIT = Symbol("process.exit");
+
+let savedEnv: Record<string, string | undefined>;
+let previousCwd: string;
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  savedEnv = {};
+  previousCwd = process.cwd();
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  originalLog = console.log;
+  originalError = console.error;
+  originalExit = process.exit;
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+  process.chdir(previousCwd);
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function captureLogs(args: string[]) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | undefined;
+  console.log = (...parts: unknown[]) => {
+    stdout.push(parts.map(String).join(" "));
+  };
+  console.error = (...parts: unknown[]) => {
+    stderr.push(parts.map(String).join(" "));
+  };
+  process.exit = ((code?: string | number | null | undefined) => {
+    exitCode = typeof code === "number" ? code : Number(code ?? 0);
+    throw EXIT;
+  }) as typeof process.exit;
+
+  try {
+    await runLogs(args);
+  } catch (err) {
+    if (err !== EXIT) throw err;
+  }
+  return { stdout, stderr: stderr.join("\n"), exitCode };
+}
+
+/**
+ * Register a pair in the registry by running a real launch path would be heavy;
+ * instead, set up the on-disk state dir for the cwd-derived "main" pair and seed
+ * its log file. resolvePairReadOnly resolves an unregistered pair to its derived
+ * state dir, so a log written there is found WITHOUT any registry write — exactly
+ * the read-only contract under test.
+ */
+function seedDaemonLog(base: string, cwd: string, name: string, contents: string): string {
+  const pairId = derivePairId(cwd, name);
+  const pairDir = join(base, "pairs", pairId);
+  mkdirSync(pairDir, { recursive: true });
+  const logPath = join(pairDir, "agentbridge.log");
+  writeFileSync(logPath, contents, "utf8");
+  return logPath;
+}
+
+function seedCodexWrapperLog(base: string, cwd: string, name: string, contents: string): string {
+  const pairId = derivePairId(cwd, name);
+  const pairDir = join(base, "pairs", pairId);
+  mkdirSync(pairDir, { recursive: true });
+  const logPath = join(pairDir, "codex-wrapper.log");
+  writeFileSync(logPath, contents, "utf8");
+  return logPath;
+}
+
+describe("parseLogsArgs", () => {
+  test("defaults: daemon log, no follow, 100 lines", () => {
+    expect(parseLogsArgs([])).toEqual({ codex: false, follow: false, lines: 100 });
+  });
+
+  test("--codex selects the wrapper log", () => {
+    expect(parseLogsArgs(["--codex"]).codex).toBe(true);
+  });
+
+  test("-f / --follow set follow mode", () => {
+    expect(parseLogsArgs(["-f"]).follow).toBe(true);
+    expect(parseLogsArgs(["--follow"]).follow).toBe(true);
+  });
+
+  test("-n N sets the line count", () => {
+    expect(parseLogsArgs(["-n", "50"]).lines).toBe(50);
+    expect(parseLogsArgs(["-n50"]).lines).toBe(50);
+    expect(parseLogsArgs(["--lines", "25"]).lines).toBe(25);
+    expect(parseLogsArgs(["--lines=25"]).lines).toBe(25);
+  });
+
+  test("flags combine", () => {
+    expect(parseLogsArgs(["--codex", "-f", "-n", "5"])).toEqual({
+      codex: true,
+      follow: true,
+      lines: 5,
+    });
+  });
+
+  test("-n rejects zero, negatives, and non-integers", () => {
+    expect(() => parseLogsArgs(["-n", "0"])).toThrow(/positive integer/);
+    expect(() => parseLogsArgs(["-n", "-5"])).toThrow(/positive integer/);
+    expect(() => parseLogsArgs(["-n", "3.5"])).toThrow(/positive integer/);
+    expect(() => parseLogsArgs(["-n", "abc"])).toThrow(/positive integer/);
+    expect(() => parseLogsArgs(["-n", "12abc"])).toThrow(/positive integer/);
+  });
+
+  test("-n with no value is a user error", () => {
+    expect(() => parseLogsArgs(["-n"])).toThrow(/positive integer/);
+  });
+
+  test("unknown flags are rejected", () => {
+    expect(() => parseLogsArgs(["--bogus"])).toThrow(/Unknown logs flag/);
+  });
+});
+
+describe("tailLines", () => {
+  test("returns the last N lines in order", () => {
+    expect(tailLines("a\nb\nc\nd\n", 2)).toEqual(["c", "d"]);
+  });
+
+  test("a file shorter than N returns all its lines", () => {
+    expect(tailLines("a\nb\n", 10)).toEqual(["a", "b"]);
+  });
+
+  test("handles a missing trailing newline", () => {
+    expect(tailLines("a\nb\nc", 2)).toEqual(["b", "c"]);
+  });
+
+  test("empty file yields no lines", () => {
+    expect(tailLines("", 5)).toEqual([]);
+    expect(tailLines("\n", 5)).toEqual([]);
+  });
+});
+
+describe("logs command (non-follow)", () => {
+  test("prints the last N lines of the resolved daemon log", async () => {
+    const root = makeTempDir("agentbridge-logs-root-");
+    const base = makeTempDir("agentbridge-logs-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    const body = Array.from({ length: 10 }, (_, i) => `line-${i + 1}`).join("\n") + "\n";
+    seedDaemonLog(base, process.cwd(), "main", body);
+
+    const result = await captureLogs(["-n", "3"]);
+
+    expect(result.exitCode).toBeUndefined();
+    expect(result.stdout).toEqual(["line-8", "line-9", "line-10"]);
+    expect(result.stderr).toBe("");
+    // Read-only: no registry entry was written.
+    expect(listPairs(base)).toEqual([]);
+  });
+
+  test("a file shorter than N tails the whole file", async () => {
+    const root = makeTempDir("agentbridge-logs-root-");
+    const base = makeTempDir("agentbridge-logs-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    seedDaemonLog(base, process.cwd(), "main", "only-one\n");
+
+    const result = await captureLogs(["-n", "100"]);
+
+    expect(result.stdout).toEqual(["only-one"]);
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  test("--codex reads the codex wrapper log", async () => {
+    const root = makeTempDir("agentbridge-logs-root-");
+    const base = makeTempDir("agentbridge-logs-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    // Seed BOTH logs with distinct content; --codex must pick the wrapper one.
+    seedDaemonLog(base, process.cwd(), "main", "DAEMON\n");
+    seedCodexWrapperLog(base, process.cwd(), "main", "WRAPPER\n");
+
+    const result = await captureLogs(["--codex"]);
+
+    expect(result.stdout).toEqual(["WRAPPER"]);
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  test("missing daemon log → clear message + non-zero exit", async () => {
+    const root = makeTempDir("agentbridge-logs-root-");
+    const base = makeTempDir("agentbridge-logs-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    const result = await captureLogs([]);
+
+    expect(result.stdout).toEqual([]);
+    expect(result.stderr).toContain("no daemon log for pair main yet");
+    expect(result.stderr).toContain("abg claude");
+    expect(result.exitCode).toBe(1);
+    expect(listPairs(base)).toEqual([]);
+  });
+
+  test("missing codex wrapper log → wrapper-specific message + non-zero exit", async () => {
+    const root = makeTempDir("agentbridge-logs-root-");
+    const base = makeTempDir("agentbridge-logs-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    // Daemon log exists but the wrapper log does not.
+    seedDaemonLog(base, process.cwd(), "main", "DAEMON\n");
+
+    const result = await captureLogs(["--codex"]);
+
+    expect(result.stderr).toContain("no codex wrapper log for pair main yet");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("invalid -n surfaces a user error and exits non-zero", async () => {
+    const root = makeTempDir("agentbridge-logs-root-");
+    const base = makeTempDir("agentbridge-logs-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    const result = await captureLogs(["-n", "0"]);
+
+    expect(result.stderr).toContain("positive integer");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("invalid --pair name is reported without an unhandled exception", async () => {
+    const root = makeTempDir("agentbridge-logs-root-");
+    const base = makeTempDir("agentbridge-logs-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    const result = await captureLogs(["--pair", "../escape"]);
+
+    expect(result.stderr).toContain("Invalid --pair name");
+    expect(result.exitCode).toBe(1);
+    expect(listPairs(base)).toEqual([]);
+  });
+
+  test("--pair selects a different pair's log (read-only)", async () => {
+    const root = makeTempDir("agentbridge-logs-root-");
+    const base = makeTempDir("agentbridge-logs-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    seedDaemonLog(base, process.cwd(), "main", "MAIN-PAIR\n");
+    seedDaemonLog(base, process.cwd(), "work", "WORK-PAIR\n");
+
+    const result = await captureLogs(["--pair", "work"]);
+
+    expect(result.stdout).toEqual(["WORK-PAIR"]);
+    expect(result.exitCode).toBeUndefined();
+    expect(listPairs(base)).toEqual([]);
+  });
+});
+
+describe("logs command (follow)", () => {
+  test("smoke: follow streams appended lines then exits on SIGINT", async () => {
+    const root = makeTempDir("agentbridge-logs-root-");
+    const base = makeTempDir("agentbridge-logs-base-");
+    process.chdir(root);
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+
+    const logPath = seedDaemonLog(base, process.cwd(), "main", "initial-line\n");
+
+    // Drive followLog directly so we can assert it streams and then bound it by
+    // killing the spawned `tail` (mirrors a user pressing Ctrl-C). This proves
+    // the child is spawned with the right path and that the promise resolves on
+    // a signal-stop instead of hanging the test.
+    const { followLog } = await import("../cli/logs");
+
+    // Capture what `tail` writes by temporarily redirecting is not trivial with
+    // stdio:"inherit"; instead we assert the call completes (no hang) within a
+    // bounded window after appending a new line.
+    const followPromise = followLog(logPath, 5);
+
+    // Give tail a moment to attach, append a line, then send SIGINT to the
+    // process group's tail child. We cannot reach the child handle from here, so
+    // we rely on the bounded timeout + resolve-on-signal contract: spawn a guard
+    // that kills any lingering `tail -f` for this log path.
+    await new Promise((r) => setTimeout(r, 150));
+    writeFileSync(logPath, "initial-line\nappended-line\n", "utf8");
+    await new Promise((r) => setTimeout(r, 150));
+
+    // Terminate the follow by killing the tail child via pkill scoped to the log
+    // path. Bound the whole test so a stuck follow fails fast rather than hanging.
+    const { spawnSync } = await import("node:child_process");
+    spawnSync("pkill", ["-INT", "-f", `tail -f -n 5 ${logPath}`]);
+
+    const settled = await Promise.race([
+      followPromise.then(() => "resolved" as const),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 2000)),
+    ]);
+
+    expect(settled).toBe("resolved");
+  });
+});


### PR DESCRIPTION
## 摘要
审视报告 P1：doctor 的 hint 让用户「查看 daemon log」却只打印深平台路径，用户得手工拼 tail、多 pair 时还要先搞清 pairId。新增 `abg logs [--codex] [-f] [-n N]`，复用 resolvePairReadOnly 只读解析。

## 变更
- 默认 daemon log 末尾 100 行；--codex 切 wrapper log；-f 跟踪（tail -f 数组 argv 无注入，SIGINT 干净退出）；-n N 校验正整数；缺日志→清晰提示+非零退出
- cli.ts 路由 + PAIR_AWARE + help/examples；不入 NOTIFY/REFRESH
- 范围克制：doctor.ts/codex.ts 的 hint 改写留 backlog（避免与并行分支冲突）

## 测试
- [x] 767 pass；ci:local 绿；cross-review **双 0 REAL**（arg 解析全覆盖、只读零 registry 写、注入安全、SIGINT、missing-log 退出）