### PR TITLE
fix: config.json 损坏 fail-loud / config.json fail-loud on corruption

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14274,7 +14274,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("5d6cb0f", "source"),
+  commit: defineString("b0c8a46", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -15028,8 +15028,51 @@ var DEFAULT_CONFIG = {
 };
 var CONFIG_DIR = ".agentbridge";
 var CONFIG_FILE = "config.json";
+var NOOP_LOGGER = () => {};
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function isCoercibleNumber(value) {
+  if (typeof value === "number")
+    return Number.isFinite(value);
+  if (typeof value === "string")
+    return Number.isFinite(Number(value));
+  return false;
+}
+function findShapeViolation(raw) {
+  if ("idleShutdownSeconds" in raw && !isCoercibleNumber(raw.idleShutdownSeconds)) {
+    return "idleShutdownSeconds is present but not a number";
+  }
+  if ("budget" in raw) {
+    const budget = raw.budget;
+    if (!isRecord(budget)) {
+      return "budget is present but not an object";
+    }
+    const numericKeys = ["pauseAt", "resumeBelow", "pollSeconds", "syncDriftPct"];
+    for (const key of numericKeys) {
+      if (key in budget && !isCoercibleNumber(budget[key])) {
+        return `budget.${key} is present but not a number`;
+      }
+    }
+    if ("parallel" in budget) {
+      const parallel = budget.parallel;
+      if (!isRecord(parallel)) {
+        return "budget.parallel is present but not an object";
+      }
+      for (const key of ["minRemainingPct", "timeWindowSec"]) {
+        if (key in parallel && !isCoercibleNumber(parallel[key])) {
+          return `budget.parallel.${key} is present but not a number`;
+        }
+      }
+    }
+  }
+  return null;
+}
+function hasCustomDecisionValues(config2) {
+  const d = DEFAULT_CONFIG;
+  const b = config2.budget;
+  const db = d.budget;
+  return config2.idleShutdownSeconds !== d.idleShutdownSeconds || config2.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config2.codex.appPort !== d.codex.appPort || config2.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -15131,15 +15174,59 @@ class ConfigService {
     return existsSync4(this.configPath);
   }
   load() {
+    let raw;
     try {
-      const raw = readFileSync2(this.configPath, "utf-8");
-      return normalizeConfig(JSON.parse(raw));
-    } catch {
-      return null;
+      raw = readFileSync2(this.configPath, "utf-8");
+    } catch (err) {
+      if (err?.code === "ENOENT") {
+        return { state: "absent" };
+      }
+      return { state: "corrupt", reason: `config.json is unreadable: ${err.message}` };
     }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      return {
+        state: "corrupt",
+        reason: `config.json is not valid JSON: ${err.message}`
+      };
+    }
+    if (!isRecord(parsed)) {
+      return { state: "corrupt", reason: "config.json is not a JSON object" };
+    }
+    const violation = findShapeViolation(parsed);
+    if (violation) {
+      return { state: "corrupt", reason: `config.json is shape-invalid: ${violation}` };
+    }
+    const config2 = normalizeConfig(parsed);
+    if (!config2) {
+      return { state: "corrupt", reason: "config.json could not be normalized" };
+    }
+    return { state: "parsed", config: config2 };
   }
-  loadOrDefault() {
-    return this.load() ?? structuredClone(DEFAULT_CONFIG);
+  loadOrDefault(log = NOOP_LOGGER) {
+    const result = this.load();
+    if (result.state === "parsed")
+      return result.config;
+    if (result.state === "corrupt") {
+      log(`config.json at ${this.configPath} is unusable (${result.reason}); ` + "falling back to defaults \u2014 your custom budget thresholds / idle-shutdown settings are NOT in effect. " + "Fix the file and restart to re-apply them.");
+    }
+    return structuredClone(DEFAULT_CONFIG);
+  }
+  describeConfig() {
+    const result = this.load();
+    if (result.state === "absent") {
+      return { state: "absent", path: this.configPath, customValues: false };
+    }
+    if (result.state === "corrupt") {
+      return { state: "corrupt", path: this.configPath, reason: result.reason, customValues: false };
+    }
+    return {
+      state: "parsed",
+      path: this.configPath,
+      customValues: hasCustomDecisionValues(result.config)
+    };
   }
   save(config2) {
     this.ensureConfigDir();
@@ -15498,10 +15585,10 @@ var envGuardResult = guardAgentBridgeEnv({
 });
 var stateDir = new StateDirResolver;
 stateDir.ensure();
-var configService = new ConfigService;
-var config2 = configService.loadOrDefault();
-var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var processLogger = createProcessLogger({ component: "AgentBridgeFrontend", logFile: stateDir.logFile });
+var configService = new ConfigService;
+var config2 = configService.loadOrDefault(processLogger.log);
+var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 var claude = new ClaudeAdapter(stateDir.logFile);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("5d6cb0f", "source"),
+  commit: defineString("b0c8a46", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2861,8 +2861,51 @@ var DEFAULT_CONFIG = {
 };
 var CONFIG_DIR = ".agentbridge";
 var CONFIG_FILE = "config.json";
+var NOOP_LOGGER = () => {};
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function isCoercibleNumber(value) {
+  if (typeof value === "number")
+    return Number.isFinite(value);
+  if (typeof value === "string")
+    return Number.isFinite(Number(value));
+  return false;
+}
+function findShapeViolation(raw) {
+  if ("idleShutdownSeconds" in raw && !isCoercibleNumber(raw.idleShutdownSeconds)) {
+    return "idleShutdownSeconds is present but not a number";
+  }
+  if ("budget" in raw) {
+    const budget = raw.budget;
+    if (!isRecord(budget)) {
+      return "budget is present but not an object";
+    }
+    const numericKeys = ["pauseAt", "resumeBelow", "pollSeconds", "syncDriftPct"];
+    for (const key of numericKeys) {
+      if (key in budget && !isCoercibleNumber(budget[key])) {
+        return `budget.${key} is present but not a number`;
+      }
+    }
+    if ("parallel" in budget) {
+      const parallel = budget.parallel;
+      if (!isRecord(parallel)) {
+        return "budget.parallel is present but not an object";
+      }
+      for (const key of ["minRemainingPct", "timeWindowSec"]) {
+        if (key in parallel && !isCoercibleNumber(parallel[key])) {
+          return `budget.parallel.${key} is present but not a number`;
+        }
+      }
+    }
+  }
+  return null;
+}
+function hasCustomDecisionValues(config) {
+  const d = DEFAULT_CONFIG;
+  const b = config.budget;
+  const db = d.budget;
+  return config.idleShutdownSeconds !== d.idleShutdownSeconds || config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config.codex.appPort !== d.codex.appPort || config.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -2980,15 +3023,59 @@ class ConfigService {
     return existsSync4(this.configPath);
   }
   load() {
+    let raw;
     try {
-      const raw = readFileSync2(this.configPath, "utf-8");
-      return normalizeConfig(JSON.parse(raw));
-    } catch {
-      return null;
+      raw = readFileSync2(this.configPath, "utf-8");
+    } catch (err) {
+      if (err?.code === "ENOENT") {
+        return { state: "absent" };
+      }
+      return { state: "corrupt", reason: `config.json is unreadable: ${err.message}` };
     }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      return {
+        state: "corrupt",
+        reason: `config.json is not valid JSON: ${err.message}`
+      };
+    }
+    if (!isRecord(parsed)) {
+      return { state: "corrupt", reason: "config.json is not a JSON object" };
+    }
+    const violation = findShapeViolation(parsed);
+    if (violation) {
+      return { state: "corrupt", reason: `config.json is shape-invalid: ${violation}` };
+    }
+    const config = normalizeConfig(parsed);
+    if (!config) {
+      return { state: "corrupt", reason: "config.json could not be normalized" };
+    }
+    return { state: "parsed", config };
   }
-  loadOrDefault() {
-    return this.load() ?? structuredClone(DEFAULT_CONFIG);
+  loadOrDefault(log = NOOP_LOGGER) {
+    const result = this.load();
+    if (result.state === "parsed")
+      return result.config;
+    if (result.state === "corrupt") {
+      log(`config.json at ${this.configPath} is unusable (${result.reason}); ` + "falling back to defaults \u2014 your custom budget thresholds / idle-shutdown settings are NOT in effect. " + "Fix the file and restart to re-apply them.");
+    }
+    return structuredClone(DEFAULT_CONFIG);
+  }
+  describeConfig() {
+    const result = this.load();
+    if (result.state === "absent") {
+      return { state: "absent", path: this.configPath, customValues: false };
+    }
+    if (result.state === "corrupt") {
+      return { state: "corrupt", path: this.configPath, reason: result.reason, customValues: false };
+    }
+    return {
+      state: "parsed",
+      path: this.configPath,
+      customValues: hasCustomDecisionValues(result.config)
+    };
   }
   save(config) {
     this.ensureConfigDir();
@@ -4320,9 +4407,9 @@ async function probeLiveness(target, options) {
 // src/daemon.ts
 var stateDir = new StateDirResolver;
 stateDir.ensure();
-var configService = new ConfigService;
-var config = configService.loadOrDefault();
 var processLogger = createProcessLogger({ component: "AgentBridgeDaemon", logFile: stateDir.logFile });
+var configService = new ConfigService;
+var config = configService.loadOrDefault(processLogger.log);
 var CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.codex.appPort), 10);
 var CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.codex.proxyPort), 10);
 var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -32,11 +32,13 @@ const envGuardResult = guardAgentBridgeEnv({
 
 const stateDir = new StateDirResolver();
 stateDir.ensure();
+const processLogger = createProcessLogger({ component: "AgentBridgeFrontend", logFile: stateDir.logFile });
 const configService = new ConfigService();
-const config = configService.loadOrDefault();
+// Thread the frontend logger so a corrupt config.json fails loud (to log +
+// stderr) instead of silently reverting custom thresholds to defaults.
+const config = configService.loadOrDefault(processLogger.log);
 
 const CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
-const processLogger = createProcessLogger({ component: "AgentBridgeFrontend", logFile: stateDir.logFile });
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 const CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -351,7 +351,15 @@ export async function runCodex(args: string[]) {
     // CODEX_PROXY_PORT (set by applyPairEnv in pair mode; user-set in manual mode)
     // else the project config. This is correct for BOTH multi-pair (env carries
     // the slot's port) and manual/legacy mode (config may be a custom port).
-    const fallbackProxyPort = process.env.CODEX_PROXY_PORT ?? String(new ConfigService().loadOrDefault().codex.proxyPort);
+    // Thread a stderr logger so a corrupt config.json warns the user here too,
+    // matching this command's existing `console.error("[agentbridge] …")` style,
+    // instead of silently using the default proxy port.
+    const fallbackProxyPort =
+      process.env.CODEX_PROXY_PORT ??
+      String(
+        new ConfigService().loadOrDefault((msg) => console.error(`[agentbridge] ${msg}`)).codex
+          .proxyPort,
+      );
     proxyUrl = `ws://127.0.0.1:${fallbackProxyPort}`;
     console.error(`[agentbridge] No daemon status found, using fallback proxy port: ${proxyUrl}`);
   }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "n
 import { join } from "node:path";
 import { pluginCacheRoot } from "./plugin-cache";
 import { BUILD_INFO, formatBuildInfo, sameRuntimeContract } from "../build-info";
+import { ConfigService } from "../config-service";
 import { fetchDaemonStatus } from "../daemon-status";
 import { inspectAgentBridgeEnv } from "../env-guard";
 import {
@@ -204,6 +205,7 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
       ? undefined
       : "环境变量与当前目录不匹配：请在正确的项目目录里重新运行 `agentbridge claude`，不要复用其他目录的会话环境。",
   });
+  checks.push(configParseabilityCheck(cwd));
   checks.push({
     name: "daemon health",
     status: health ? "ok" : "warn",
@@ -404,6 +406,40 @@ function extractBundleCommit(path: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Config parseability + whether custom values are actually in effect. A corrupt
+ * config.json silently reverts the user's custom budget/idle thresholds to
+ * defaults at startup (P1); surface that loudly here so doctor — run by someone
+ * already stuck — can see it instead of chasing why their thresholds "don't work".
+ */
+function configParseabilityCheck(cwd: string): DoctorCheck {
+  const desc = new ConfigService(cwd).describeConfig();
+  if (desc.state === "absent") {
+    return {
+      name: "config.json",
+      status: "ok",
+      detail: `no project config at ${desc.path} — built-in defaults in effect`,
+    };
+  }
+  if (desc.state === "corrupt") {
+    return {
+      name: "config.json",
+      status: "warn",
+      detail: `unparseable at ${desc.path} (${desc.reason}) — custom thresholds NOT in effect, using defaults`,
+      hint:
+        "config.json 损坏或字段类型错误：bridge 已回退到默认阈值，你的自定义 budget/idle 设置未生效。" +
+        "修正该文件的 JSON 语法/字段类型后重启 `agentbridge claude` 即可重新生效。",
+    };
+  }
+  return {
+    name: "config.json",
+    status: "ok",
+    detail: desc.customValues
+      ? `parsed at ${desc.path} — custom values in effect`
+      : `parsed at ${desc.path} — all values match defaults`,
+  };
 }
 
 function logCheck(name: string, path: string): DoctorCheck {

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -55,6 +55,41 @@ const DEFAULT_CONFIG: AgentBridgeConfig = {
 const CONFIG_DIR = ".agentbridge";
 const CONFIG_FILE = "config.json";
 
+/**
+ * Discriminated result of {@link ConfigService.load}. Distinguishes the three
+ * states that the old `AgentBridgeConfig | null` conflated:
+ *  - `parsed`  — a valid config was read and normalized.
+ *  - `absent`  — the file does not exist (ENOENT); the normal, non-error case.
+ *  - `corrupt` — the file exists but is unparseable JSON or shape-invalid; the
+ *                caller falls back to defaults but MUST surface a warning, since
+ *                the user's custom thresholds are silently NOT in effect.
+ */
+export type ConfigLoadResult =
+  | { state: "parsed"; config: AgentBridgeConfig }
+  | { state: "absent" }
+  | { state: "corrupt"; reason: string };
+
+/** Diagnostic summary of config parseability, surfaced by `abg doctor`. */
+export interface ConfigDescription {
+  state: ConfigLoadResult["state"];
+  /** Resolved path to the config file (whether or not it exists). */
+  path: string;
+  /** True only when a parsed config sets a decision-grade value away from defaults. */
+  customValues: boolean;
+  /** Present only when state is "corrupt". */
+  reason?: string;
+}
+
+/**
+ * Minimal logger surface threaded through {@link ConfigService.loadOrDefault}
+ * so daemon/CLI can surface a corrupt-config warning in their own channel
+ * (daemon: processLogger; CLI: stderr). A no-op default keeps existing call
+ * sites working unchanged.
+ */
+export type ConfigWarnLogger = (message: string) => void;
+
+const NOOP_LOGGER: ConfigWarnLogger = () => {};
+
 interface LegacyAgentBridgeConfig {
   version?: unknown;
   daemon?: {
@@ -74,6 +109,85 @@ interface LegacyAgentBridgeConfig {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * True when a value is a finite number OR a string that parses to one. Mirrors
+ * `normalizeInteger`'s coercion so the shape check accepts exactly the inputs
+ * normalize accepts (env-style string-numbers, out-of-range numbers) — a value
+ * is "shape invalid" only when it is genuinely uncoercible (e.g. "ninety").
+ */
+function isCoercibleNumber(value: unknown): boolean {
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value === "string") return Number.isFinite(Number(value));
+  return false;
+}
+
+/**
+ * Decision-grade fields whose PRESENCE-with-garbage must fail loud (config is
+ * "shape invalid"), instead of silently reverting to defaults. We only flag a
+ * field that is PRESENT but uncoercible: an ABSENT field is a legacy/partial
+ * config and is normalized to defaults as before. Scope is deliberately the
+ * numeric thresholds the P1 proposal calls out (budget thresholds, idle
+ * shutdown) — booleans and tier-override sub-objects keep their lenient
+ * normalize-to-default behavior so a typo in those is not startup-affecting.
+ *
+ * Returns a human-readable reason string when invalid, else null.
+ */
+function findShapeViolation(raw: Record<string, unknown>): string | null {
+  if ("idleShutdownSeconds" in raw && !isCoercibleNumber(raw.idleShutdownSeconds)) {
+    return "idleShutdownSeconds is present but not a number";
+  }
+  if ("budget" in raw) {
+    const budget = raw.budget;
+    if (!isRecord(budget)) {
+      return "budget is present but not an object";
+    }
+    const numericKeys = ["pauseAt", "resumeBelow", "pollSeconds", "syncDriftPct"] as const;
+    for (const key of numericKeys) {
+      if (key in budget && !isCoercibleNumber(budget[key])) {
+        return `budget.${key} is present but not a number`;
+      }
+    }
+    if ("parallel" in budget) {
+      const parallel = budget.parallel;
+      if (!isRecord(parallel)) {
+        return "budget.parallel is present but not an object";
+      }
+      for (const key of ["minRemainingPct", "timeWindowSec"] as const) {
+        if (key in parallel && !isCoercibleNumber(parallel[key])) {
+          return `budget.parallel.${key} is present but not a number`;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * True when a parsed config sets any decision-grade field away from the
+ * defaults. Used only for the doctor diagnostic — lets the user confirm their
+ * custom thresholds are actually live (vs. a config that exists but matches
+ * defaults, in which case "custom values" is honestly false).
+ */
+function hasCustomDecisionValues(config: AgentBridgeConfig): boolean {
+  const d = DEFAULT_CONFIG;
+  const b = config.budget;
+  const db = d.budget;
+  return (
+    config.idleShutdownSeconds !== d.idleShutdownSeconds ||
+    config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds ||
+    config.codex.appPort !== d.codex.appPort ||
+    config.codex.proxyPort !== d.codex.proxyPort ||
+    b.enabled !== db.enabled ||
+    b.pollSeconds !== db.pollSeconds ||
+    b.pauseAt !== db.pauseAt ||
+    b.resumeBelow !== db.resumeBelow ||
+    b.syncDriftPct !== db.syncDriftPct ||
+    b.parallel.minRemainingPct !== db.parallel.minRemainingPct ||
+    b.parallel.timeWindowSec !== db.parallel.timeWindowSec ||
+    b.codexTierControl !== db.codexTierControl
+  );
 }
 
 function normalizeInteger(value: unknown, fallback: number): number {
@@ -271,19 +385,94 @@ export class ConfigService {
     return existsSync(this.configPath);
   }
 
-  /** Load project config, returns null if not found. */
-  load(): AgentBridgeConfig | null {
+  /**
+   * Load project config as a discriminated result distinguishing absence
+   * (ENOENT, normal) from corruption (unparseable JSON or shape-invalid).
+   * Unlike the old `null`-for-everything contract, a corrupt config is reported
+   * as such so {@link loadOrDefault} can fail loud instead of silently
+   * reverting the user's custom thresholds to defaults.
+   */
+  load(): ConfigLoadResult {
+    let raw: string;
     try {
-      const raw = readFileSync(this.configPath, "utf-8");
-      return normalizeConfig(JSON.parse(raw));
-    } catch {
-      return null;
+      raw = readFileSync(this.configPath, "utf-8");
+    } catch (err) {
+      // ENOENT is the normal "no project config" case; any other read error
+      // (permissions, etc.) is reported as corrupt so it is not silently
+      // mistaken for "absent" and masked behind defaults.
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+        return { state: "absent" };
+      }
+      return { state: "corrupt", reason: `config.json is unreadable: ${(err as Error).message}` };
     }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      return {
+        state: "corrupt",
+        reason: `config.json is not valid JSON: ${(err as Error).message}`,
+      };
+    }
+
+    if (!isRecord(parsed)) {
+      return { state: "corrupt", reason: "config.json is not a JSON object" };
+    }
+
+    const violation = findShapeViolation(parsed);
+    if (violation) {
+      return { state: "corrupt", reason: `config.json is shape-invalid: ${violation}` };
+    }
+
+    const config = normalizeConfig(parsed);
+    if (!config) {
+      // Defensive: normalizeConfig only returns null for a non-record, already
+      // handled above. Treat any residual null as corrupt rather than absent.
+      return { state: "corrupt", reason: "config.json could not be normalized" };
+    }
+    return { state: "parsed", config };
   }
 
-  /** Load project config, falling back to defaults. */
-  loadOrDefault(): AgentBridgeConfig {
-    return this.load() ?? structuredClone(DEFAULT_CONFIG);
+  /**
+   * Load project config, falling back to defaults. On a CORRUPT config (not on
+   * normal absence), emits exactly one clear warning via the injected logger so
+   * the user knows their custom thresholds are NOT in effect — the bridge must
+   * never silently drift to defaults, but a corrupt config must also never
+   * wedge startup, so this still returns defaults.
+   */
+  loadOrDefault(log: ConfigWarnLogger = NOOP_LOGGER): AgentBridgeConfig {
+    const result = this.load();
+    if (result.state === "parsed") return result.config;
+    if (result.state === "corrupt") {
+      log(
+        `config.json at ${this.configPath} is unusable (${result.reason}); ` +
+          "falling back to defaults — your custom budget thresholds / idle-shutdown settings are NOT in effect. " +
+          "Fix the file and restart to re-apply them.",
+      );
+    }
+    return structuredClone(DEFAULT_CONFIG);
+  }
+
+  /**
+   * Diagnostic summary of config parseability for `abg doctor`. Reports the
+   * load state and, for a parsed config, whether any decision-grade value
+   * differs from the defaults (so the user can confirm their custom thresholds
+   * are actually in effect, the exact thing a silent corrupt-fallback hides).
+   */
+  describeConfig(): ConfigDescription {
+    const result = this.load();
+    if (result.state === "absent") {
+      return { state: "absent", path: this.configPath, customValues: false };
+    }
+    if (result.state === "corrupt") {
+      return { state: "corrupt", path: this.configPath, reason: result.reason, customValues: false };
+    }
+    return {
+      state: "parsed",
+      path: this.configPath,
+      customValues: hasCustomDecisionValues(result.config),
+    };
   }
 
   /** Save project config. */

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -59,9 +59,11 @@ interface ControlSocketData {
 
 const stateDir = new StateDirResolver();
 stateDir.ensure();
-const configService = new ConfigService();
-const config = configService.loadOrDefault();
 const processLogger = createProcessLogger({ component: "AgentBridgeDaemon", logFile: stateDir.logFile });
+const configService = new ConfigService();
+// Thread the daemon logger so a corrupt config.json fails loud (to log + stderr)
+// instead of silently reverting custom budget/idle thresholds to defaults.
+const config = configService.loadOrDefault(processLogger.log);
 
 const CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.codex.appPort), 10);
 const CODEX_PROXY_PORT = parseInt(process.env.CODEX_PROXY_PORT ?? String(config.codex.proxyPort), 10);

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -2,7 +2,24 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { ConfigService, DEFAULT_CONFIG, applyBudgetEnvOverrides } from "../config-service";
+import {
+  ConfigService,
+  DEFAULT_CONFIG,
+  applyBudgetEnvOverrides,
+  type AgentBridgeConfig,
+} from "../config-service";
+
+/**
+ * Helper: unwrap a parsed load() result, failing the test loudly if the config
+ * was absent/corrupt. Most existing tests expect a good parse; this keeps them
+ * terse while the new discriminated contract is exercised explicitly elsewhere.
+ */
+function expectParsed(svc: ConfigService): AgentBridgeConfig {
+  const result = svc.load();
+  expect(result.state).toBe("parsed");
+  if (result.state !== "parsed") throw new Error("unreachable");
+  return result.config;
+}
 
 describe("ConfigService", () => {
   let tempDir: string;
@@ -20,9 +37,11 @@ describe("ConfigService", () => {
     expect(svc.hasConfig()).toBe(false);
   });
 
-  test("load returns null when no config exists", () => {
+  test("load reports absent when no config exists", () => {
     const svc = new ConfigService(tempDir);
-    expect(svc.load()).toBeNull();
+    // Previously `load()` returned null for ENOENT; the discriminated contract
+    // distinguishes this normal-absence case from corruption.
+    expect(svc.load()).toEqual({ state: "absent" });
   });
 
   test("loadOrDefault returns defaults when no config exists", () => {
@@ -41,10 +60,9 @@ describe("ConfigService", () => {
 
     expect(svc.hasConfig()).toBe(true);
 
-    const loaded = svc.load();
-    expect(loaded).not.toBeNull();
-    expect(loaded!.idleShutdownSeconds).toBe(60);
-    expect(loaded!.version).toBe("1.0");
+    const loaded = expectParsed(svc);
+    expect(loaded.idleShutdownSeconds).toBe(60);
+    expect(loaded.version).toBe("1.0");
   });
 
   test("load normalizes legacy daemon config into codex config", () => {
@@ -72,12 +90,11 @@ describe("ConfigService", () => {
       "utf-8",
     );
 
-    const loaded = svc.load();
-    expect(loaded).not.toBeNull();
-    expect(loaded!.codex.appPort).toBe(4600);
-    expect(loaded!.codex.proxyPort).toBe(4601);
-    expect(loaded!.turnCoordination.attentionWindowSeconds).toBe(20);
-    expect(loaded!.idleShutdownSeconds).toBe(45);
+    const loaded = expectParsed(svc);
+    expect(loaded.codex.appPort).toBe(4600);
+    expect(loaded.codex.proxyPort).toBe(4601);
+    expect(loaded.turnCoordination.attentionWindowSeconds).toBe(20);
+    expect(loaded.idleShutdownSeconds).toBe(45);
   });
 
   test("load normalizes string numbers in legacy config", () => {
@@ -104,12 +121,11 @@ describe("ConfigService", () => {
       "utf-8",
     );
 
-    const loaded = svc.load();
-    expect(loaded).not.toBeNull();
-    expect(loaded!.codex.appPort).toBe(4600);
-    expect(loaded!.codex.proxyPort).toBe(4601);
-    expect(loaded!.turnCoordination.attentionWindowSeconds).toBe(20);
-    expect(loaded!.idleShutdownSeconds).toBe(45);
+    const loaded = expectParsed(svc);
+    expect(loaded.codex.appPort).toBe(4600);
+    expect(loaded.codex.proxyPort).toBe(4601);
+    expect(loaded.turnCoordination.attentionWindowSeconds).toBe(20);
+    expect(loaded.idleShutdownSeconds).toBe(45);
   });
 
   test("initDefaults creates only config.json", () => {
@@ -121,8 +137,8 @@ describe("ConfigService", () => {
     expect(existsSync(join(tempDir, ".agentbridge", "collaboration.md"))).toBe(false);
 
     // Verify content
-    const config = svc.load();
-    expect(config!.version).toBe("1.0");
+    const config = expectParsed(svc);
+    expect(config.version).toBe("1.0");
   });
 
   test("initDefaults does not overwrite existing files", () => {
@@ -136,13 +152,202 @@ describe("ConfigService", () => {
     const created = svc.initDefaults();
     expect(created.length).toBe(0);
 
-    const loaded = svc.load();
-    expect(loaded!.idleShutdownSeconds).toBe(99); // not overwritten
+    const loaded = expectParsed(svc);
+    expect(loaded.idleShutdownSeconds).toBe(99); // not overwritten
   });
 
   test("config file paths are correct", () => {
     const svc = new ConfigService(tempDir);
     expect(svc.configFilePath).toBe(join(tempDir, ".agentbridge", "config.json"));
+  });
+});
+
+describe("ConfigService — fail-loud on corrupt config (P1)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "agentbridge-config-corrupt-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeRaw(raw: string) {
+    mkdirSync(join(tempDir, ".agentbridge"), { recursive: true });
+    writeFileSync(join(tempDir, ".agentbridge", "config.json"), raw);
+  }
+
+  // ---- load() discriminated states ----
+
+  test("ENOENT → absent (not corrupt)", () => {
+    const svc = new ConfigService(tempDir);
+    expect(svc.load()).toEqual({ state: "absent" });
+  });
+
+  test("malformed JSON → corrupt", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw("{ not valid json");
+    const result = svc.load();
+    expect(result.state).toBe("corrupt");
+    if (result.state === "corrupt") {
+      expect(result.reason).toContain("not valid JSON");
+    }
+  });
+
+  test("valid JSON but not an object → corrupt", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw("[1, 2, 3]");
+    const result = svc.load();
+    expect(result.state).toBe("corrupt");
+    if (result.state === "corrupt") {
+      expect(result.reason).toContain("not a JSON object");
+    }
+  });
+
+  test("valid JSON, wrong shape (non-numeric budget threshold) → corrupt", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw(JSON.stringify({ budget: { pauseAt: "ninety" } }));
+    const result = svc.load();
+    expect(result.state).toBe("corrupt");
+    if (result.state === "corrupt") {
+      expect(result.reason).toContain("budget.pauseAt");
+    }
+  });
+
+  test("valid JSON, non-numeric idleShutdownSeconds → corrupt", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw(JSON.stringify({ idleShutdownSeconds: "soon" }));
+    const result = svc.load();
+    expect(result.state).toBe("corrupt");
+    if (result.state === "corrupt") {
+      expect(result.reason).toContain("idleShutdownSeconds");
+    }
+  });
+
+  test("valid JSON, budget present but not an object → corrupt", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw(JSON.stringify({ budget: "tight" }));
+    const result = svc.load();
+    expect(result.state).toBe("corrupt");
+    if (result.state === "corrupt") {
+      expect(result.reason).toContain("budget is present but not an object");
+    }
+  });
+
+  test("valid JSON, non-numeric parallel field → corrupt", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw(JSON.stringify({ budget: { parallel: { timeWindowSec: "later" } } }));
+    const result = svc.load();
+    expect(result.state).toBe("corrupt");
+    if (result.state === "corrupt") {
+      expect(result.reason).toContain("budget.parallel.timeWindowSec");
+    }
+  });
+
+  test("valid good config → parsed", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw(JSON.stringify({ budget: { pauseAt: 85, resumeBelow: 20 } }));
+    const result = svc.load();
+    expect(result.state).toBe("parsed");
+    if (result.state === "parsed") {
+      expect(result.config.budget.pauseAt).toBe(85);
+    }
+  });
+
+  test("absent budget section is NOT corrupt (legacy/partial config normalizes to defaults)", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw(JSON.stringify({ version: "1.0" }));
+    const result = svc.load();
+    expect(result.state).toBe("parsed");
+    if (result.state === "parsed") {
+      expect(result.config.budget.pauseAt).toBe(90);
+    }
+  });
+
+  test("string-number thresholds stay valid (coercible, not corrupt)", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw(JSON.stringify({ idleShutdownSeconds: "45", budget: { pauseAt: "85", resumeBelow: "20" } }));
+    const result = svc.load();
+    expect(result.state).toBe("parsed");
+    if (result.state === "parsed") {
+      expect(result.config.idleShutdownSeconds).toBe(45);
+      expect(result.config.budget.pauseAt).toBe(85);
+    }
+  });
+
+  // ---- loadOrDefault() warning behavior ----
+
+  test("loadOrDefault logs a warning ONLY on corrupt; returns defaults", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw("{ broken");
+    const warnings: string[] = [];
+    const config = svc.loadOrDefault((msg) => warnings.push(msg));
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings.length).toBe(1); // exactly one clear line, no spam
+    expect(warnings[0]).toContain("NOT in effect");
+  });
+
+  test("loadOrDefault does NOT log on ENOENT (normal absence)", () => {
+    const svc = new ConfigService(tempDir);
+    const warnings: string[] = [];
+    const config = svc.loadOrDefault((msg) => warnings.push(msg));
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings.length).toBe(0);
+  });
+
+  test("loadOrDefault does NOT log on a good config", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw(JSON.stringify({ budget: { pauseAt: 85, resumeBelow: 20 } }));
+    const warnings: string[] = [];
+    const config = svc.loadOrDefault((msg) => warnings.push(msg));
+
+    expect(warnings.length).toBe(0);
+    expect(config.budget.pauseAt).toBe(85);
+  });
+
+  test("loadOrDefault works with the default no-arg logger (no throw)", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw("{ broken");
+    // The default no-op logger path must keep existing callers working.
+    expect(() => svc.loadOrDefault()).not.toThrow();
+    expect(svc.loadOrDefault()).toEqual(DEFAULT_CONFIG);
+  });
+
+  // ---- describeConfig() for doctor ----
+
+  test("describeConfig reports absent when no config exists", () => {
+    const svc = new ConfigService(tempDir);
+    const desc = svc.describeConfig();
+    expect(desc.state).toBe("absent");
+    expect(desc.customValues).toBe(false);
+  });
+
+  test("describeConfig reports corrupt with a reason", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw("{ broken");
+    const desc = svc.describeConfig();
+    expect(desc.state).toBe("corrupt");
+    expect(desc.reason).toBeDefined();
+    expect(desc.customValues).toBe(false);
+  });
+
+  test("describeConfig reports parsed with customValues=false when all match defaults", () => {
+    const svc = new ConfigService(tempDir);
+    svc.save(structuredClone(DEFAULT_CONFIG));
+    const desc = svc.describeConfig();
+    expect(desc.state).toBe("parsed");
+    expect(desc.customValues).toBe(false);
+  });
+
+  test("describeConfig reports parsed with customValues=true when a threshold differs", () => {
+    const svc = new ConfigService(tempDir);
+    writeRaw(JSON.stringify({ budget: { pauseAt: 85, resumeBelow: 20 } }));
+    const desc = svc.describeConfig();
+    expect(desc.state).toBe("parsed");
+    expect(desc.customValues).toBe(true);
   });
 });
 
@@ -160,6 +365,13 @@ describe("ConfigService — budget section", () => {
   function writeRawConfig(raw: unknown) {
     mkdirSync(join(tempDir, ".agentbridge"), { recursive: true });
     writeFileSync(join(tempDir, ".agentbridge", "config.json"), JSON.stringify(raw));
+  }
+
+  function loadBudget(svc: ConfigService) {
+    const result = svc.load();
+    expect(result.state).toBe("parsed");
+    if (result.state !== "parsed") throw new Error("unreachable");
+    return result.config.budget;
   }
 
   test("loadOrDefault includes budget defaults", () => {
@@ -184,9 +396,9 @@ describe("ConfigService — budget section", () => {
   test("load fills budget defaults when section is missing", () => {
     const svc = new ConfigService(tempDir);
     writeRawConfig({ version: "1.0" });
-    const loaded = svc.load();
-    expect(loaded!.budget.pauseAt).toBe(90);
-    expect(loaded!.budget.enabled).toBe(true);
+    const budget = loadBudget(svc);
+    expect(budget.pauseAt).toBe(90);
+    expect(budget.enabled).toBe(true);
   });
 
   test("load accepts valid custom budget values", () => {
@@ -203,8 +415,8 @@ describe("ConfigService — budget section", () => {
         codexTiers: { full: { effort: "high" }, eco: { effort: "minimal" } },
       },
     });
-    const loaded = svc.load();
-    expect(loaded!.budget).toEqual({
+    const budget = loadBudget(svc);
+    expect(budget).toEqual({
       enabled: false,
       pollSeconds: 120,
       pauseAt: 85,
@@ -223,10 +435,10 @@ describe("ConfigService — budget section", () => {
   test("codexTierControl degrades to false when codexTiers.full is missing", () => {
     const svc = new ConfigService(tempDir);
     writeRawConfig({ budget: { codexTierControl: true } });
-    const loaded = svc.load();
+    const budget = loadBudget(svc);
     // Sticky turn/start overrides need an explicit restore point.
-    expect(loaded!.budget.codexTierControl).toBe(false);
-    expect(loaded!.budget.codexTiers.full).toBeNull();
+    expect(budget.codexTierControl).toBe(false);
+    expect(budget.codexTiers.full).toBeNull();
   });
 
   test("tier overrides drop empty/non-string fields", () => {
@@ -240,45 +452,48 @@ describe("ConfigService — budget section", () => {
         },
       },
     });
-    const loaded = svc.load();
-    expect(loaded!.budget.codexTiers.full).toEqual({ effort: "high" }); // trimmed, empty model dropped
-    expect(loaded!.budget.codexTiers.balanced).toEqual({ effort: "medium" }); // invalid → default
-    expect(loaded!.budget.codexTierControl).toBe(true);
+    const budget = loadBudget(svc);
+    expect(budget.codexTiers.full).toEqual({ effort: "high" }); // trimmed, empty model dropped
+    expect(budget.codexTiers.balanced).toEqual({ effort: "medium" }); // invalid → default
+    expect(budget.codexTierControl).toBe(true);
   });
 
   test("out-of-range budget values fall back to defaults", () => {
     const svc = new ConfigService(tempDir);
     writeRawConfig({
       budget: {
-        pollSeconds: 1, // below min 5
+        pollSeconds: 1, // below min 5 — coercible number, NOT shape-invalid
         pauseAt: 150, // above 100
         syncDriftPct: 0, // below min 1
         parallel: { minRemainingPct: 200, timeWindowSec: 10 },
       },
     });
-    const loaded = svc.load();
-    expect(loaded!.budget.pollSeconds).toBe(300);
-    expect(loaded!.budget.pauseAt).toBe(90);
-    expect(loaded!.budget.syncDriftPct).toBe(10);
-    expect(loaded!.budget.parallel.minRemainingPct).toBe(60);
-    expect(loaded!.budget.parallel.timeWindowSec).toBe(3600);
+    const budget = loadBudget(svc);
+    expect(budget.pollSeconds).toBe(300);
+    expect(budget.pauseAt).toBe(90);
+    expect(budget.syncDriftPct).toBe(10);
+    expect(budget.parallel.minRemainingPct).toBe(60);
+    expect(budget.parallel.timeWindowSec).toBe(3600);
   });
 
   test("pauseAt <= resumeBelow resets BOTH thresholds to defaults", () => {
     const svc = new ConfigService(tempDir);
     writeRawConfig({ budget: { pauseAt: 25, resumeBelow: 40 } });
-    const loaded = svc.load();
+    const budget = loadBudget(svc);
     // An unsatisfiable pause lifecycle must never survive normalization.
-    expect(loaded!.budget.pauseAt).toBe(90);
-    expect(loaded!.budget.resumeBelow).toBe(30);
+    expect(budget.pauseAt).toBe(90);
+    expect(budget.resumeBelow).toBe(30);
   });
 
-  test("non-boolean enabled/codexTierControl fall back to defaults", () => {
+  test("non-boolean enabled/codexTierControl fall back to defaults (lenient, not corrupt)", () => {
     const svc = new ConfigService(tempDir);
+    // P1 shape-validation depth is the NUMERIC decision-grade fields the proposal
+    // calls out. Booleans keep the lenient normalize-to-default behavior, so a
+    // typo here is not startup-affecting and the config still parses.
     writeRawConfig({ budget: { enabled: "yes", codexTierControl: 1 } });
-    const loaded = svc.load();
-    expect(loaded!.budget.enabled).toBe(true);
-    expect(loaded!.budget.codexTierControl).toBe(false);
+    const budget = loadBudget(svc);
+    expect(budget.enabled).toBe(true);
+    expect(budget.codexTierControl).toBe(false);
   });
 });
 

--- a/src/unit-test/doctor.test.ts
+++ b/src/unit-test/doctor.test.ts
@@ -89,6 +89,7 @@ describe("doctor command", () => {
       expect(report.checks.map((check: { name: string }) => check.name)).toEqual([
         "pair registration",
         "env",
+        "config.json",
         "daemon health",
         "daemon readiness",
         "build drift",
@@ -148,6 +149,72 @@ describe("doctor command", () => {
 
       expect(daemonLog.status).toBe("warn");
       expect(daemonLog.detail).toContain("oversized");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("config.json check is OK and reports default-in-effect when no config exists", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-doctor-"));
+    const base = mkdtempSync(join(tmpdir(), "agentbridge-doctor-base-"));
+    try {
+      process.chdir(root);
+      process.env.AGENTBRIDGE_BASE_DIR = base;
+      seedPair(root, base);
+
+      const report = await runDoctorJson(["--pair", "main"]);
+      const cfg = report.checks.find((c: { name: string }) => c.name === "config.json");
+
+      expect(cfg.status).toBe("ok");
+      expect(cfg.detail).toContain("no project config");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("config.json check is OK and reports custom-values-in-effect for a good custom config", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-doctor-"));
+    const base = mkdtempSync(join(tmpdir(), "agentbridge-doctor-base-"));
+    try {
+      process.chdir(root);
+      process.env.AGENTBRIDGE_BASE_DIR = base;
+      seedPair(root, base);
+      mkdirSync(join(root, ".agentbridge"), { recursive: true });
+      writeFileSync(
+        join(root, ".agentbridge", "config.json"),
+        JSON.stringify({ budget: { pauseAt: 85, resumeBelow: 20 } }),
+        "utf-8",
+      );
+
+      const report = await runDoctorJson(["--pair", "main"]);
+      const cfg = report.checks.find((c: { name: string }) => c.name === "config.json");
+
+      expect(cfg.status).toBe("ok");
+      expect(cfg.detail).toContain("custom values in effect");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("config.json check WARNs on a corrupt config", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-doctor-"));
+    const base = mkdtempSync(join(tmpdir(), "agentbridge-doctor-base-"));
+    try {
+      process.chdir(root);
+      process.env.AGENTBRIDGE_BASE_DIR = base;
+      seedPair(root, base);
+      mkdirSync(join(root, ".agentbridge"), { recursive: true });
+      writeFileSync(join(root, ".agentbridge", "config.json"), "{ broken json", "utf-8");
+
+      const report = await runDoctorJson(["--pair", "main"]);
+      const cfg = report.checks.find((c: { name: string }) => c.name === "config.json");
+
+      expect(cfg.status).toBe("warn");
+      expect(cfg.detail).toContain("NOT in effect");
+      expect(cfg.hint).toBeDefined();
     } finally {
       rmSync(root, { recursive: true, force: true });
       rmSync(base, { recursive: true, force: true });


### PR DESCRIPTION
## 摘要
审视报告 P1：ConfigService.load() catch 全吞，文件不存在与 JSON 损坏/形状非法都返回 null → 用户自定义 budget 阈值在手编打错/截断后**静默变回默认**，无告警，与 registry 的 fail-loud 不一致。

## 变更
- load() 三态：absent(ENOENT) / corrupt / parsed
- loadOrDefault(logger?) 仅 corrupt 时打明确 warning（daemon→log，CLI→stderr）；**从不中断启动**
- shape 校验聚焦数值决策字段（present-but-uncoercible 才 corrupt，absent 仍 lenient → 向后兼容部分配置）
- abg doctor 增 config 可解析性检查

## 测试
- [x] 764 pass；ci:local 绿；cross-review **双 0 REAL**（含真实 loader 探针验证三态 + 向后兼容 legacy 配置）