### PR TITLE
feat: 协作协议 v2 PR B——turn/interrupt 打断 + turn_started ACK + 注入幂等 / protocol v2 PR B

### DIFF
--- a/docs/collaboration-protocol-v2.md
+++ b/docs/collaboration-protocol-v2.md
@@ -1,11 +1,11 @@
 # Collaboration Protocol v2 — 设计契约 / Design Contract
 
-> 状态：PR A 实施中。本文档是 Claude × Codex 两轮设计共识的固化版本（2026-06-10），
-> 实施任何一个 PR 时以此为契约；修改契约需双方重新共识。
+> 状态：PR A、B0、B 已实施；PR C 未实施。本文档是 Claude × Codex 两轮设计共识的
+> 固化版本（2026-06-10），实施任何一个 PR 时以此为契约；修改契约需双方重新共识。
 >
-> Status: PR A in progress. This document freezes the two-round design
-> consensus between Claude and Codex (2026-06-10). Implementations MUST follow
-> it; contract changes require renewed consensus.
+> Status: PR A, B0 and B implemented; PR C pending. This document freezes the
+> two-round design consensus between Claude and Codex (2026-06-10).
+> Implementations MUST follow it; contract changes require renewed consensus.
 
 ## 背景 / Background
 
@@ -62,7 +62,7 @@ observable, correlatable contract.
   `turn_started` ACK 补足。
 - `turn/interrupt`（打断入口）**不在 B0**，与 ACK/幂等机制一起进 PR B。
 
-### PR B — 核心协议：ACK + 幂等 / core protocol: ACK + idempotency（未实施）
+### PR B — 核心协议：ACK + 幂等 / core protocol: ACK + idempotency（已实施）
 
 - `claude_to_codex_result` 维持即时返回，语义收窄为 **accepted** =
   「daemon 已接收并已尝试写入 turn/start」；Claude 侧 15s 超时仅适用于
@@ -83,6 +83,50 @@ observable, correlatable contract.
 - 结构化 result 最小版：`{ok:false, code, phase?, retryAfterMs?, retryAfterEpoch?}`；
   旧 `error` 字符串并存一个版本。`phase` 引用 turnPhase 值域；
   `code/phase/retryAfter` 是 per-request 诊断，不与 status 状态合并改造。
+
+#### PR B 实施定案 / Implementation deltas（2026-06-11）
+
+- **打断入口 = `reply` 的 `on_busy:"interrupt"`**：busy 时经 app-server
+  `turn/interrupt {threadId, turnId}` 终结**全部**可寻址 active turn（多 turn
+  歧义按共识「全部终结」处理；只有 `unknown:` fallback key 时本地结构化失败
+  `interrupt_unavailable`，不发 wire）。等待 terminal 边界
+  （`waitForTurnsTerminal`：**仅** targeted ids 全部离开 activeTurnIds 且不再
+  被标记 stalled——按 targeted id 逐一判定，**不**读全局 phase，否则一个共存的
+  不可寻址 `unknown:` turn 会让 phase 永远 running 而误判超时；超时默认 10s，
+  `AGENTBRIDGE_INTERRUPT_TIMEOUT_MS` 可调但**被钳制**在 client reply timeout
+  之下（见 `interrupt-timing.ts`：`clampInterruptTimeoutMs`，防 false client
+  timeout + 重试 double-turn）。等待可经 `AbortSignal` 取消，`interruptFailed`
+  抢先时立即拆掉内层 listeners/timer）
+  后走**与普通 reply 完全相同的注入路径**（tier overrides / require_reply
+  arming / attention window 收口）。失败面：`interrupt_unavailable` /
+  `interrupt_rejected`（原 turn 继续跑，文案明示）/ `interrupt_timeout`
+  （**不注入**，防 double-turn race）。codex-rs 实证：interrupt 的 success
+  response（`{}`）被 app-server 推迟到 TurnAborted 才回；被打断 turn 的
+  terminal 通知是带 `status:"interrupted"` 的普通 `turn/completed` ——
+  既有 turn/completed 处理就是 terminal 边界。
+- **结构化 result codes 清单**：`invalid_source / no_thread / busy_reject /
+  budget_paused / steer_failed / interrupt_unavailable / interrupt_rejected /
+  interrupt_timeout / duplicate_in_flight / duplicate_terminal /
+  internal_error`。`ok` 与 `success` 镜像并存一个版本；`phase` 每个 result
+  都带；`retryAfterMs` 仅 busy_reject（建议性轮询间隔 15s，无诚实的 turn
+  结束估计）与 budget_paused（由 resumeAfterEpoch 推导）填。
+- **幂等键注册时机**：只有**真正发生 wire 写入尝试**（turn/start、turn/steer
+  传输受理，或 interrupt 等待窗开启）才注册 key；前置拒绝
+  （busy_reject / budget_paused / no_thread）**不注册**——消息从未进管道，
+  同 key 重试必须放行。interrupt 失败/超时路径 `release()` 已注册的 key，
+  同理保持可重试。带 key 的 steer 在传输受理时绑定到所加入的 turn
+  （started(steeredTurnId)），随该 turn 的 terminal 终结，不会滞留；若 steer
+  **被 app-server 拒绝**（`steerFailed`），daemon 也 `release()` 该 key——steer
+  从未到达 Codex，同 key 必须立即可重试（与 interrupt 失败释放对称，修复
+  「被拒 steer 把 key 滞留在 started」）。
+- **require_reply × steer 正式语义**：tool 层与 daemon 层的拒绝均已移除；
+  steer 正文携带 reply-required instruction，daemon 在 **steerAccepted**
+  事件（app-server 受理）时 arm 期望——「steer-accept 之后、该 turn terminal
+  之前的新 agentMessage 即视为 reply」。steer dispatch 与响应**按 bridge
+  request id 关联**（`steerAccepted`/`steerFailed` 携带 id），而非 FIFO ——
+  丢失/乱序的 steer 响应不会把 dispatch（含 require_reply 期望与幂等键）误配
+  到错误 turn；`turnTrackingReset` 一并清掉孤儿 dispatch。require_reply ×
+  interrupt 允许（最终开新 turn，注入成功后照常 arm）。
 
 ### PR C — 预算指令降噪分层 / budget directive layering（未实施）
 

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13973,7 +13973,7 @@ var CLAUDE_INSTRUCTIONS = [
   "## Turn coordination",
   "- When you see '\u23F3 Codex is working', do NOT call the reply tool \u2014 wait for '\u2705 Codex finished'.",
   "- After Codex finishes a turn, you have an attention window to review and respond before new messages arrive.",
-  '- If the reply tool returns a busy error, Codex is still executing. You decide: wait and retry later, or resend with on_busy="steer" to feed the message INTO the running turn (good for mid-course corrections; it does not interrupt or restart the work).',
+  '- If the reply tool returns a busy error, Codex is still executing. You decide: wait and retry later, resend with on_busy="steer" to feed the message INTO the running turn (good for mid-course corrections; it does not interrupt or restart the work), or resend with on_busy="interrupt" to STOP the running turn and start a new one with your message (use only when the current work is obsolete \u2014 prefer steer otherwise).',
   "",
   "## Budget awareness",
   "- Use the get_budget tool to check both agents' subscription quota (5h/weekly windows, drift, pause state).",
@@ -14124,12 +14124,16 @@ ${formatted}`
               },
               require_reply: {
                 type: "boolean",
-                description: "When true, Codex is required to send a reply. All Codex messages from this turn will be forwarded immediately (bypassing STATUS buffering). Use this when you need a direct answer from Codex."
+                description: 'When true, Codex is required to send a reply. All Codex messages from this turn will be forwarded immediately (bypassing STATUS buffering). Use this when you need a direct answer from Codex. Combinable with on_busy="steer": the reply expectation arms once the steer is accepted into the running turn.'
               },
               on_busy: {
                 type: "string",
-                enum: ["reject", "steer"],
-                description: `What to do when Codex is mid-turn. "reject" (default): fail with a busy error \u2014 wait and retry. "steer": feed this message INTO the running turn \u2014 Codex sees it immediately and integrates it without losing work. Use steer for mid-course corrections, added constraints, or updated acceptance criteria; it does NOT start a new turn, so don't combine it with require_reply. If you need Codex to STOP and do something else, wait for the turn to finish (interrupt support is coming separately).`
+                enum: ["reject", "steer", "interrupt"],
+                description: 'What to do when Codex is mid-turn. "reject" (default): fail with a busy error \u2014 wait and retry. "steer": feed this message INTO the running turn \u2014 Codex sees it immediately and integrates it without losing work; use it for mid-course corrections, added constraints, or updated acceptance criteria (it does NOT start a new turn). "interrupt": STOP the running turn, wait for it to terminate, then send this message as a NEW turn \u2014 use only when the current work is obsolete; prefer steer otherwise.'
+              },
+              idempotency_key: {
+                type: "string",
+                description: "Optional client-generated key (non-empty, max 128 chars) that makes this reply idempotent: a retry carrying the same key is NOT re-injected \u2014 the bridge answers duplicate_in_flight / duplicate_terminal instead. Use a fresh key per logical message."
               }
             },
             required: ["text"]
@@ -14189,19 +14193,29 @@ ${formatted}`
     }
     const requireReply = args?.require_reply === true;
     const onBusyRaw = args?.on_busy;
-    const onBusy = onBusyRaw === "steer" ? "steer" : "reject";
-    if (onBusyRaw !== undefined && onBusyRaw !== "reject" && onBusyRaw !== "steer") {
+    if (onBusyRaw !== undefined && onBusyRaw !== "reject" && onBusyRaw !== "steer" && onBusyRaw !== "interrupt") {
       return {
-        content: [{ type: "text", text: `Error: invalid on_busy value ${JSON.stringify(onBusyRaw)} \u2014 use "reject" or "steer".` }],
+        content: [{ type: "text", text: `Error: invalid on_busy value ${JSON.stringify(onBusyRaw)} \u2014 use "reject", "steer" or "interrupt".` }],
         isError: true
       };
     }
-    if (onBusy === "steer" && requireReply) {
-      return {
-        content: [{ type: "text", text: 'Error: require_reply cannot be combined with on_busy="steer" yet \u2014 a steer joins the RUNNING turn instead of starting a new one, so reply tracking would mis-arm. Send the steer without require_reply.' }],
-        isError: true
-      };
+    const onBusy = onBusyRaw === "steer" || onBusyRaw === "interrupt" ? onBusyRaw : "reject";
+    const idempotencyKeyRaw = args?.idempotency_key;
+    if (idempotencyKeyRaw !== undefined) {
+      if (typeof idempotencyKeyRaw !== "string" || idempotencyKeyRaw.length === 0) {
+        return {
+          content: [{ type: "text", text: "Error: idempotency_key must be a non-empty string." }],
+          isError: true
+        };
+      }
+      if (idempotencyKeyRaw.length > 128) {
+        return {
+          content: [{ type: "text", text: `Error: idempotency_key is too long (${idempotencyKeyRaw.length} chars, max 128).` }],
+          isError: true
+        };
+      }
     }
+    const idempotencyKey = idempotencyKeyRaw;
     const bridgeMsg = {
       id: args?.chat_id ?? `reply_${Date.now()}`,
       source: "claude",
@@ -14215,16 +14229,22 @@ ${formatted}`
         isError: true
       };
     }
-    const result = await this.replySender(bridgeMsg, requireReply, onBusy);
+    const result = await this.replySender(bridgeMsg, requireReply, onBusy, idempotencyKey);
     if (!result.success) {
-      this.log(`Reply delivery failed: ${result.error}`);
+      this.log(`Reply delivery failed: ${result.error}${result.code ? ` (code=${result.code})` : ""}`);
+      const codePrefix = result.code ? ` [${result.code}]` : "";
       return {
-        content: [{ type: "text", text: `Error: ${result.error}` }],
+        content: [{ type: "text", text: `Error${codePrefix}: ${result.error}` }],
         isError: true
       };
     }
     const pending = this.pendingMessages.length;
-    let responseText = onBusy === "steer" ? "Reply sent to Codex (will be steered into the running turn if one is active; watch for a system_steer_failed notice if the app-server rejects it)." : "Reply sent to Codex.";
+    let responseText = "Reply sent to Codex.";
+    if (onBusy === "steer") {
+      responseText = "Reply sent to Codex (will be steered into the running turn if one is active; watch for a system_steer_failed notice if the app-server rejects it).";
+    } else if (onBusy === "interrupt") {
+      responseText = "Reply sent to Codex as a new turn (any turn still running was interrupted first; if it had already finished, your message was simply injected).";
+    }
     if (pending > 0) {
       responseText += ` Note: ${pending} unread Codex message${pending > 1 ? "s" : ""} already waiting \u2014 call get_messages to read them.`;
     }
@@ -14254,7 +14274,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("a2eb5fa", "source"),
+  commit: defineString("2d4804a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14282,6 +14302,11 @@ var CLOSE_CODE_REPLACED = 4001;
 var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 var CLOSE_CODE_PAIR_MISMATCH = 4004;
+
+// src/interrupt-timing.ts
+var CLIENT_REPLY_TIMEOUT_MS = 15000;
+var INTERRUPT_CLIENT_MARGIN_MS = 2000;
+var MAX_INTERRUPT_TIMEOUT_MS = CLIENT_REPLY_TIMEOUT_MS - INTERRUPT_CLIENT_MARGIN_MS;
 
 // src/daemon-client.ts
 var nextSocketId = 0;
@@ -14426,7 +14451,7 @@ class DaemonClient extends EventEmitter2 {
     this.ws = null;
     this.rejectPendingReplies("Daemon connection closed");
   }
-  async sendReply(message, requireReply, onBusy) {
+  async sendReply(message, requireReply, onBusy, idempotencyKey) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return { success: false, error: "AgentBridge daemon is not connected." };
     }
@@ -14435,14 +14460,15 @@ class DaemonClient extends EventEmitter2 {
       const timer = setTimeout(() => {
         this.pendingReplies.delete(requestId);
         resolve({ success: false, error: "Timed out waiting for AgentBridge daemon reply." });
-      }, 15000);
+      }, CLIENT_REPLY_TIMEOUT_MS);
       this.pendingReplies.set(requestId, { resolve, timer });
       this.send({
         type: "claude_to_codex",
         requestId,
         message,
         ...requireReply ? { requireReply: true } : {},
-        ...onBusy && onBusy !== "reject" ? { onBusy } : {}
+        ...onBusy && onBusy !== "reject" ? { onBusy } : {},
+        ...idempotencyKey ? { idempotencyKey } : {}
       });
     });
   }
@@ -14465,9 +14491,23 @@ class DaemonClient extends EventEmitter2 {
             return;
           clearTimeout(pending.timer);
           this.pendingReplies.delete(message.requestId);
-          pending.resolve({ success: message.success, error: message.error });
+          pending.resolve({
+            success: message.success,
+            error: message.error,
+            ...message.code !== undefined ? { code: message.code } : {},
+            ...message.phase !== undefined ? { phase: message.phase } : {},
+            ...message.retryAfterMs !== undefined ? { retryAfterMs: message.retryAfterMs } : {}
+          });
           return;
         }
+        case "turn_started":
+          this.emit("turnStarted", {
+            requestId: message.requestId,
+            ...message.idempotencyKey !== undefined ? { idempotencyKey: message.idempotencyKey } : {},
+            threadId: message.threadId,
+            turnId: message.turnId
+          });
+          return;
         case "status":
           this.emit("status", message.status);
           return;
@@ -15501,7 +15541,7 @@ if (process.env.AGENTBRIDGE_TRACE === "1") {
     });
   } catch {}
 }
-claude.setReplySender(async (msg, requireReply, onBusy) => {
+claude.setReplySender(async (msg, requireReply, onBusy, idempotencyKey) => {
   if (msg.source !== "claude") {
     return { success: false, error: "Invalid message source" };
   }
@@ -15511,7 +15551,10 @@ claude.setReplySender(async (msg, requireReply, onBusy) => {
       error: disabledReplyError(daemonDisabledReason ?? "killed")
     };
   }
-  return daemonClient.sendReply(msg, requireReply, onBusy);
+  return daemonClient.sendReply(msg, requireReply, onBusy, idempotencyKey);
+});
+daemonClient.on("turnStarted", ({ requestId, idempotencyKey, threadId, turnId }) => {
+  log(`Codex turn started for reply ${requestId} (turn=${turnId}, thread=${threadId}` + `${idempotencyKey ? `, idempotencyKey=${idempotencyKey}` : ""})`);
 });
 daemonClient.on("codexMessage", (message) => {
   log(`Forwarding daemon \u2192 Claude (${message.content.length} chars)`);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("a2eb5fa", "source"),
+  commit: defineString("2d4804a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -383,6 +383,28 @@ function isAppServerResponseMessage(value) {
   if (!isObjectRecord(value))
     return false;
   return (typeof value.id === "number" || typeof value.id === "string") && value.method === undefined && (("result" in value) || ("error" in value));
+}
+
+// src/env-utils.ts
+function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) {
+  const raw = env[name];
+  if (raw == null || raw === "")
+    return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > Number.MAX_SAFE_INTEGER) {
+    log(`Invalid ${name}=${JSON.stringify(raw)} (must be a positive integer within ` + `Number.MAX_SAFE_INTEGER); falling back to ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
+// src/interrupt-timing.ts
+var CLIENT_REPLY_TIMEOUT_MS = 15000;
+var INTERRUPT_CLIENT_MARGIN_MS = 2000;
+var DEFAULT_INTERRUPT_TIMEOUT_MS = 1e4;
+var MAX_INTERRUPT_TIMEOUT_MS = CLIENT_REPLY_TIMEOUT_MS - INTERRUPT_CLIENT_MARGIN_MS;
+function clampInterruptTimeoutMs(requested) {
+  return Math.min(requested, MAX_INTERRUPT_TIMEOUT_MS);
 }
 
 // src/codex-transport.ts
@@ -806,15 +828,15 @@ class CodexAdapter extends EventEmitter {
   injectMessage(text, overrides) {
     if (!this.threadId) {
       this.log("Cannot inject: no active thread");
-      return false;
+      return null;
     }
     if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
       this.log("Cannot inject: app-server WebSocket not connected");
-      return false;
+      return null;
     }
     if (this.turnInProgress) {
       this.log(`Rejected injection: Codex turn is in progress (thread ${this.threadId})`);
-      return false;
+      return null;
     }
     this.log(`Injecting message into Codex (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
@@ -833,30 +855,30 @@ class CodexAdapter extends EventEmitter {
         id: requestId,
         params
       }));
-      return true;
+      return requestId;
     } catch (err) {
       this.untrackBridgeRequestId(requestId);
       this.log(`Injection send failed: ${err.message}`);
-      return false;
+      return null;
     }
   }
   steerMessage(text) {
     if (!this.threadId) {
       this.log("Cannot steer: no active thread");
-      return false;
+      return null;
     }
     if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
       this.log("Cannot steer: app-server WebSocket not connected");
-      return false;
+      return null;
     }
     if (!this.turnInProgress) {
       this.log("Cannot steer: no turn in progress (use injectMessage)");
-      return false;
+      return null;
     }
     const expectedTurnId = this.currentSteerableTurnId();
     if (!expectedTurnId) {
       this.log("Cannot steer: no addressable active turn id (turn/started carried no id)");
-      return false;
+      return null;
     }
     this.log(`Steering message into active Codex turn ${expectedTurnId} (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
@@ -872,12 +894,96 @@ class CodexAdapter extends EventEmitter {
         id: requestId,
         params
       }));
-      return true;
+      return requestId;
     } catch (err) {
       this.untrackBridgeRequestId(requestId);
       this.log(`Steer send failed: ${err.message}`);
-      return false;
+      return null;
     }
+  }
+  interruptActiveTurns() {
+    if (!this.threadId) {
+      this.log("Cannot interrupt: no active thread");
+      return { ok: false, code: "interrupt_unavailable", error: "no active thread" };
+    }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      this.log("Cannot interrupt: app-server WebSocket not connected");
+      return { ok: false, code: "interrupt_unavailable", error: "app-server WebSocket not connected" };
+    }
+    const addressable = [...this.activeTurnIds].filter((id) => !id.startsWith("unknown:"));
+    if (addressable.length === 0) {
+      this.log("Cannot interrupt: no addressable active turn id (turn/started carried no id)");
+      return {
+        ok: false,
+        code: "interrupt_unavailable",
+        error: "no addressable active turn id (turn/started carried no id)"
+      };
+    }
+    for (const turnId of addressable) {
+      const requestId = this.nextInjectionId--;
+      this.trackBridgeRequestId(requestId, "interrupt");
+      const params = { threadId: this.threadId, turnId };
+      try {
+        this.appServerWs.send(JSON.stringify({
+          method: "turn/interrupt",
+          id: requestId,
+          params
+        }));
+        this.log(`Sent turn/interrupt for active turn ${turnId} (request ${requestId})`);
+      } catch (err) {
+        this.untrackBridgeRequestId(requestId);
+        this.log(`turn/interrupt send failed for ${turnId}: ${err.message}`);
+        return {
+          ok: false,
+          code: "interrupt_unavailable",
+          error: `turn/interrupt send failed (${err.message}); earlier interrupts may still land`
+        };
+      }
+    }
+    return { ok: true, turnIds: addressable };
+  }
+  interruptTimeoutMs() {
+    const requested = parsePositiveIntEnv("AGENTBRIDGE_INTERRUPT_TIMEOUT_MS", DEFAULT_INTERRUPT_TIMEOUT_MS, (m) => this.log(m));
+    const clamped = clampInterruptTimeoutMs(requested);
+    if (clamped !== requested) {
+      this.log(`AGENTBRIDGE_INTERRUPT_TIMEOUT_MS=${requested}ms exceeds the safe ceiling \u2014 ` + `clamped to ${clamped}ms (must resolve before the client reply timeout to avoid a double-turn)`);
+    }
+    return clamped;
+  }
+  waitForTurnsTerminal(turnIds, timeoutMs = this.interruptTimeoutMs(), signal) {
+    const satisfied = () => turnIds.every((id) => !this.activeTurnIds.has(id) && !this.currentlyStalledTurnIds.has(id));
+    if (satisfied())
+      return Promise.resolve({ ok: true });
+    if (signal?.aborted)
+      return Promise.resolve({ ok: false, code: "interrupt_aborted" });
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = (result) => {
+        if (settled)
+          return;
+        settled = true;
+        clearTimeout(timer);
+        this.off("turnIdCompleted", check);
+        this.off("turnTrackingReset", check);
+        this.off("turnPhaseChanged", check);
+        signal?.removeEventListener("abort", onAbort);
+        resolve(result);
+      };
+      const check = () => {
+        if (satisfied())
+          finish({ ok: true });
+      };
+      const onAbort = () => finish({ ok: false, code: "interrupt_aborted" });
+      const timer = setTimeout(() => {
+        this.log(`waitForTurnsTerminal timed out after ${timeoutMs}ms (still active: ` + `${turnIds.filter((id) => this.activeTurnIds.has(id)).join(", ") || "none"}, phase=${this.turnPhase})`);
+        finish({ ok: false, code: "interrupt_timeout" });
+      }, timeoutMs);
+      timer.unref?.();
+      this.on("turnIdCompleted", check);
+      this.on("turnTrackingReset", check);
+      this.on("turnPhaseChanged", check);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
   }
   async waitForHealthy(maxRetries = 20, delayMs = 500) {
     for (let i = 0;i < maxRetries; i++) {
@@ -1610,16 +1716,30 @@ class CodexAdapter extends EventEmitter {
       if (parsed.error) {
         this.log(`Bridge-originated ${bridgeKind} request failed (id ${responseId}): ${parsed.error.message ?? "unknown error"}`);
         if (bridgeKind === "steer") {
-          this.emit("steerFailed", parsed.error.message ?? "unknown error");
+          this.emit("steerFailed", { requestId: numericId, reason: parsed.error.message ?? "unknown error" });
+        } else if (bridgeKind === "interrupt") {
+          this.emit("interruptFailed", parsed.error.message ?? "unknown error");
         } else {
           this.lastTurnEndedAbnormally = true;
           this.emit("turnAborted", `injected turn/start rejected: ${parsed.error.message ?? "unknown error"}`);
+          this.emit("bridgeTurnRejected", {
+            requestId: numericId,
+            error: parsed.error.message ?? "unknown error"
+          });
           this.notifyPhaseIfChanged();
         }
       } else {
         this.log(`Bridge-originated ${bridgeKind} request completed (id ${responseId})`);
         if (bridgeKind === "steer") {
-          this.emit("steerAccepted");
+          this.emit("steerAccepted", { requestId: numericId });
+        } else if (bridgeKind === "turn-start") {
+          const result = parsed.result;
+          const turnId = result?.turn?.id;
+          if (typeof turnId === "string" && turnId.length > 0) {
+            this.emit("bridgeTurnStarted", { requestId: numericId, turnId });
+          } else {
+            this.log(`Bridge-originated turn/start response carried no turn id (id ${responseId}) \u2014 turn_started ACK skipped`);
+          }
         }
       }
       return null;
@@ -1821,6 +1941,9 @@ class CodexAdapter extends EventEmitter {
     }
     return newest;
   }
+  get steerableTurnId() {
+    return this.currentSteerableTurnId();
+  }
   get turnPhase() {
     if (this.activeTurnIds.size > 0) {
       const allStalled = [...this.activeTurnIds].every((id) => this.currentlyStalledTurnIds.has(id));
@@ -1852,11 +1975,12 @@ class CodexAdapter extends EventEmitter {
     this.notifyPhaseIfChanged();
   }
   markTurnCompleted(turnId) {
-    if (typeof turnId === "string" && turnId.length > 0) {
-      this.activeTurnIds.delete(turnId);
-      this.clearTurnWatchdog(turnId);
-      this.stalledTurnIds.delete(turnId);
-      this.currentlyStalledTurnIds.delete(turnId);
+    const completedId = typeof turnId === "string" && turnId.length > 0 ? turnId : null;
+    if (completedId !== null) {
+      this.activeTurnIds.delete(completedId);
+      this.clearTurnWatchdog(completedId);
+      this.stalledTurnIds.delete(completedId);
+      this.currentlyStalledTurnIds.delete(completedId);
     } else {
       this.activeTurnIds.clear();
       this.clearAllTurnWatchdogs();
@@ -1865,6 +1989,7 @@ class CodexAdapter extends EventEmitter {
     }
     this.lastTurnEndedAbnormally = false;
     this.turnInProgress = this.activeTurnIds.size > 0;
+    this.emit("turnIdCompleted", completedId);
     this.notifyPhaseIfChanged();
   }
   turnWatchdogMs() {
@@ -1934,6 +2059,7 @@ class CodexAdapter extends EventEmitter {
       this.log(`Turn state reset (${reason})`);
     }
     this.notifyPhaseIfChanged();
+    this.emit("turnTrackingReset", reason);
   }
   requestKey(id) {
     if (typeof id === "number" || typeof id === "string")
@@ -2274,19 +2400,6 @@ class TuiConnectionState {
 import { spawn as spawn2 } from "child_process";
 import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync2, writeFileSync, openSync, closeSync, constants } from "fs";
 import { fileURLToPath } from "url";
-
-// src/env-utils.ts
-function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) {
-  const raw = env[name];
-  if (raw == null || raw === "")
-    return fallback;
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > Number.MAX_SAFE_INTEGER) {
-    log(`Invalid ${name}=${JSON.stringify(raw)} (must be a positive integer within ` + `Number.MAX_SAFE_INTEGER); falling back to ${fallback}`);
-    return fallback;
-  }
-  return parsed;
-}
 
 // src/process-lifecycle.ts
 import { execFileSync as execFileSync2 } from "child_process";
@@ -3879,6 +3992,127 @@ function createQuotaSource(options) {
   return new QuotaSource(options);
 }
 
+// src/idempotency-tracker.ts
+var DEFAULT_TOMBSTONE_TTL_MS = 20 * 60 * 1000;
+
+class IdempotencyTracker {
+  entries = new Map;
+  ttlMs;
+  now;
+  constructor(options = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TOMBSTONE_TTL_MS;
+    this.now = options.now ?? Date.now;
+  }
+  get size() {
+    return this.entries.size;
+  }
+  check(threadId, key) {
+    const entry = this.getLive(threadId, key);
+    if (!entry)
+      return { duplicate: false };
+    if (entry.state.phase === "terminal") {
+      return { duplicate: true, code: "duplicate_terminal", state: entry.state };
+    }
+    return { duplicate: true, code: "duplicate_in_flight", state: entry.state };
+  }
+  peek(threadId, key) {
+    return this.getLive(threadId, key)?.state ?? null;
+  }
+  accept(threadId, key) {
+    if (this.getLive(threadId, key))
+      return;
+    this.entries.set(this.compositeKey(threadId, key), {
+      threadId,
+      state: { phase: "accepted" },
+      expiresAtMs: null,
+      timer: null
+    });
+  }
+  release(threadId, key) {
+    const composite = this.compositeKey(threadId, key);
+    const entry = this.entries.get(composite);
+    if (!entry || entry.state.phase === "terminal")
+      return;
+    this.entries.delete(composite);
+  }
+  markStarted(threadId, key, turnId) {
+    const entry = this.getLive(threadId, key);
+    if (!entry || entry.state.phase === "terminal")
+      return;
+    entry.state = { phase: "started", turnId };
+  }
+  markRejected(threadId, key) {
+    const entry = this.getLive(threadId, key);
+    if (!entry || entry.state.phase === "terminal")
+      return;
+    this.terminate(entry, "rejected");
+  }
+  completeTurn(turnId, threadId) {
+    for (const entry of this.entries.values()) {
+      if (entry.state.phase !== "started")
+        continue;
+      if (turnId !== null) {
+        if (entry.state.turnId !== turnId)
+          continue;
+      } else if (threadId !== undefined && entry.threadId !== threadId) {
+        continue;
+      }
+      this.terminate(entry, "completed");
+    }
+  }
+  terminateThread(threadId, outcome) {
+    for (const entry of this.entries.values()) {
+      if (entry.threadId !== threadId || entry.state.phase === "terminal")
+        continue;
+      this.terminate(entry, outcome);
+    }
+  }
+  terminateAll(outcome) {
+    for (const entry of this.entries.values()) {
+      if (entry.state.phase === "terminal")
+        continue;
+      this.terminate(entry, outcome);
+    }
+  }
+  dispose() {
+    for (const entry of this.entries.values()) {
+      if (entry.timer)
+        clearTimeout(entry.timer);
+    }
+    this.entries.clear();
+  }
+  compositeKey(threadId, key) {
+    return `${threadId}\x00${key}`;
+  }
+  getLive(threadId, key) {
+    const composite = this.compositeKey(threadId, key);
+    const entry = this.entries.get(composite);
+    if (!entry)
+      return null;
+    if (entry.expiresAtMs !== null && this.now() >= entry.expiresAtMs) {
+      if (entry.timer)
+        clearTimeout(entry.timer);
+      this.entries.delete(composite);
+      return null;
+    }
+    return entry;
+  }
+  terminate(entry, outcome) {
+    entry.state = { phase: "terminal", outcome };
+    entry.expiresAtMs = this.now() + this.ttlMs;
+    const timer = setTimeout(() => {
+      for (const [composite, candidate] of this.entries.entries()) {
+        if (candidate === entry) {
+          this.entries.delete(composite);
+          break;
+        }
+      }
+    }, this.ttlMs);
+    timer.unref?.();
+    entry.timer = timer;
+  }
+}
+
 // src/reply-required-tracker.ts
 class ReplyRequiredTracker {
   armed = false;
@@ -4113,6 +4347,10 @@ var codexBootstrapped = false;
 var attentionWindowTimer = null;
 var inAttentionWindow = false;
 var replyTracker = new ReplyRequiredTracker;
+var idempotencyTracker = new IdempotencyTracker;
+var pendingTurnStarts = new Map;
+var pendingSteerDispatches = new Map;
+var BUSY_RETRY_ADVISORY_MS = 15000;
 var shuttingDown = false;
 var bootDeadlineTimer = null;
 var idleShutdownTimer = null;
@@ -4187,13 +4425,70 @@ codex.on("turnPhaseChanged", ({ phase, previous }) => {
   tryWriteStatusFile(`turnPhase:${phase}`);
   broadcastStatus();
 });
-codex.on("steerFailed", (reason) => {
+codex.on("steerFailed", ({ requestId, reason }) => {
   log(`Steer rejected by app-server: ${reason}`);
+  const dispatch = pendingSteerDispatches.get(requestId);
+  pendingSteerDispatches.delete(requestId);
+  if (dispatch?.idempotencyKey && dispatch.threadId) {
+    idempotencyTracker.release(dispatch.threadId, dispatch.idempotencyKey);
+    log(`Released idempotency key after steer failure (request ${requestId}) \u2014 same key is retryable again`);
+  }
   const advice = codex.turnInProgress ? "wait for it to finish (\u2705), then send normally" : "the turn has ended \u2014 resend as a normal reply";
   emitToClaude(systemMessage("system_steer_failed", `\u26A0\uFE0F Your steer message did NOT reach Codex (${reason}). The original turn continues unaffected \u2014 ${advice}.`));
 });
-codex.on("steerAccepted", () => {
+codex.on("steerAccepted", ({ requestId }) => {
   log("Steer accepted by app-server");
+  const dispatch = pendingSteerDispatches.get(requestId);
+  pendingSteerDispatches.delete(requestId);
+  if (dispatch?.requireReply) {
+    replyTracker.arm();
+    log("Reply required armed on steer-accept (steer-scoped expectation)");
+  }
+});
+codex.on("bridgeTurnStarted", ({ requestId, turnId }) => {
+  const pending = pendingTurnStarts.get(requestId);
+  if (!pending) {
+    log(`bridgeTurnStarted for unknown injection ${requestId} (turn ${turnId}) \u2014 correlation dropped`);
+    return;
+  }
+  pendingTurnStarts.delete(requestId);
+  log(`Bridge turn started: injection ${requestId} \u2192 turn ${turnId} (request ${pending.requestId})`);
+  if (pending.idempotencyKey) {
+    idempotencyTracker.markStarted(pending.threadId, pending.idempotencyKey, turnId);
+  }
+  if (attachedClaude) {
+    sendProtocolMessage(attachedClaude, {
+      type: "turn_started",
+      requestId: pending.requestId,
+      ...pending.idempotencyKey ? { idempotencyKey: pending.idempotencyKey } : {},
+      threadId: pending.threadId,
+      turnId
+    });
+  }
+});
+codex.on("bridgeTurnRejected", ({ requestId, error }) => {
+  const pending = pendingTurnStarts.get(requestId);
+  if (!pending)
+    return;
+  pendingTurnStarts.delete(requestId);
+  log(`Bridge turn rejected before start: injection ${requestId} (request ${pending.requestId}): ${error}`);
+  if (pending.idempotencyKey) {
+    idempotencyTracker.markRejected(pending.threadId, pending.idempotencyKey);
+  }
+});
+codex.on("turnIdCompleted", (turnId) => {
+  idempotencyTracker.completeTurn(turnId, codex.activeThreadId ?? undefined);
+});
+codex.on("turnTrackingReset", (reason) => {
+  idempotencyTracker.terminateAll("aborted");
+  if (pendingTurnStarts.size > 0) {
+    log(`Cleared ${pendingTurnStarts.size} pending turn-start correlation(s) on turn tracking reset (${reason})`);
+  }
+  if (pendingSteerDispatches.size > 0) {
+    log(`Cleared ${pendingSteerDispatches.size} pending steer dispatch(es) on turn tracking reset (${reason})`);
+  }
+  pendingTurnStarts.clear();
+  pendingSteerDispatches.clear();
 });
 codex.on("turnStarted", () => {
   log("Codex turn started");
@@ -4301,6 +4596,9 @@ codex.on("exit", (code) => {
   log(`Codex process exited (code ${code})`);
   codexBootstrapped = false;
   replyTracker.reset();
+  idempotencyTracker.terminateAll("aborted");
+  pendingTurnStarts.clear();
+  pendingSteerDispatches.clear();
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
@@ -4402,98 +4700,217 @@ function handleControlMessage(ws, raw) {
       });
       return;
     case "claude_to_codex": {
-      if (message.message.source !== "claude") {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
+      handleClaudeToCodex(ws, message).catch((err) => {
+        log(`handleClaudeToCodex threw for request ${message.requestId}: ${err?.message ?? err}`);
+        sendClaudeToCodexResult(ws, message.requestId, {
           success: false,
-          error: "Invalid message source"
+          code: "internal_error",
+          error: `Internal bridge error: ${err?.message ?? err}`
         });
-        return;
-      }
-      if (!tuiConnectionState.canReply()) {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Codex is not ready. Wait for TUI to connect and create a thread."
-        });
-        return;
-      }
-      if (budgetCoordinator?.isGateClosed()) {
-        const reason = budgetPauseGateError();
-        log(`Injection rejected by budget pause gate`);
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: reason
-        });
-        return;
-      }
-      const requireReply = !!message.requireReply;
-      let contentToSend = message.message.content;
-      if (requireReply) {
-        contentToSend += REPLY_REQUIRED_INSTRUCTION;
-      }
-      log(`Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-      const tierOverrides = BUDGET_CONFIG.codexTierControl ? budgetCoordinator?.getCodexTurnOverrides() ?? undefined : undefined;
-      if (codex.turnInProgress && message.onBusy === "steer") {
-        if (requireReply) {
-          sendProtocolMessage(ws, {
-            type: "claude_to_codex_result",
-            requestId: message.requestId,
-            success: false,
-            error: 'require_reply is not supported together with on_busy="steer" yet. Send the steer without require_reply, or wait for the turn to finish.'
-          });
-          return;
-        }
-        const steerContent = `[STEER from Claude]
-` + `Mid-turn update for the current Codex turn. Integrate if relevant; do not restart work unless explicitly requested.
-
-` + message.message.content;
-        const steered = codex.steerMessage(steerContent);
-        log(`Steer ${steered ? "transport-accepted" : "failed"} (${message.message.content.length} chars)`);
-        if (steered) {
-          clearAttentionWindow();
-        }
-        const steerFailureAdvice = codex.turnInProgress ? "Steer failed: the running turn cannot be steered right now \u2014 wait for it to finish (\u2705), then send normally." : "Steer failed: the turn may have just ended or the connection dropped \u2014 retry as a normal reply.";
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: steered,
-          error: steered ? undefined : steerFailureAdvice
-        });
-        return;
-      }
-      const injected = codex.injectMessage(contentToSend, tierOverrides);
-      if (!injected) {
-        const reason = codex.turnInProgress ? 'Codex is busy executing a turn. Options: wait for it to finish, or retry with on_busy="steer" to feed this message into the running turn without interrupting it.' : "Injection failed: no active thread or WebSocket not connected.";
-        log(`Injection rejected: ${reason}`);
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: reason
-        });
-        return;
-      }
-      if (tierOverrides) {
-        budgetCoordinator?.notifyOverridesDelivered();
-      }
-      if (requireReply) {
-        replyTracker.arm();
-        log(`Reply required flag set for this message`);
-      }
-      clearAttentionWindow();
-      sendProtocolMessage(ws, {
-        type: "claude_to_codex_result",
-        requestId: message.requestId,
-        success: true
       });
       return;
     }
   }
+}
+function sendClaudeToCodexResult(ws, requestId, opts) {
+  sendProtocolMessage(ws, {
+    type: "claude_to_codex_result",
+    requestId,
+    success: opts.success,
+    ...opts.error !== undefined ? { error: opts.error } : {},
+    ok: opts.success,
+    ...opts.code !== undefined ? { code: opts.code } : {},
+    phase: codex.turnPhase,
+    ...opts.retryAfterMs !== undefined ? { retryAfterMs: opts.retryAfterMs } : {}
+  });
+}
+function describeDuplicate(dup) {
+  if (dup.code === "duplicate_terminal") {
+    const outcome = dup.state.phase === "terminal" ? dup.state.outcome : "unknown";
+    return `Duplicate idempotency_key: the original message already reached a terminal state (${outcome}) ` + `and was NOT re-injected. Use a fresh key to send a genuinely new message.`;
+  }
+  const detail = dup.state.phase === "started" ? `already running as turn ${dup.state.turnId}` : "still in flight";
+  return `Duplicate idempotency_key: a message with this key is ${detail} \u2014 NOT re-injected. ` + `Wait for its outcome, or use a fresh key for a genuinely new message.`;
+}
+function waitForInterruptOutcome(turnIds) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const abort = new AbortController;
+    const finish = (result) => {
+      if (settled)
+        return;
+      settled = true;
+      codex.off("interruptFailed", onFailed);
+      abort.abort();
+      resolve(result);
+    };
+    const onFailed = (reason) => finish({ ok: false, code: "interrupt_rejected", reason });
+    codex.on("interruptFailed", onFailed);
+    codex.waitForTurnsTerminal(turnIds, undefined, abort.signal).then((result) => {
+      if (result.ok) {
+        finish({ ok: true });
+      } else if (result.code === "interrupt_timeout") {
+        finish({ ok: false, code: "interrupt_timeout" });
+      }
+    });
+  });
+}
+async function handleClaudeToCodex(ws, message) {
+  if (message.message.source !== "claude") {
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: "invalid_source",
+      error: "Invalid message source"
+    });
+    return;
+  }
+  const idempotencyKey = typeof message.idempotencyKey === "string" && message.idempotencyKey.length > 0 ? message.idempotencyKey : undefined;
+  if (idempotencyKey && codex.activeThreadId) {
+    const dup = idempotencyTracker.check(codex.activeThreadId, idempotencyKey);
+    if (dup.duplicate) {
+      log(`Rejected duplicate idempotency key (${dup.code})`);
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: dup.code,
+        error: describeDuplicate(dup)
+      });
+      return;
+    }
+  }
+  if (!tuiConnectionState.canReply()) {
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: "no_thread",
+      error: "Codex is not ready. Wait for TUI to connect and create a thread."
+    });
+    return;
+  }
+  if (budgetCoordinator?.isGateClosed()) {
+    const reason = budgetPauseGateError();
+    log(`Injection rejected by budget pause gate`);
+    const resumeAfterEpoch2 = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
+    const retryAfterMs = resumeAfterEpoch2 !== null ? Math.max(0, resumeAfterEpoch2 * 1000 - Date.now()) : undefined;
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: "budget_paused",
+      error: reason,
+      ...retryAfterMs !== undefined ? { retryAfterMs } : {}
+    });
+    return;
+  }
+  const requireReply = !!message.requireReply;
+  let contentToSend = message.message.content;
+  if (requireReply) {
+    contentToSend += REPLY_REQUIRED_INSTRUCTION;
+  }
+  log(`Forwarding Claude \u2192 Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
+  const tierOverrides = BUDGET_CONFIG.codexTierControl ? budgetCoordinator?.getCodexTurnOverrides() ?? undefined : undefined;
+  if (codex.turnInProgress && message.onBusy === "steer") {
+    const steerContent = `[STEER from Claude]
+` + `Mid-turn update for the current Codex turn. Integrate if relevant; do not restart work unless explicitly requested.
+
+` + contentToSend;
+    const steerTurnId = codex.steerableTurnId;
+    const steerThreadId = codex.activeThreadId;
+    const steerRequestId = codex.steerMessage(steerContent);
+    const steered = steerRequestId !== null;
+    log(`Steer ${steered ? "transport-accepted" : "failed"} (${message.message.content.length} chars, requireReply=${requireReply})`);
+    if (steered) {
+      clearAttentionWindow();
+      pendingSteerDispatches.set(steerRequestId, {
+        requireReply,
+        ...idempotencyKey ? { idempotencyKey } : {},
+        ...steerThreadId ? { threadId: steerThreadId } : {}
+      });
+      if (idempotencyKey && steerThreadId) {
+        idempotencyTracker.accept(steerThreadId, idempotencyKey);
+        if (steerTurnId) {
+          idempotencyTracker.markStarted(steerThreadId, idempotencyKey, steerTurnId);
+        }
+      }
+    }
+    const steerFailureAdvice = codex.turnInProgress ? "Steer failed: the running turn cannot be steered right now \u2014 wait for it to finish (\u2705), then send normally." : "Steer failed: the turn may have just ended or the connection dropped \u2014 retry as a normal reply.";
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: steered,
+      ...steered ? {} : { code: "steer_failed", error: steerFailureAdvice }
+    });
+    return;
+  }
+  if (codex.turnInProgress && message.onBusy === "interrupt") {
+    const interruptThreadId = codex.activeThreadId;
+    if (idempotencyKey && interruptThreadId) {
+      idempotencyTracker.accept(interruptThreadId, idempotencyKey);
+    }
+    const releaseInterruptKey = () => {
+      if (idempotencyKey && interruptThreadId) {
+        idempotencyTracker.release(interruptThreadId, idempotencyKey);
+      }
+    };
+    const interrupted = codex.interruptActiveTurns();
+    if (!interrupted.ok) {
+      releaseInterruptKey();
+      log(`Interrupt unavailable: ${interrupted.error}`);
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: interrupted.code,
+        error: `Interrupt failed (${interrupted.error}). The original turn keeps running \u2014 ` + `your message was NOT injected. Wait for \u2705, or retry with on_busy="steer".`
+      });
+      return;
+    }
+    log(`Interrupt dispatched for turn(s) ${interrupted.turnIds.join(", ")} \u2014 waiting for terminal boundary`);
+    const outcome = await waitForInterruptOutcome(interrupted.turnIds);
+    if (!outcome.ok) {
+      releaseInterruptKey();
+      const error = outcome.code === "interrupt_rejected" ? `Interrupt was rejected by the app-server (${outcome.reason ?? "unknown reason"}). ` + `The original turn keeps running \u2014 your message was NOT injected. ` + `Wait for \u2705, or retry with on_busy="steer".` : `Interrupt did not reach a terminal boundary in time. The turn MAY still be running \u2014 ` + `do not assume it stopped. Your message was NOT injected (this avoids a double-turn race); ` + `check for \u2705/\u26A0\uFE0F notices before retrying.`;
+      log(`Interrupt failed (${outcome.code})`);
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: outcome.code,
+        error
+      });
+      return;
+    }
+    log("Interrupt reached terminal boundary \u2014 injecting the message as a new turn");
+    if (interruptThreadId && codex.activeThreadId !== interruptThreadId) {
+      releaseInterruptKey();
+    }
+  }
+  const injectThreadId = codex.activeThreadId;
+  const injectionId = codex.injectMessage(contentToSend, tierOverrides);
+  if (injectionId === null) {
+    if (idempotencyKey && injectThreadId) {
+      idempotencyTracker.release(injectThreadId, idempotencyKey);
+    }
+    const busy = codex.turnInProgress;
+    const reason = busy ? 'Codex is busy executing a turn. Options: wait for it to finish, retry with on_busy="steer" to feed this message into the running turn without interrupting it, or retry with on_busy="interrupt" to stop the current turn and start a new one with this message.' : "Injection failed: no active thread or WebSocket not connected.";
+    log(`Injection rejected: ${reason}`);
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: busy ? "busy_reject" : "no_thread",
+      error: reason,
+      ...busy ? { retryAfterMs: BUSY_RETRY_ADVISORY_MS } : {}
+    });
+    return;
+  }
+  if (tierOverrides) {
+    budgetCoordinator?.notifyOverridesDelivered();
+  }
+  if (requireReply) {
+    replyTracker.arm();
+    log(`Reply required flag set for this message`);
+  }
+  clearAttentionWindow();
+  if (injectThreadId) {
+    if (idempotencyKey) {
+      idempotencyTracker.accept(injectThreadId, idempotencyKey);
+    }
+    pendingTurnStarts.set(injectionId, {
+      requestId: message.requestId,
+      ...idempotencyKey ? { idempotencyKey } : {},
+      threadId: injectThreadId
+    });
+  }
+  sendClaudeToCodexResult(ws, message.requestId, { success: true });
 }
 async function attachClaude(ws, identity) {
   const occupant = attachedClaude;
@@ -4881,6 +5298,7 @@ function shutdown(reason, exitCode = 0) {
   log(`Shutting down daemon (${reason})...`);
   clearBootDeadline();
   stopBudgetCoordinator();
+  idempotencyTracker.dispose();
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);
   clearPendingClaudeDisconnect(`daemon shutdown (${reason})`);
   controlServer?.stop();

--- a/src/app-server-protocol.ts
+++ b/src/app-server-protocol.ts
@@ -95,6 +95,28 @@ export interface TurnSteerParams {
   [key: string]: unknown;
 }
 
+/**
+ * turn/interrupt — terminate the CURRENTLY RUNNING turn (protocol v2 PR B).
+ * Verified against codex-rs (app-server-protocol/src/protocol/v2/turn.rs:
+ * TurnInterruptParams { thread_id, turn_id }, camelCase on the wire).
+ *
+ * Semantics verified in app-server/src/request_processors/turn_processor.rs
+ * (turn_interrupt_inner) + bespoke_event_handling.rs:
+ *   - turnId must match the active turn, else an immediate JSON-RPC error
+ *     ("expected active turn id X but found Y" / "no active turn to interrupt").
+ *   - The SUCCESS response ({}) is DEFERRED until the core emits TurnAborted —
+ *     it arrives at roughly the same time as the terminal notification.
+ *   - The interrupted turn's terminal notification is a normal `turn/completed`
+ *     with `turn.status = "interrupted"` (handle_turn_interrupted →
+ *     emit_turn_completed_with_status) — the adapter's existing turn/completed
+ *     handling IS the terminal boundary; no extra notification type exists.
+ */
+export interface TurnInterruptParams {
+  threadId: string;
+  turnId: string;
+  [key: string]: unknown;
+}
+
 export interface ThreadStartResponse {
   thread?: AppServerThread;
   [key: string]: unknown;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -90,7 +90,12 @@ if (process.env.AGENTBRIDGE_TRACE === "1") {
   }
 }
 
-claude.setReplySender(async (msg: BridgeMessage, requireReply?: boolean, onBusy?: "reject" | "steer") => {
+claude.setReplySender(async (
+  msg: BridgeMessage,
+  requireReply?: boolean,
+  onBusy?: "reject" | "steer" | "interrupt",
+  idempotencyKey?: string,
+) => {
   if (msg.source !== "claude") {
     return { success: false, error: "Invalid message source" };
   }
@@ -102,7 +107,18 @@ claude.setReplySender(async (msg: BridgeMessage, requireReply?: boolean, onBusy?
     };
   }
 
-  return daemonClient.sendReply(msg, requireReply, onBusy);
+  return daemonClient.sendReply(msg, requireReply, onBusy, idempotencyKey);
+});
+
+// turn_started ACK (protocol v2 PR B): logged for correlation forensics. The
+// reply tool's synchronous result already told the model its message was
+// accepted; the ACK confirms the turn actually started (the "Claude saw a
+// timeout but the turn WAS injected" trail).
+daemonClient.on("turnStarted", ({ requestId, idempotencyKey, threadId, turnId }) => {
+  log(
+    `Codex turn started for reply ${requestId} (turn=${turnId}, thread=${threadId}` +
+    `${idempotencyKey ? `, idempotencyKey=${idempotencyKey}` : ""})`,
+  );
 });
 
 daemonClient.on("codexMessage", (message) => {

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -26,7 +26,12 @@ import type { BridgeMessage } from "./types";
 import type { BudgetSnapshot } from "./budget/types";
 import { renderBudgetSnapshot, BUDGET_UNAVAILABLE_TEXT } from "./budget/render";
 
-export type ReplySender = (msg: BridgeMessage, requireReply?: boolean, onBusy?: "reject" | "steer") => Promise<{ success: boolean; error?: string }>;
+export type ReplySender = (
+  msg: BridgeMessage,
+  requireReply?: boolean,
+  onBusy?: "reject" | "steer" | "interrupt",
+  idempotencyKey?: string,
+) => Promise<{ success: boolean; error?: string; code?: string; phase?: string; retryAfterMs?: number }>;
 
 export const CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
@@ -58,7 +63,7 @@ export const CLAUDE_INSTRUCTIONS = [
   "## Turn coordination",
   "- When you see '⏳ Codex is working', do NOT call the reply tool — wait for '✅ Codex finished'.",
   "- After Codex finishes a turn, you have an attention window to review and respond before new messages arrive.",
-  "- If the reply tool returns a busy error, Codex is still executing. You decide: wait and retry later, or resend with on_busy=\"steer\" to feed the message INTO the running turn (good for mid-course corrections; it does not interrupt or restart the work).",
+  "- If the reply tool returns a busy error, Codex is still executing. You decide: wait and retry later, resend with on_busy=\"steer\" to feed the message INTO the running turn (good for mid-course corrections; it does not interrupt or restart the work), or resend with on_busy=\"interrupt\" to STOP the running turn and start a new one with your message (use only when the current work is obsolete — prefer steer otherwise).",
   "",
   "## Budget awareness",
   "- Use the get_budget tool to check both agents' subscription quota (5h/weekly windows, drift, pause state).",
@@ -247,12 +252,16 @@ export class ClaudeAdapter extends EventEmitter {
               },
               require_reply: {
                 type: "boolean",
-                description: "When true, Codex is required to send a reply. All Codex messages from this turn will be forwarded immediately (bypassing STATUS buffering). Use this when you need a direct answer from Codex.",
+                description: "When true, Codex is required to send a reply. All Codex messages from this turn will be forwarded immediately (bypassing STATUS buffering). Use this when you need a direct answer from Codex. Combinable with on_busy=\"steer\": the reply expectation arms once the steer is accepted into the running turn.",
               },
               on_busy: {
                 type: "string",
-                enum: ["reject", "steer"],
-                description: "What to do when Codex is mid-turn. \"reject\" (default): fail with a busy error — wait and retry. \"steer\": feed this message INTO the running turn — Codex sees it immediately and integrates it without losing work. Use steer for mid-course corrections, added constraints, or updated acceptance criteria; it does NOT start a new turn, so don't combine it with require_reply. If you need Codex to STOP and do something else, wait for the turn to finish (interrupt support is coming separately).",
+                enum: ["reject", "steer", "interrupt"],
+                description: "What to do when Codex is mid-turn. \"reject\" (default): fail with a busy error — wait and retry. \"steer\": feed this message INTO the running turn — Codex sees it immediately and integrates it without losing work; use it for mid-course corrections, added constraints, or updated acceptance criteria (it does NOT start a new turn). \"interrupt\": STOP the running turn, wait for it to terminate, then send this message as a NEW turn — use only when the current work is obsolete; prefer steer otherwise.",
+              },
+              idempotency_key: {
+                type: "string",
+                description: "Optional client-generated key (non-empty, max 128 chars) that makes this reply idempotent: a retry carrying the same key is NOT re-injected — the bridge answers duplicate_in_flight / duplicate_terminal instead. Use a fresh key per logical message.",
               },
             },
             required: ["text"],
@@ -324,19 +333,35 @@ export class ClaudeAdapter extends EventEmitter {
 
     const requireReply = args?.require_reply === true;
     const onBusyRaw = args?.on_busy;
-    const onBusy: "reject" | "steer" = onBusyRaw === "steer" ? "steer" : "reject";
-    if (onBusyRaw !== undefined && onBusyRaw !== "reject" && onBusyRaw !== "steer") {
+    if (onBusyRaw !== undefined && onBusyRaw !== "reject" && onBusyRaw !== "steer" && onBusyRaw !== "interrupt") {
       return {
-        content: [{ type: "text" as const, text: `Error: invalid on_busy value ${JSON.stringify(onBusyRaw)} — use "reject" or "steer".` }],
+        content: [{ type: "text" as const, text: `Error: invalid on_busy value ${JSON.stringify(onBusyRaw)} — use "reject", "steer" or "interrupt".` }],
         isError: true,
       };
     }
-    if (onBusy === "steer" && requireReply) {
-      return {
-        content: [{ type: "text" as const, text: "Error: require_reply cannot be combined with on_busy=\"steer\" yet — a steer joins the RUNNING turn instead of starting a new one, so reply tracking would mis-arm. Send the steer without require_reply." }],
-        isError: true,
-      };
+    const onBusy: "reject" | "steer" | "interrupt" =
+      onBusyRaw === "steer" || onBusyRaw === "interrupt" ? onBusyRaw : "reject";
+    // require_reply × steer is allowed (protocol v2 PR B): the daemon arms the
+    // reply expectation once the steer is ACCEPTED into the running turn.
+    // require_reply × interrupt is allowed too — it ultimately starts a NEW
+    // turn, so the tracker arms after injection exactly like a normal reply.
+
+    const idempotencyKeyRaw = args?.idempotency_key;
+    if (idempotencyKeyRaw !== undefined) {
+      if (typeof idempotencyKeyRaw !== "string" || idempotencyKeyRaw.length === 0) {
+        return {
+          content: [{ type: "text" as const, text: "Error: idempotency_key must be a non-empty string." }],
+          isError: true,
+        };
+      }
+      if (idempotencyKeyRaw.length > 128) {
+        return {
+          content: [{ type: "text" as const, text: `Error: idempotency_key is too long (${idempotencyKeyRaw.length} chars, max 128).` }],
+          isError: true,
+        };
+      }
     }
+    const idempotencyKey = idempotencyKeyRaw as string | undefined;
 
     const bridgeMsg: BridgeMessage = {
       id: (args?.chat_id as string) ?? `reply_${Date.now()}`,
@@ -353,20 +378,31 @@ export class ClaudeAdapter extends EventEmitter {
       };
     }
 
-    const result = await this.replySender(bridgeMsg, requireReply, onBusy);
+    const result = await this.replySender(bridgeMsg, requireReply, onBusy, idempotencyKey);
     if (!result.success) {
-      this.log(`Reply delivery failed: ${result.error}`);
+      this.log(`Reply delivery failed: ${result.error}${result.code ? ` (code=${result.code})` : ""}`);
+      // Surface the machine-readable code (PR B structured result) alongside
+      // the human error so the model can branch on it deterministically.
+      const codePrefix = result.code ? ` [${result.code}]` : "";
       return {
-        content: [{ type: "text" as const, text: `Error: ${result.error}` }],
+        content: [{ type: "text" as const, text: `Error${codePrefix}: ${result.error}` }],
         isError: true,
       };
     }
 
     // Include pending message hint
     const pending = this.pendingMessages.length;
-    let responseText = onBusy === "steer"
-      ? "Reply sent to Codex (will be steered into the running turn if one is active; watch for a system_steer_failed notice if the app-server rejects it)."
-      : "Reply sent to Codex.";
+    let responseText = "Reply sent to Codex.";
+    if (onBusy === "steer") {
+      responseText = "Reply sent to Codex (will be steered into the running turn if one is active; watch for a system_steer_failed notice if the app-server rejects it).";
+    } else if (onBusy === "interrupt") {
+      // Honest wording: a success can mean EITHER an interrupt happened then the
+      // message was injected, OR the running turn had already ended by dispatch
+      // time so it fell straight through to a normal injection (race-degrade) —
+      // nothing was interrupted in that case. The result does not distinguish
+      // the two, so do not assert an interrupt occurred.
+      responseText = "Reply sent to Codex as a new turn (any turn still running was interrupted first; if it had already finished, your message was simply injected).";
+    }
     if (pending > 0) {
       responseText += ` Note: ${pending} unread Codex message${pending > 1 ? "s" : ""} already waiting \u2014 call get_messages to read them.`;
     }

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -28,9 +28,12 @@ import {
   type AppServerResponse,
   type AppServerServerRequestMethod,
   type AppServerTrackedRequestMethod,
+  type TurnInterruptParams,
   type TurnStartParams,
   type TurnSteerParams,
 } from "./app-server-protocol";
+import { parsePositiveIntEnv } from "./env-utils";
+import { DEFAULT_INTERRUPT_TIMEOUT_MS, clampInterruptTimeoutMs } from "./interrupt-timing";
 import {
   CODEX_TRANSPORT_ENV,
   TcpToUnixRelay,
@@ -167,10 +170,13 @@ export class CodexAdapter extends EventEmitter {
   private staleProxyIds = new Map<number, ReturnType<typeof setTimeout>>();
   private bridgeRequestIds = new Map<number, ReturnType<typeof setTimeout>>();
   // What each bridge-originated request was (turn/start injection vs
-  // turn/steer) — error handling differs: a rejected injection emits
-  // turnAborted, a rejected steer must NOT (the original turn is still
-  // running) and surfaces steerFailed instead.
-  private bridgeRequestKinds = new Map<number, "turn-start" | "steer">();
+  // turn/steer vs turn/interrupt) — error handling differs: a rejected
+  // injection emits turnAborted (+ bridgeTurnRejected for correlation), a
+  // rejected steer must NOT (the original turn is still running) and surfaces
+  // steerFailed instead, and a rejected interrupt surfaces interruptFailed
+  // (the original turn keeps running — response handlers never mutate turn
+  // state; the notification flow owns it).
+  private bridgeRequestKinds = new Map<number, "turn-start" | "steer" | "interrupt">();
   private intentionalDisconnect = false;
   // Fresh-session reconnection: buffer TUI messages while reconnecting app-server
   private pendingTuiMessages: string[] = [];
@@ -370,7 +376,12 @@ export class CodexAdapter extends EventEmitter {
   }
 
   /**
-   * Inject a message into the active Codex thread via turn/start. Returns true if sent.
+   * Inject a message into the active Codex thread via turn/start.
+   *
+   * Returns the (negative) bridge-originated JSON-RPC request id when the
+   * message was transport-accepted, or null on failure. Callers use the id to
+   * correlate the later "bridgeTurnStarted"/"bridgeTurnRejected" events back
+   * to the originating request (protocol v2 PR B turn_started ACK).
    *
    * Optional budget-tier overrides (plan v2.3 P4/R5) ride on the same turn/start:
    * `model`/`effort` are sticky for this thread's subsequent turns
@@ -378,18 +389,18 @@ export class CodexAdapter extends EventEmitter {
    * own the restore lifecycle. No JSON-RPC error for the request means
    * transport-accepted — NOT confirmed-applied (turn/started carries no model).
    */
-  injectMessage(text: string, overrides?: { model?: string; effort?: string }): boolean {
+  injectMessage(text: string, overrides?: { model?: string; effort?: string }): number | null {
     if (!this.threadId) {
       this.log("Cannot inject: no active thread");
-      return false;
+      return null;
     }
     if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
       this.log("Cannot inject: app-server WebSocket not connected");
-      return false;
+      return null;
     }
     if (this.turnInProgress) {
       this.log(`Rejected injection: Codex turn is in progress (thread ${this.threadId})`);
-      return false;
+      return null;
     }
     this.log(`Injecting message into Codex (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
@@ -408,11 +419,11 @@ export class CodexAdapter extends EventEmitter {
         id: requestId,
         params,
       } satisfies AppServerRequest<"turn/start", TurnStartParams>));
-      return true;
+      return requestId;
     } catch (err: any) {
       this.untrackBridgeRequestId(requestId);
       this.log(`Injection send failed: ${err.message}`);
-      return false;
+      return null;
     }
   }
 
@@ -420,21 +431,26 @@ export class CodexAdapter extends EventEmitter {
    * Feed additional input into the CURRENTLY RUNNING turn via turn/steer —
    * Codex sees it mid-turn and adjusts without losing work (protocol v2 B0,
    * design consensus: explicit [STEER] framing is the CALLER's job).
-   * Returns true when transport-accepted; a later JSON-RPC error surfaces as
-   * a "steerFailed" event (NOT turnAborted — the original turn keeps running).
+   * Returns the (negative) bridge request id when transport-accepted, or null
+   * on failure. The id correlates the later steerAccepted/steerFailed event
+   * back to this dispatch so the daemon can release the steer's idempotency
+   * key + reply expectation by id (NOT by FIFO) — a lost or out-of-order
+   * response cannot then strand them onto the wrong turn. A later JSON-RPC
+   * error surfaces as a "steerFailed" event (NOT turnAborted — the original
+   * turn keeps running).
    */
-  steerMessage(text: string): boolean {
+  steerMessage(text: string): number | null {
     if (!this.threadId) {
       this.log("Cannot steer: no active thread");
-      return false;
+      return null;
     }
     if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
       this.log("Cannot steer: app-server WebSocket not connected");
-      return false;
+      return null;
     }
     if (!this.turnInProgress) {
       this.log("Cannot steer: no turn in progress (use injectMessage)");
-      return false;
+      return null;
     }
     // turn/steer requires the active turn id as a precondition (expectedTurnId
     // — REQUIRED on every codex release that has turn/steer; omitting it gets
@@ -444,7 +460,7 @@ export class CodexAdapter extends EventEmitter {
     const expectedTurnId = this.currentSteerableTurnId();
     if (!expectedTurnId) {
       this.log("Cannot steer: no addressable active turn id (turn/started carried no id)");
-      return false;
+      return null;
     }
     this.log(`Steering message into active Codex turn ${expectedTurnId} (${text.length} chars)`);
     const requestId = this.nextInjectionId--;
@@ -460,12 +476,171 @@ export class CodexAdapter extends EventEmitter {
         id: requestId,
         params,
       } satisfies AppServerRequest<"turn/steer", TurnSteerParams>));
-      return true;
+      return requestId;
     } catch (err: any) {
       this.untrackBridgeRequestId(requestId);
       this.log(`Steer send failed: ${err.message}`);
-      return false;
+      return null;
     }
+  }
+
+  /**
+   * Interrupt EVERY addressable active turn via turn/interrupt (protocol v2
+   * PR B; design consensus with Codex: multi-turn ambiguity is resolved as
+   * "terminate ALL active turns"). `unknown:` fallback keys carry no
+   * addressable id and cannot be interrupted — when no addressable id exists
+   * this fails locally with a structured result instead of sending anything.
+   *
+   * Wire facts verified against codex-rs: params are {threadId, turnId}
+   * (turn.rs TurnInterruptParams); a mismatching/inactive turnId gets an
+   * immediate JSON-RPC error, while the SUCCESS response ({}) is deferred by
+   * the app-server until the core's TurnAborted — arriving alongside the
+   * terminal `turn/completed` (status "interrupted") notification. Callers
+   * must therefore wait for the terminal boundary via waitForTurnsTerminal,
+   * NOT for the interrupt responses.
+   */
+  interruptActiveTurns():
+    | { ok: true; turnIds: string[] }
+    | { ok: false; code: "interrupt_unavailable"; error: string } {
+    if (!this.threadId) {
+      this.log("Cannot interrupt: no active thread");
+      return { ok: false, code: "interrupt_unavailable", error: "no active thread" };
+    }
+    if (!this.appServerWs || this.appServerWs.readyState !== WebSocket.OPEN) {
+      this.log("Cannot interrupt: app-server WebSocket not connected");
+      return { ok: false, code: "interrupt_unavailable", error: "app-server WebSocket not connected" };
+    }
+    const addressable = [...this.activeTurnIds].filter((id) => !id.startsWith("unknown:"));
+    if (addressable.length === 0) {
+      this.log("Cannot interrupt: no addressable active turn id (turn/started carried no id)");
+      return {
+        ok: false,
+        code: "interrupt_unavailable",
+        error: "no addressable active turn id (turn/started carried no id)",
+      };
+    }
+    for (const turnId of addressable) {
+      const requestId = this.nextInjectionId--;
+      this.trackBridgeRequestId(requestId, "interrupt");
+      const params: TurnInterruptParams = { threadId: this.threadId, turnId };
+      try {
+        this.appServerWs.send(JSON.stringify({
+          method: "turn/interrupt",
+          id: requestId,
+          params,
+        } satisfies AppServerRequest<"turn/interrupt", TurnInterruptParams>));
+        this.log(`Sent turn/interrupt for active turn ${turnId} (request ${requestId})`);
+      } catch (err: any) {
+        // A send failure here means the socket just died mid-loop; earlier
+        // interrupts MAY already be in flight, but the caller must not assume
+        // the turns stopped — surface a loud structured failure (the close
+        // path will reset turn state on its own if the socket is truly gone).
+        this.untrackBridgeRequestId(requestId);
+        this.log(`turn/interrupt send failed for ${turnId}: ${err.message}`);
+        return {
+          ok: false,
+          code: "interrupt_unavailable",
+          error: `turn/interrupt send failed (${err.message}); earlier interrupts may still land`,
+        };
+      }
+    }
+    return { ok: true, turnIds: addressable };
+  }
+
+  /**
+   * Interrupt terminal-wait budget (env-overridable; default 10 seconds).
+   *
+   * INVARIANT (see interrupt-timing.ts): this budget must resolve BEFORE the
+   * bridge client's reply timeout (daemon-client CLIENT_REPLY_TIMEOUT_MS), or
+   * the client reports a false "Timed out waiting for daemon" while the daemon
+   * still proceeds to inject — a Claude retry then double-turns. parsePositiveIntEnv
+   * has no upper bound, so we CLAMP the env value below the client timeout to
+   * make the relationship impossible to misconfigure.
+   */
+  private interruptTimeoutMs(): number {
+    const requested = parsePositiveIntEnv(
+      "AGENTBRIDGE_INTERRUPT_TIMEOUT_MS",
+      DEFAULT_INTERRUPT_TIMEOUT_MS,
+      (m) => this.log(m),
+    );
+    const clamped = clampInterruptTimeoutMs(requested);
+    if (clamped !== requested) {
+      this.log(
+        `AGENTBRIDGE_INTERRUPT_TIMEOUT_MS=${requested}ms exceeds the safe ceiling — ` +
+        `clamped to ${clamped}ms (must resolve before the client reply timeout to avoid a double-turn)`,
+      );
+    }
+    return clamped;
+  }
+
+  /**
+   * Resolve once every TARGETED turnId has reached its terminal boundary — i.e.
+   * each is gone from activeTurnIds AND no longer flagged stalled — the safe
+   * point after which a new turn/start cannot race the dying targeted turn(s).
+   * On timeout the caller must NOT inject (double-turn race) — it gets a
+   * structured failure instead.
+   *
+   * SCOPING (PR B fix): the predicate keys ONLY on the targeted ids, NOT on the
+   * global turnPhase. turnPhase reports "running" whenever ANY turn is active,
+   * so a coexisting NON-targeted turn — e.g. an unaddressable `unknown:` turn
+   * that interruptActiveTurns can never target — would otherwise hold turnPhase
+   * at "running" forever and guarantee a spurious timeout even after every
+   * targeted turn ended. Per-id scoping makes the wait depend solely on the
+   * turns we actually interrupted.
+   *
+   * Listens on the existing event funnels that mutate turn state:
+   * turnIdCompleted (per-turn completion), turnTrackingReset (close /
+   * reconnect / stop / abort resets) and turnPhaseChanged (covers
+   * stalled↔running moves). The timeout timer is unref'd so a pending wait
+   * never keeps the process alive.
+   */
+  waitForTurnsTerminal(
+    turnIds: string[],
+    timeoutMs = this.interruptTimeoutMs(),
+    signal?: AbortSignal,
+  ): Promise<{ ok: true } | { ok: false; code: "interrupt_timeout" | "interrupt_aborted" }> {
+    const satisfied = () =>
+      turnIds.every(
+        (id) => !this.activeTurnIds.has(id) && !this.currentlyStalledTurnIds.has(id),
+      );
+
+    if (satisfied()) return Promise.resolve({ ok: true });
+    // Cancelable (PR B recommend #4): when the caller already settled on another
+    // signal (e.g. interruptFailed), aborting tears down THIS wait's listeners +
+    // timer promptly instead of leaking them until timeoutMs elapses.
+    if (signal?.aborted) return Promise.resolve({ ok: false, code: "interrupt_aborted" });
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = (
+        result: { ok: true } | { ok: false; code: "interrupt_timeout" | "interrupt_aborted" },
+      ) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.off("turnIdCompleted", check);
+        this.off("turnTrackingReset", check);
+        this.off("turnPhaseChanged", check);
+        signal?.removeEventListener("abort", onAbort);
+        resolve(result);
+      };
+      const check = () => {
+        if (satisfied()) finish({ ok: true });
+      };
+      const onAbort = () => finish({ ok: false, code: "interrupt_aborted" });
+      const timer = setTimeout(() => {
+        this.log(
+          `waitForTurnsTerminal timed out after ${timeoutMs}ms (still active: ` +
+          `${turnIds.filter((id) => this.activeTurnIds.has(id)).join(", ") || "none"}, phase=${this.turnPhase})`,
+        );
+        finish({ ok: false, code: "interrupt_timeout" });
+      }, timeoutMs);
+      timer.unref?.();
+      this.on("turnIdCompleted", check);
+      this.on("turnTrackingReset", check);
+      this.on("turnPhaseChanged", check);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
   }
 
   // ── Health Check ───────────────────────────────────────────
@@ -1520,24 +1695,58 @@ export class CodexAdapter extends EventEmitter {
           // no abort, no phase change. Surface it so the daemon can tell
           // Claude the mid-turn message did NOT reach Codex (e.g.
           // ActiveTurnNotSteerable on Review/Compact turns, or the turn ended
-          // in the NoActiveTurn race window).
-          this.emit("steerFailed", parsed.error.message ?? "unknown error");
+          // in the NoActiveTurn race window). The bridge requestId (numericId)
+          // correlates this verdict back to its dispatch so the daemon can
+          // release the steer's idempotency key + reply expectation by id
+          // instead of relying on FIFO ordering (lost-response orphan guard).
+          this.emit("steerFailed", { requestId: numericId, reason: parsed.error.message ?? "unknown error" });
+        } else if (bridgeKind === "interrupt") {
+          // A rejected turn/interrupt ("expected active turn id X but found Y",
+          // "no active turn to interrupt") means the ORIGINAL turn keeps
+          // running. Like steer rejections, the response handler must NOT
+          // touch turn state — the notification flow owns it. Surface the
+          // failure so the daemon can abort its terminal wait loudly.
+          this.emit("interruptFailed", parsed.error.message ?? "unknown error");
         } else {
           // An injected turn/start was REJECTED before any turn/started — no
           // turn ever goes in-progress, so resetTurnState's wasInProgress-gated
           // turnAborted never fires. Signal the abort here so daemon-level
           // per-turn state (the require_reply tracker) is not stranded.
-          // turnPhase must agree with the emitted event (PR A contract); the
-          // richer "rejected" terminal classification is PR B territory.
+          // turnPhase must agree with the emitted event (PR A contract).
+          // bridgeTurnRejected adds per-request correlation so the daemon can
+          // mark the matching idempotency key terminal `rejected` (PR B).
           this.lastTurnEndedAbnormally = true;
           this.emit("turnAborted", `injected turn/start rejected: ${parsed.error.message ?? "unknown error"}`);
+          this.emit("bridgeTurnRejected", {
+            requestId: numericId,
+            error: parsed.error.message ?? "unknown error",
+          });
           this.notifyPhaseIfChanged();
         }
       } else {
         this.log(`Bridge-originated ${bridgeKind} request completed (id ${responseId})`);
         if (bridgeKind === "steer") {
-          this.emit("steerAccepted");
+          // Carry the bridge requestId so the daemon correlates the accept
+          // back to its dispatch by id (same orphan guard as steerFailed).
+          this.emit("steerAccepted", { requestId: numericId });
+        } else if (bridgeKind === "turn-start") {
+          // turn_started ACK correlation (PR B): the turn/start response
+          // carries the created turn (TurnStartResponse.turn.id). Emit the
+          // correlation so the daemon can send the turn_started control event
+          // and advance the idempotency machine to started(turnId).
+          const result = parsed.result as { turn?: { id?: unknown } } | undefined;
+          const turnId = result?.turn?.id;
+          if (typeof turnId === "string" && turnId.length > 0) {
+            this.emit("bridgeTurnStarted", { requestId: numericId, turnId });
+          } else {
+            this.log(
+              `Bridge-originated turn/start response carried no turn id (id ${responseId}) — turn_started ACK skipped`,
+            );
+          }
         }
+        // interrupt success (TurnInterruptResponse is {}): log only — the
+        // app-server defers it until TurnAborted, and the terminal
+        // turn/completed notification is what drives state.
       }
       return null;
     }
@@ -1802,6 +2011,16 @@ export class CodexAdapter extends EventEmitter {
   }
 
   /**
+   * Public view of the steer target (PR B): the daemon reads it BEFORE calling
+   * steerMessage so an idempotency key dispatched as a steer can be bound to
+   * the turn it joined (started(turnId)) without changing steerMessage's
+   * boolean contract.
+   */
+  get steerableTurnId(): string | null {
+    return this.currentSteerableTurnId();
+  }
+
+  /**
    * Turn lifecycle phase (protocol v2 PR A). Strictly the turn axis — the
    * bridge's attention/routing window is reported separately by the daemon.
    */
@@ -1849,11 +2068,12 @@ export class CodexAdapter extends EventEmitter {
   }
 
   private markTurnCompleted(turnId?: string) {
-    if (typeof turnId === "string" && turnId.length > 0) {
-      this.activeTurnIds.delete(turnId);
-      this.clearTurnWatchdog(turnId);
-      this.stalledTurnIds.delete(turnId);
-      this.currentlyStalledTurnIds.delete(turnId);
+    const completedId = typeof turnId === "string" && turnId.length > 0 ? turnId : null;
+    if (completedId !== null) {
+      this.activeTurnIds.delete(completedId);
+      this.clearTurnWatchdog(completedId);
+      this.stalledTurnIds.delete(completedId);
+      this.currentlyStalledTurnIds.delete(completedId);
     } else {
       this.activeTurnIds.clear();
       this.clearAllTurnWatchdogs();
@@ -1863,6 +2083,12 @@ export class CodexAdapter extends EventEmitter {
 
     this.lastTurnEndedAbnormally = false;
     this.turnInProgress = this.activeTurnIds.size > 0;
+    // Per-turn completion signal (PR B): unlike the aggregate "turnCompleted"
+    // (which fires only when ALL turns are done), this carries the specific
+    // turn id so the daemon can terminate the matching idempotency key and
+    // waitForTurnsTerminal can re-check after EVERY completion. null = the
+    // notification carried no id and ALL active turns were cleared.
+    this.emit("turnIdCompleted", completedId);
     this.notifyPhaseIfChanged();
   }
 
@@ -1963,6 +2189,12 @@ export class CodexAdapter extends EventEmitter {
       this.log(`Turn state reset (${reason})`);
     }
     this.notifyPhaseIfChanged();
+    // Unconditional (NOT wasInProgress-gated) reset signal (PR B): an
+    // app-server close / reconnect / stop also invalidates bridge requests
+    // that were transport-accepted but never answered — the daemon must clear
+    // its per-injection correlation state and terminate idempotency keys even
+    // when no turn/started ever arrived for them.
+    this.emit("turnTrackingReset", reason);
   }
 
   private requestKey(id: unknown): string | null {
@@ -2019,7 +2251,7 @@ export class CodexAdapter extends EventEmitter {
     return this.clearTrackedId(this.staleProxyIds, proxyId);
   }
 
-  private trackBridgeRequestId(requestId: number, kind: "turn-start" | "steer" = "turn-start") {
+  private trackBridgeRequestId(requestId: number, kind: "turn-start" | "steer" | "interrupt" = "turn-start") {
     this.clearTrackedId(this.bridgeRequestIds, requestId);
 
     const timer = setTimeout(() => {
@@ -2032,7 +2264,7 @@ export class CodexAdapter extends EventEmitter {
   }
 
   /** Returns the request kind when this id was bridge-originated, else null. */
-  private consumeBridgeRequestId(requestId: number): "turn-start" | "steer" | null {
+  private consumeBridgeRequestId(requestId: number): "turn-start" | "steer" | "interrupt" | null {
     const kind = this.bridgeRequestKinds.get(requestId) ?? "turn-start";
     this.bridgeRequestKinds.delete(requestId);
     return this.clearTrackedId(this.bridgeRequestIds, requestId) ? kind : null;

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -64,12 +64,22 @@ export type ControlClientMessage =
       message: BridgeMessage;
       requireReply?: boolean;
       /**
-       * Busy-turn policy (protocol v2 B0). "reject" (default): fail with the
+       * Busy-turn policy (protocol v2 B0/B). "reject" (default): fail with the
        * busy error when a Codex turn is running. "steer": feed the message
        * into the RUNNING turn via turn/steer — Codex sees it mid-turn without
-       * losing work. ("interrupt" lands with PR B's ACK/idempotency machinery.)
+       * losing work. "interrupt" (PR B): terminate ALL active turns via
+       * turn/interrupt, wait for the terminal boundary, then inject this
+       * message as a normal new turn.
        */
-      onBusy?: "reject" | "steer";
+      onBusy?: "reject" | "steer" | "interrupt";
+      /**
+       * Optional idempotency key (protocol v2 PR B). Keyed messages are
+       * deduplicated per (threadId, idempotencyKey): a retry whose key is
+       * already tracked (live or terminal tombstone) is NOT re-injected — the
+       * daemon answers with duplicate_in_flight / duplicate_terminal instead.
+       * Messages without a key bypass the machine entirely (backward compat).
+       */
+      idempotencyKey?: string;
     }
   | { type: "status" }
   // Non-attaching probe: ask the daemon whether it already has a LIVE Claude
@@ -81,7 +91,38 @@ export type ControlClientMessage =
 
 export type ControlServerMessage =
   | { type: "codex_to_claude"; message: BridgeMessage }
-  | { type: "claude_to_codex_result"; requestId: string; success: boolean; error?: string }
+  | {
+      type: "claude_to_codex_result";
+      requestId: string;
+      success: boolean;
+      error?: string;
+      /**
+       * Structured result (protocol v2 PR B). `ok` mirrors `success` and both
+       * are populated for one version; `code` is the machine-readable failure
+       * code (e.g. busy_reject / budget_paused / steer_failed /
+       * interrupt_timeout / interrupt_rejected / interrupt_unavailable /
+       * duplicate_in_flight / duplicate_terminal / no_thread); `phase` is the
+       * codex turnPhase at result time; `retryAfterMs` is advisory and only
+       * set where a meaningful estimate exists.
+       */
+      ok?: boolean;
+      code?: string;
+      phase?: TurnPhase;
+      retryAfterMs?: number;
+    }
+  /**
+   * turn_started ACK (protocol v2 PR B): a bridge-originated turn/start was
+   * confirmed by the app-server (its response carried the created turn id).
+   * `requestId` correlates back to the originating claude_to_codex request;
+   * `idempotencyKey` is echoed when the request carried one.
+   */
+  | {
+      type: "turn_started";
+      requestId: string;
+      idempotencyKey?: string;
+      threadId: string;
+      turnId: string;
+    }
   | { type: "status"; status: DaemonStatus }
   // Reply to `probe_incumbent`. `connected` = a Claude frontend socket is
   // currently attached; `alive` = it responded to a liveness ping (a half-open

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -6,7 +6,21 @@ import {
   CLOSE_CODE_PROBE_IN_PROGRESS,
   CLOSE_CODE_PAIR_MISMATCH,
 } from "./control-protocol";
-import type { ControlClientIdentity, ControlClientMessage, ControlServerMessage, DaemonStatus } from "./control-protocol";
+import type { ControlClientIdentity, ControlClientMessage, ControlServerMessage, DaemonStatus, TurnPhase } from "./control-protocol";
+import { CLIENT_REPLY_TIMEOUT_MS } from "./interrupt-timing";
+
+/**
+ * Result of a claude_to_codex round trip. `code` / `phase` / `retryAfterMs`
+ * are the protocol v2 PR B structured fields (populated by newer daemons
+ * alongside the legacy error string; absent against older daemons).
+ */
+export interface SendReplyResult {
+  success: boolean;
+  error?: string;
+  code?: string;
+  phase?: TurnPhase;
+  retryAfterMs?: number;
+}
 
 interface DaemonClientEvents {
   codexMessage: [BridgeMessage];
@@ -14,6 +28,8 @@ interface DaemonClientEvents {
   rejected: [number];
   status: [DaemonStatus];
   incumbentStatus: [{ connected: boolean; alive: boolean }];
+  /** turn_started ACK (protocol v2 PR B): a bridge-injected turn was confirmed started. */
+  turnStarted: [{ requestId: string; idempotencyKey?: string; threadId: string; turnId: string }];
 }
 
 let nextSocketId = 0;
@@ -29,7 +45,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   private pendingReplies = new Map<
     string,
     {
-      resolve: (value: { success: boolean; error?: string }) => void;
+      resolve: (value: SendReplyResult) => void;
       timer: ReturnType<typeof setTimeout>;
     }
   >();
@@ -195,17 +211,30 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     this.rejectPendingReplies("Daemon connection closed");
   }
 
-  async sendReply(message: BridgeMessage, requireReply?: boolean, onBusy?: "reject" | "steer"): Promise<{ success: boolean; error?: string }> {
+  async sendReply(
+    message: BridgeMessage,
+    requireReply?: boolean,
+    onBusy?: "reject" | "steer" | "interrupt",
+    idempotencyKey?: string,
+  ): Promise<SendReplyResult> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return { success: false, error: "AgentBridge daemon is not connected." };
     }
 
     const requestId = `reply_${Date.now()}_${this.nextRequestId++}`;
     return new Promise((resolve) => {
+      // CLIENT_REPLY_TIMEOUT_MS applies to the daemon's IMMEDIATE result. The
+      // interrupt path can legitimately defer the result until the daemon-side
+      // terminal-wait budget elapses — that budget is CLAMPED below this value
+      // (see interrupt-timing.ts: clampInterruptTimeoutMs), so the daemon always
+      // answers before this timer fires. INVARIANT: do not shrink this timeout
+      // without also lowering MAX_INTERRUPT_TIMEOUT_MS, or an over-large
+      // AGENTBRIDGE_INTERRUPT_TIMEOUT_MS could outlast it and a false timeout +
+      // Claude retry would double-turn.
       const timer = setTimeout(() => {
         this.pendingReplies.delete(requestId);
         resolve({ success: false, error: "Timed out waiting for AgentBridge daemon reply." });
-      }, 15000);
+      }, CLIENT_REPLY_TIMEOUT_MS);
 
       this.pendingReplies.set(requestId, { resolve, timer });
       this.send({
@@ -214,6 +243,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
         message,
         ...(requireReply ? { requireReply: true } : {}),
         ...(onBusy && onBusy !== "reject" ? { onBusy } : {}),
+        ...(idempotencyKey ? { idempotencyKey } : {}),
       });
     });
   }
@@ -238,9 +268,25 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
           if (!pending) return;
           clearTimeout(pending.timer);
           this.pendingReplies.delete(message.requestId);
-          pending.resolve({ success: message.success, error: message.error });
+          // Pass the PR B structured fields through when the daemon sent them
+          // (older daemons only populate success/error).
+          pending.resolve({
+            success: message.success,
+            error: message.error,
+            ...(message.code !== undefined ? { code: message.code } : {}),
+            ...(message.phase !== undefined ? { phase: message.phase } : {}),
+            ...(message.retryAfterMs !== undefined ? { retryAfterMs: message.retryAfterMs } : {}),
+          });
           return;
         }
+        case "turn_started":
+          this.emit("turnStarted", {
+            requestId: message.requestId,
+            ...(message.idempotencyKey !== undefined ? { idempotencyKey: message.idempotencyKey } : {}),
+            threadId: message.threadId,
+            turnId: message.turnId,
+          });
+          return;
         case "status":
           this.emit("status", message.status);
           return;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -23,6 +23,7 @@ import {
 } from "./control-protocol";
 import { parsePositiveIntEnv } from "./env-utils";
 import { isAllowedWsUpgrade, wsOriginRejectedResponse } from "./ws-origin-guard";
+import { IdempotencyTracker, type IdempotencyDuplicate } from "./idempotency-tracker";
 import { ReplyRequiredTracker } from "./reply-required-tracker";
 import { persistCurrentThreadWithRolloutRetry } from "./thread-state";
 import { createProcessLogger } from "./process-log";
@@ -99,6 +100,32 @@ let codexBootstrapped = false;
 let attentionWindowTimer: ReturnType<typeof setTimeout> | null = null;
 let inAttentionWindow = false;
 const replyTracker = new ReplyRequiredTracker();
+// --- Protocol v2 PR B state ---
+// Idempotency machine: (threadId, idempotencyKey) → accepted → started → terminal.
+const idempotencyTracker = new IdempotencyTracker();
+// Correlation from a bridge injection's negative JSON-RPC id back to the
+// originating claude_to_codex request (turn_started ACK + idempotency started).
+const pendingTurnStarts = new Map<
+  number,
+  { requestId: string; idempotencyKey?: string; threadId: string }
+>();
+// Transport-accepted steers awaiting their JSON-RPC verdict, keyed by the
+// bridge request id the adapter assigned (steerAccepted/steerFailed echo that
+// id). Keying by id — instead of a FIFO that assumes responses arrive in send
+// order — means a LOST or out-of-order steer response can never strand a
+// dispatch onto the wrong turn (PR B #3). Each entry ties together the steer's
+// reply expectation (armed ONLY once the steer is accepted — contract: "armed
+// since steer accepted") and its idempotency key, so steerFailed /
+// turnTrackingReset clean up BOTH together (PR B #2).
+interface PendingSteerDispatch {
+  requireReply: boolean;
+  idempotencyKey?: string;
+  threadId?: string;
+}
+const pendingSteerDispatches = new Map<number, PendingSteerDispatch>();
+// Advisory retry hint for busy_reject results: no honest turn-end estimate
+// exists, so this is a suggested poll interval, not a promise.
+const BUSY_RETRY_ADVISORY_MS = 15_000;
 let shuttingDown = false;
 let bootDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
 let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
@@ -252,8 +279,24 @@ codex.on("turnPhaseChanged", ({ phase, previous }: { phase: string; previous: st
 // (Review/Compact turns are not steerable; the turn may have ended in the race
 // window) means Claude's mid-turn message did NOT reach Codex — say so
 // explicitly instead of letting Claude assume it landed.
-codex.on("steerFailed", (reason: string) => {
+codex.on("steerFailed", ({ requestId, reason }: { requestId: number; reason: string }) => {
   log(`Steer rejected by app-server: ${reason}`);
+  // Correlate the verdict to its dispatch by id (not FIFO) so a lost/reordered
+  // response cannot mis-consume a later dispatch.
+  const dispatch = pendingSteerDispatches.get(requestId);
+  pendingSteerDispatches.delete(requestId);
+  // The steer never reached Codex — its requireReply expectation (if any) must
+  // not arm (handled by NOT calling replyTracker.arm() here), AND its
+  // idempotency key must be RELEASED (PR B #2): the key was accept()+markStarted
+  // bound to the still-running ORIGINAL turn at dispatch, so without this it
+  // would strand in `started` until that turn terminates and a legitimate
+  // same-key retry would wrongly get duplicate_in_flight. Release mirrors the
+  // interrupt-failure path. release() is a no-op if the turn already terminated
+  // and tombstoned the key (terminal entries are preserved).
+  if (dispatch?.idempotencyKey && dispatch.threadId) {
+    idempotencyTracker.release(dispatch.threadId, dispatch.idempotencyKey);
+    log(`Released idempotency key after steer failure (request ${requestId}) — same key is retryable again`);
+  }
   // Branch the advice on the live turn state (same reasoning as the sync
   // steer-failure path): while the turn still runs (e.g. ActiveTurnNotSteerable
   // on a Review/Compact turn), "resend as a normal reply" just bounces off the
@@ -269,8 +312,88 @@ codex.on("steerFailed", (reason: string) => {
   );
 });
 
-codex.on("steerAccepted", () => {
+codex.on("steerAccepted", ({ requestId }: { requestId: number }) => {
   log("Steer accepted by app-server");
+  // require_reply × steer (PR B): the expectation arms only NOW — "a NEW
+  // forwarded agentMessage after steer-accept and before the turn's terminal
+  // counts as the reply". Arming at dispatch would mis-attribute pre-steer
+  // chatter of the running turn as the reply. Correlate by id so a lost/reordered
+  // response cannot mis-arm against the wrong dispatch (PR B #3).
+  const dispatch = pendingSteerDispatches.get(requestId);
+  pendingSteerDispatches.delete(requestId);
+  if (dispatch?.requireReply) {
+    replyTracker.arm();
+    log("Reply required armed on steer-accept (steer-scoped expectation)");
+  }
+  // The idempotency key stays bound (accept()+markStarted at dispatch) to the
+  // turn the steer joined; that turn's terminal boundary (turnIdCompleted /
+  // turnTrackingReset) terminates it. Nothing to release on the success path.
+});
+
+// --- Protocol v2 PR B: turn_started ACK + idempotency terminal wiring ---
+
+codex.on("bridgeTurnStarted", ({ requestId, turnId }: { requestId: number; turnId: string }) => {
+  const pending = pendingTurnStarts.get(requestId);
+  if (!pending) {
+    // Possible after a turnTrackingReset cleared the map while the response
+    // was in flight — the reset already terminated the idempotency keys.
+    log(`bridgeTurnStarted for unknown injection ${requestId} (turn ${turnId}) — correlation dropped`);
+    return;
+  }
+  pendingTurnStarts.delete(requestId);
+  log(`Bridge turn started: injection ${requestId} → turn ${turnId} (request ${pending.requestId})`);
+  if (pending.idempotencyKey) {
+    idempotencyTracker.markStarted(pending.threadId, pending.idempotencyKey, turnId);
+  }
+  if (attachedClaude) {
+    sendProtocolMessage(attachedClaude, {
+      type: "turn_started",
+      requestId: pending.requestId,
+      ...(pending.idempotencyKey ? { idempotencyKey: pending.idempotencyKey } : {}),
+      threadId: pending.threadId,
+      turnId,
+    });
+  }
+});
+
+codex.on("bridgeTurnRejected", ({ requestId, error }: { requestId: number; error: string }) => {
+  const pending = pendingTurnStarts.get(requestId);
+  if (!pending) return;
+  pendingTurnStarts.delete(requestId);
+  log(`Bridge turn rejected before start: injection ${requestId} (request ${pending.requestId}): ${error}`);
+  if (pending.idempotencyKey) {
+    // Contract: a bridge-originated JSON-RPC error BEFORE started → rejected.
+    idempotencyTracker.markRejected(pending.threadId, pending.idempotencyKey);
+  }
+});
+
+codex.on("turnIdCompleted", (turnId: string | null) => {
+  // turn/completed terminates the key whose started.turnId matches (null =
+  // the notification carried no id and ALL active turns were cleared). Scope
+  // the null case to the active thread so a null completion can never reach a
+  // different thread's started keys (consistent with terminateThread;
+  // single-thread-per-pair makes this benign today but explicit + future-proof).
+  idempotencyTracker.completeTurn(turnId, codex.activeThreadId ?? undefined);
+});
+
+codex.on("turnTrackingReset", (reason: string) => {
+  // app-server close / reconnect / stop: every pending/running idempotency key
+  // is now unresolvable (responses for in-flight bridge requests will never
+  // arrive), and per-injection correlation state is stale.
+  // terminateAll already tombstones every steer-bound idempotency key as
+  // `aborted` (so a same-key retry is told duplicate_terminal(aborted), not
+  // stranded), so dropping the dispatch entries here is enough to clean up the
+  // steer-scoped reply expectation + key correlation together (PR B #2/#3): a
+  // never-delivered steer response can no longer orphan either.
+  idempotencyTracker.terminateAll("aborted");
+  if (pendingTurnStarts.size > 0) {
+    log(`Cleared ${pendingTurnStarts.size} pending turn-start correlation(s) on turn tracking reset (${reason})`);
+  }
+  if (pendingSteerDispatches.size > 0) {
+    log(`Cleared ${pendingSteerDispatches.size} pending steer dispatch(es) on turn tracking reset (${reason})`);
+  }
+  pendingTurnStarts.clear();
+  pendingSteerDispatches.clear();
 });
 
 codex.on("turnStarted", () => {
@@ -439,6 +562,11 @@ codex.on("exit", (code: number | null) => {
   log(`Codex process exited (code ${code})`);
   codexBootstrapped = false;
   replyTracker.reset(); // any in-flight require_reply turn is gone with the process
+  // The process is gone — every pending/running idempotency key is terminal,
+  // and per-injection correlation can never resolve (PR B).
+  idempotencyTracker.terminateAll("aborted");
+  pendingTurnStarts.clear();
+  pendingSteerDispatches.clear();
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
@@ -572,142 +700,359 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
       });
       return;
     case "claude_to_codex": {
-      if (message.message.source !== "claude") {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
+      // The handler is async only on the interrupt path (terminal-boundary
+      // wait); steer/inject paths run synchronously to the first result.
+      handleClaudeToCodex(ws, message).catch((err: any) => {
+        log(`handleClaudeToCodex threw for request ${message.requestId}: ${err?.message ?? err}`);
+        sendClaudeToCodexResult(ws, message.requestId, {
           success: false,
-          error: "Invalid message source",
+          code: "internal_error",
+          error: `Internal bridge error: ${err?.message ?? err}`,
         });
-        return;
-      }
-
-      if (!tuiConnectionState.canReply()) {
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: "Codex is not ready. Wait for TUI to connect and create a thread.",
-        });
-        return;
-      }
-
-      // Budget pause gate (plan v2.4 side-aware R4): the gate protects the
-      // TARGET side's quota, so it closes only when the Codex side is exhausted
-      // (gateClosed = pauseSide codex/both). A Claude-only handoff keeps the
-      // gate OPEN so the baton reply can reach Codex. Same rejection shape as
-      // the busy-guard below.
-      if (budgetCoordinator?.isGateClosed()) {
-        const reason = budgetPauseGateError();
-        log(`Injection rejected by budget pause gate`);
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: reason,
-        });
-        return;
-      }
-
-      const requireReply = !!message.requireReply;
-      // The static bridge contract (markers / git-forbidden / role guidance) now
-      // lives in AGENTS.md (injected by `abg init`), so it is no longer appended to
-      // every message — appending it polluted every Codex turn and the thread title.
-      // Only the DYNAMIC reply-required instruction is appended, on demand.
-      let contentToSend = message.message.content;
-      if (requireReply) {
-        contentToSend += REPLY_REQUIRED_INSTRUCTION;
-      }
-      log(`Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
-      // Budget tier overrides (P4/R5) piggyback on this user-initiated turn —
-      // never injected standalone. Delivery is confirmed back to the coordinator
-      // so the pending override is sent at most once per tier change.
-      const tierOverrides = BUDGET_CONFIG.codexTierControl
-        ? budgetCoordinator?.getCodexTurnOverrides() ?? undefined
-        : undefined;
-      // Busy-turn policy (protocol v2 B0): when a turn is running and the
-      // caller opted into "steer", feed the message INTO the running turn via
-      // turn/steer instead of rejecting — Codex integrates it mid-turn without
-      // losing work. Framed explicitly so Codex can distinguish it from the
-      // original task instructions (design consensus with Codex).
-      if (codex.turnInProgress && message.onBusy === "steer") {
-        if (requireReply) {
-          // B0 limitation (explicit, not silent): require_reply semantics for
-          // steer ("a NEW agentMessage after steer-accept, before terminal")
-          // need the PR B state machine. Reject loudly instead of mis-arming
-          // the tracker on the already-running turn.
-          sendProtocolMessage(ws, {
-            type: "claude_to_codex_result",
-            requestId: message.requestId,
-            success: false,
-            error: "require_reply is not supported together with on_busy=\"steer\" yet. Send the steer without require_reply, or wait for the turn to finish.",
-          });
-          return;
-        }
-        const steerContent =
-          "[STEER from Claude]\n" +
-          "Mid-turn update for the current Codex turn. Integrate if relevant; do not restart work unless explicitly requested.\n\n" +
-          message.message.content;
-        const steered = codex.steerMessage(steerContent);
-        log(`Steer ${steered ? "transport-accepted" : "failed"} (${message.message.content.length} chars)`);
-        if (steered) {
-          // An IMPORTANT message forwarded mid-turn opens an attention window;
-          // a steer is exactly Claude responding to it — close the window like
-          // the inject path does, so status buffering resumes promptly.
-          clearAttentionWindow();
-        }
-        // "Retry as a normal reply" is only good advice when the turn actually
-        // ended — while it is still running, a normal reply just bounces off
-        // the busy guard, whose error suggests steer again: an advice
-        // ping-pong. Branch on the live turn state. (The "ended" branch is
-        // defensive: in the current synchronous flow turnInProgress was true
-        // at dispatch and nothing async runs before this re-read.)
-        const steerFailureAdvice = codex.turnInProgress
-          ? "Steer failed: the running turn cannot be steered right now — wait for it to finish (✅), then send normally."
-          : "Steer failed: the turn may have just ended or the connection dropped — retry as a normal reply.";
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: steered,
-          error: steered ? undefined : steerFailureAdvice,
-        });
-        return;
-      }
-
-      const injected = codex.injectMessage(contentToSend, tierOverrides);
-      if (!injected) {
-        const reason = codex.turnInProgress
-          ? "Codex is busy executing a turn. Options: wait for it to finish, or retry with on_busy=\"steer\" to feed this message into the running turn without interrupting it."
-          : "Injection failed: no active thread or WebSocket not connected.";
-        log(`Injection rejected: ${reason}`);
-        sendProtocolMessage(ws, {
-          type: "claude_to_codex_result",
-          requestId: message.requestId,
-          success: false,
-          error: reason,
-        });
-        return;
-      }
-      if (tierOverrides) {
-        budgetCoordinator?.notifyOverridesDelivered();
-      }
-      // Arm reply-required tracking ONLY after a successful injection: a turn has
-      // now started, so turnCompleted will reset it. Arming before this guard
-      // (on a rejected injection, e.g. Codex busy) would strand the flag on an
-      // unrelated in-flight turn and silently lose this require_reply request.
-      if (requireReply) {
-        replyTracker.arm();
-        log(`Reply required flag set for this message`);
-      }
-      clearAttentionWindow(); // Claude successfully replied, end attention window
-      sendProtocolMessage(ws, {
-        type: "claude_to_codex_result",
-        requestId: message.requestId,
-        success: true,
       });
       return;
     }
   }
+}
+
+/**
+ * Single funnel for claude_to_codex_result (protocol v2 PR B structured
+ * result): legacy success/error stay populated, and every result also carries
+ * ok (mirror of success), the machine-readable code on failure, the live
+ * turnPhase at result time, and an advisory retryAfterMs where meaningful.
+ */
+function sendClaudeToCodexResult(
+  ws: ServerWebSocket<ControlSocketData>,
+  requestId: string,
+  opts: { success: boolean; error?: string; code?: string; retryAfterMs?: number },
+) {
+  sendProtocolMessage(ws, {
+    type: "claude_to_codex_result",
+    requestId,
+    success: opts.success,
+    ...(opts.error !== undefined ? { error: opts.error } : {}),
+    ok: opts.success,
+    ...(opts.code !== undefined ? { code: opts.code } : {}),
+    phase: codex.turnPhase,
+    ...(opts.retryAfterMs !== undefined ? { retryAfterMs: opts.retryAfterMs } : {}),
+  });
+}
+
+function describeDuplicate(dup: Extract<IdempotencyDuplicate, { duplicate: true }>): string {
+  if (dup.code === "duplicate_terminal") {
+    const outcome = dup.state.phase === "terminal" ? dup.state.outcome : "unknown";
+    return (
+      `Duplicate idempotency_key: the original message already reached a terminal state (${outcome}) ` +
+      `and was NOT re-injected. Use a fresh key to send a genuinely new message.`
+    );
+  }
+  const detail = dup.state.phase === "started"
+    ? `already running as turn ${dup.state.turnId}`
+    : "still in flight";
+  return (
+    `Duplicate idempotency_key: a message with this key is ${detail} — NOT re-injected. ` +
+    `Wait for its outcome, or use a fresh key for a genuinely new message.`
+  );
+}
+
+/**
+ * Wait for the interrupt's terminal boundary, racing the adapter's
+ * interruptFailed signal: an app-server rejection ("expected active turn id X
+ * but found Y" / "no active turn to interrupt") means the ORIGINAL turn keeps
+ * running and waiting out the timeout would only delay the loud failure.
+ */
+function waitForInterruptOutcome(
+  turnIds: string[],
+): Promise<{ ok: true } | { ok: false; code: "interrupt_timeout" | "interrupt_rejected"; reason?: string }> {
+  return new Promise((resolve) => {
+    let settled = false;
+    // Recommend #4: abort the inner terminal wait the moment interruptFailed
+    // wins so its listeners + timer are torn down promptly instead of leaking
+    // until the (clamped) interrupt budget elapses.
+    const abort = new AbortController();
+    const finish = (
+      result: { ok: true } | { ok: false; code: "interrupt_timeout" | "interrupt_rejected"; reason?: string },
+    ) => {
+      if (settled) return;
+      settled = true;
+      codex.off("interruptFailed", onFailed);
+      abort.abort();
+      resolve(result);
+    };
+    const onFailed = (reason: string) => finish({ ok: false, code: "interrupt_rejected", reason });
+    codex.on("interruptFailed", onFailed);
+    codex.waitForTurnsTerminal(turnIds, undefined, abort.signal).then((result) => {
+      if (result.ok) {
+        finish({ ok: true });
+      } else if (result.code === "interrupt_timeout") {
+        finish({ ok: false, code: "interrupt_timeout" });
+      }
+      // result.code === "interrupt_aborted" → interruptFailed already settled
+      // this outcome; discard (the settled guard would drop it anyway).
+    });
+  });
+}
+
+async function handleClaudeToCodex(
+  ws: ServerWebSocket<ControlSocketData>,
+  message: Extract<ControlClientMessage, { type: "claude_to_codex" }>,
+): Promise<void> {
+  if (message.message.source !== "claude") {
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: "invalid_source",
+      error: "Invalid message source",
+    });
+    return;
+  }
+
+  // Idempotency duplicate guard (PR B): a key already tracked in ANY state
+  // (live or unexpired tombstone) is answered with the original-outcome code
+  // instead of re-injecting. Messages without a key bypass the machine.
+  // NOTE: a key is REGISTERED only when a wire attempt actually happens (see
+  // idempotency-tracker.ts header) — pre-wire rejections below stay retryable
+  // with the same key on purpose.
+  const idempotencyKey =
+    typeof message.idempotencyKey === "string" && message.idempotencyKey.length > 0
+      ? message.idempotencyKey
+      : undefined;
+  if (idempotencyKey && codex.activeThreadId) {
+    const dup = idempotencyTracker.check(codex.activeThreadId, idempotencyKey);
+    if (dup.duplicate) {
+      log(`Rejected duplicate idempotency key (${dup.code})`);
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: dup.code,
+        error: describeDuplicate(dup),
+      });
+      return;
+    }
+  }
+
+  if (!tuiConnectionState.canReply()) {
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: "no_thread",
+      error: "Codex is not ready. Wait for TUI to connect and create a thread.",
+    });
+    return;
+  }
+
+  // Budget pause gate (plan v2.4 side-aware R4): the gate protects the
+  // TARGET side's quota, so it closes only when the Codex side is exhausted
+  // (gateClosed = pauseSide codex/both). A Claude-only handoff keeps the
+  // gate OPEN so the baton reply can reach Codex. Same rejection shape as
+  // the busy-guard below.
+  if (budgetCoordinator?.isGateClosed()) {
+    const reason = budgetPauseGateError();
+    log(`Injection rejected by budget pause gate`);
+    const resumeAfterEpoch = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
+    const retryAfterMs = resumeAfterEpoch !== null
+      ? Math.max(0, resumeAfterEpoch * 1000 - Date.now())
+      : undefined;
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: "budget_paused",
+      error: reason,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+    return;
+  }
+
+  const requireReply = !!message.requireReply;
+  // The static bridge contract (markers / git-forbidden / role guidance) now
+  // lives in AGENTS.md (injected by `abg init`), so it is no longer appended to
+  // every message — appending it polluted every Codex turn and the thread title.
+  // Only the DYNAMIC reply-required instruction is appended, on demand.
+  let contentToSend = message.message.content;
+  if (requireReply) {
+    contentToSend += REPLY_REQUIRED_INSTRUCTION;
+  }
+  log(`Forwarding Claude → Codex (${message.message.content.length} chars, requireReply=${requireReply})`);
+  // Budget tier overrides (P4/R5) piggyback on this user-initiated turn —
+  // never injected standalone. Delivery is confirmed back to the coordinator
+  // so the pending override is sent at most once per tier change.
+  const tierOverrides = BUDGET_CONFIG.codexTierControl
+    ? budgetCoordinator?.getCodexTurnOverrides() ?? undefined
+    : undefined;
+  // Busy-turn policy (protocol v2 B0): when a turn is running and the
+  // caller opted into "steer", feed the message INTO the running turn via
+  // turn/steer instead of rejecting — Codex integrates it mid-turn without
+  // losing work. Framed explicitly so Codex can distinguish it from the
+  // original task instructions (design consensus with Codex).
+  if (codex.turnInProgress && message.onBusy === "steer") {
+    // require_reply × steer (PR B): allowed — the steer body carries the
+    // reply-required instruction and the daemon arms the expectation when
+    // the app-server ACCEPTS the steer (steerAccepted handler), so any new
+    // forwarded agentMessage before the turn's terminal counts as the reply.
+    const steerContent =
+      "[STEER from Claude]\n" +
+      "Mid-turn update for the current Codex turn. Integrate if relevant; do not restart work unless explicitly requested.\n\n" +
+      contentToSend;
+    // Read the steer target BEFORE dispatch so an idempotency key can be
+    // bound to the turn this steer joins (started(turnId)).
+    const steerTurnId = codex.steerableTurnId;
+    const steerThreadId = codex.activeThreadId;
+    const steerRequestId = codex.steerMessage(steerContent);
+    const steered = steerRequestId !== null;
+    log(`Steer ${steered ? "transport-accepted" : "failed"} (${message.message.content.length} chars, requireReply=${requireReply})`);
+    if (steered) {
+      // An IMPORTANT message forwarded mid-turn opens an attention window;
+      // a steer is exactly Claude responding to it — close the window like
+      // the inject path does, so status buffering resumes promptly.
+      clearAttentionWindow();
+      // Key the dispatch by the bridge request id so steerAccepted/steerFailed
+      // correlate to THIS dispatch by id (PR B #3). Carry the idempotency key +
+      // thread so steerFailed can release the key and turnTrackingReset can
+      // clean both up together (PR B #2).
+      pendingSteerDispatches.set(steerRequestId, {
+        requireReply,
+        ...(idempotencyKey ? { idempotencyKey } : {}),
+        ...(steerThreadId ? { threadId: steerThreadId } : {}),
+      });
+      if (idempotencyKey && steerThreadId) {
+        idempotencyTracker.accept(steerThreadId, idempotencyKey);
+        if (steerTurnId) {
+          // The key lives and dies with the turn the steer joined: the
+          // turn's terminal boundary (turnIdCompleted / turnTrackingReset)
+          // terminates it, so it can never strand in accepted/started. If the
+          // app-server later REJECTS the steer, steerFailed releases the key.
+          idempotencyTracker.markStarted(steerThreadId, idempotencyKey, steerTurnId);
+        }
+      }
+    }
+    // "Retry as a normal reply" is only good advice when the turn actually
+    // ended — while it is still running, a normal reply just bounces off
+    // the busy guard, whose error suggests steer again: an advice
+    // ping-pong. Branch on the live turn state. (The "ended" branch is
+    // defensive: in the current synchronous flow turnInProgress was true
+    // at dispatch and nothing async runs before this re-read.)
+    const steerFailureAdvice = codex.turnInProgress
+      ? "Steer failed: the running turn cannot be steered right now — wait for it to finish (✅), then send normally."
+      : "Steer failed: the turn may have just ended or the connection dropped — retry as a normal reply.";
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: steered,
+      ...(steered ? {} : { code: "steer_failed", error: steerFailureAdvice }),
+    });
+    return;
+  }
+
+  // Busy-turn policy "interrupt" (protocol v2 PR B): terminate ALL active
+  // turns, wait for the terminal boundary, then inject this message as a
+  // NORMAL new turn (the shared injection block below — tier overrides,
+  // require_reply arming and attention-window close all apply unchanged).
+  // Race degradation mirrors steer: if the turn ended between the caller's
+  // decision and this dispatch, fall straight through to normal injection.
+  if (codex.turnInProgress && message.onBusy === "interrupt") {
+    // Register the key BEFORE the async wait so a concurrent retry with the
+    // same key during the window is answered duplicate_in_flight instead of
+    // double-interrupting/double-injecting. Released on every failure exit —
+    // nothing was injected, so the same key must stay retryable. (Corner
+    // race: if the app-server CLOSES during the wait, turnTrackingReset
+    // terminates this key as `aborted` and release() preserves the tombstone
+    // — semantically honest: the attempt aborted mid-flight, and a retry is
+    // told duplicate_terminal(aborted) so it knows to use a fresh key.)
+    const interruptThreadId = codex.activeThreadId;
+    if (idempotencyKey && interruptThreadId) {
+      idempotencyTracker.accept(interruptThreadId, idempotencyKey);
+    }
+    const releaseInterruptKey = () => {
+      if (idempotencyKey && interruptThreadId) {
+        idempotencyTracker.release(interruptThreadId, idempotencyKey);
+      }
+    };
+
+    const interrupted = codex.interruptActiveTurns();
+    if (!interrupted.ok) {
+      releaseInterruptKey();
+      log(`Interrupt unavailable: ${interrupted.error}`);
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: interrupted.code,
+        error:
+          `Interrupt failed (${interrupted.error}). The original turn keeps running — ` +
+          `your message was NOT injected. Wait for ✅, or retry with on_busy="steer".`,
+      });
+      return;
+    }
+
+    log(`Interrupt dispatched for turn(s) ${interrupted.turnIds.join(", ")} — waiting for terminal boundary`);
+    const outcome = await waitForInterruptOutcome(interrupted.turnIds);
+    if (!outcome.ok) {
+      releaseInterruptKey();
+      const error = outcome.code === "interrupt_rejected"
+        ? `Interrupt was rejected by the app-server (${outcome.reason ?? "unknown reason"}). ` +
+          `The original turn keeps running — your message was NOT injected. ` +
+          `Wait for ✅, or retry with on_busy="steer".`
+        : `Interrupt did not reach a terminal boundary in time. The turn MAY still be running — ` +
+          `do not assume it stopped. Your message was NOT injected (this avoids a double-turn race); ` +
+          `check for ✅/⚠️ notices before retrying.`;
+      log(`Interrupt failed (${outcome.code})`);
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: outcome.code,
+        error,
+      });
+      return;
+    }
+    log("Interrupt reached terminal boundary — injecting the message as a new turn");
+    // Defensive: if the active thread changed during the wait, the upfront
+    // accept() would strand under the old thread — release it; the shared
+    // injection block re-registers under the thread it actually injects into.
+    if (interruptThreadId && codex.activeThreadId !== interruptThreadId) {
+      releaseInterruptKey();
+    }
+    // Fall through to the shared injection block.
+  }
+
+  const injectThreadId = codex.activeThreadId;
+  const injectionId = codex.injectMessage(contentToSend, tierOverrides);
+  if (injectionId === null) {
+    // No wire attempt happened — any upfront interrupt-path accept() must not
+    // block a retry with the same key.
+    if (idempotencyKey && injectThreadId) {
+      idempotencyTracker.release(injectThreadId, idempotencyKey);
+    }
+    const busy = codex.turnInProgress;
+    const reason = busy
+      ? "Codex is busy executing a turn. Options: wait for it to finish, retry with on_busy=\"steer\" to feed this message into the running turn without interrupting it, or retry with on_busy=\"interrupt\" to stop the current turn and start a new one with this message."
+      : "Injection failed: no active thread or WebSocket not connected.";
+    log(`Injection rejected: ${reason}`);
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: busy ? "busy_reject" : "no_thread",
+      error: reason,
+      ...(busy ? { retryAfterMs: BUSY_RETRY_ADVISORY_MS } : {}),
+    });
+    return;
+  }
+  if (tierOverrides) {
+    budgetCoordinator?.notifyOverridesDelivered();
+  }
+  // Arm reply-required tracking ONLY after a successful injection: a turn has
+  // now started, so turnCompleted will reset it. Arming before this guard
+  // (on a rejected injection, e.g. Codex busy) would strand the flag on an
+  // unrelated in-flight turn and silently lose this require_reply request.
+  if (requireReply) {
+    replyTracker.arm();
+    log(`Reply required flag set for this message`);
+  }
+  clearAttentionWindow(); // Claude successfully replied, end attention window
+  // turn_started ACK correlation (PR B): remember which control request this
+  // injection belongs to so bridgeTurnStarted/bridgeTurnRejected can emit the
+  // turn_started event / drive the idempotency machine. injectMessage only
+  // succeeds with an active thread, so injectThreadId is non-null here.
+  if (injectThreadId) {
+    if (idempotencyKey) {
+      idempotencyTracker.accept(injectThreadId, idempotencyKey); // no-op if the interrupt path already accepted
+    }
+    pendingTurnStarts.set(injectionId, {
+      requestId: message.requestId,
+      ...(idempotencyKey ? { idempotencyKey } : {}),
+      threadId: injectThreadId,
+    });
+  }
+  sendClaudeToCodexResult(ws, message.requestId, { success: true });
 }
 
 async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: ControlClientIdentity) {
@@ -1283,6 +1628,7 @@ function shutdown(reason: string, exitCode = 0) {
   log(`Shutting down daemon (${reason})...`);
   clearBootDeadline();
   stopBudgetCoordinator();
+  idempotencyTracker.dispose();
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);
   clearPendingClaudeDisconnect(`daemon shutdown (${reason})`);
   controlServer?.stop();

--- a/src/idempotency-tracker.ts
+++ b/src/idempotency-tracker.ts
@@ -1,0 +1,240 @@
+/**
+ * Idempotency state machine for bridge-originated Codex injections
+ * (collaboration-protocol v2, PR B).
+ *
+ * Key = (threadId, idempotencyKey). Lifecycle:
+ *
+ *   accepted → started(turnId) → terminal(completed | aborted | rejected)
+ *
+ * `stalled` is NOT terminal — a stalled turn is still a live busy turn, so its
+ * key stays in `started` until a real terminal boundary.
+ *
+ * After a key reaches terminal it is kept as a TOMBSTONE for a TTL (default
+ * 20 minutes): without the tombstone, a fast-completing turn would let a late
+ * retry re-inject right after terminal, defeating idempotency. Expiry is
+ * enforced two ways: a lazy `now()` check on every lookup (authoritative,
+ * test-controllable via the injected clock) and an unref'd cleanup timer
+ * (memory hygiene; never keeps the process alive).
+ *
+ * Registration policy (daemon-side contract): a key is registered only once
+ * the daemon has actually attempted a wire write for the message (turn/start
+ * or turn/steer, or upfront across the interrupt wait window). Pre-wire
+ * rejections (busy_reject / budget_paused / not-ready) deliberately do NOT
+ * register — the message never entered the pipeline, so retrying with the
+ * SAME key later must go through. `release()` exists for attempts that abort
+ * before any injection hit the wire (e.g. interrupt failed/timed out).
+ *
+ * Pure and timer-injectable so it is unit-testable without the daemon wiring.
+ */
+
+export type IdempotencyTerminalOutcome = "completed" | "aborted" | "rejected";
+
+export type IdempotencyEntryState =
+  | { phase: "accepted" }
+  | { phase: "started"; turnId: string }
+  | { phase: "terminal"; outcome: IdempotencyTerminalOutcome };
+
+export type IdempotencyDuplicate =
+  | { duplicate: false }
+  | {
+      duplicate: true;
+      code: "duplicate_in_flight" | "duplicate_terminal";
+      state: IdempotencyEntryState;
+    };
+
+interface TrackedEntry {
+  threadId: string;
+  state: IdempotencyEntryState;
+  /** Wall-clock (per injected now()) at which a terminal tombstone expires; null while live. */
+  expiresAtMs: number | null;
+  /** Unref'd cleanup timer for the tombstone; null while live. */
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+export const DEFAULT_TOMBSTONE_TTL_MS = 20 * 60 * 1000;
+
+export interface IdempotencyTrackerOptions {
+  /** Tombstone TTL after a key reaches terminal. Default 20 minutes. */
+  ttlMs?: number;
+  /** Injectable clock for tests (lazy-expiry checks use it). Default Date.now. */
+  now?: () => number;
+}
+
+export class IdempotencyTracker {
+  private readonly entries = new Map<string, TrackedEntry>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(options: IdempotencyTrackerOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TOMBSTONE_TTL_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  /** Number of live + tombstoned keys currently tracked (diagnostics/tests). */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Duplicate lookup WITHOUT mutating state. Expired tombstones are treated
+   * as absent (and dropped). accepted/started → duplicate_in_flight;
+   * unexpired terminal tombstone → duplicate_terminal.
+   */
+  check(threadId: string, key: string): IdempotencyDuplicate {
+    const entry = this.getLive(threadId, key);
+    if (!entry) return { duplicate: false };
+    if (entry.state.phase === "terminal") {
+      return { duplicate: true, code: "duplicate_terminal", state: entry.state };
+    }
+    return { duplicate: true, code: "duplicate_in_flight", state: entry.state };
+  }
+
+  /** Current state of a key, or null when untracked/expired (diagnostics/tests). */
+  peek(threadId: string, key: string): IdempotencyEntryState | null {
+    return this.getLive(threadId, key)?.state ?? null;
+  }
+
+  /**
+   * Register a key as accepted (= an injection attempt is hitting the wire,
+   * or — for the interrupt path — the async interrupt window has opened).
+   * No-op when the key is already tracked: a live entry must not be reset and
+   * a tombstone must not be resurrected (callers run check() first).
+   */
+  accept(threadId: string, key: string): void {
+    if (this.getLive(threadId, key)) return;
+    this.entries.set(this.compositeKey(threadId, key), {
+      threadId,
+      state: { phase: "accepted" },
+      expiresAtMs: null,
+      timer: null,
+    });
+  }
+
+  /**
+   * Drop a NON-terminal entry: the attempt aborted before any turn/start hit
+   * the wire (e.g. interrupt failed/timed out, sync injection failure), so a
+   * retry with the same key is legitimate and must go through. Terminal
+   * tombstones are deliberately preserved.
+   */
+  release(threadId: string, key: string): void {
+    const composite = this.compositeKey(threadId, key);
+    const entry = this.entries.get(composite);
+    if (!entry || entry.state.phase === "terminal") return;
+    this.entries.delete(composite);
+  }
+
+  /**
+   * accepted → started(turnId), driven by the turn_started ACK correlation
+   * (or by the known steered turn id on the steer path). No-op for untracked
+   * or already-terminal keys (a late ACK must not resurrect a tombstone).
+   */
+  markStarted(threadId: string, key: string, turnId: string): void {
+    const entry = this.getLive(threadId, key);
+    if (!entry || entry.state.phase === "terminal") return;
+    entry.state = { phase: "started", turnId };
+  }
+
+  /**
+   * Terminal `rejected`: a bridge-originated JSON-RPC error arrived BEFORE
+   * started — the app-server definitively did not start a turn for this key.
+   */
+  markRejected(threadId: string, key: string): void {
+    const entry = this.getLive(threadId, key);
+    if (!entry || entry.state.phase === "terminal") return;
+    this.terminate(entry, "rejected");
+  }
+
+  /**
+   * turn/completed boundary: terminal `completed` for every key whose
+   * started.turnId matches. A null turnId (turn/completed without an id — the
+   * adapter clears ALL active turns there) completes every started key.
+   * accepted keys are left alone — their turn/start response is still owed.
+   *
+   * `threadId` SCOPES the null-turnId case to one thread (consistent with
+   * terminateThread, which is always thread-scoped). The adapter's null-id
+   * completion clears every active turn on the connection; today there is one
+   * thread per pair so unscoped and scoped behave identically, but passing the
+   * active thread makes the blast radius explicit and future-proofs the
+   * (latent) multi-thread case so a null completion on thread A cannot
+   * silently terminate thread B's started keys. When `threadId` is omitted a
+   * null turnId completes every started key regardless of thread (legacy
+   * behavior). A non-null turnId matches by id only; thread scope is moot
+   * because turn ids are globally unique.
+   */
+  completeTurn(turnId: string | null, threadId?: string): void {
+    for (const entry of this.entries.values()) {
+      if (entry.state.phase !== "started") continue;
+      if (turnId !== null) {
+        if (entry.state.turnId !== turnId) continue;
+      } else if (threadId !== undefined && entry.threadId !== threadId) {
+        continue;
+      }
+      this.terminate(entry, "completed");
+    }
+  }
+
+  /**
+   * Thread-wide terminal boundary (turnAborted / app-server close / reconnect
+   * / stop): terminate ALL pending/running keys for the thread.
+   */
+  terminateThread(threadId: string, outcome: IdempotencyTerminalOutcome): void {
+    for (const entry of this.entries.values()) {
+      if (entry.threadId !== threadId || entry.state.phase === "terminal") continue;
+      this.terminate(entry, outcome);
+    }
+  }
+
+  /** Terminate every non-terminal key regardless of thread (connection-level resets). */
+  terminateAll(outcome: IdempotencyTerminalOutcome): void {
+    for (const entry of this.entries.values()) {
+      if (entry.state.phase === "terminal") continue;
+      this.terminate(entry, outcome);
+    }
+  }
+
+  /** Cancel all tombstone timers and forget everything (shutdown/tests). */
+  dispose(): void {
+    for (const entry of this.entries.values()) {
+      if (entry.timer) clearTimeout(entry.timer);
+    }
+    this.entries.clear();
+  }
+
+  // ── internals ──────────────────────────────────────────────
+
+  private compositeKey(threadId: string, key: string): string {
+    // The NUL separator cannot occur in either part (thread ids are UUIDs, keys are
+    // validated tool input), so the composite cannot collide across pairs.
+    return `${threadId}\u0000${key}`;
+  }
+
+  /** Entry lookup with lazy tombstone expiry (injected-clock authoritative). */
+  private getLive(threadId: string, key: string): TrackedEntry | null {
+    const composite = this.compositeKey(threadId, key);
+    const entry = this.entries.get(composite);
+    if (!entry) return null;
+    if (entry.expiresAtMs !== null && this.now() >= entry.expiresAtMs) {
+      if (entry.timer) clearTimeout(entry.timer);
+      this.entries.delete(composite);
+      return null;
+    }
+    return entry;
+  }
+
+  private terminate(entry: TrackedEntry, outcome: IdempotencyTerminalOutcome): void {
+    entry.state = { phase: "terminal", outcome };
+    entry.expiresAtMs = this.now() + this.ttlMs;
+    const timer = setTimeout(() => {
+      // Best-effort memory cleanup; the lazy now() check in getLive is the
+      // authoritative expiry (and the one tests drive via the injected clock).
+      for (const [composite, candidate] of this.entries.entries()) {
+        if (candidate === entry) {
+          this.entries.delete(composite);
+          break;
+        }
+      }
+    }, this.ttlMs);
+    timer.unref?.();
+    entry.timer = timer;
+  }
+}

--- a/src/interrupt-timing.ts
+++ b/src/interrupt-timing.ts
@@ -1,0 +1,58 @@
+/**
+ * Single source of truth for the interrupt / reply timeout relationship
+ * (collaboration-protocol v2, PR B).
+ *
+ * INVARIANT: the daemon-side interrupt terminal-wait budget MUST resolve
+ * (success OR failure) strictly BEFORE the bridge client's reply timeout
+ * fires. Otherwise the client reports a FALSE "Timed out waiting for daemon"
+ * to Claude WHILE the daemon still proceeds to inject the message and arm
+ * requireReply — a Claude retry then causes a DOUBLE turn.
+ *
+ * The interrupt budget is operator-overridable via
+ * AGENTBRIDGE_INTERRUPT_TIMEOUT_MS (parsePositiveIntEnv has NO upper bound),
+ * so a large value could otherwise exceed the client timeout. We make the
+ * relationship impossible to misconfigure by CLAMPING the effective interrupt
+ * budget to at most `CLIENT_REPLY_TIMEOUT_MS - INTERRUPT_CLIENT_MARGIN_MS`.
+ * The clamp bounds the worst case regardless of the configured env value, and
+ * the margin leaves room for the daemon to send its structured result and for
+ * that result to traverse the control WS before the client gives up.
+ *
+ * Both call sites (daemon-client.sendReply, codex-adapter.waitForTurnsTerminal)
+ * reference these constants and document the invariant inline.
+ */
+
+/**
+ * The bridge client's hard reply timeout for a claude_to_codex round trip.
+ * Applies to the daemon's IMMEDIATE result; the interrupt path is the only
+ * one that legitimately defers the result (up to the clamped interrupt
+ * budget), which is why that budget is clamped below this value.
+ */
+export const CLIENT_REPLY_TIMEOUT_MS = 15_000;
+
+/**
+ * Safety margin reserved below CLIENT_REPLY_TIMEOUT_MS for the daemon to emit
+ * its claude_to_codex_result and for that result to reach the client before
+ * the client's reply timer fires.
+ */
+export const INTERRUPT_CLIENT_MARGIN_MS = 2_000;
+
+/** Default interrupt terminal-wait budget when the env override is unset. */
+export const DEFAULT_INTERRUPT_TIMEOUT_MS = 10_000;
+
+/**
+ * The largest interrupt budget that still guarantees the daemon answers
+ * before the client reply timeout fires. Any configured value at or above
+ * this is clamped down to it.
+ */
+export const MAX_INTERRUPT_TIMEOUT_MS =
+  CLIENT_REPLY_TIMEOUT_MS - INTERRUPT_CLIENT_MARGIN_MS;
+
+/**
+ * Clamp a (validated, positive) interrupt-timeout value to the safe ceiling.
+ * `requested` is assumed already validated by parsePositiveIntEnv (positive
+ * integer); this only enforces the upper bound that keeps the double-turn
+ * race impossible.
+ */
+export function clampInterruptTimeoutMs(requested: number): number {
+  return Math.min(requested, MAX_INTERRUPT_TIMEOUT_MS);
+}

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -5,6 +5,7 @@ import { createServer, Socket, type AddressInfo, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CodexAdapter } from "../codex-adapter";
+import { CLIENT_REPLY_TIMEOUT_MS, MAX_INTERRUPT_TIMEOUT_MS } from "../interrupt-timing";
 
 // Hermetic log sink: the constructor's default logFile resolves the REAL pair
 // state dir — these tests were appending into (and could rotate!) a live
@@ -323,15 +324,17 @@ describe("CodexAdapter turn state machine", () => {
     adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
 
     adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
-    expect(adapter.injectMessage("hello")).toBe(false);
+    expect(adapter.injectMessage("hello")).toBeNull();
   });
 
-  test("injectMessage succeeds when no turn active", () => {
+  test("injectMessage succeeds when no turn active and returns the negative request id", () => {
     const adapter = createAdapter();
     adapter.threadId = "thread-1";
     adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
 
-    expect(adapter.injectMessage("hello")).toBe(true);
+    const injectionId = adapter.injectMessage("hello");
+    expect(typeof injectionId).toBe("number");
+    expect(injectionId).toBeLessThan(0);
   });
 
   test("clearResponseTrackingState + turn reset simulates onclose behavior", () => {
@@ -351,7 +354,7 @@ describe("CodexAdapter turn state machine", () => {
     // After reset, injection should work again
     adapter.threadId = "thread-1";
     adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
-    expect(adapter.injectMessage("hello after reset")).toBe(true);
+    expect(adapter.injectMessage("hello after reset")).toBeLessThan(0);
   });
 
   test("thread/start tracked request lifecycle emits ready from response thread id", () => {
@@ -1662,7 +1665,7 @@ describe("CodexAdapter initialize reconnect", () => {
     adapter.onTuiConnect(ws);
 
     expect(adapter.threadId).toBeNull();
-    expect(adapter.injectMessage("hello")).toBe(false);
+    expect(adapter.injectMessage("hello")).toBeNull();
   });
 });
 
@@ -2284,7 +2287,7 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     const adapter = createAdapter();
     adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
     adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
-    expect(adapter.steerMessage("hello")).toBe(false);
+    expect(adapter.steerMessage("hello")).toBeNull();
   });
 
   test("steerMessage rejects when the app-server WebSocket is not connected", () => {
@@ -2292,7 +2295,7 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     adapter.threadId = "thread-steer";
     adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
     adapter.appServerWs = null;
-    expect(adapter.steerMessage("hello")).toBe(false);
+    expect(adapter.steerMessage("hello")).toBeNull();
   });
 
   test("steerMessage rejects when NO turn is in progress (injectMessage territory)", () => {
@@ -2300,14 +2303,19 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     adapter.threadId = "thread-steer";
     adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
     expect(adapter.turnInProgress).toBe(false);
-    expect(adapter.steerMessage("hello")).toBe(false);
+    expect(adapter.steerMessage("hello")).toBeNull();
   });
 
   test("steerMessage sends turn/steer with a tracked negative id, expectedTurnId and text input", () => {
     const { adapter, appSent } = createSteerableAdapter();
 
-    expect(adapter.steerMessage("mid-turn correction")).toBe(true);
+    // Returns the (negative) bridge request id when transport-accepted (PR B:
+    // the daemon correlates steerAccepted/steerFailed back to the dispatch by id).
+    const steerReqId = adapter.steerMessage("mid-turn correction");
+    expect(typeof steerReqId).toBe("number");
+    expect(steerReqId).toBeLessThan(0);
     expect(appSent).toHaveLength(1);
+    expect(JSON.parse(appSent[0]).id).toBe(steerReqId);
 
     const sent = JSON.parse(appSent[0]);
     expect(sent.method).toBe("turn/steer");
@@ -2334,7 +2342,7 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     adapter.handleServerNotification({ method: "turn/started", params: {} });
     expect(adapter.turnInProgress).toBe(true);
 
-    expect(adapter.steerMessage("hello")).toBe(false);
+    expect(adapter.steerMessage("hello")).toBeNull();
   });
 
   test("steerMessage targets the NEWEST real turn id when several are active", () => {
@@ -2342,7 +2350,7 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     // A second (nested/newer) turn starts; insertion order makes it the newest.
     adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t2" } } });
 
-    expect(adapter.steerMessage("target the newest")).toBe(true);
+    expect(adapter.steerMessage("target the newest")).toBeLessThan(0);
     expect(JSON.parse(appSent[0]).params.expectedTurnId).toBe("t2");
 
     adapter.clearResponseTrackingState();
@@ -2354,7 +2362,7 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t2" } } });
 
     expect(adapter.turnInProgress).toBe(true); // t1 still active
-    expect(adapter.steerMessage("back to t1")).toBe(true);
+    expect(adapter.steerMessage("back to t1")).toBeLessThan(0);
     expect(JSON.parse(appSent[0]).params.expectedTurnId).toBe("t1");
 
     adapter.clearResponseTrackingState();
@@ -2364,12 +2372,12 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     // Core B0 invariant: ActiveTurnNotSteerable / NoActiveTurn-race rejections
     // must not be confused with a turn abort — the ORIGINAL turn is untouched.
     const { adapter, appSent } = createSteerableAdapter();
-    const failures: string[] = [];
+    const failures: Array<{ requestId: number; reason: string }> = [];
     const aborts: string[] = [];
-    adapter.on("steerFailed", (reason: string) => failures.push(reason));
+    adapter.on("steerFailed", (e: { requestId: number; reason: string }) => failures.push(e));
     adapter.on("turnAborted", (reason: string) => aborts.push(reason));
 
-    adapter.steerMessage("mid-turn correction");
+    const steerReqId = adapter.steerMessage("mid-turn correction");
     const steerId = JSON.parse(appSent[0]).id;
 
     const forwarded = adapter.handleAppServerPayload(JSON.stringify({
@@ -2378,7 +2386,8 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     }));
 
     expect(forwarded).toBeNull(); // swallowed, never forwarded to the TUI
-    expect(failures).toEqual(["ActiveTurnNotSteerable"]);
+    // steerFailed now carries the bridge requestId (PR B id correlation).
+    expect(failures).toEqual([{ requestId: steerReqId as number, reason: "ActiveTurnNotSteerable" }]);
     expect(aborts).toEqual([]);
     expect(adapter.turnInProgress).toBe(true);
     expect(adapter.turnPhase).toBe("running");
@@ -2387,19 +2396,21 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     adapter.clearResponseTrackingState();
   });
 
-  test("an accepted steer emits steerAccepted and nothing else", () => {
+  test("an accepted steer emits steerAccepted (carrying the requestId) and nothing else", () => {
     const { adapter, appSent } = createSteerableAdapter();
     const events: string[] = [];
-    adapter.on("steerAccepted", () => events.push("accepted"));
+    const acceptedIds: number[] = [];
+    adapter.on("steerAccepted", (e: { requestId: number }) => { events.push("accepted"); acceptedIds.push(e.requestId); });
     adapter.on("steerFailed", () => events.push("failed"));
     adapter.on("turnAborted", () => events.push("aborted"));
 
-    adapter.steerMessage("mid-turn correction");
+    const steerReqId = adapter.steerMessage("mid-turn correction");
     const steerId = JSON.parse(appSent[0]).id;
 
     adapter.handleAppServerPayload(JSON.stringify({ id: steerId, result: {} }));
 
     expect(events).toEqual(["accepted"]);
+    expect(acceptedIds).toEqual([steerReqId as number]);
     expect(adapter.turnInProgress).toBe(true);
 
     adapter.clearResponseTrackingState();
@@ -2410,9 +2421,9 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
     // turn-start error path must keep its abort semantics.
     const { adapter } = createSteerableAdapter();
     const aborts: string[] = [];
-    const failures: string[] = [];
+    const failures: Array<{ requestId: number; reason: string }> = [];
     adapter.on("turnAborted", (reason: string) => aborts.push(reason));
-    adapter.on("steerFailed", (reason: string) => failures.push(reason));
+    adapter.on("steerFailed", (e: { requestId: number; reason: string }) => failures.push(e));
 
     adapter.trackBridgeRequestId(-77); // default kind: "turn-start"
     adapter.handleAppServerPayload(JSON.stringify({
@@ -2451,14 +2462,385 @@ describe("CodexAdapter turn/steer (protocol v2 B0)", () => {
       readyState: WebSocket.OPEN,
       send: () => { throw new Error("socket write failed"); },
     } as any;
-    const failures: string[] = [];
-    adapter.on("steerFailed", (reason: string) => failures.push(reason));
+    const failures: Array<{ requestId: number; reason: string }> = [];
+    adapter.on("steerFailed", (e: { requestId: number; reason: string }) => failures.push(e));
 
-    expect(adapter.steerMessage("doomed")).toBe(false);
+    expect(adapter.steerMessage("doomed")).toBeNull();
     expect(adapter.bridgeRequestIds.size).toBe(0);
     expect(adapter.bridgeRequestKinds.size).toBe(0);
     expect(failures).toEqual([]); // send failure is the return value's job, not the event's
 
     adapter.clearResponseTrackingState();
+  });
+
+  test("steerableTurnId exposes the newest addressable turn id (daemon's idempotency binding)", () => {
+    const { adapter } = createSteerableAdapter();
+    expect(adapter.steerableTurnId).toBe("t1");
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t2" } } });
+    expect(adapter.steerableTurnId).toBe("t2");
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t2" } } });
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
+    expect(adapter.steerableTurnId).toBeNull();
+  });
+});
+
+describe("CodexAdapter turn/interrupt (protocol v2 PR B)", () => {
+  function createBusyAdapter(turnIds: string[] = ["t1"]) {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.threadId = "thread-int";
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    for (const id of turnIds) {
+      adapter.handleServerNotification({ method: "turn/started", params: { turn: { id } } });
+    }
+    return { adapter, appSent };
+  }
+
+  test("interruptActiveTurns sends turn/interrupt {threadId, turnId} per addressable active id, kind-tracked", () => {
+    const { adapter, appSent } = createBusyAdapter(["t1", "t2"]);
+
+    const result = adapter.interruptActiveTurns();
+    expect(result.ok).toBe(true);
+    expect(result.turnIds).toEqual(["t1", "t2"]);
+    expect(appSent).toHaveLength(2);
+
+    const sentTurnIds: string[] = [];
+    for (const raw of appSent) {
+      const sent = JSON.parse(raw);
+      expect(sent.method).toBe("turn/interrupt");
+      expect(typeof sent.id).toBe("number");
+      expect(sent.id).toBeLessThan(0);
+      // Wire shape verified against codex-rs TurnInterruptParams (turn.rs):
+      // {threadId, turnId}, nothing else.
+      expect(sent.params).toEqual({ threadId: "thread-int", turnId: sent.params.turnId });
+      sentTurnIds.push(sent.params.turnId);
+      expect(adapter.bridgeRequestIds.has(sent.id)).toBe(true);
+      expect(adapter.bridgeRequestKinds.get(sent.id)).toBe("interrupt");
+    }
+    expect(sentTurnIds).toEqual(["t1", "t2"]);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("interruptActiveTurns fails structured when the only active turn has no addressable id", () => {
+    const adapter = createAdapter();
+    const appSent: string[] = [];
+    adapter.threadId = "thread-int";
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    // turn/started without a turn id → tracked under an `unknown:<ts>` key.
+    adapter.handleServerNotification({ method: "turn/started", params: {} });
+    expect(adapter.turnInProgress).toBe(true);
+
+    const result = adapter.interruptActiveTurns();
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("interrupt_unavailable");
+    expect(appSent).toHaveLength(0); // local failure — nothing hit the wire
+  });
+
+  test("interruptActiveTurns fails structured with no thread or no app-server WS", () => {
+    const noThread = createAdapter();
+    noThread.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+    noThread.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    const r1 = noThread.interruptActiveTurns();
+    expect(r1.ok).toBe(false);
+    expect(r1.code).toBe("interrupt_unavailable");
+
+    const noWs = createAdapter();
+    noWs.threadId = "thread-int";
+    noWs.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    noWs.appServerWs = null;
+    const r2 = noWs.interruptActiveTurns();
+    expect(r2.ok).toBe(false);
+    expect(r2.code).toBe("interrupt_unavailable");
+  });
+
+  test("a rejected turn/interrupt emits interruptFailed and does NOT touch turn state", () => {
+    // Real app-server rejections: "expected active turn id X but found Y",
+    // "no active turn to interrupt" (turn_processor.rs). The original turn
+    // keeps running — response handlers never mutate turn state.
+    const { adapter, appSent } = createBusyAdapter(["t1"]);
+    const failures: string[] = [];
+    const aborts: string[] = [];
+    adapter.on("interruptFailed", (reason: string) => failures.push(reason));
+    adapter.on("turnAborted", (reason: string) => aborts.push(reason));
+
+    adapter.interruptActiveTurns();
+    const interruptId = JSON.parse(appSent[0]).id;
+
+    const forwarded = adapter.handleAppServerPayload(JSON.stringify({
+      id: interruptId,
+      error: { message: "no active turn to interrupt" },
+    }));
+
+    expect(forwarded).toBeNull(); // swallowed, never forwarded to the TUI
+    expect(failures).toEqual(["no active turn to interrupt"]);
+    expect(aborts).toEqual([]);
+    expect(adapter.turnInProgress).toBe(true);
+    expect(adapter.turnPhase).toBe("running");
+    expect(adapter.bridgeRequestIds.has(interruptId)).toBe(false); // consumed
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("an interrupt SUCCESS response ({}) is log-only — no events, no state change", () => {
+    // The real app-server defers this response until TurnAborted; the
+    // terminal turn/completed (status interrupted) notification owns state.
+    const { adapter, appSent } = createBusyAdapter(["t1"]);
+    const events: string[] = [];
+    adapter.on("interruptFailed", () => events.push("failed"));
+    adapter.on("turnAborted", () => events.push("aborted"));
+    adapter.on("steerAccepted", () => events.push("steerAccepted"));
+    adapter.on("bridgeTurnStarted", () => events.push("bridgeTurnStarted"));
+
+    adapter.interruptActiveTurns();
+    const interruptId = JSON.parse(appSent[0]).id;
+    const forwarded = adapter.handleAppServerPayload(JSON.stringify({ id: interruptId, result: {} }));
+
+    expect(forwarded).toBeNull();
+    expect(events).toEqual([]);
+    expect(adapter.turnInProgress).toBe(true); // still running until turn/completed
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("waitForTurnsTerminal resolves immediately when already terminal", async () => {
+    const adapter = createAdapter();
+    const result = await adapter.waitForTurnsTerminal(["t1"], 50);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("waitForTurnsTerminal resolves when the targeted turn completes", async () => {
+    const { adapter } = createBusyAdapter(["t1"]);
+    const wait = adapter.waitForTurnsTerminal(["t1"], 2000);
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
+    expect(await wait).toEqual({ ok: true });
+  });
+
+  test("waitForTurnsTerminal holds until ALL targeted ids leave (a still-targeted turn holds)", async () => {
+    // The wait is now per-TARGETED-id: targeting both t1 and t2 must hold until
+    // both complete (a residual targeted turn keeps the wait pending).
+    const { adapter } = createBusyAdapter(["t1", "t2"]);
+    const wait = adapter.waitForTurnsTerminal(["t1", "t2"], 2000);
+
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
+    const pending = await Promise.race([wait, sleep(50).then(() => "pending")]);
+    expect(pending).toBe("pending"); // t2 still targeted + running
+
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t2" } } });
+    expect(await wait).toEqual({ ok: true });
+  });
+
+  test("waitForTurnsTerminal resolves when the TARGETED turns end even if an UNtargeted turn is still active (recommend #3 latent-REAL fix)", async () => {
+    // PR B fix: the predicate must key on the TARGETED ids only, NOT the global
+    // turnPhase. A coexisting unaddressable `unknown:` turn (which the interrupt
+    // path can never target) keeps turnPhase at "running" forever — under the
+    // OLD predicate that guaranteed a spurious interrupt_timeout. The residual
+    // turn is harmless: the daemon's injectMessage busy-guard rejects an
+    // injection while ANY turn is still in progress, so resolving early here
+    // cannot double-turn.
+    const adapter = createAdapter();
+    adapter.threadId = "thread-int";
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    // An id-less turn/started → tracked under an `unknown:<ts>` key; it coexists
+    // and is NEVER addressable/targetable by the interrupt path.
+    adapter.handleServerNotification({ method: "turn/started", params: {} });
+    expect(adapter.turnPhase).toBe("running");
+
+    const wait = adapter.waitForTurnsTerminal(["t1"], 2000);
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
+
+    // Resolves as soon as the targeted t1 ends, even though the unknown: turn
+    // keeps turnPhase === "running".
+    expect(await wait).toEqual({ ok: true });
+    expect(adapter.turnPhase).toBe("running"); // unknown: turn still active
+
+    adapter.resetTurnState("test cleanup");
+  });
+
+  test("waitForTurnsTerminal holds while a TARGETED turn is stalled, then resolves on completion", async () => {
+    // A stalled turn is still busy: a targeted id flagged stalled must keep the
+    // wait pending (scoped to currentlyStalledTurnIds, not the global phase).
+    const { adapter } = createBusyAdapter(["t1"]);
+    // Simulate the watchdog marking the targeted turn stalled.
+    (adapter as any).markTurnStalled("t1");
+    expect(adapter.turnPhase).toBe("stalled");
+
+    const wait = adapter.waitForTurnsTerminal(["t1"], 2000);
+    const pending = await Promise.race([wait, sleep(50).then(() => "pending")]);
+    expect(pending).toBe("pending"); // t1 stalled but still active+targeted
+
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
+    expect(await wait).toEqual({ ok: true });
+  });
+
+  test("waitForTurnsTerminal is cancelable via AbortSignal (recommend #4 — prompt listener teardown)", async () => {
+    const { adapter } = createBusyAdapter(["t1"]);
+    const controller = new AbortController();
+    const wait = adapter.waitForTurnsTerminal(["t1"], 5000, controller.signal);
+
+    // Abort BEFORE the (large) timeout — the wait must resolve promptly with a
+    // distinct interrupt_aborted code instead of leaking listeners until 5s.
+    const startedAt = Date.now();
+    controller.abort();
+    const result = await wait;
+    expect(result).toEqual({ ok: false, code: "interrupt_aborted" });
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    // Listeners were removed on abort — the turn state is untouched.
+    expect(adapter.turnInProgress).toBe(true);
+
+    adapter.resetTurnState("test cleanup");
+  });
+
+  test("waitForTurnsTerminal returns interrupt_aborted synchronously when the signal is already aborted", async () => {
+    const { adapter } = createBusyAdapter(["t1"]);
+    const controller = new AbortController();
+    controller.abort();
+    const result = await adapter.waitForTurnsTerminal(["t1"], 5000, controller.signal);
+    expect(result).toEqual({ ok: false, code: "interrupt_aborted" });
+
+    adapter.resetTurnState("test cleanup");
+  });
+
+  test("waitForTurnsTerminal resolves on an abnormal turn end (reset/abort path)", async () => {
+    const { adapter } = createBusyAdapter(["t1"]);
+    const wait = adapter.waitForTurnsTerminal(["t1"], 2000);
+    adapter.resetTurnState("app-server connection closed");
+    // phase is "aborted" after the reset — explicitly within the boundary.
+    expect(adapter.turnPhase).toBe("aborted");
+    expect(await wait).toEqual({ ok: true });
+  });
+
+  test("waitForTurnsTerminal times out with a structured interrupt_timeout", async () => {
+    const { adapter } = createBusyAdapter(["t1"]);
+    const result = await adapter.waitForTurnsTerminal(["t1"], 40);
+    expect(result).toEqual({ ok: false, code: "interrupt_timeout" });
+    expect(adapter.turnInProgress).toBe(true); // the wait never mutates state
+
+    adapter.resetTurnState("test cleanup");
+  });
+
+  test("AGENTBRIDGE_INTERRUPT_TIMEOUT_MS overrides the default wait budget", async () => {
+    const previous = process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS;
+    process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS = "30";
+    try {
+      const { adapter } = createBusyAdapter(["t1"]);
+      const startedAt = Date.now();
+      const result = await adapter.waitForTurnsTerminal(["t1"]); // default arg reads the env
+      expect(result).toEqual({ ok: false, code: "interrupt_timeout" });
+      expect(Date.now() - startedAt).toBeLessThan(5_000); // far below the 10s default
+      adapter.resetTurnState("test cleanup");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS;
+      } else {
+        process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS = previous;
+      }
+    }
+  });
+
+  test("AGENTBRIDGE_INTERRUPT_TIMEOUT_MS is CLAMPED below the client reply timeout (REAL #1 double-turn guard)", () => {
+    const previous = process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS;
+    // An operator sets a wildly over-large budget (10 minutes) — far past the
+    // client's 15s reply timeout. Without the clamp, the client would report a
+    // FALSE "Timed out waiting for daemon" while the daemon still injects, and a
+    // Claude retry would double-turn.
+    process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS = "600000";
+    try {
+      const adapter = createAdapter();
+      const effective = (adapter as any).interruptTimeoutMs() as number;
+      expect(effective).toBe(MAX_INTERRUPT_TIMEOUT_MS);
+      expect(effective).toBeLessThan(CLIENT_REPLY_TIMEOUT_MS);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS;
+      } else {
+        process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS = previous;
+      }
+    }
+  });
+
+  test("a within-ceiling AGENTBRIDGE_INTERRUPT_TIMEOUT_MS passes through unchanged", () => {
+    const previous = process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS;
+    process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS = "5000";
+    try {
+      const adapter = createAdapter();
+      expect((adapter as any).interruptTimeoutMs()).toBe(5000);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS;
+      } else {
+        process.env.AGENTBRIDGE_INTERRUPT_TIMEOUT_MS = previous;
+      }
+    }
+  });
+
+  test("bridgeTurnStarted correlates a turn/start success response to the injection id", () => {
+    const adapter = createAdapter();
+    adapter.threadId = "thread-int";
+    const appSent: string[] = [];
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: (data: string) => appSent.push(data) } as any;
+    const started: Array<{ requestId: number; turnId: string }> = [];
+    adapter.on("bridgeTurnStarted", (event: { requestId: number; turnId: string }) => started.push(event));
+
+    const injectionId = adapter.injectMessage("hello");
+    expect(injectionId).toBeLessThan(0);
+
+    const forwarded = adapter.handleAppServerPayload(JSON.stringify({
+      id: injectionId,
+      result: { turn: { id: "turn-xyz" } },
+    }));
+
+    expect(forwarded).toBeNull(); // swallowed — never forwarded to the TUI
+    expect(started).toEqual([{ requestId: injectionId, turnId: "turn-xyz" }]);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("a turn/start success response WITHOUT a turn id skips the ACK (log-only)", () => {
+    const adapter = createAdapter();
+    adapter.threadId = "thread-int";
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+    const started: unknown[] = [];
+    adapter.on("bridgeTurnStarted", (event: unknown) => started.push(event));
+
+    const injectionId = adapter.injectMessage("hello");
+    adapter.handleAppServerPayload(JSON.stringify({ id: injectionId, result: {} }));
+
+    expect(started).toEqual([]);
+    adapter.clearResponseTrackingState();
+  });
+
+  test("a rejected injected turn/start emits bridgeTurnRejected alongside turnAborted", () => {
+    const adapter = createAdapter();
+    adapter.threadId = "thread-int";
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+    const rejections: Array<{ requestId: number; error: string }> = [];
+    const aborts: string[] = [];
+    adapter.on("bridgeTurnRejected", (event: { requestId: number; error: string }) => rejections.push(event));
+    adapter.on("turnAborted", (reason: string) => aborts.push(reason));
+
+    const injectionId = adapter.injectMessage("hello");
+    adapter.handleAppServerPayload(JSON.stringify({
+      id: injectionId,
+      error: { message: "turn/start rejected" },
+    }));
+
+    expect(rejections).toEqual([{ requestId: injectionId, error: "turn/start rejected" }]);
+    expect(aborts).toHaveLength(1);
+
+    adapter.clearResponseTrackingState();
+  });
+
+  test("turnIdCompleted fires per turn/completed with the specific id (null when absent)", () => {
+    const { adapter } = createBusyAdapter(["t1", "t2"]);
+    const completedIds: Array<string | null> = [];
+    adapter.on("turnIdCompleted", (turnId: string | null) => completedIds.push(turnId));
+
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
+    expect(adapter.turnInProgress).toBe(true); // t2 still active — aggregate event silent
+    adapter.handleServerNotification({ method: "turn/completed", params: {} });
+
+    expect(completedIds).toEqual(["t1", null]);
   });
 });

--- a/src/unit-test/daemon-client.test.ts
+++ b/src/unit-test/daemon-client.test.ts
@@ -321,6 +321,85 @@ describe("DaemonClient", () => {
     expect(result.success).toBe(true);
   });
 
+  test("sendReply passes the PR B structured result fields through", async () => {
+    onServerMessage = (ws: any, raw: any) => {
+      const msg = JSON.parse(typeof raw === "string" ? raw : raw.toString());
+      if (msg.type === "claude_to_codex") {
+        ws.send(JSON.stringify({
+          type: "claude_to_codex_result",
+          requestId: msg.requestId,
+          success: false,
+          error: "Codex is busy executing a turn.",
+          ok: false,
+          code: "busy_reject",
+          phase: "running",
+          retryAfterMs: 15000,
+        }));
+      }
+    };
+
+    await client.connect();
+
+    const result = await client.sendReply({
+      id: "r-structured",
+      source: "claude",
+      content: "structured fields",
+      timestamp: Date.now(),
+    });
+    expect(result.success).toBe(false);
+    expect(result.code).toBe("busy_reject");
+    expect(result.phase).toBe("running");
+    expect(result.retryAfterMs).toBe(15000);
+    expect(result.error).toContain("busy");
+  });
+
+  test("sendReply serializes onBusy=interrupt and idempotencyKey onto the control message", async () => {
+    const seen: any[] = [];
+    onServerMessage = (ws: any, raw: any) => {
+      const msg = JSON.parse(typeof raw === "string" ? raw : raw.toString());
+      if (msg.type === "claude_to_codex") {
+        seen.push(msg);
+        ws.send(JSON.stringify({ type: "claude_to_codex_result", requestId: msg.requestId, success: true }));
+      }
+    };
+
+    await client.connect();
+
+    await client.sendReply(
+      { id: "r-int", source: "claude", content: "interrupt me", timestamp: Date.now() },
+      false,
+      "interrupt",
+      "key-77",
+    );
+    expect(seen).toHaveLength(1);
+    expect(seen[0].onBusy).toBe("interrupt");
+    expect(seen[0].idempotencyKey).toBe("key-77");
+  });
+
+  test("emits turnStarted on a turn_started control event", async () => {
+    await client.connect();
+
+    const ackPromise = new Promise<any>((resolve) => {
+      client.on("turnStarted", (ack) => resolve(ack));
+    });
+
+    sendToClient({
+      type: "turn_started",
+      requestId: "reply_1_1",
+      idempotencyKey: "key-9",
+      threadId: "thread-1",
+      turnId: "turn-abc",
+    });
+
+    const ack = await ackPromise;
+    expect(ack).toEqual({
+      requestId: "reply_1_1",
+      idempotencyKey: "key-9",
+      threadId: "thread-1",
+      turnId: "turn-abc",
+    });
+  });
+
   test("pending replies rejected on disconnect", async () => {
     await client.connect();
 

--- a/src/unit-test/daemon-wiring.test.ts
+++ b/src/unit-test/daemon-wiring.test.ts
@@ -44,7 +44,7 @@ interface Harness {
   sendClaudeToCodex: (
     requestId: string,
     text: string,
-    opts?: { onBusy?: "reject" | "steer"; requireReply?: boolean },
+    opts?: { onBusy?: "reject" | "steer" | "interrupt"; requireReply?: boolean; idempotencyKey?: string },
   ) => void;
 }
 
@@ -517,23 +517,24 @@ describe("daemon wiring", () => {
       );
 
       // Default policy unchanged: a plain reply during the turn is rejected,
-      // and the busy error now advertises the steer escape hatch.
+      // and the busy error advertises both escape hatches. The structured
+      // result fields (PR B) ride alongside the legacy error string.
       harness.sendClaudeToCodex("req-steer-0", "plain message during turn");
       const rejected = await waitForResult("req-steer-0");
       expect(rejected.success).toBe(false);
       expect(rejected.error).toContain('on_busy="steer"');
-
-      // B0 limitation is loud, not silent: require_reply×steer is refused.
-      harness.sendClaudeToCodex("req-steer-rr", "needs ack", { onBusy: "steer", requireReply: true });
-      const refused = await waitForResult("req-steer-rr");
-      expect(refused.success).toBe(false);
-      expect(refused.error).toContain("require_reply is not supported");
+      expect(rejected.error).toContain('on_busy="interrupt"');
+      expect(rejected.ok).toBe(false);
+      expect(rejected.code).toBe("busy_reject");
+      expect(rejected.phase).toBe("running");
+      expect(typeof rejected.retryAfterMs).toBe("number");
 
       // The steer path: message reaches the app-server as turn/steer with the
       // explicit [STEER from Claude] framing, on the live thread.
       harness.sendClaudeToCodex("req-steer-1", "course correction: use approach B", { onBusy: "steer" });
       const accepted = await waitForResult("req-steer-1");
       expect(accepted.success).toBe(true);
+      expect(accepted.ok).toBe(true);
       await waitFor(() => readSteers().length >= 1, "recorded turn/steer", 100, 100);
       const steer = readSteers()[0]!;
       expect(steer.threadId).toBe("thread-fake-1");
@@ -557,6 +558,259 @@ describe("daemon wiring", () => {
       expect(failedNotice.content).toContain("did NOT reach Codex");
       expect(failedNotice.content).toContain("ActiveTurnNotSteerable");
       expect(harness.messages.some((m) => m.id.startsWith("system_turn_aborted"))).toBe(false);
+
+      // require_reply × steer is now ALLOWED (PR B real semantics): the steer
+      // is accepted, the body carries the reply-required instruction, and the
+      // daemon arms the expectation on steer-accept.
+      harness.sendClaudeToCodex("req-steer-rr", "needs ack", { onBusy: "steer", requireReply: true });
+      const rrResult = await waitForResult("req-steer-rr");
+      expect(rrResult.success).toBe(true);
+      await waitFor(() => readSteers().length >= 3, "recorded require_reply steer", 100, 100);
+      const rrSteer = readSteers()[2]!;
+      expect(rrSteer.input[0]!.text).toContain("needs ack");
+      expect(rrSteer.input[0]!.text).toContain("[⚠️ REPLY REQUIRED]");
+
+      // Completing the turn WITHOUT any agentMessage must fire the
+      // reply-missing warning — proof the expectation armed on steer-accept.
+      await sleep(300); // let the fake's steer-success verdict arrive and arm the tracker
+      harness.sendAppCommand("complete-turn");
+      const replyMissing = await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_reply_missing"),
+        "system_reply_missing after require_reply steer",
+      );
+      expect(replyMissing.content).toContain("require_reply");
+      expect(harness.messages.some((m) => m.id.startsWith("system_turn_completed"))).toBe(true);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  test("on_busy=interrupt stops the running turn, injects as a new turn, and turn_started ACK correlates (protocol v2 PR B)", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-interrupt-fixture-"));
+    const interruptLog = join(fixtureRoot, "turninterrupt.jsonl");
+    const turnStartLog = join(fixtureRoot, "turn-starts.jsonl");
+    const readJsonl = (path: string): Array<Record<string, any>> =>
+      existsSync(path)
+        ? readFileSync(path, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+        : [];
+    const resultFor = (requestId: string) =>
+      harness.statusMessages.find(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === requestId,
+      ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }> | undefined;
+    const waitForResult = async (requestId: string) => {
+      await waitFor(() => resultFor(requestId) !== undefined, `claude_to_codex_result for ${requestId}`);
+      return resultFor(requestId)!;
+    };
+
+    const harness = await startHarness({
+      pairId: "main-intrabcde",
+      pairName: "main",
+      extraEnv: {
+        FAKE_APP_TURNINTERRUPT_LOG: interruptLog,
+        FAKE_APP_TURNSTART_LOG: turnStartLog,
+      },
+    });
+
+    try {
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      // Drive the adapter into a running turn so the interrupt path is active.
+      harness.sendAppCommand("start-turn");
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_turn_started"),
+        "system_turn_started",
+      );
+
+      // Interrupt + inject, carrying an idempotency key.
+      harness.sendClaudeToCodex("req-int-1", "drop everything: new priority task", {
+        onBusy: "interrupt",
+        idempotencyKey: "key-int-1",
+      });
+      const result = await waitForResult("req-int-1");
+      expect(result.success).toBe(true);
+      expect(result.ok).toBe(true);
+
+      // The fake app-server received turn/interrupt with the RIGHT ids.
+      expect(readJsonl(interruptLog)).toEqual([{ threadId: "thread-fake-1", turnId: "turn-1" }]);
+
+      // The message was then injected as a NORMAL turn/start (no steer framing).
+      await waitFor(() => readJsonl(turnStartLog).length >= 1, "recorded post-interrupt turn/start", 100, 100);
+      const injected = readJsonl(turnStartLog)[0]!;
+      expect(injected.threadId).toBe("thread-fake-1");
+      expect(injected.input[0].type).toBe("text");
+      expect(injected.input[0].text).toContain("drop everything: new priority task");
+      expect(injected.input[0].text).not.toContain("[STEER from Claude]");
+
+      // turn_started control event correlates requestId + idempotencyKey.
+      await waitFor(
+        () => harness.statusMessages.some((m) => m.type === "turn_started" && m.requestId === "req-int-1"),
+        "turn_started control event for req-int-1",
+      );
+      const ack = harness.statusMessages.find(
+        (m) => m.type === "turn_started" && m.requestId === "req-int-1",
+      ) as Extract<ControlServerMessage, { type: "turn_started" }>;
+      expect(ack.idempotencyKey).toBe("key-int-1");
+      expect(ack.threadId).toBe("thread-fake-1");
+      expect(ack.turnId).toMatch(/^turn-injected-/);
+
+      // A duplicate idempotencyKey while the key is in flight (started, no
+      // terminal yet) is NOT re-injected and reports duplicate_in_flight.
+      harness.sendClaudeToCodex("req-int-2", "same message retried", { idempotencyKey: "key-int-1" });
+      const dup = await waitForResult("req-int-2");
+      expect(dup.success).toBe(false);
+      expect(dup.ok).toBe(false);
+      expect(dup.code).toBe("duplicate_in_flight");
+      expect(dup.error).toContain("Duplicate idempotency_key");
+
+      // ...and the fake never saw a second turn/start.
+      await sleep(200);
+      expect(readJsonl(turnStartLog)).toHaveLength(1);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  test("a rejected keyed steer RELEASES its idempotency key — a same-key retry is allowed (PR B REAL #2)", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-steerfail-fixture-"));
+    const steerLog = join(fixtureRoot, "turnsteer.jsonl");
+    const readSteers = (): Array<{ threadId: string; expectedTurnId?: string; input: Array<{ type: string; text: string }> }> =>
+      existsSync(steerLog)
+        ? readFileSync(steerLog, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+        : [];
+    const resultFor = (requestId: string) =>
+      harness.statusMessages.find(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === requestId,
+      ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }> | undefined;
+    const waitForResult = async (requestId: string) => {
+      await waitFor(() => resultFor(requestId) !== undefined, `claude_to_codex_result for ${requestId}`);
+      return resultFor(requestId)!;
+    };
+
+    const harness = await startHarness({
+      pairId: "main-strflabcd",
+      pairName: "main",
+      extraEnv: { FAKE_APP_TURNSTEER_LOG: steerLog },
+    });
+
+    try {
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      // Drive into a running turn so the steer path is active.
+      harness.sendAppCommand("start-turn");
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_turn_started"),
+        "system_turn_started",
+      );
+
+      // A KEYED steer that the fake app-server REJECTS ([force-steer-error]).
+      // The daemon transport-accepts it (so the sync result is success) and
+      // accept()+markStarted-binds the key to the running original turn; the
+      // async rejection then fires steerFailed.
+      harness.sendClaudeToCodex("req-sf-1", "[force-steer-error] doomed steer", {
+        onBusy: "steer",
+        idempotencyKey: "key-sf-1",
+      });
+      const first = await waitForResult("req-sf-1");
+      expect(first.success).toBe(true); // transport-accepted
+      await waitFor(() => readSteers().length >= 1, "recorded the doomed turn/steer", 100, 100);
+
+      // The async rejection surfaces as system_steer_failed (the key is released here).
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_steer_failed"),
+        "system_steer_failed for the doomed steer",
+      );
+
+      // The SAME key is now retryable: a fresh steer with key-sf-1 must NOT be
+      // rejected as duplicate_in_flight — it reaches the wire as a real steer.
+      harness.sendClaudeToCodex("req-sf-2", "second attempt, same key", {
+        onBusy: "steer",
+        idempotencyKey: "key-sf-1",
+      });
+      const second = await waitForResult("req-sf-2");
+      expect(second.success).toBe(true);
+      // Critically NOT duplicate_in_flight — the release made the key retryable.
+      expect(second.code).not.toBe("duplicate_in_flight");
+      await waitFor(() => readSteers().length >= 2, "recorded the retried turn/steer", 100, 100);
+      const retried = readSteers()[1]!;
+      expect(retried.input[0]!.text).toContain("second attempt, same key");
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  test("a lost-response (orphaned) require_reply steer cannot mis-arm a LATER steer's reply expectation (PR B REAL #3)", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-steerorphan-fixture-"));
+    const steerLog = join(fixtureRoot, "turnsteer.jsonl");
+    const readSteers = (): Array<{ input: Array<{ type: string; text: string }> }> =>
+      existsSync(steerLog)
+        ? readFileSync(steerLog, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+        : [];
+    const resultFor = (requestId: string) =>
+      harness.statusMessages.find(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === requestId,
+      ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }> | undefined;
+    const waitForResult = async (requestId: string) => {
+      await waitFor(() => resultFor(requestId) !== undefined, `claude_to_codex_result for ${requestId}`);
+      return resultFor(requestId)!;
+    };
+
+    const harness = await startHarness({
+      pairId: "main-strorabcd",
+      pairName: "main",
+      extraEnv: { FAKE_APP_TURNSTEER_LOG: steerLog },
+    });
+
+    try {
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      harness.sendAppCommand("start-turn");
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_turn_started"),
+        "system_turn_started",
+      );
+
+      // 1) A require_reply steer whose app-server verdict is LOST ([hang-steer]).
+      // It orphans a dispatch entry carrying requireReply=true. Under the OLD
+      // FIFO pairing, a LATER steerAccepted would shift() this orphan and arm
+      // the reply expectation against the wrong turn.
+      harness.sendClaudeToCodex("req-orphan-1", "[hang-steer] never answered", {
+        onBusy: "steer",
+        requireReply: true,
+      });
+      await waitForResult("req-orphan-1"); // transport-accepted, but no verdict
+      await waitFor(() => readSteers().length >= 1, "recorded the hung steer", 100, 100);
+
+      // 2) A SECOND steer (NO require_reply) that the fake ACCEPTS → steerAccepted.
+      // Id-keyed correlation must consume THIS dispatch (req-orphan-2), never the
+      // orphaned require_reply one.
+      harness.sendClaudeToCodex("req-orphan-2", "plain steer that gets accepted", {
+        onBusy: "steer",
+      });
+      await waitForResult("req-orphan-2");
+      await waitFor(() => readSteers().length >= 2, "recorded the accepted steer", 100, 100);
+
+      // Give the accepted steer's verdict time to (wrongly, under the old bug)
+      // arm the orphaned require_reply expectation.
+      await sleep(300);
+
+      // 3) Complete the turn WITHOUT any agentMessage. If the orphan had mis-armed
+      // the reply expectation, a system_reply_missing warning would fire. With the
+      // id-keyed fix it must NOT — the orphan was never consumed by req-orphan-2.
+      harness.sendAppCommand("complete-turn");
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_turn_completed"),
+        "system_turn_completed",
+      );
+      expect(harness.messages.some((m) => m.id.startsWith("system_reply_missing"))).toBe(false);
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
@@ -702,13 +956,14 @@ async function startHarness(opts: {
         }
       }, "bridge ready after TUI handshake", 100, 100);
     },
-    sendClaudeToCodex: (requestId: string, text: string, sendOpts?: { onBusy?: "reject" | "steer"; requireReply?: boolean }) => {
+    sendClaudeToCodex: (requestId: string, text: string, sendOpts?: { onBusy?: "reject" | "steer" | "interrupt"; requireReply?: boolean; idempotencyKey?: string }) => {
       harness.controlWs?.send(JSON.stringify({
         type: "claude_to_codex",
         requestId,
         message: { id: requestId, source: "claude", content: text, timestamp: Date.now() },
         ...(sendOpts?.requireReply ? { requireReply: true } : {}),
         ...(sendOpts?.onBusy && sendOpts.onBusy !== "reject" ? { onBusy: sendOpts.onBusy } : {}),
+        ...(sendOpts?.idempotencyKey ? { idempotencyKey: sendOpts.idempotencyKey } : {}),
       }));
     },
   };
@@ -785,6 +1040,7 @@ const port = Number(new URL(listen).port);
 const commandFile = process.env.FAKE_APP_COMMAND_FILE;
 let appWs = null;
 let lastStartedTurnId = null;
+let turnStartCounter = 0;
 
 const server = Bun.serve({
   hostname: "127.0.0.1",
@@ -809,9 +1065,32 @@ const server = Bun.serve({
         if (msg.method === "thread/start") {
           ws.send(JSON.stringify({ id: msg.id, result: { thread: { id: "thread-fake-1" } } }));
         }
-        // Record received turn/start params (tier-override assertions).
-        if (msg.method === "turn/start" && process.env.FAKE_APP_TURNSTART_LOG) {
-          appendFileSync(process.env.FAKE_APP_TURNSTART_LOG, JSON.stringify(msg.params) + "\\n");
+        // Record received turn/start params (tier-override assertions), then
+        // respond success with the created turn id like the real app-server
+        // (TurnStartResponse.turn.id) so the bridge's turn_started ACK
+        // correlation can be asserted end-to-end. NOTE: deliberately NO
+        // turn/started notification here — emitting one would mark the
+        // adapter busy and break the multi-injection budget tests; the
+        // "start-turn" command drives the busy state explicitly.
+        if (msg.method === "turn/start") {
+          if (process.env.FAKE_APP_TURNSTART_LOG) {
+            appendFileSync(process.env.FAKE_APP_TURNSTART_LOG, JSON.stringify(msg.params) + "\\n");
+          }
+          turnStartCounter += 1;
+          ws.send(JSON.stringify({ id: msg.id, result: { turn: { id: "turn-injected-" + turnStartCounter } } }));
+        }
+        // turn/interrupt: record params, respond success ({}), then emit the
+        // terminal turn/completed for that turnId — mirroring the REAL
+        // app-server (verified in codex-rs): the success response is deferred
+        // until TurnAborted and the interrupted turn's terminal notification
+        // is a normal turn/completed with status "interrupted".
+        if (msg.method === "turn/interrupt") {
+          if (process.env.FAKE_APP_TURNINTERRUPT_LOG) {
+            appendFileSync(process.env.FAKE_APP_TURNINTERRUPT_LOG, JSON.stringify(msg.params) + "\\n");
+          }
+          ws.send(JSON.stringify({ id: msg.id, result: {} }));
+          ws.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: msg.params.turnId, status: "interrupted" } } }));
+          if (lastStartedTurnId === msg.params.turnId) lastStartedTurnId = null;
         }
         // turn/steer: record params, then ack — or reject when the text carries
         // the [force-steer-error] marker (drives the steerFailed wiring test).
@@ -828,6 +1107,10 @@ const server = Bun.serve({
             ws.send(JSON.stringify({ id: msg.id, error: { message: "Invalid request: missing field \`expectedTurnId\`" } }));
           } else if (lastStartedTurnId && msg.params.expectedTurnId !== lastStartedTurnId) {
             ws.send(JSON.stringify({ id: msg.id, error: { message: "expected active turn id \`" + msg.params.expectedTurnId + "\` but found \`" + lastStartedTurnId + "\`" } }));
+          } else if (steerText.includes("[hang-steer]")) {
+            // Deliberately send NO verdict — simulate a steer whose app-server
+            // response is lost while the WS stays open (drives the PR B #3
+            // lost-response orphan test: turnTrackingReset must clean it up).
           } else if (steerText.includes("[force-steer-error]")) {
             ws.send(JSON.stringify({ id: msg.id, error: { message: "ActiveTurnNotSteerable" } }));
           } else {
@@ -850,6 +1133,10 @@ setInterval(() => {
   if (command === "start-turn") {
     lastStartedTurnId = "turn-1";
     appWs.send(JSON.stringify({ method: "turn/started", params: { turn: { id: "turn-1" } } }));
+  }
+  if (command === "complete-turn" && lastStartedTurnId) {
+    appWs.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: lastStartedTurnId } } }));
+    lastStartedTurnId = null;
   }
   if (command === "close-app-server") {
     appWs.close(1011, "test app-server close");

--- a/src/unit-test/idempotency-tracker.test.ts
+++ b/src/unit-test/idempotency-tracker.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  DEFAULT_TOMBSTONE_TTL_MS,
+  IdempotencyTracker,
+} from "../idempotency-tracker";
+
+const THREAD = "thread-1";
+const OTHER_THREAD = "thread-2";
+const KEY = "key-a";
+
+describe("IdempotencyTracker state machine", () => {
+  const trackers: IdempotencyTracker[] = [];
+  afterEach(() => {
+    while (trackers.length > 0) trackers.pop()!.dispose();
+  });
+  function createTracker(opts: ConstructorParameters<typeof IdempotencyTracker>[0] = {}) {
+    const tracker = new IdempotencyTracker(opts);
+    trackers.push(tracker);
+    return tracker;
+  }
+
+  test("unknown keys are not duplicates", () => {
+    const tracker = createTracker();
+    expect(tracker.check(THREAD, KEY)).toEqual({ duplicate: false });
+    expect(tracker.peek(THREAD, KEY)).toBeNull();
+    expect(tracker.size).toBe(0);
+  });
+
+  test("accept registers the key; check reports duplicate_in_flight", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    const dup = tracker.check(THREAD, KEY);
+    expect(dup).toEqual({
+      duplicate: true,
+      code: "duplicate_in_flight",
+      state: { phase: "accepted" },
+    });
+  });
+
+  test("check is read-only — repeated checks do not mutate state", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.check(THREAD, KEY);
+    tracker.check(THREAD, KEY);
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "accepted" });
+    expect(tracker.size).toBe(1);
+  });
+
+  test("accepted → started carries the turn id and stays duplicate_in_flight", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.markStarted(THREAD, KEY, "turn-7");
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "started", turnId: "turn-7" });
+    const dup = tracker.check(THREAD, KEY);
+    expect(dup.duplicate).toBe(true);
+    expect(dup.duplicate && dup.code).toBe("duplicate_in_flight");
+  });
+
+  test("completeTurn terminates ONLY the key whose started.turnId matches", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, "key-1");
+    tracker.markStarted(THREAD, "key-1", "turn-1");
+    tracker.accept(THREAD, "key-2");
+    tracker.markStarted(THREAD, "key-2", "turn-2");
+
+    tracker.completeTurn("turn-1");
+
+    expect(tracker.peek(THREAD, "key-1")).toEqual({ phase: "terminal", outcome: "completed" });
+    expect(tracker.peek(THREAD, "key-2")).toEqual({ phase: "started", turnId: "turn-2" });
+  });
+
+  test("completeTurn(null) terminates every started key, leaving accepted keys alone", () => {
+    // null = turn/completed carried no id; the adapter cleared ALL active
+    // turns. accepted keys still owe a turn/start response, so they stay.
+    const tracker = createTracker();
+    tracker.accept(THREAD, "key-started");
+    tracker.markStarted(THREAD, "key-started", "turn-1");
+    tracker.accept(THREAD, "key-accepted");
+
+    tracker.completeTurn(null);
+
+    expect(tracker.peek(THREAD, "key-started")).toEqual({ phase: "terminal", outcome: "completed" });
+    expect(tracker.peek(THREAD, "key-accepted")).toEqual({ phase: "accepted" });
+  });
+
+  test("terminal tombstone answers duplicate_terminal", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.markStarted(THREAD, KEY, "turn-1");
+    tracker.completeTurn("turn-1");
+    const dup = tracker.check(THREAD, KEY);
+    expect(dup).toEqual({
+      duplicate: true,
+      code: "duplicate_terminal",
+      state: { phase: "terminal", outcome: "completed" },
+    });
+  });
+
+  test("markRejected is terminal `rejected` from accepted (pre-started JSON-RPC error)", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.markRejected(THREAD, KEY);
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "terminal", outcome: "rejected" });
+    const dup = tracker.check(THREAD, KEY);
+    expect(dup.duplicate && dup.code).toBe("duplicate_terminal");
+  });
+
+  test("markStarted / markRejected are no-ops for untracked keys", () => {
+    const tracker = createTracker();
+    tracker.markStarted(THREAD, KEY, "turn-1");
+    tracker.markRejected(THREAD, KEY);
+    expect(tracker.size).toBe(0);
+    expect(tracker.check(THREAD, KEY)).toEqual({ duplicate: false });
+  });
+
+  test("a late markStarted cannot resurrect a terminal tombstone", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.markStarted(THREAD, KEY, "turn-1");
+    tracker.completeTurn("turn-1");
+    tracker.markStarted(THREAD, KEY, "turn-2");
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "terminal", outcome: "completed" });
+  });
+
+  test("accept is a no-op when the key already exists (live or tombstone)", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.markStarted(THREAD, KEY, "turn-1");
+    tracker.accept(THREAD, KEY); // must not reset started → accepted
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "started", turnId: "turn-1" });
+
+    tracker.completeTurn("turn-1");
+    tracker.accept(THREAD, KEY); // must not resurrect the tombstone
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "terminal", outcome: "completed" });
+  });
+
+  test("release drops non-terminal entries so the key becomes retryable", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.release(THREAD, KEY);
+    expect(tracker.check(THREAD, KEY)).toEqual({ duplicate: false });
+  });
+
+  test("release preserves terminal tombstones", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.markRejected(THREAD, KEY);
+    tracker.release(THREAD, KEY);
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "terminal", outcome: "rejected" });
+  });
+
+  test("release frees a STARTED key so a same-key retry is allowed (REAL #2 steer-fail release)", () => {
+    // A keyed steer is accept()+markStarted(originalTurnId) at dispatch (bound to
+    // the still-running original turn). When the app-server later REJECTS the
+    // steer, the daemon must release the key — it never reached Codex, so the
+    // same key must be retryable instead of stranded in `started` until the
+    // original turn terminates.
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.markStarted(THREAD, KEY, "original-turn");
+    expect(tracker.check(THREAD, KEY).duplicate).toBe(true); // would block a retry
+
+    tracker.release(THREAD, KEY); // steerFailed path
+
+    expect(tracker.check(THREAD, KEY)).toEqual({ duplicate: false });
+    // And the same key can be re-accepted cleanly (a genuine retry).
+    tracker.accept(THREAD, KEY);
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "accepted" });
+  });
+
+  test("releasing a steer-failed key does NOT disturb the original turn's OWN key", () => {
+    // The original turn may itself carry a different idempotency key in started;
+    // releasing the failed steer's key must leave that one untouched.
+    const tracker = createTracker();
+    tracker.accept(THREAD, "original-key");
+    tracker.markStarted(THREAD, "original-key", "original-turn");
+    tracker.accept(THREAD, "steer-key");
+    tracker.markStarted(THREAD, "steer-key", "original-turn");
+
+    tracker.release(THREAD, "steer-key");
+
+    expect(tracker.check(THREAD, "steer-key")).toEqual({ duplicate: false });
+    expect(tracker.peek(THREAD, "original-key")).toEqual({ phase: "started", turnId: "original-turn" });
+  });
+
+  test("completeTurn(null, threadId) scopes the all-started completion to ONE thread (recommend #2)", () => {
+    // null-turnId completion is thread-scoped when a threadId is supplied:
+    // a null completion on THREAD must not terminate OTHER_THREAD's started keys.
+    const tracker = createTracker();
+    tracker.accept(THREAD, "key-a");
+    tracker.markStarted(THREAD, "key-a", "turn-a");
+    tracker.accept(OTHER_THREAD, "key-b");
+    tracker.markStarted(OTHER_THREAD, "key-b", "turn-b");
+
+    tracker.completeTurn(null, THREAD);
+
+    expect(tracker.peek(THREAD, "key-a")).toEqual({ phase: "terminal", outcome: "completed" });
+    // OTHER_THREAD's started key is untouched.
+    expect(tracker.peek(OTHER_THREAD, "key-b")).toEqual({ phase: "started", turnId: "turn-b" });
+  });
+
+  test("completeTurn(null) without a threadId still terminates every started key (legacy behavior)", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, "key-a");
+    tracker.markStarted(THREAD, "key-a", "turn-a");
+    tracker.accept(OTHER_THREAD, "key-b");
+    tracker.markStarted(OTHER_THREAD, "key-b", "turn-b");
+
+    tracker.completeTurn(null);
+
+    expect(tracker.peek(THREAD, "key-a")).toEqual({ phase: "terminal", outcome: "completed" });
+    expect(tracker.peek(OTHER_THREAD, "key-b")).toEqual({ phase: "terminal", outcome: "completed" });
+  });
+
+  test("completeTurn(turnId, threadId) still matches by id regardless of thread scope", () => {
+    // A non-null turnId matches by id only — thread scope is moot (turn ids are
+    // globally unique). Passing a threadId must not change id-matching.
+    const tracker = createTracker();
+    tracker.accept(OTHER_THREAD, "key-x");
+    tracker.markStarted(OTHER_THREAD, "key-x", "turn-x");
+
+    tracker.completeTurn("turn-x", THREAD); // threadId differs from the key's thread
+
+    expect(tracker.peek(OTHER_THREAD, "key-x")).toEqual({ phase: "terminal", outcome: "completed" });
+  });
+
+  test("terminateThread terminates all pending/running keys for that thread only", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, "key-accepted");
+    tracker.accept(THREAD, "key-started");
+    tracker.markStarted(THREAD, "key-started", "turn-1");
+    tracker.accept(OTHER_THREAD, "key-other");
+
+    tracker.terminateThread(THREAD, "aborted");
+
+    expect(tracker.peek(THREAD, "key-accepted")).toEqual({ phase: "terminal", outcome: "aborted" });
+    expect(tracker.peek(THREAD, "key-started")).toEqual({ phase: "terminal", outcome: "aborted" });
+    expect(tracker.peek(OTHER_THREAD, "key-other")).toEqual({ phase: "accepted" });
+  });
+
+  test("terminateThread does not overwrite an existing terminal outcome", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    tracker.markStarted(THREAD, KEY, "turn-1");
+    tracker.completeTurn("turn-1");
+    tracker.terminateThread(THREAD, "aborted");
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "terminal", outcome: "completed" });
+  });
+
+  test("terminateAll terminates every non-terminal key regardless of thread", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, "key-1");
+    tracker.accept(OTHER_THREAD, "key-2");
+    tracker.terminateAll("aborted");
+    expect(tracker.peek(THREAD, "key-1")).toEqual({ phase: "terminal", outcome: "aborted" });
+    expect(tracker.peek(OTHER_THREAD, "key-2")).toEqual({ phase: "terminal", outcome: "aborted" });
+  });
+
+  test("the same key on a DIFFERENT thread is independent", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, KEY);
+    expect(tracker.check(OTHER_THREAD, KEY)).toEqual({ duplicate: false });
+  });
+
+  test("composite key cannot collide across (threadId, key) boundaries", () => {
+    // "a" + "b-key" vs "a-b" + "key" style splits must stay distinct.
+    const tracker = createTracker();
+    tracker.accept("t", "x-y");
+    expect(tracker.check("t-x", "y")).toEqual({ duplicate: false });
+  });
+
+  test("tombstone expires after the TTL via the injected clock", () => {
+    let nowMs = 1_000_000;
+    const tracker = createTracker({ ttlMs: 60_000, now: () => nowMs });
+    tracker.accept(THREAD, KEY);
+    tracker.markStarted(THREAD, KEY, "turn-1");
+    tracker.completeTurn("turn-1");
+
+    nowMs += 59_999;
+    expect(tracker.check(THREAD, KEY).duplicate).toBe(true);
+
+    nowMs += 1; // exactly at the TTL boundary → expired
+    expect(tracker.check(THREAD, KEY)).toEqual({ duplicate: false });
+    expect(tracker.size).toBe(0); // lazy expiry dropped the entry
+  });
+
+  test("after tombstone expiry the key is reusable from scratch", () => {
+    let nowMs = 0;
+    const tracker = createTracker({ ttlMs: 10, now: () => nowMs });
+    tracker.accept(THREAD, KEY);
+    tracker.markRejected(THREAD, KEY);
+    nowMs = 11;
+    expect(tracker.check(THREAD, KEY)).toEqual({ duplicate: false });
+    tracker.accept(THREAD, KEY);
+    expect(tracker.peek(THREAD, KEY)).toEqual({ phase: "accepted" });
+  });
+
+  test("live (non-terminal) entries never expire — only tombstones have a TTL", () => {
+    let nowMs = 0;
+    const tracker = createTracker({ ttlMs: 10, now: () => nowMs });
+    tracker.accept(THREAD, KEY);
+    nowMs = 1_000_000; // way past any TTL
+    expect(tracker.check(THREAD, KEY).duplicate).toBe(true);
+  });
+
+  test("the unref'd cleanup timer also removes the tombstone (real clock)", async () => {
+    const tracker = createTracker({ ttlMs: 20 });
+    tracker.accept(THREAD, KEY);
+    tracker.markRejected(THREAD, KEY);
+    expect(tracker.size).toBe(1);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(tracker.size).toBe(0);
+  });
+
+  test("default TTL is 20 minutes", () => {
+    expect(DEFAULT_TOMBSTONE_TTL_MS).toBe(20 * 60 * 1000);
+  });
+
+  test("dispose clears everything", () => {
+    const tracker = createTracker();
+    tracker.accept(THREAD, "k1");
+    tracker.accept(THREAD, "k2");
+    tracker.markRejected(THREAD, "k2");
+    tracker.dispose();
+    expect(tracker.size).toBe(0);
+    expect(tracker.check(THREAD, "k1")).toEqual({ duplicate: false });
+    expect(tracker.check(THREAD, "k2")).toEqual({ duplicate: false });
+  });
+});

--- a/src/unit-test/interrupt-timing.test.ts
+++ b/src/unit-test/interrupt-timing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CLIENT_REPLY_TIMEOUT_MS,
+  DEFAULT_INTERRUPT_TIMEOUT_MS,
+  INTERRUPT_CLIENT_MARGIN_MS,
+  MAX_INTERRUPT_TIMEOUT_MS,
+  clampInterruptTimeoutMs,
+} from "../interrupt-timing";
+
+describe("interrupt-timing invariant (PR B REAL #1 — no double-turn)", () => {
+  test("MAX_INTERRUPT_TIMEOUT_MS is strictly below the client reply timeout", () => {
+    // The whole point: the daemon-side interrupt budget must resolve BEFORE the
+    // bridge client's reply timeout fires, or a false client timeout + a Claude
+    // retry would double-turn.
+    expect(MAX_INTERRUPT_TIMEOUT_MS).toBeLessThan(CLIENT_REPLY_TIMEOUT_MS);
+    expect(MAX_INTERRUPT_TIMEOUT_MS).toBe(CLIENT_REPLY_TIMEOUT_MS - INTERRUPT_CLIENT_MARGIN_MS);
+  });
+
+  test("a positive margin is reserved for the result to traverse the control WS", () => {
+    expect(INTERRUPT_CLIENT_MARGIN_MS).toBeGreaterThan(0);
+  });
+
+  test("the default interrupt budget is within the safe ceiling", () => {
+    expect(DEFAULT_INTERRUPT_TIMEOUT_MS).toBeLessThanOrEqual(MAX_INTERRUPT_TIMEOUT_MS);
+    expect(clampInterruptTimeoutMs(DEFAULT_INTERRUPT_TIMEOUT_MS)).toBe(DEFAULT_INTERRUPT_TIMEOUT_MS);
+  });
+
+  test("a value below the ceiling passes through unchanged", () => {
+    expect(clampInterruptTimeoutMs(30)).toBe(30);
+    expect(clampInterruptTimeoutMs(MAX_INTERRUPT_TIMEOUT_MS - 1)).toBe(MAX_INTERRUPT_TIMEOUT_MS - 1);
+  });
+
+  test("a value AT the ceiling is preserved (boundary)", () => {
+    expect(clampInterruptTimeoutMs(MAX_INTERRUPT_TIMEOUT_MS)).toBe(MAX_INTERRUPT_TIMEOUT_MS);
+  });
+
+  test("an OVER-large value is clamped below the client timeout (the misconfiguration guard)", () => {
+    const huge = 600_000; // operator sets a 10-minute interrupt budget
+    const clamped = clampInterruptTimeoutMs(huge);
+    expect(clamped).toBe(MAX_INTERRUPT_TIMEOUT_MS);
+    // The clamped value is strictly below the client reply timeout — so the
+    // daemon ALWAYS answers before the client gives up, regardless of the env.
+    expect(clamped).toBeLessThan(CLIENT_REPLY_TIMEOUT_MS);
+  });
+
+  test("even a value just above the client timeout is clamped strictly below it", () => {
+    const clamped = clampInterruptTimeoutMs(CLIENT_REPLY_TIMEOUT_MS + 1);
+    expect(clamped).toBe(MAX_INTERRUPT_TIMEOUT_MS);
+    expect(clamped).toBeLessThan(CLIENT_REPLY_TIMEOUT_MS);
+  });
+});

--- a/src/unit-test/message-delivery.test.ts
+++ b/src/unit-test/message-delivery.test.ts
@@ -256,12 +256,12 @@ describe("Message delivery: reply pending hint", () => {
   });
 });
 
-describe("Reply on_busy option (protocol v2 B0)", () => {
-  function withCapturingSender(adapter: any) {
-    const calls: Array<{ content: string; requireReply?: boolean; onBusy?: string }> = [];
-    adapter.replySender = async (msg: any, requireReply?: boolean, onBusy?: string) => {
-      calls.push({ content: msg.content, requireReply, onBusy });
-      return { success: true };
+describe("Reply on_busy option (protocol v2 B0/B)", () => {
+  function withCapturingSender(adapter: any, result: Record<string, unknown> = { success: true }) {
+    const calls: Array<{ content: string; requireReply?: boolean; onBusy?: string; idempotencyKey?: string }> = [];
+    adapter.replySender = async (msg: any, requireReply?: boolean, onBusy?: string, idempotencyKey?: string) => {
+      calls.push({ content: msg.content, requireReply, onBusy, idempotencyKey });
+      return result;
     };
     return calls;
   }
@@ -291,27 +291,58 @@ describe("Reply on_busy option (protocol v2 B0)", () => {
     expect(result.content[0].text).toContain("system_steer_failed");
   });
 
+  test("on_busy=interrupt is accepted and passed through (protocol v2 PR B)", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "drop everything, new priority", on_busy: "interrupt" });
+
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].onBusy).toBe("interrupt");
+    expect(result.content[0].text).toContain("new turn");
+    // Recommend #1: the wording must NOT unconditionally assert an interrupt
+    // happened (the race-degrade path injects without interrupting anything).
+    expect(result.content[0].text).toContain("interrupted first");
+    expect(result.content[0].text).toContain("already finished");
+  });
+
   test("invalid on_busy value errors before sending anything", async () => {
     const adapter = createAdapter();
     const calls = withCapturingSender(adapter);
 
-    const result = await adapter.handleReply({ text: "hello", on_busy: "interrupt" });
+    const result = await adapter.handleReply({ text: "hello", on_busy: "abort" });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("invalid on_busy value");
-    expect(result.content[0].text).toContain('"interrupt"');
+    expect(result.content[0].text).toContain('"abort"');
     expect(calls).toHaveLength(0);
   });
 
-  test("on_busy=steer combined with require_reply errors before sending (B0 limitation)", async () => {
+  test("require_reply combined with on_busy=steer is now allowed (PR B real semantics)", async () => {
+    // The B0 loud rejection is gone: the daemon arms the reply expectation
+    // when the steer is ACCEPTED into the running turn.
     const adapter = createAdapter();
     const calls = withCapturingSender(adapter);
 
     const result = await adapter.handleReply({ text: "hello", on_busy: "steer", require_reply: true });
 
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("require_reply cannot be combined");
-    expect(calls).toHaveLength(0);
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].onBusy).toBe("steer");
+    expect(calls[0].requireReply).toBe(true);
+  });
+
+  test("require_reply combined with on_busy=interrupt is allowed (starts a NEW turn)", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello", on_busy: "interrupt", require_reply: true });
+
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].onBusy).toBe("interrupt");
+    expect(calls[0].requireReply).toBe(true);
   });
 
   test("on_busy=reject explicit value behaves like the default", async () => {
@@ -324,6 +355,104 @@ describe("Reply on_busy option (protocol v2 B0)", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].onBusy).toBe("reject");
     expect(calls[0].requireReply).toBe(true);
+  });
+
+  test("a failure result's machine-readable code is surfaced in the error text", async () => {
+    const adapter = createAdapter();
+    withCapturingSender(adapter, { success: false, error: "Codex is busy executing a turn.", code: "busy_reject" });
+
+    const result = await adapter.handleReply({ text: "hello" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("[busy_reject]");
+    expect(result.content[0].text).toContain("Codex is busy");
+  });
+
+  test("a failure result without a code keeps the legacy error shape", async () => {
+    const adapter = createAdapter();
+    withCapturingSender(adapter, { success: false, error: "plain failure" });
+
+    const result = await adapter.handleReply({ text: "hello" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("Error: plain failure");
+  });
+});
+
+describe("Reply idempotency_key option (protocol v2 PR B)", () => {
+  function withCapturingSender(adapter: any) {
+    const calls: Array<{ idempotencyKey?: string }> = [];
+    adapter.replySender = async (_msg: any, _requireReply?: boolean, _onBusy?: string, idempotencyKey?: string) => {
+      calls.push({ idempotencyKey });
+      return { success: true };
+    };
+    return calls;
+  }
+
+  test("idempotency_key is passed through to the sender", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello", idempotency_key: "task-42-attempt-1" });
+
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].idempotencyKey).toBe("task-42-attempt-1");
+  });
+
+  test("omitted idempotency_key sends undefined (bypasses the machine)", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    await adapter.handleReply({ text: "hello" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].idempotencyKey).toBeUndefined();
+  });
+
+  test("empty idempotency_key errors before sending", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello", idempotency_key: "" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("non-empty string");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("non-string idempotency_key errors before sending", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello", idempotency_key: 42 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("non-empty string");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("idempotency_key longer than 128 chars errors before sending", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello", idempotency_key: "x".repeat(129) });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("too long");
+    expect(result.content[0].text).toContain("max 128");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("a 128-char idempotency_key is exactly at the limit and accepted", async () => {
+    const adapter = createAdapter();
+    const calls = withCapturingSender(adapter);
+
+    const result = await adapter.handleReply({ text: "hello", idempotency_key: "k".repeat(128) });
+
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].idempotencyKey).toBe("k".repeat(128));
   });
 });
 


### PR DESCRIPTION
## 摘要
按 docs/collaboration-protocol-v2.md 冻结契约实施 PR B——把「打断 Codex」入口补齐，并落地 ACK + 幂等。

## 变更
- **on_busy="interrupt"**：turn 运行中 → 对全部可寻址 active turn 发 turn/interrupt → 等终态边界（waitForTurnsTerminal 默认 10s，clamp 到 client 15s 之下防双 turn）→ 普通注入。结构化失败码 interrupt_unavailable/rejected/timeout
- **turn_started ACK**：bridge turn/start 成功 → turn_started 控制事件（requestId/idempotencyKey/threadId/turnId）
- **幂等状态机**（idempotency-tracker.ts）：(threadId,key) accepted→started→terminal，20min tombstone；重复键 → duplicate_in_flight/duplicate_terminal；无键绕过
- **结构化 result** ok/code/phase/retryAfterMs 与旧 success/error 并存
- **require_reply×steer** 严格语义：steerAccepted 按 requestId arm（id-keyed Map 防 FIFO orphan）
- codex-rs 实证：TurnInterruptParams / deferred-success / turn-completed-status-interrupted 终态边界

## 测试
- [x] 817 pass；ci:local 绿；cross-review R1(3 REAL+latent 全修)→**R2/R3 连续双轮 0 REAL**；codex-rs wire 事实逐项复证

## 后续
PR C（预算指令降噪分层）