### PR TITLE
feat: budget 轮询自适应节奏 + reset-epoch 对齐唤醒 / adaptive budget poll cadence

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14231,7 +14231,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("63c4412", "source"),
+  commit: defineString("bbdc792", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14936,7 +14936,7 @@ import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSy
 import { join as join2 } from "path";
 var DEFAULT_BUDGET_CONFIG = {
   enabled: true,
-  pollSeconds: 60,
+  pollSeconds: 300,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,
@@ -15003,35 +15003,35 @@ function normalizeCodexOverride(raw) {
     override.effort = raw.effort.trim();
   return Object.keys(override).length > 0 ? override : null;
 }
-function normalizeCodexTiers(raw) {
+function normalizeCodexTiers(raw, fallback = DEFAULT_BUDGET_CONFIG.codexTiers) {
   const tiers = isRecord(raw) ? raw : {};
   return {
     full: normalizeCodexOverride(tiers.full),
-    balanced: normalizeCodexOverride(tiers.balanced) ?? DEFAULT_BUDGET_CONFIG.codexTiers.balanced,
-    eco: normalizeCodexOverride(tiers.eco) ?? DEFAULT_BUDGET_CONFIG.codexTiers.eco
+    balanced: normalizeCodexOverride(tiers.balanced) ?? fallback.balanced,
+    eco: normalizeCodexOverride(tiers.eco) ?? fallback.eco
   };
 }
-function normalizeBudgetConfig(raw) {
+function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
   const budget = isRecord(raw) ? raw : {};
   const parallel = isRecord(budget.parallel) ? budget.parallel : {};
-  const codexTiers = normalizeCodexTiers(budget.codexTiers);
-  let pauseAt = normalizeBoundedInteger(budget.pauseAt, DEFAULT_BUDGET_CONFIG.pauseAt, 1, 100);
-  let resumeBelow = normalizeBoundedInteger(budget.resumeBelow, DEFAULT_BUDGET_CONFIG.resumeBelow, 0, 99);
+  const codexTiers = normalizeCodexTiers(budget.codexTiers, fallback.codexTiers);
+  let pauseAt = normalizeBoundedInteger(budget.pauseAt, fallback.pauseAt, 1, 100);
+  let resumeBelow = normalizeBoundedInteger(budget.resumeBelow, fallback.resumeBelow, 0, 99);
   if (pauseAt <= resumeBelow) {
     pauseAt = DEFAULT_BUDGET_CONFIG.pauseAt;
     resumeBelow = DEFAULT_BUDGET_CONFIG.resumeBelow;
   }
   return {
-    enabled: normalizeBoolean(budget.enabled, DEFAULT_BUDGET_CONFIG.enabled),
-    pollSeconds: normalizeBoundedInteger(budget.pollSeconds, DEFAULT_BUDGET_CONFIG.pollSeconds, 5, 3600),
+    enabled: normalizeBoolean(budget.enabled, fallback.enabled),
+    pollSeconds: normalizeBoundedInteger(budget.pollSeconds, fallback.pollSeconds, 5, 3600),
     pauseAt,
     resumeBelow,
-    syncDriftPct: normalizeBoundedInteger(budget.syncDriftPct, DEFAULT_BUDGET_CONFIG.syncDriftPct, 1, 100),
+    syncDriftPct: normalizeBoundedInteger(budget.syncDriftPct, fallback.syncDriftPct, 1, 100),
     parallel: {
-      minRemainingPct: normalizeBoundedInteger(parallel.minRemainingPct, DEFAULT_BUDGET_CONFIG.parallel.minRemainingPct, 1, 100),
-      timeWindowSec: normalizeBoundedInteger(parallel.timeWindowSec, DEFAULT_BUDGET_CONFIG.parallel.timeWindowSec, 60, 604800)
+      minRemainingPct: normalizeBoundedInteger(parallel.minRemainingPct, fallback.parallel.minRemainingPct, 1, 100),
+      timeWindowSec: normalizeBoundedInteger(parallel.timeWindowSec, fallback.parallel.timeWindowSec, 60, 604800)
     },
-    codexTierControl: normalizeBoolean(budget.codexTierControl, DEFAULT_BUDGET_CONFIG.codexTierControl) && codexTiers.full !== null,
+    codexTierControl: normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) && codexTiers.full !== null,
     codexTiers
   };
 }

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("63c4412", "source"),
+  commit: defineString("bbdc792", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2673,7 +2673,7 @@ import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSy
 import { join as join3 } from "path";
 var DEFAULT_BUDGET_CONFIG = {
   enabled: true,
-  pollSeconds: 60,
+  pollSeconds: 300,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,
@@ -2740,35 +2740,35 @@ function normalizeCodexOverride(raw) {
     override.effort = raw.effort.trim();
   return Object.keys(override).length > 0 ? override : null;
 }
-function normalizeCodexTiers(raw) {
+function normalizeCodexTiers(raw, fallback = DEFAULT_BUDGET_CONFIG.codexTiers) {
   const tiers = isRecord(raw) ? raw : {};
   return {
     full: normalizeCodexOverride(tiers.full),
-    balanced: normalizeCodexOverride(tiers.balanced) ?? DEFAULT_BUDGET_CONFIG.codexTiers.balanced,
-    eco: normalizeCodexOverride(tiers.eco) ?? DEFAULT_BUDGET_CONFIG.codexTiers.eco
+    balanced: normalizeCodexOverride(tiers.balanced) ?? fallback.balanced,
+    eco: normalizeCodexOverride(tiers.eco) ?? fallback.eco
   };
 }
-function normalizeBudgetConfig(raw) {
+function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
   const budget = isRecord(raw) ? raw : {};
   const parallel = isRecord(budget.parallel) ? budget.parallel : {};
-  const codexTiers = normalizeCodexTiers(budget.codexTiers);
-  let pauseAt = normalizeBoundedInteger(budget.pauseAt, DEFAULT_BUDGET_CONFIG.pauseAt, 1, 100);
-  let resumeBelow = normalizeBoundedInteger(budget.resumeBelow, DEFAULT_BUDGET_CONFIG.resumeBelow, 0, 99);
+  const codexTiers = normalizeCodexTiers(budget.codexTiers, fallback.codexTiers);
+  let pauseAt = normalizeBoundedInteger(budget.pauseAt, fallback.pauseAt, 1, 100);
+  let resumeBelow = normalizeBoundedInteger(budget.resumeBelow, fallback.resumeBelow, 0, 99);
   if (pauseAt <= resumeBelow) {
     pauseAt = DEFAULT_BUDGET_CONFIG.pauseAt;
     resumeBelow = DEFAULT_BUDGET_CONFIG.resumeBelow;
   }
   return {
-    enabled: normalizeBoolean(budget.enabled, DEFAULT_BUDGET_CONFIG.enabled),
-    pollSeconds: normalizeBoundedInteger(budget.pollSeconds, DEFAULT_BUDGET_CONFIG.pollSeconds, 5, 3600),
+    enabled: normalizeBoolean(budget.enabled, fallback.enabled),
+    pollSeconds: normalizeBoundedInteger(budget.pollSeconds, fallback.pollSeconds, 5, 3600),
     pauseAt,
     resumeBelow,
-    syncDriftPct: normalizeBoundedInteger(budget.syncDriftPct, DEFAULT_BUDGET_CONFIG.syncDriftPct, 1, 100),
+    syncDriftPct: normalizeBoundedInteger(budget.syncDriftPct, fallback.syncDriftPct, 1, 100),
     parallel: {
-      minRemainingPct: normalizeBoundedInteger(parallel.minRemainingPct, DEFAULT_BUDGET_CONFIG.parallel.minRemainingPct, 1, 100),
-      timeWindowSec: normalizeBoundedInteger(parallel.timeWindowSec, DEFAULT_BUDGET_CONFIG.parallel.timeWindowSec, 60, 604800)
+      minRemainingPct: normalizeBoundedInteger(parallel.minRemainingPct, fallback.parallel.minRemainingPct, 1, 100),
+      timeWindowSec: normalizeBoundedInteger(parallel.timeWindowSec, fallback.parallel.timeWindowSec, 60, 604800)
     },
-    codexTierControl: normalizeBoolean(budget.codexTierControl, DEFAULT_BUDGET_CONFIG.codexTierControl) && codexTiers.full !== null,
+    codexTierControl: normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) && codexTiers.full !== null,
     codexTiers
   };
 }
@@ -2786,7 +2786,7 @@ function applyBudgetEnvOverrides(budget, env = process.env) {
     codexTierControl: env.AGENTBRIDGE_BUDGET_CODEX_TIER_CONTROL ?? budget.codexTierControl,
     codexTiers: budget.codexTiers
   };
-  return normalizeBudgetConfig(overlay);
+  return normalizeBudgetConfig(overlay, budget);
 }
 function normalizeConfig(raw) {
   if (!isRecord(raw))
@@ -3082,6 +3082,23 @@ function computeBudgetState(claude, codex, cfg, now) {
 
 // src/budget/budget-coordinator.ts
 var RESET_FINGERPRINT_BUCKET_SEC = 600;
+var LOW_UTIL_PCT = 50;
+var NEAR_PAUSE_MARGIN_PCT = 10;
+var NEAR_WARN_UTIL_PCT = 75;
+var NEAR_THRESHOLD_POLL_MS = 60000;
+var PAUSED_POLL_MS = 15000;
+var RESET_WAKE_AFTER_SEC = 5;
+var RESET_RECENTLY_PASSED_WINDOW_SEC = 120;
+var REAL_BUDGET_POLL_SCHEDULER = {
+  setTimeout(callback, delayMs) {
+    return setTimeout(() => {
+      callback();
+    }, delayMs);
+  },
+  clearTimeout(timer) {
+    clearTimeout(timer);
+  }
+};
 var AGENT_LABEL2 = {
   claude: "Claude",
   codex: "Codex"
@@ -3104,6 +3121,55 @@ function matchingGateReset2(usage) {
     return 0;
   return Math.min(...candidates.map((window) => window.resetEpoch));
 }
+function maxPollDelayMs(config) {
+  return Math.max(0, config.pollSeconds * 1000);
+}
+function capDelay(delayMs, maxDelayMs) {
+  if (maxDelayMs <= 0)
+    return 0;
+  return Math.min(delayMs, maxDelayMs);
+}
+function usagePressure(usage) {
+  const readings = [usage?.claude, usage?.codex].filter((agentUsage) => agentUsage !== null && agentUsage !== undefined).flatMap((agentUsage) => [agentUsage.gateUtil, agentUsage.warnUtil]);
+  if (readings.length === 0)
+    return null;
+  return Math.max(...readings);
+}
+function usageResetEpochs(usage) {
+  return [usage?.claude, usage?.codex].filter((agentUsage) => agentUsage !== null && agentUsage !== undefined).flatMap((agentUsage) => [agentUsage.fiveHour?.resetEpoch ?? 0, agentUsage.weekly?.resetEpoch ?? 0]).filter((epoch) => epoch > 0);
+}
+function adaptiveBudgetPollDelayMs(input) {
+  const maxDelayMs = maxPollDelayMs(input.config);
+  if (input.paused)
+    return capDelay(PAUSED_POLL_MS, maxDelayMs);
+  const pressure = usagePressure(input.usage);
+  if (pressure === null || pressure < LOW_UTIL_PCT)
+    return maxDelayMs;
+  const nearPauseAt = Math.max(0, input.config.pauseAt - NEAR_PAUSE_MARGIN_PCT);
+  if (pressure >= nearPauseAt || pressure >= NEAR_WARN_UTIL_PCT) {
+    return capDelay(NEAR_THRESHOLD_POLL_MS, maxDelayMs);
+  }
+  return capDelay(maxDelayMs / 2, maxDelayMs);
+}
+function resetAlignedDelayMs(input, adaptiveDelayMs) {
+  const epochs = usageResetEpochs(input.usage);
+  if (epochs.length === 0)
+    return null;
+  const candidates = epochs.map((epoch) => {
+    if (epoch >= input.now)
+      return (epoch - input.now + RESET_WAKE_AFTER_SEC) * 1000;
+    if (input.now - epoch <= RESET_RECENTLY_PASSED_WINDOW_SEC)
+      return RESET_WAKE_AFTER_SEC * 1000;
+    return null;
+  }).filter((delayMs) => delayMs !== null && delayMs >= 0 && delayMs <= adaptiveDelayMs);
+  if (candidates.length === 0)
+    return null;
+  return Math.min(...candidates);
+}
+function nextBudgetPollDelayMs(input) {
+  const adaptiveDelayMs = adaptiveBudgetPollDelayMs(input);
+  return resetAlignedDelayMs(input, adaptiveDelayMs) ?? adaptiveDelayMs;
+}
 
 class BudgetCoordinator {
   source;
@@ -3111,6 +3177,7 @@ class BudgetCoordinator {
   emit;
   onPauseChange;
   now;
+  scheduler;
   log;
   timer = null;
   running = false;
@@ -3130,6 +3197,7 @@ class BudgetCoordinator {
     this.emit = options.emit;
     this.onPauseChange = options.onPauseChange;
     this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
+    this.scheduler = options.scheduler ?? REAL_BUDGET_POLL_SCHEDULER;
     this.log = options.log ?? (() => {});
   }
   async start() {
@@ -3143,7 +3211,7 @@ class BudgetCoordinator {
   stop() {
     this.running = false;
     if (this.timer) {
-      clearTimeout(this.timer);
+      this.scheduler.clearTimeout(this.timer);
       this.timer = null;
     }
   }
@@ -3177,11 +3245,17 @@ class BudgetCoordinator {
     if (!this.running)
       return;
     if (this.timer)
-      clearTimeout(this.timer);
-    const delayMs = Math.max(0, this.config.pollSeconds * 1000);
-    this.timer = setTimeout(() => {
+      this.scheduler.clearTimeout(this.timer);
+    const snapshotUsage = this.latestSnapshot ? { claude: this.latestSnapshot.claude, codex: this.latestSnapshot.codex } : null;
+    const delayMs = nextBudgetPollDelayMs({
+      config: this.config,
+      usage: snapshotUsage,
+      now: this.now(),
+      paused: this.isPaused()
+    });
+    this.timer = this.scheduler.setTimeout(() => {
       this.timer = null;
-      this.pollAndReschedule();
+      return this.pollAndReschedule();
     }, delayMs);
   }
   async pollAndReschedule() {

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -12,10 +12,42 @@ import type { QuotaSource } from "./quota-source";
 
 type QuotaSourceLike = Pick<QuotaSource, "fetchBoth">;
 type PauseSide = BudgetSnapshot["pauseSide"];
+type BudgetPollTimer = unknown;
+type BudgetPollCallback = () => void | Promise<void>;
+
+export interface BudgetPollScheduler {
+  setTimeout(callback: BudgetPollCallback, delayMs: number): BudgetPollTimer;
+  clearTimeout(timer: BudgetPollTimer): void;
+}
+
+export interface BudgetPollDelayInput {
+  config: Pick<BudgetConfig, "pollSeconds" | "pauseAt">;
+  usage: { claude: AgentUsage | null; codex: AgentUsage | null } | null;
+  now: number;
+  paused: boolean;
+}
 
 // Directive-fingerprint quantum for reset epochs. Must absorb probe jitter
 // (seconds) while still distinguishing a genuine window reset (hours).
 const RESET_FINGERPRINT_BUCKET_SEC = 600;
+const LOW_UTIL_PCT = 50;
+const NEAR_PAUSE_MARGIN_PCT = 10;
+const NEAR_WARN_UTIL_PCT = 75;
+const NEAR_THRESHOLD_POLL_MS = 60_000;
+const PAUSED_POLL_MS = 15_000;
+const RESET_WAKE_AFTER_SEC = 5;
+const RESET_RECENTLY_PASSED_WINDOW_SEC = 120;
+
+const REAL_BUDGET_POLL_SCHEDULER: BudgetPollScheduler = {
+  setTimeout(callback, delayMs) {
+    return setTimeout(() => {
+      void callback();
+    }, delayMs);
+  },
+  clearTimeout(timer) {
+    clearTimeout(timer as ReturnType<typeof setTimeout>);
+  },
+};
 
 export interface BudgetCoordinatorOptions {
   source: QuotaSourceLike;
@@ -23,6 +55,7 @@ export interface BudgetCoordinatorOptions {
   emit: (id: string, content: string) => void;
   onPauseChange: (paused: boolean) => void;
   now?: () => number;
+  scheduler?: BudgetPollScheduler;
   log?: (message: string) => void;
 }
 
@@ -52,15 +85,76 @@ function matchingGateReset(usage: AgentUsage | null): number {
   return Math.min(...candidates.map((window) => window.resetEpoch));
 }
 
+function maxPollDelayMs(config: Pick<BudgetConfig, "pollSeconds">): number {
+  return Math.max(0, config.pollSeconds * 1000);
+}
+
+function capDelay(delayMs: number, maxDelayMs: number): number {
+  if (maxDelayMs <= 0) return 0;
+  return Math.min(delayMs, maxDelayMs);
+}
+
+function usagePressure(usage: { claude: AgentUsage | null; codex: AgentUsage | null } | null): number | null {
+  const readings = [usage?.claude, usage?.codex]
+    .filter((agentUsage): agentUsage is AgentUsage => agentUsage !== null && agentUsage !== undefined)
+    .flatMap((agentUsage) => [agentUsage.gateUtil, agentUsage.warnUtil]);
+  if (readings.length === 0) return null;
+  return Math.max(...readings);
+}
+
+function usageResetEpochs(usage: { claude: AgentUsage | null; codex: AgentUsage | null } | null): number[] {
+  return [usage?.claude, usage?.codex]
+    .filter((agentUsage): agentUsage is AgentUsage => agentUsage !== null && agentUsage !== undefined)
+    .flatMap((agentUsage) => [agentUsage.fiveHour?.resetEpoch ?? 0, agentUsage.weekly?.resetEpoch ?? 0])
+    .filter((epoch) => epoch > 0);
+}
+
+function adaptiveBudgetPollDelayMs(input: BudgetPollDelayInput): number {
+  const maxDelayMs = maxPollDelayMs(input.config);
+  if (input.paused) return capDelay(PAUSED_POLL_MS, maxDelayMs);
+
+  const pressure = usagePressure(input.usage);
+  if (pressure === null || pressure < LOW_UTIL_PCT) return maxDelayMs;
+
+  const nearPauseAt = Math.max(0, input.config.pauseAt - NEAR_PAUSE_MARGIN_PCT);
+  if (pressure >= nearPauseAt || pressure >= NEAR_WARN_UTIL_PCT) {
+    return capDelay(NEAR_THRESHOLD_POLL_MS, maxDelayMs);
+  }
+
+  return capDelay(maxDelayMs / 2, maxDelayMs);
+}
+
+function resetAlignedDelayMs(input: BudgetPollDelayInput, adaptiveDelayMs: number): number | null {
+  const epochs = usageResetEpochs(input.usage);
+  if (epochs.length === 0) return null;
+
+  const candidates = epochs
+    .map((epoch) => {
+      if (epoch >= input.now) return (epoch - input.now + RESET_WAKE_AFTER_SEC) * 1000;
+      if (input.now - epoch <= RESET_RECENTLY_PASSED_WINDOW_SEC) return RESET_WAKE_AFTER_SEC * 1000;
+      return null;
+    })
+    .filter((delayMs): delayMs is number => delayMs !== null && delayMs >= 0 && delayMs <= adaptiveDelayMs);
+
+  if (candidates.length === 0) return null;
+  return Math.min(...candidates);
+}
+
+export function nextBudgetPollDelayMs(input: BudgetPollDelayInput): number {
+  const adaptiveDelayMs = adaptiveBudgetPollDelayMs(input);
+  return resetAlignedDelayMs(input, adaptiveDelayMs) ?? adaptiveDelayMs;
+}
+
 export class BudgetCoordinator {
   private readonly source: QuotaSourceLike;
   private readonly config: BudgetConfig;
   private readonly emit: (id: string, content: string) => void;
   private readonly onPauseChange: (paused: boolean) => void;
   private readonly now: () => number;
+  private readonly scheduler: BudgetPollScheduler;
   private readonly log: (message: string) => void;
 
-  private timer: ReturnType<typeof setTimeout> | null = null;
+  private timer: BudgetPollTimer | null = null;
   private running = false;
   private readonly activeSides = new Set<AgentName>();
   private lastDirectiveFingerprint: string | null = null;
@@ -79,6 +173,7 @@ export class BudgetCoordinator {
     this.emit = options.emit;
     this.onPauseChange = options.onPauseChange;
     this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
+    this.scheduler = options.scheduler ?? REAL_BUDGET_POLL_SCHEDULER;
     this.log = options.log ?? (() => {});
   }
 
@@ -92,7 +187,7 @@ export class BudgetCoordinator {
   stop(): void {
     this.running = false;
     if (this.timer) {
-      clearTimeout(this.timer);
+      this.scheduler.clearTimeout(this.timer);
       this.timer = null;
     }
   }
@@ -138,11 +233,19 @@ export class BudgetCoordinator {
     if (!this.running) return;
     // Defensive: never fork a second polling chain if a timer is already armed
     // (e.g. a future stop()→start() reentry pattern).
-    if (this.timer) clearTimeout(this.timer);
-    const delayMs = Math.max(0, this.config.pollSeconds * 1000);
-    this.timer = setTimeout(() => {
+    if (this.timer) this.scheduler.clearTimeout(this.timer);
+    const snapshotUsage = this.latestSnapshot
+      ? { claude: this.latestSnapshot.claude, codex: this.latestSnapshot.codex }
+      : null;
+    const delayMs = nextBudgetPollDelayMs({
+      config: this.config,
+      usage: snapshotUsage,
+      now: this.now(),
+      paused: this.isPaused(),
+    });
+    this.timer = this.scheduler.setTimeout(() => {
       this.timer = null;
-      void this.pollAndReschedule();
+      return this.pollAndReschedule();
     }, delayMs);
   }
 

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -18,7 +18,7 @@ export interface AgentBridgeConfig {
 
 const DEFAULT_BUDGET_CONFIG: BudgetConfig = {
   enabled: true,
-  pollSeconds: 60,
+  pollSeconds: 300,
   // Intentionally below quota-guard's per-agent hard line (92) so the bridge's
   // coordinated pause fires first and leaves wrap-up headroom; the guard stays
   // as the per-agent backstop.
@@ -114,13 +114,16 @@ function normalizeCodexOverride(raw: unknown): CodexTurnOverrides | null {
   return Object.keys(override).length > 0 ? override : null;
 }
 
-function normalizeCodexTiers(raw: unknown): CodexTierMap {
+function normalizeCodexTiers(
+  raw: unknown,
+  fallback: CodexTierMap = DEFAULT_BUDGET_CONFIG.codexTiers,
+): CodexTierMap {
   const tiers = isRecord(raw) ? raw : {};
   return {
     full: normalizeCodexOverride(tiers.full),
     balanced:
-      normalizeCodexOverride(tiers.balanced) ?? DEFAULT_BUDGET_CONFIG.codexTiers.balanced,
-    eco: normalizeCodexOverride(tiers.eco) ?? DEFAULT_BUDGET_CONFIG.codexTiers.eco,
+      normalizeCodexOverride(tiers.balanced) ?? fallback.balanced,
+    eco: normalizeCodexOverride(tiers.eco) ?? fallback.eco,
   };
 }
 
@@ -134,15 +137,18 @@ function normalizeCodexTiers(raw: unknown): CodexTierMap {
  * stays true ONLY when `codexTiers.full` is configured — sticky turn/start
  * overrides cannot be restored without an explicit restore point.
  */
-function normalizeBudgetConfig(raw: unknown): BudgetConfig {
+function normalizeBudgetConfig(
+  raw: unknown,
+  fallback: BudgetConfig = DEFAULT_BUDGET_CONFIG,
+): BudgetConfig {
   const budget = isRecord(raw) ? raw : {};
   const parallel = isRecord(budget.parallel) ? budget.parallel : {};
-  const codexTiers = normalizeCodexTiers(budget.codexTiers);
+  const codexTiers = normalizeCodexTiers(budget.codexTiers, fallback.codexTiers);
 
-  let pauseAt = normalizeBoundedInteger(budget.pauseAt, DEFAULT_BUDGET_CONFIG.pauseAt, 1, 100);
+  let pauseAt = normalizeBoundedInteger(budget.pauseAt, fallback.pauseAt, 1, 100);
   let resumeBelow = normalizeBoundedInteger(
     budget.resumeBelow,
-    DEFAULT_BUDGET_CONFIG.resumeBelow,
+    fallback.resumeBelow,
     0,
     99,
   );
@@ -152,10 +158,10 @@ function normalizeBudgetConfig(raw: unknown): BudgetConfig {
   }
 
   return {
-    enabled: normalizeBoolean(budget.enabled, DEFAULT_BUDGET_CONFIG.enabled),
+    enabled: normalizeBoolean(budget.enabled, fallback.enabled),
     pollSeconds: normalizeBoundedInteger(
       budget.pollSeconds,
-      DEFAULT_BUDGET_CONFIG.pollSeconds,
+      fallback.pollSeconds,
       5,
       3600,
     ),
@@ -163,26 +169,26 @@ function normalizeBudgetConfig(raw: unknown): BudgetConfig {
     resumeBelow,
     syncDriftPct: normalizeBoundedInteger(
       budget.syncDriftPct,
-      DEFAULT_BUDGET_CONFIG.syncDriftPct,
+      fallback.syncDriftPct,
       1,
       100,
     ),
     parallel: {
       minRemainingPct: normalizeBoundedInteger(
         parallel.minRemainingPct,
-        DEFAULT_BUDGET_CONFIG.parallel.minRemainingPct,
+        fallback.parallel.minRemainingPct,
         1,
         100,
       ),
       timeWindowSec: normalizeBoundedInteger(
         parallel.timeWindowSec,
-        DEFAULT_BUDGET_CONFIG.parallel.timeWindowSec,
+        fallback.parallel.timeWindowSec,
         60,
         604800,
       ),
     },
     codexTierControl:
-      normalizeBoolean(budget.codexTierControl, DEFAULT_BUDGET_CONFIG.codexTierControl) &&
+      normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) &&
       codexTiers.full !== null,
     codexTiers,
   };
@@ -213,7 +219,7 @@ export function applyBudgetEnvOverrides(
     // re-normalization re-applies the full-restore activation rule.
     codexTiers: budget.codexTiers,
   };
-  return normalizeBudgetConfig(overlay);
+  return normalizeBudgetConfig(overlay, budget);
 }
 
 function normalizeConfig(raw: unknown): AgentBridgeConfig | null {

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { BudgetCoordinator } from "../budget/budget-coordinator";
+import { BudgetCoordinator, nextBudgetPollDelayMs } from "../budget/budget-coordinator";
 import type { AgentUsage, BudgetConfig } from "../budget/types";
 
 const NOW = 1_700_000_000;
@@ -23,6 +23,7 @@ const CONFIG: BudgetConfig = {
 };
 
 type FetchResult = { claude: AgentUsage | null; codex: AgentUsage | null } | null;
+type ScheduledCallback = () => void | Promise<void>;
 
 function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {
   const gateUtil = overrides.gateUtil ?? 20;
@@ -58,6 +59,27 @@ class FakeSource {
   }
 }
 
+class FakeScheduler {
+  scheduled: Array<{ delayMs: number; callback: ScheduledCallback; active: boolean }> = [];
+
+  setTimeout(callback: ScheduledCallback, delayMs: number): number {
+    const id = this.scheduled.length;
+    this.scheduled.push({ delayMs, callback, active: true });
+    return id;
+  }
+
+  clearTimeout(id: number): void {
+    if (this.scheduled[id]) this.scheduled[id].active = false;
+  }
+
+  async runNext(): Promise<void> {
+    const next = this.scheduled.find((timer) => timer.active);
+    if (!next) throw new Error("no active scheduled timer");
+    next.active = false;
+    await next.callback();
+  }
+}
+
 function makeCoordinator(source: FakeSource, config: BudgetConfig = CONFIG) {
   const emitted: Array<{ id: string; content: string }> = [];
   const pauseChanges: boolean[] = [];
@@ -74,6 +96,14 @@ function makeCoordinator(source: FakeSource, config: BudgetConfig = CONFIG) {
   return { coordinator, emitted, pauseChanges, logs };
 }
 
+function longPollConfig(overrides: Partial<BudgetConfig> = {}): BudgetConfig {
+  return {
+    ...CONFIG,
+    pollSeconds: 300,
+    ...overrides,
+  };
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -88,6 +118,132 @@ async function waitFor(condition: () => boolean, timeoutMs = 250): Promise<void>
 }
 
 describe("BudgetCoordinator", () => {
+  test("adaptive poll delay uses longer intervals far from thresholds", () => {
+    const config = longPollConfig();
+
+    expect(nextBudgetPollDelayMs({
+      config,
+      now: NOW,
+      usage: { claude: usage({ gateUtil: 20, warnUtil: 25 }), codex: usage({ gateUtil: 10, warnUtil: 15 }) },
+      paused: false,
+    })).toBe(300_000);
+
+    expect(nextBudgetPollDelayMs({
+      config,
+      now: NOW,
+      usage: { claude: usage({ gateUtil: 55, warnUtil: 55 }), codex: usage({ gateUtil: 40, warnUtil: 40 }) },
+      paused: false,
+    })).toBe(150_000);
+
+    expect(nextBudgetPollDelayMs({
+      config,
+      now: NOW,
+      usage: { claude: usage({ gateUtil: 82, warnUtil: 82 }), codex: usage({ gateUtil: 40, warnUtil: 40 }) },
+      paused: false,
+    })).toBe(60_000);
+  });
+
+  test("adaptive poll delay stays short during an active intervention", () => {
+    expect(nextBudgetPollDelayMs({
+      config: longPollConfig(),
+      now: NOW,
+      usage: { claude: usage({ gateUtil: 91, warnUtil: 91 }), codex: usage() },
+      paused: true,
+    })).toBe(15_000);
+  });
+
+  test("adaptive poll delay aligns to nearby reset epochs", () => {
+    const config = longPollConfig();
+    expect(nextBudgetPollDelayMs({
+      config,
+      now: NOW,
+      usage: {
+        claude: usage({ gateUtil: 20, warnUtil: 20, fiveHour: { util: 20, resetEpoch: NOW + 42 } }),
+        codex: usage({ gateUtil: 15, warnUtil: 15, fiveHour: { util: 15, resetEpoch: NOW + 3600 } }),
+      },
+      paused: false,
+    })).toBe(47_000);
+
+    expect(nextBudgetPollDelayMs({
+      config,
+      now: NOW,
+      usage: {
+        claude: usage({ gateUtil: 20, warnUtil: 20, fiveHour: { util: 20, resetEpoch: NOW - 20 } }),
+        codex: usage({ gateUtil: 15, warnUtil: 15 }),
+      },
+      paused: false,
+    })).toBe(5_000);
+  });
+
+  test("scheduler seam arms reset-aligned timers without wall-clock waits", async () => {
+    let now = NOW;
+    const scheduler = new FakeScheduler();
+    const source = new FakeSource([
+      {
+        claude: usage({ gateUtil: 20, warnUtil: 20, fiveHour: { util: 20, resetEpoch: NOW + 42 } }),
+        codex: usage({ gateUtil: 15, warnUtil: 15 }),
+      },
+      { claude: usage({ gateUtil: 21, warnUtil: 21 }), codex: usage({ gateUtil: 16, warnUtil: 16 }) },
+    ]);
+    const coordinator = new BudgetCoordinator({
+      source,
+      config: longPollConfig(),
+      emit: () => {},
+      onPauseChange: () => {},
+      now: () => now,
+      scheduler,
+    });
+
+    await coordinator.start();
+    expect(source.calls).toBe(1);
+    expect(scheduler.scheduled.at(-1)?.delayMs).toBe(47_000);
+
+    now += 47;
+    await scheduler.runNext();
+    coordinator.stop();
+
+    expect(source.calls).toBe(2);
+    expect(scheduler.scheduled.at(-1)?.delayMs).toBe(300_000);
+  });
+
+  test("fake scheduler preserves pause hysteresis and quick recovery polling", async () => {
+    let now = NOW;
+    const scheduler = new FakeScheduler();
+    const source = new FakeSource([
+      { claude: usage(), codex: usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }) },
+      { claude: usage(), codex: usage({ gateUtil: 50, warnUtil: 50, remaining: 50 }) },
+      { claude: usage(), codex: usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }) },
+    ]);
+    const emitted: Array<{ id: string; content: string }> = [];
+    const pauseChanges: boolean[] = [];
+    const coordinator = new BudgetCoordinator({
+      source,
+      config: longPollConfig(),
+      emit: (id, content) => emitted.push({ id, content }),
+      onPauseChange: (paused) => pauseChanges.push(paused),
+      now: () => now,
+      scheduler,
+    });
+
+    await coordinator.start();
+    expect(coordinator.isPaused()).toBe(true);
+    expect(scheduler.scheduled.at(-1)?.delayMs).toBe(15_000);
+
+    now += 15;
+    await scheduler.runNext();
+    expect(coordinator.isPaused()).toBe(true);
+    expect(emitted.some((event) => event.id.startsWith("system_budget_resume"))).toBe(false);
+    expect(scheduler.scheduled.at(-1)?.delayMs).toBe(15_000);
+
+    now += 15;
+    await scheduler.runNext();
+    coordinator.stop();
+
+    expect(coordinator.isPaused()).toBe(false);
+    expect(pauseChanges).toEqual([true, false]);
+    expect(emitted.some((event) => event.id.startsWith("system_budget_resume"))).toBe(true);
+  });
+
   test("start immediately polls and stores the first snapshot", async () => {
     const source = new FakeSource([{ claude: usage(), codex: usage({ gateUtil: 21, warnUtil: 21 }) }]);
     const { coordinator, emitted } = makeCoordinator(source);

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -167,7 +167,7 @@ describe("ConfigService — budget section", () => {
     const config = svc.loadOrDefault();
     expect(config.budget).toEqual({
       enabled: true,
-      pollSeconds: 60,
+      pollSeconds: 300,
       pauseAt: 90,
       resumeBelow: 30,
       syncDriftPct: 10,
@@ -257,7 +257,7 @@ describe("ConfigService — budget section", () => {
       },
     });
     const loaded = svc.load();
-    expect(loaded!.budget.pollSeconds).toBe(60);
+    expect(loaded!.budget.pollSeconds).toBe(300);
     expect(loaded!.budget.pauseAt).toBe(90);
     expect(loaded!.budget.syncDriftPct).toBe(10);
     expect(loaded!.budget.parallel.minRemainingPct).toBe(60);


### PR DESCRIPTION
## 摘要
审视报告 P1（Codex 实现，Claude 代提交）：轮询固定 pollSeconds（默认 60s）× 2 子进程 spawn，无视距 reset 远近——平时浪费 spawn，又可能错过 reset 点附近关键变化。

## 变更
- **nextBudgetPollDelayMs 纯函数**：util 远离阈值拉长间隔（省 spawn），接近 warn/pause 缩短
- **reset-epoch 对齐唤醒**：临近 5h/weekly 重置点精确安排一次唤醒
- **可注入 scheduler/clock seam**：自适应定时用假时钟单测，无墙钟等待
- active-pause 保持 15s 快轮询（300s cap 不延迟解暂停）；pause/resume 滞回不变
- 默认 pollSeconds 60→300（作长间隔 cap）；invalid env override 保持 base config

## 测试
- [x] 786 pass；ci:local 绿；cross-review **双 0 REAL**（自适应档位单调、reset 对齐时机、滞回保持、向后兼容）