### PR TITLE
perf: install:global 缩短停机窗口 + 失败路径零停机 / shrink install:global downtime

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14228,7 +14228,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("51a44cb", "source"),
+  commit: defineString("48eb0ed", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("51a44cb", "source"),
+  commit: defineString("48eb0ed", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/scripts/install-global.mjs
+++ b/scripts/install-global.mjs
@@ -3,11 +3,16 @@
  * Install AgentBridge globally in a way that is convenient for local testing.
  *
  * Modes:
- *   local  build this checkout, pack it, uninstall the global package, install the tarball
- *   npm    verify npm latest exists, uninstall the global package, install latest
+ *   local  build + verify this checkout, pack it, install the tarball (`--force`),
+ *          THEN stop running daemons and sync the Claude Code plugin
+ *   npm    verify npm latest exists, install latest (`--force`), THEN stop daemons
  *
- * The uninstall step is intentionally ignored when the package is not installed:
- * the goal is a clean replacement, not a brittle precondition.
+ * Ordering invariant (downtime + failure safety):
+ *   - `npm install -g --force` is a full replace, so no separate `npm uninstall`
+ *     is needed — dropping it removes the window where no binary is on PATH.
+ *   - stop-running fires AFTER the install succeeds, so the old daemon keeps
+ *     serving until the new bytes are on disk and a FAILED install (red build,
+ *     unreachable registry, missing version) never kills the running daemon.
  *
  * PREFIX RESOLUTION: a plain `npm install -g` targets npm's configured global
  * prefix, which is NOT always where the user's `agentbridge` command resolves —
@@ -149,9 +154,8 @@ function installLocal() {
     printDry("node", ["scripts/install-safety.cjs", "verify-built"]);
     printDry("npm", ["pack", "--pack-destination", "<temp>"]);
     printDry("node", ["scripts/install-safety.cjs", "verify-tarball", "<packed-tarball>"]);
-    printDry("node", ["scripts/install-safety.cjs", "stop-running", "--dry-run"], "  # after build verifies — red builds no longer cause an outage");
-    printDry("npm", ["uninstall", "-g", packageName], "  # ignored if not installed");
     printDry("npm", ["install", "-g", "--force", "<packed-tarball>"]);
+    printDry("node", ["scripts/install-safety.cjs", "stop-running", "--dry-run"], "  # after install succeeds — the old daemon keeps serving until the new bytes are on disk");
     if (!skipPlugin) {
       printDry("bun", ["src/cli.ts", "dev", "--skip-build"], "  # sync Claude Code plugin (skip with --skip-plugin)");
     }
@@ -163,19 +167,24 @@ function installLocal() {
   const env = prefixEnv(target);
   let packDir = "";
   try {
-    // Build + verify FIRST, stop running daemons LAST: the old order killed
-    // every running pair before the build was even validated, so a red build
-    // meant a pointless machine-wide outage. Now the stop window shrinks to
-    // just the npm replacement.
+    // Ordering rationale (downtime-minimizing, failure-safe):
+    //   1. Build + verify FIRST so a red build aborts BEFORE anything is killed
+    //      (PR #101 — a broken build must never cause a machine-wide outage).
+    //   2. `npm install -g --force` is ALREADY a full replace, so the previous
+    //      `npm uninstall -g` step is redundant: it only widened the window in
+    //      which no `agentbridge` binary exists on PATH. Removed.
+    //   3. Stop running daemons AFTER the install succeeds, not before: the old
+    //      daemon keeps serving while the new bytes land, so the downtime window
+    //      shrinks to "stop -> user restart". A FAILED install (build/pack/verify
+    //      /npm install) returns before this line, leaving the daemon untouched.
     run("bun", ["run", "prepublishOnly"]);
     run("node", ["scripts/install-safety.cjs", "verify-built"]);
     packDir = mkdtempSync(join(tmpdir(), "agentbridge-pack-"));
     const packed = run("npm", ["pack", "--pack-destination", packDir], { captureStdout: true });
     const tarball = packedTarballFrom(packed.stdout ?? "", packDir);
     run("node", ["scripts/install-safety.cjs", "verify-tarball", tarball]);
-    run("node", ["scripts/install-safety.cjs", "stop-running"]);
-    run("npm", ["uninstall", "-g", packageName], { allowFailure: true, envExtra: env });
     run("npm", ["install", "-g", "--force", tarball], { envExtra: env });
+    run("node", ["scripts/install-safety.cjs", "stop-running"]);
     process.stdout.write(`install-global: installed ${packageName} globally from local source\n`);
   } finally {
     if (packDir) rmSync(packDir, { recursive: true, force: true });
@@ -195,7 +204,7 @@ function installLocal() {
     }
   }
 
-  // Running daemons/sessions were stopped before the npm replacement — make
+  // Running daemons/sessions were stopped after the new bytes landed — make
   // the required restart explicit instead of leaving it implied.
   process.stdout.write(
     "# note: running AgentBridge sessions were stopped — start fresh with `agentbridge claude` / `agentbridge codex`\n",
@@ -239,20 +248,24 @@ function installNpm() {
   const prefix = dryRun ? resolveInstallPrefix() : null;
   if (dryRun) {
     reportPrefix(prefix);
-    printDry("node", ["scripts/install-safety.cjs", "stop-running", "--dry-run"]);
     printDry("npm", ["view", spec, "version"]);
-    printDry("npm", ["uninstall", "-g", packageName], "  # ignored if not installed");
     printDry("npm", ["install", "-g", "--force", spec]);
+    printDry("node", ["scripts/install-safety.cjs", "stop-running", "--dry-run"], "  # after install succeeds — a failed `npm view` / install leaves the running daemon untouched");
     return;
   }
 
   const target = resolveInstallPrefix();
   reportPrefix(target);
   const env = prefixEnv(target);
-  run("node", ["scripts/install-safety.cjs", "stop-running"]);
+  // Validate + install BEFORE stopping anything: the old order killed every
+  // running pair before `npm view` even confirmed the registry was reachable,
+  // so an unreachable registry or a missing version caused a pointless
+  // machine-wide outage. `--force` is a full replace (no separate uninstall
+  // needed). A failure on any line below returns before stop-running, leaving
+  // the running daemon untouched — zero downtime on the failure path.
   run("npm", ["view", spec, "version"]);
-  run("npm", ["uninstall", "-g", packageName], { allowFailure: true, envExtra: env });
   run("npm", ["install", "-g", "--force", spec], { envExtra: env });
+  run("node", ["scripts/install-safety.cjs", "stop-running"]);
   process.stdout.write(`install-global: installed ${packageName} globally from npm latest\n`);
 }
 

--- a/src/unit-test/install-global-script.test.ts
+++ b/src/unit-test/install-global-script.test.ts
@@ -1,10 +1,87 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { installPrefixFromBinPath, resolveInstallPrefix } from "../../scripts/install-global.mjs";
 
 const SCRIPT = join(process.cwd(), "scripts/install-global.mjs");
 const PACKAGE_NAME = "@raysonmeng/agentbridge";
+
+/**
+ * Run the REAL (non-dry-run) installer with `npm`/`node`/`bun` stubbed onto PATH.
+ * Each stub appends its full argv to a record file so the test can assert the
+ * command sequence AND prove a configured failure aborts BEFORE stop-running.
+ *
+ * `failWhen` is a substring matched against the joined argv of each stub call;
+ * the matching call (and only it) exits non-zero, simulating e.g. an
+ * unreachable registry (`npm view ...`) or a failed install.
+ *
+ * stop-running is observable because install-safety's stop spawns the real CLI:
+ * we additionally stub it by matching `install-safety.cjs stop-running` and
+ * `kill --all` against the recorded argv — if a failure aborted correctly,
+ * neither ever appears in the record.
+ */
+function runRealWithStubs(
+  mode: string,
+  extraArgs: string[],
+  failWhen: string,
+): { status: number | null; record: string[] } {
+  const dir = mkdtempSync(join(tmpdir(), "install-global-stub-"));
+  const recordFile = join(dir, "record.log");
+  const binDir = join(dir, "bin");
+  // A single stub script reused for npm/node/bun: log argv, then exit 1 if the
+  // joined argv contains FAIL_WHEN, else 0. It deliberately does NOT execute the
+  // real tool — we only care about the call sequence and the abort behavior.
+  const stub = `#!/usr/bin/env bash
+name="$(basename "$0")"
+echo "$name $*" >> "$RECORD_FILE"
+joined="$name $*"
+if [ -n "$FAIL_WHEN" ] && [[ "$joined" == *"$FAIL_WHEN"* ]]; then
+  exit 1
+fi
+# 'npm pack' parses stdout for the tarball name — emit a plausible one so the
+# local-mode flow can proceed past packing in the success-path-up-to-install case.
+if [ "$name" = "npm" ] && [ "$1" = "pack" ]; then
+  echo "agentbridge-0.0.0.tgz"
+fi
+exit 0
+`;
+  const { mkdirSync } = require("node:fs") as typeof import("node:fs");
+  mkdirSync(binDir, { recursive: true });
+  for (const name of ["npm", "node", "bun"]) {
+    const p = join(binDir, name);
+    writeFileSync(p, stub);
+    chmodSync(p, 0o755);
+  }
+  try {
+    // Launch the script with the REAL node (absolute path) so the script itself
+    // runs, but with PATH pointing at the stubs so its child spawns hit them.
+    const realNode = process.execPath;
+    const res = Bun.spawnSync([realNode, SCRIPT, mode, ...extraArgs], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        RECORD_FILE: recordFile,
+        FAIL_WHEN: failWhen,
+      },
+    });
+    let record: string[] = [];
+    try {
+      record = readFileSync(recordFile, "utf-8").split("\n").map((l) => l.trim()).filter(Boolean);
+    } catch {
+      record = [];
+    }
+    return { status: res.exitCode, record };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function recordHasStop(record: string[]): boolean {
+  return record.some(
+    (line) => line.includes("install-safety.cjs stop-running") || line.includes("kill --all"),
+  );
+}
 
 function runDry(mode: string, extraArgs: string[] = []): { status: number | null; stdout: string; stderr: string } {
   const res = Bun.spawnSync(["node", SCRIPT, mode, "--dry-run", ...extraArgs], {
@@ -27,36 +104,130 @@ function dryRunCommands(mode: string, extraArgs: string[] = []): string[] {
 }
 
 describe("scripts/install-global.mjs", () => {
-  test("local mode builds and VERIFIES before stopping anything, then installs and syncs the plugin", () => {
-    // Ordering contract: stop-running comes AFTER build verification — a red
-    // build must not cause a machine-wide daemon outage.
+  test("local mode builds, verifies and INSTALLS before stopping anything, then syncs the plugin", () => {
+    // Ordering contract (P1 downtime reduction):
+    //   - stop-running comes AFTER `npm install` succeeds, so the old daemon
+    //     keeps serving until the new bytes are on disk (downtime shrinks to
+    //     "stop -> user restart"); a red build/pack/verify/install aborts BEFORE
+    //     stop-running, so a failed install never kills the running daemon.
+    //   - the redundant `npm uninstall -g` is gone: `--force` is a full replace,
+    //     and uninstalling only widened the window with no binary on PATH.
     const commands = dryRunCommands("local");
     expect(commands).toEqual([
       "$ bun run prepublishOnly",
       "$ node scripts/install-safety.cjs verify-built",
       "$ npm pack --pack-destination <temp>",
       "$ node scripts/install-safety.cjs verify-tarball <packed-tarball>",
-      "$ node scripts/install-safety.cjs stop-running --dry-run  # after build verifies — red builds no longer cause an outage",
-      `$ npm uninstall -g ${PACKAGE_NAME}  # ignored if not installed`,
       "$ npm install -g --force <packed-tarball>",
+      "$ node scripts/install-safety.cjs stop-running --dry-run  # after install succeeds — the old daemon keeps serving until the new bytes are on disk",
       "$ bun src/cli.ts dev --skip-build  # sync Claude Code plugin (skip with --skip-plugin)",
     ]);
+    // The redundant uninstall must be gone entirely.
+    expect(commands.some((line) => line.includes("npm uninstall"))).toBe(false);
+    // stop-running must come strictly AFTER the install in local mode.
+    const installIdx = commands.findIndex((l) => l.startsWith("$ npm install -g --force"));
+    const stopIdx = commands.findIndex((l) => l.includes("stop-running"));
+    expect(installIdx).toBeGreaterThanOrEqual(0);
+    expect(stopIdx).toBeGreaterThan(installIdx);
   });
 
-  test("local mode --skip-plugin omits the plugin sync step", () => {
+  test("local mode --skip-plugin omits the plugin sync step (stop-running still last)", () => {
     const commands = dryRunCommands("local", ["--skip-plugin"]);
     expect(commands.some((line) => line.includes("dev --skip-build"))).toBe(false);
-    expect(commands[commands.length - 1]).toBe("$ npm install -g --force <packed-tarball>");
+    // With the plugin sync skipped, stop-running is the final step — and it is
+    // still AFTER the install (downtime + failure-safety invariant preserved).
+    expect(commands[commands.length - 1]).toBe(
+      "$ node scripts/install-safety.cjs stop-running --dry-run  # after install succeeds — the old daemon keeps serving until the new bytes are on disk",
+    );
+    const installIdx = commands.findIndex((l) => l.startsWith("$ npm install -g --force"));
+    const stopIdx = commands.findIndex((l) => l.includes("stop-running"));
+    expect(stopIdx).toBeGreaterThan(installIdx);
   });
 
-  test("npm mode verifies the registry package before replacing the global install", () => {
+  test("npm mode verifies the registry and installs BEFORE stopping the running daemon", () => {
+    // Ordering contract (P1): a failed `npm view` (registry unreachable / version
+    // missing) or a failed install must leave the running daemon untouched, so
+    // stop-running runs LAST — after both validation and install succeed.
     const commands = dryRunCommands("npm");
     expect(commands).toEqual([
-      "$ node scripts/install-safety.cjs stop-running --dry-run",
       `$ npm view ${PACKAGE_NAME}@latest version`,
-      `$ npm uninstall -g ${PACKAGE_NAME}  # ignored if not installed`,
       `$ npm install -g --force ${PACKAGE_NAME}@latest`,
+      "$ node scripts/install-safety.cjs stop-running --dry-run  # after install succeeds — a failed `npm view` / install leaves the running daemon untouched",
     ]);
+    // stop-running must be the LAST step (after view + install).
+    expect(commands[commands.length - 1]).toContain("stop-running");
+    const viewIdx = commands.findIndex((l) => l.startsWith("$ npm view"));
+    const installIdx = commands.findIndex((l) => l.startsWith("$ npm install -g --force"));
+    const stopIdx = commands.findIndex((l) => l.includes("stop-running"));
+    expect(viewIdx).toBe(0);
+    expect(stopIdx).toBeGreaterThan(installIdx);
+  });
+
+  // --- Behavioral failure-path tests: a FAILED install must NOT touch the
+  //     running daemon (zero downtime on the failure path). These run the REAL
+  //     installer with stubbed npm/node/bun and assert stop-running never fired.
+
+  test("npm mode: a failed `npm view` aborts BEFORE stop-running (daemon untouched)", () => {
+    const { status, record } = runRealWithStubs("npm", [], "view");
+    expect(status).not.toBe(0); // the installer propagates the failure
+    // npm view was attempted...
+    expect(record.some((l) => l.startsWith("npm view"))).toBe(true);
+    // ...but install and stop-running never ran.
+    expect(record.some((l) => l.startsWith("npm install"))).toBe(false);
+    expect(recordHasStop(record)).toBe(false);
+  });
+
+  test("npm mode: a failed `npm install` aborts BEFORE stop-running (daemon untouched)", () => {
+    const { status, record } = runRealWithStubs("npm", [], "install -g --force");
+    expect(status).not.toBe(0);
+    expect(record.some((l) => l.startsWith("npm view"))).toBe(true);
+    expect(record.some((l) => l.startsWith("npm install"))).toBe(true);
+    expect(recordHasStop(record)).toBe(false);
+  });
+
+  test("npm mode: full success runs stop-running LAST, after view + install", () => {
+    const { status, record } = runRealWithStubs("npm", [], "");
+    expect(status).toBe(0);
+    const viewIdx = record.findIndex((l) => l.startsWith("npm view"));
+    const installIdx = record.findIndex((l) => l.startsWith("npm install"));
+    const stopIdx = record.findIndex(
+      (l) => l.includes("install-safety.cjs stop-running") || l.includes("kill --all"),
+    );
+    expect(viewIdx).toBeGreaterThanOrEqual(0);
+    expect(installIdx).toBeGreaterThan(viewIdx);
+    expect(stopIdx).toBeGreaterThan(installIdx);
+  });
+
+  test("local mode: a failed build (prepublishOnly) aborts BEFORE stop-running", () => {
+    const { status, record } = runRealWithStubs("local", ["--skip-plugin"], "run prepublishOnly");
+    expect(status).not.toBe(0);
+    expect(record.some((l) => l.startsWith("bun run prepublishOnly"))).toBe(true);
+    // Nothing destructive ran: no install, no stop-running.
+    expect(record.some((l) => l.startsWith("npm install"))).toBe(false);
+    expect(recordHasStop(record)).toBe(false);
+  });
+
+  test("local mode: a failed `npm install` aborts BEFORE stop-running (daemon untouched)", () => {
+    const { status, record } = runRealWithStubs("local", ["--skip-plugin"], "install -g --force");
+    expect(status).not.toBe(0);
+    // Build + verify + pack + install were attempted...
+    expect(record.some((l) => l.startsWith("bun run prepublishOnly"))).toBe(true);
+    expect(record.some((l) => l.startsWith("npm install -g --force"))).toBe(true);
+    // ...but stop-running never fired, and the redundant uninstall is gone.
+    expect(recordHasStop(record)).toBe(false);
+    expect(record.some((l) => l.startsWith("npm uninstall"))).toBe(false);
+  });
+
+  test("local mode: full success runs stop-running AFTER install, with no uninstall", () => {
+    const { status, record } = runRealWithStubs("local", ["--skip-plugin"], "");
+    expect(status).toBe(0);
+    const installIdx = record.findIndex((l) => l.startsWith("npm install -g --force"));
+    const stopIdx = record.findIndex(
+      (l) => l.includes("install-safety.cjs stop-running") || l.includes("kill --all"),
+    );
+    expect(installIdx).toBeGreaterThanOrEqual(0);
+    expect(stopIdx).toBeGreaterThan(installIdx);
+    expect(record.some((l) => l.startsWith("npm uninstall"))).toBe(false);
   });
 
   test("package.json exposes one-line local and npm install commands", () => {


### PR DESCRIPTION
## 摘要
审视报告 P1：local 模式 stop-running 在前覆盖 uninstall+install+sync 全程；npm 模式 stop-running 跑在 npm view 之前——registry 不可达时全机 pair 已被白杀。PR#101 修对的『红构建不停机』顺序没贯彻到这两段。

## 变更
- local 模式：删冗余 npm uninstall，stop-running 移到 install 成功后、plugin sync 前
- npm 模式：stop-running 移到 npm view 验证 + install 成功之后
- 净效果：**失败安装绝不杀运行中 daemon（零停机）**；成功安装窗口缩为 stop→用户重启

## 测试
- [x] 749 pass；ci:local 绿；cross-review **双 0 REAL**（含真实 stub 的 no-stop-on-failure 测试）