### PR TITLE
ci: CI 平台矩阵补 macOS（生产平台）/ add macOS to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,26 @@ on:
     branches: [master]
 
 jobs:
+  # AgentBridge's PRIMARY real runtime is macOS (default state dir is
+  # ~/Library/Application Support/AgentBridge — see CLAUDE.md). Platform-sensitive
+  # surfaces — state-dir resolution, `ps`-output column matching, SIGTERM/SIGKILL
+  # process-group semantics, and Bun.serve socket behavior (prior permessage-deflate
+  # platform bug) — were previously validated ONLY on ubuntu, a platform no
+  # maintainer runs. This matrix runs the IDENTICAL full gate on both OSes so macOS
+  # regressions are caught in CI, not by accident on a dev machine.
+  #
+  # Cost/coverage trade-off: macOS runners bill ~10x ubuntu minutes, but the full
+  # suite is ~60s (743 tests + trivial smokes), so running the whole gate on every
+  # PR + push is cheap enough to justify against the alternative of macOS bugs
+  # escaping CI entirely. Both legs run the same steps/commands; only `runs-on`
+  # differs. `fail-fast: false` so a macOS-only failure doesn't mask the ubuntu
+  # result (and vice versa).
   check:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 摘要
审视报告 P1：ci.yml 单 job 只跑 ubuntu-latest，而项目主要真实运行环境是 macOS。平台敏感路径（state-dir 解析、ps 输出匹配、SIGTERM/SIGKILL 进程组语义、Bun.serve socket 行为）每个 PR 只在用户不用的平台验证。

## 变更
- check job 加 `strategy.matrix.os:[ubuntu-latest,macos-latest]`，fail-fast:false，两腿全量
- 所有 step + windows-port-cleanup job 字节不变；ubuntu 腿与 HEAD 行为等价
- master 无 classic branch-protection required-status-checks（仅 ruleset），故 status-check 改名不破坏 gate

## 测试
- [x] macOS 全量本地实测 ~61s，743 pass；ci:local 绿；cross-review **双 0 REAL**