### PR TITLE
fix: 收口新用户 init 失败旅程 + abg claude 插件预检 / close the init failure journey

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14274,7 +14274,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("2d4804a", "source"),
+  commit: defineString("5d6cb0f", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("2d4804a", "source"),
+  commit: defineString("5d6cb0f", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -1,5 +1,11 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
+import {
+  MARKETPLACE_STEPS,
+  pluginCacheRoot,
+  shouldWarnMissingPluginCache,
+} from "./plugin-cache";
 import { DaemonClient } from "../daemon-client";
 import { DaemonLifecycle } from "../daemon-lifecycle";
 import { BUILD_INFO } from "../build-info";
@@ -78,6 +84,12 @@ export async function runClaude(args: string[]) {
 
   lifecycle.clearKilled();
 
+  // Cheap fail-open preflight: if the plugin was never installed, the channel
+  // flag below loads nothing and the bridge stays silent. Warn (stderr) so the
+  // user knows to run `abg init`, but never block the launch — matching the
+  // fail-open style of the guards above.
+  warnIfPluginCacheMissing();
+
   // Channel entry format: "server:<mcp-server-name>" for MCP-based channels,
   // or "plugin:<plugin>@<marketplace>" for plugin-based channels.
   // AgentBridge is installed as a plugin, so use the plugin channel format.
@@ -114,6 +126,32 @@ export async function runClaude(args: string[]) {
     console.error(`Error starting Claude Code: ${err.message}`);
     process.exit(1);
   });
+}
+
+/**
+ * Fail-open preflight: warn (but never block) when the AgentBridge plugin cache
+ * dir is missing — that means the plugin was never installed, so the channel
+ * flag will load nothing. Resolves the cache path via the SAME pluginCacheRoot()
+ * doctor uses (single source of truth). Any error is swallowed (fail-open).
+ *
+ * `cacheRoot` and `log` are injectable for tests; returns whether it warned.
+ */
+export function warnIfPluginCacheMissing(
+  cacheRoot: string = pluginCacheRoot(),
+  log: (msg: string) => void = (msg) => console.error(msg),
+): boolean {
+  let cacheExists: boolean;
+  try {
+    cacheExists = existsSync(cacheRoot);
+  } catch {
+    return false; // can't tell → don't warn, never block
+  }
+  if (!shouldWarnMissingPluginCache(cacheExists)) return false;
+  log(
+    "[agentbridge] ⚠️  Plugin not installed (no plugin cache found). Run `abg init`, " +
+      `or in Claude Code: ${MARKETPLACE_STEPS.join(" → ")}. Launching anyway…`,
+  );
+  return true;
 }
 
 function traceCliStart(

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -1,9 +1,9 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { existsSync, cpSync, rmSync } from "node:fs";
-import { homedir } from "node:os";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { findPackageRoot, registerMarketplace } from "./pkg-root";
+import { isInsideRepoCheckout, pluginCacheRoot } from "./plugin-cache";
 
 export async function runDev(args: string[] = []) {
   console.log("AgentBridge Dev Setup\n");
@@ -19,9 +19,9 @@ export async function runDev(args: string[] = []) {
   // Guard: `dev` only works inside a repository checkout. When invoked from a
   // globally installed package, findPackageRoot() resolves to the published
   // package directory, which does not ship the build scripts — fail with
-  // guidance instead of a raw MODULE_NOT_FOUND from the build step.
-  const buildScript = resolve(projectRoot, "scripts", "build-bundles.mjs");
-  if (!existsSync(buildScript)) {
+  // guidance instead of a raw MODULE_NOT_FOUND from the build step. The same
+  // repo-vs-npm-global signal is reused by init's plugin-install fallback.
+  if (!isInsideRepoCheckout(projectRoot)) {
     console.error("  ERROR: 'agentbridge dev' must run inside an AgentBridge repository checkout —");
     console.error("  the published package does not ship the build scripts.");
     console.error("");
@@ -98,7 +98,7 @@ export async function runDev(args: string[] = []) {
 
   // Step 4: Force-sync local plugin files to cache (bypasses version check)
   console.log("\nSyncing local plugin to cache...");
-  const cacheDir = resolve(homedir(), ".claude", "plugins", "cache", MARKETPLACE_NAME, PLUGIN_NAME);
+  const cacheDir = pluginCacheRoot();
   if (existsSync(cacheDir)) {
     // Find the version directory (e.g., 0.1.0)
     const versionDirs = Bun.spawnSync(["ls", cacheDir]).stdout.toString().trim().split("\n").filter(Boolean);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { pluginCacheRoot } from "./plugin-cache";
 import { BUILD_INFO, formatBuildInfo, sameRuntimeContract } from "../build-info";
 import { fetchDaemonStatus } from "../daemon-status";
 import { inspectAgentBridgeEnv } from "../env-guard";
@@ -359,7 +359,7 @@ function artifactAlignmentCheck(): DoctorCheck {
       if (commit) stamps.push({ label: "global-cli", commit });
     } catch {}
   }
-  const cacheRoot = join(homedir(), ".claude", "plugins", "cache", "agentbridge", "agentbridge");
+  const cacheRoot = pluginCacheRoot();
   try {
     for (const version of readdirSync(cacheRoot)) {
       const commit = extractBundleCommit(join(cacheRoot, version, "server", "daemon.js"));

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { ConfigService } from "../config-service";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { findPackageRoot, registerMarketplace } from "./pkg-root";
+import { isInsideRepoCheckout, MARKETPLACE_STEPS } from "./plugin-cache";
 import { upsertMarkedSection } from "../marker-section";
 import { compareVersions } from "../version-utils";
 import {
@@ -49,25 +50,72 @@ export async function runInit() {
 
   // Step 4: Register marketplace + install plugin (best-effort)
   console.log("Installing AgentBridge plugin...");
+  let pluginInstalled = false;
   try {
-    registerMarketplace(findPackageRoot());
+    const packageRoot = findPackageRoot();
+    registerMarketplace(packageRoot);
     execFileSync("claude", ["plugin", "install", `${PLUGIN_NAME}@${MARKETPLACE_NAME}`], {
       stdio: "inherit",
     });
     console.log("  Plugin installed successfully.");
+    pluginInstalled = true;
   } catch {
+    // Context-aware fallback: a global npm install (no repo build scripts)
+    // cannot use `abg dev`, so point those users at the documented marketplace
+    // steps instead. Only inside a repo checkout is `abg dev` the right path.
+    // Detect context independently here so a findPackageRoot() failure above
+    // (no package.json) is still treated as "not a repo" → marketplace steps.
     console.log("  Plugin install skipped (marketplace registration or install failed).");
-    console.log("  You can install it later with:");
-    console.log(`    abg dev   # registers marketplace and installs plugin`);
+    for (const line of pluginInstallFallbackGuidance(detectRepoCheckout())) {
+      console.log(line);
+    }
   }
   console.log("");
 
-  // Step 5: Done
-  console.log("Setup complete!\n");
+  // Step 5: Done — be honest about a failed plugin install instead of faking
+  // success, and surface it to the shell via a non-zero exit code.
+  if (pluginInstalled) {
+    console.log("Setup complete!\n");
+  } else {
+    console.log("Setup incomplete — plugin not installed.\n");
+    process.exitCode = 1;
+  }
   console.log("Next steps:");
   console.log("  1. If Claude Code is already running, execute /reload-plugins in your session");
   console.log("  2. Start Claude Code:  agentbridge claude");
   console.log("  3. Start Codex TUI:    agentbridge codex");
+}
+
+/**
+ * Best-effort repo-vs-npm-global detection for the failure fallback. If the
+ * package root cannot be resolved at all (no package.json), treat it as a
+ * non-repo install so the user gets the recoverable marketplace steps.
+ */
+function detectRepoCheckout(): boolean {
+  try {
+    return isInsideRepoCheckout(findPackageRoot());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Guidance lines printed when step-4 plugin install fails. Repo checkouts can
+ * recover with `abg dev`; global npm installs cannot (the published package
+ * ships no build scripts), so those users get the README marketplace steps.
+ * Pure + exported for unit testing.
+ */
+export function pluginInstallFallbackGuidance(insideRepo: boolean): string[] {
+  if (insideRepo) {
+    return [
+      "  You can install it later with:",
+      "    abg dev   # registers marketplace and installs plugin",
+    ];
+  }
+  return [
+    "  Install the plugin from Claude Code with these steps:",
+    ...MARKETPLACE_STEPS.map((step) => `    ${step}`),
+  ];
 }
 
 function checkBun() {

--- a/src/cli/plugin-cache.ts
+++ b/src/cli/plugin-cache.ts
@@ -1,0 +1,50 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
+
+/**
+ * Single source of truth for the Claude Code plugin cache directory of this
+ * plugin: `~/.claude/plugins/cache/<marketplace>/<plugin>`.
+ *
+ * Built from MARKETPLACE_NAME / PLUGIN_NAME (not hardcoded string literals) so
+ * doctor's artifact-alignment check and the `abg claude` preflight resolve the
+ * exact same path. `home` is injectable for tests.
+ */
+export function pluginCacheRoot(home: string = homedir()): string {
+  return join(home, ".claude", "plugins", "cache", MARKETPLACE_NAME, PLUGIN_NAME);
+}
+
+/**
+ * Detect whether we are running from a real AgentBridge repository checkout
+ * (as opposed to a globally installed npm package). Uses the SAME signal as
+ * `abg dev`: the published package does not ship the build scripts, so the
+ * presence of `scripts/build-bundles.mjs` under the package root means "repo".
+ *
+ * `projectRoot` should be the result of findPackageRoot().
+ */
+export function isInsideRepoCheckout(projectRoot: string): boolean {
+  const buildScript = resolve(projectRoot, "scripts", "build-bundles.mjs");
+  return existsSync(buildScript);
+}
+
+/**
+ * The three marketplace install steps, sourced verbatim from README.md
+ * "Install via Plugin Marketplace". Used by init's failure fallback (npm-global
+ * context) and the `abg claude` preflight warning so both stay in sync with the
+ * documented marketplace name + plugin id.
+ */
+export const MARKETPLACE_STEPS: readonly string[] = [
+  `/plugin marketplace add raysonmeng/agent-bridge`,
+  `/plugin install ${PLUGIN_NAME}@${MARKETPLACE_NAME}`,
+  `/reload-plugins`,
+];
+
+/**
+ * Pure preflight decision for `abg claude`: given whether the plugin cache dir
+ * exists, decide whether to emit the "plugin not installed" warning. Extracted
+ * so the fail-open behaviour is unit-testable without touching a real HOME.
+ */
+export function shouldWarnMissingPluginCache(cacheExists: boolean): boolean {
+  return !cacheExists;
+}

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -422,6 +422,25 @@ describe("E2E: CLI surface", () => {
     });
   }, 20000);
 
+  test("agentbridge init reports incomplete and exits non-zero when plugin install fails", async () => {
+    await withHarness(async (harness) => {
+      rmSync(join(harness.projectDir, ".agentbridge"), { recursive: true, force: true });
+
+      const result = await harness.runCliWithEnv(["init"], {
+        AGENTBRIDGE_SHIM_CLAUDE_PLUGIN_INSTALL_FAIL: "1",
+      });
+
+      // Honest failure: non-zero exit, "incomplete" not "complete".
+      expect(result.code).toBe(1);
+      expect(result.stdout).toContain("Setup incomplete — plugin not installed");
+      expect(result.stdout).not.toContain("Setup complete!");
+      // The CLI runs from the repo checkout here, so guidance points at `abg dev`.
+      expect(result.stdout).toContain("abg dev");
+      // Config still gets generated even though the plugin step failed.
+      expect(existsSync(join(harness.projectDir, ".agentbridge", "config.json"))).toBe(true);
+    });
+  }, 20000);
+
   test("agentbridge claude injects channel flags", async () => {
     await withHarness(async (harness) => {
       const result = await harness.runCli(["claude", "--resume"]);
@@ -1359,6 +1378,12 @@ if (args[0] === "--version") {
 }
 
 if ("${commandName}" === "claude" && args[0] === "plugin" && args[1] === "install") {
+  // Test hook: force plugin install to fail so init's failure journey can be
+  // exercised end-to-end (exit code + context-aware guidance).
+  if (process.env.AGENTBRIDGE_SHIM_CLAUDE_PLUGIN_INSTALL_FAIL === "1") {
+    console.error("simulated plugin install failure");
+    process.exit(1);
+  }
   process.exit(0);
 }
 

--- a/src/unit-test/cli.test.ts
+++ b/src/unit-test/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { compareVersions } from "../cli/init";
-import { checkOwnedFlagConflicts } from "../cli/claude";
+import { checkOwnedFlagConflicts, warnIfPluginCacheMissing } from "../cli/claude";
 import {
   buildCodexArgs,
   parseAgentBridgeCodexArgs,
@@ -134,6 +134,32 @@ describe("CLI: owned flag conflict detection", () => {
     console.error = origError;
     expect(output).toContain("codex [your flags here]");
     expect(output).not.toContain("claude [your flags here]");
+  });
+});
+
+describe("CLI: claude plugin-cache preflight (fail-open)", () => {
+  test("missing cache dir → emits a warning pointing at `abg init`", () => {
+    const missing = join(mkdtempSync(join(tmpdir(), "agentbridge-preflight-")), "no-such-cache");
+    let warned = "";
+    const didWarn = warnIfPluginCacheMissing(missing, (msg) => {
+      warned += msg + "\n";
+    });
+    expect(didWarn).toBe(true);
+    expect(warned).toContain("abg init");
+    expect(warned).toContain("/plugin marketplace add raysonmeng/agent-bridge");
+    // Fail-open: this is only a warning; runClaude continues to spawn after it.
+    expect(warned).toContain("Launching anyway");
+  });
+
+  test("present cache dir → no warning", () => {
+    const present = mkdtempSync(join(tmpdir(), "agentbridge-preflight-present-"));
+    let warned = "";
+    const didWarn = warnIfPluginCacheMissing(present, (msg) => {
+      warned += msg + "\n";
+    });
+    expect(didWarn).toBe(false);
+    expect(warned).toBe("");
+    rmSync(present, { recursive: true, force: true });
   });
 });
 

--- a/src/unit-test/plugin-cache.test.ts
+++ b/src/unit-test/plugin-cache.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
+import {
+  pluginCacheRoot,
+  isInsideRepoCheckout,
+  MARKETPLACE_STEPS,
+  shouldWarnMissingPluginCache,
+} from "../cli/plugin-cache";
+import { pluginInstallFallbackGuidance } from "../cli/init";
+
+describe("plugin-cache: pluginCacheRoot", () => {
+  test("builds the path from the marketplace + plugin constants (no hardcoded literal)", () => {
+    const home = "/tmp/fake-home";
+    expect(pluginCacheRoot(home)).toBe(
+      join(home, ".claude", "plugins", "cache", MARKETPLACE_NAME, PLUGIN_NAME),
+    );
+  });
+
+  test("matches the documented marketplace + plugin id segments", () => {
+    // README markets this as agentbridge@agentbridge — the cache root must agree.
+    const root = pluginCacheRoot("/h");
+    expect(root.endsWith(join("cache", "agentbridge", "agentbridge"))).toBe(true);
+  });
+});
+
+describe("plugin-cache: isInsideRepoCheckout", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "agentbridge-repo-detect-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("true when scripts/build-bundles.mjs exists (repo checkout)", () => {
+    mkdirSync(join(tempDir, "scripts"), { recursive: true });
+    writeFileSync(join(tempDir, "scripts", "build-bundles.mjs"), "// build\n", "utf-8");
+    expect(isInsideRepoCheckout(tempDir)).toBe(true);
+  });
+
+  test("false when build scripts are absent (global npm install)", () => {
+    // A published package dir with no scripts/ folder.
+    expect(isInsideRepoCheckout(tempDir)).toBe(false);
+  });
+});
+
+describe("plugin-cache: MARKETPLACE_STEPS", () => {
+  test("matches README.md marketplace install steps verbatim", () => {
+    expect(MARKETPLACE_STEPS).toEqual([
+      "/plugin marketplace add raysonmeng/agent-bridge",
+      "/plugin install agentbridge@agentbridge",
+      "/reload-plugins",
+    ]);
+  });
+});
+
+describe("plugin-cache: shouldWarnMissingPluginCache", () => {
+  test("warns when cache dir is missing", () => {
+    expect(shouldWarnMissingPluginCache(false)).toBe(true);
+  });
+
+  test("does not warn when cache dir is present", () => {
+    expect(shouldWarnMissingPluginCache(true)).toBe(false);
+  });
+});
+
+describe("init: pluginInstallFallbackGuidance", () => {
+  test("npm-global context → marketplace steps, never `abg dev`", () => {
+    const lines = pluginInstallFallbackGuidance(false);
+    const joined = lines.join("\n");
+    // All three documented marketplace steps appear.
+    for (const step of MARKETPLACE_STEPS) {
+      expect(joined).toContain(step);
+    }
+    // The non-repo audience must NOT be pointed at `abg dev` (it hard-errors).
+    expect(joined).not.toContain("abg dev");
+  });
+
+  test("repo context → suggests `abg dev`, not marketplace steps", () => {
+    const lines = pluginInstallFallbackGuidance(true);
+    const joined = lines.join("\n");
+    expect(joined).toContain("abg dev");
+    expect(joined).not.toContain("/plugin marketplace add");
+  });
+});


### PR DESCRIPTION
## 摘要
审视报告 P1：npm 全局用户 abg init 第4步插件安装失败时，兜底指引指向只在 repo 内可用的 abg dev（对目标人群必然失败），且无条件打印 Setup complete! 退出 0。abg claude 也无 preflight。

## 变更
- 新 src/cli/plugin-cache.ts 单一真源：pluginCacheRoot / isInsideRepoCheckout / MARKETPLACE_STEPS
- init 失败按场景分叉：npm-global → marketplace 三步（README 逐字），repo → abg dev；失败时 **Setup incomplete + process.exitCode=1**（不再伪装成功）
- abg claude **fail-open 预检**：插件缓存缺失 → stderr 警告指向 abg init，不阻断启动
- doctor.ts / dev.ts 改用共享 pluginCacheRoot/isInsideRepoCheckout，消除硬编码副本

## 测试
- [x] 755 pass；ci:local 绿；cross-review **双 0 REAL**
- 注：rebase v0.1.11 时 claude.ts 与 #114 max-permission 默认 git 三方自动合并（preflight + planMaxPermissions 共存，已核验 typecheck + cli 测试绿）