### PR TITLE
fix: 日志轮转跨进程竞态 crash-safe + trace 保留 / crash-safe log rotation + trace retention

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -6518,7 +6518,7 @@ var require_dist = __commonJS((exports, module) => {
 });
 
 // src/bridge.ts
-import { existsSync as existsSync6 } from "fs";
+import { existsSync as existsSync7 } from "fs";
 
 // node_modules/zod/v4/core/core.js
 var NEVER = Object.freeze({
@@ -13668,13 +13668,14 @@ import { appendFileSync, existsSync, renameSync, statSync, unlinkSync } from "fs
 import { dirname } from "path";
 var DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
 var DEFAULT_KEEP = 3;
-function appendRotatingLog(path, content, options = {}) {
+var REAL_FS_OPS = { statSync, renameSync, unlinkSync, appendFileSync, existsSync };
+function appendRotatingLog(path, content, options = {}, fsOps = REAL_FS_OPS) {
   const maxBytes = options.maxBytes ?? positiveIntFromEnv("AGENTBRIDGE_LOG_MAX_BYTES", DEFAULT_MAX_BYTES);
   const keep = options.keep ?? positiveIntFromEnv("AGENTBRIDGE_LOG_ROTATE_KEEP", DEFAULT_KEEP);
-  if (!existsSync(dirname(path)))
+  if (!fsOps.existsSync(dirname(path)))
     return;
-  rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep);
-  appendFileSync(path, content, "utf-8");
+  rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep, fsOps);
+  fsOps.appendFileSync(path, content, "utf-8");
 }
 function positiveIntFromEnv(name, fallback) {
   const value = process.env[name];
@@ -13683,26 +13684,48 @@ function positiveIntFromEnv(name, fallback) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
-function rotateIfNeeded(path, incomingBytes, maxBytes, keep) {
+function isEnoent(error2) {
+  return !!error2 && error2.code === "ENOENT";
+}
+function renameIfPresent(from, to, fsOps) {
+  try {
+    fsOps.renameSync(from, to);
+  } catch (error2) {
+    if (!isEnoent(error2))
+      throw error2;
+  }
+}
+function unlinkIfPresent(path, fsOps) {
+  try {
+    fsOps.unlinkSync(path);
+  } catch (error2) {
+    if (!isEnoent(error2))
+      throw error2;
+  }
+}
+function rotateIfNeeded(path, incomingBytes, maxBytes, keep, fsOps) {
   if (!Number.isFinite(maxBytes) || maxBytes <= 0 || keep <= 0)
     return;
-  if (!existsSync(path))
-    return;
-  const size = statSync(path).size;
+  let size;
+  try {
+    size = fsOps.statSync(path).size;
+  } catch (error2) {
+    if (isEnoent(error2))
+      return;
+    throw error2;
+  }
   if (size + incomingBytes <= maxBytes)
     return;
   for (let index = keep;index >= 1; index--) {
     const current = `${path}.${index}`;
     const next = `${path}.${index + 1}`;
-    if (!existsSync(current))
-      continue;
     if (index === keep) {
-      unlinkSync(current);
+      unlinkIfPresent(current, fsOps);
     } else {
-      renameSync(current, next);
+      renameIfPresent(current, next, fsOps);
     }
   }
-  renameSync(path, `${path}.1`);
+  renameIfPresent(path, `${path}.1`, fsOps);
 }
 
 // src/process-log.ts
@@ -14231,7 +14254,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("63c4412", "source"),
+  commit: defineString("bbdc792", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -15309,8 +15332,10 @@ function nonEmpty(value) {
 }
 
 // src/trace-log.ts
-import { appendFileSync as appendFileSync2, mkdirSync as mkdirSync4 } from "fs";
+import { appendFileSync as appendFileSync2, existsSync as existsSync6, mkdirSync as mkdirSync4, readdirSync as readdirSync2, statSync as statSync4, unlinkSync as unlinkSync4 } from "fs";
 import { join as join4 } from "path";
+var TRACE_RETENTION_DAYS = 7;
+var TRACE_FILE_RE = /^trace-\d{4}-\d{2}-\d{2}\.jsonl$/;
 var SECRET_KEY_RE = /(token|secret|password|passwd|api[_-]?key|auth|cookie|session)/i;
 var SECRET_ARG_RE = /^--?(?:token|secret|password|passwd|apikey|api-key|api_key|auth|cookie|session)(?:=.*)?$/i;
 var RELEVANT_ENV_RE = /^(AGENTBRIDGE_|CODEX_)/;
@@ -15362,10 +15387,38 @@ function appendTraceEvent(input) {
     ...input.env ? { env: pickRelevantEnv(input.env) } : {},
     ...input.data ? { data: redactData(input.data) } : {}
   };
-  mkdirSync4(join4(input.cwd, ".agentbridge", "logs"), { recursive: true });
+  const logsDir = join4(input.cwd, ".agentbridge", "logs");
+  const isNewDayFile = !existsSync6(path);
+  mkdirSync4(logsDir, { recursive: true });
+  if (isNewDayFile) {
+    pruneOldTraceLogs(logsDir, path, Date.parse(timestamp));
+  }
   appendFileSync2(path, JSON.stringify(event) + `
 `, "utf-8");
   return path;
+}
+function pruneOldTraceLogs(logsDir, keepPath, nowMs) {
+  if (!Number.isFinite(nowMs))
+    return;
+  const cutoff = nowMs - TRACE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  let entries;
+  try {
+    entries = readdirSync2(logsDir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (!TRACE_FILE_RE.test(name))
+      continue;
+    const filePath = join4(logsDir, name);
+    if (filePath === keepPath)
+      continue;
+    try {
+      if (statSync4(filePath).mtimeMs < cutoff) {
+        unlinkSync4(filePath);
+      }
+    } catch {}
+  }
 }
 function isEnvSnapshot(key, value) {
   return /env$/i.test(key) && !!value && typeof value === "object" && !Array.isArray(value);
@@ -15601,7 +15654,7 @@ async function notifyIfDaemonKilled(logMessage) {
   return true;
 }
 async function notifyIfPairRemoved(logMessage) {
-  if (existsSync6(stateDir.dir))
+  if (existsSync7(stateDir.dir))
     return false;
   await enterDisabledState(logMessage, `\u26D4 This pair's state directory was removed (\`abg pairs rm\` / \`prune\`). Bridge is staying idle. Start fresh with \`${pairScopedCommand("claude")}\` if you still need this pair. \u8BE5 pair \u7684\u72B6\u6001\u76EE\u5F55\u5DF2\u88AB\u5220\u9664\uFF08pairs rm / prune\uFF09\uFF0C\u6865\u63A5\u4FDD\u6301\u5F85\u673A\uFF1B\u5982\u4ECD\u9700\u8981\u8BF7\u7528 \`${pairScopedCommand("claude")}\` \u91CD\u65B0\u542F\u52A8\u3002`);
   return true;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("63c4412", "source"),
+  commit: defineString("bbdc792", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -209,13 +209,14 @@ import { appendFileSync, existsSync as existsSync2, renameSync, statSync, unlink
 import { dirname } from "path";
 var DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
 var DEFAULT_KEEP = 3;
-function appendRotatingLog(path, content, options = {}) {
+var REAL_FS_OPS = { statSync, renameSync, unlinkSync, appendFileSync, existsSync: existsSync2 };
+function appendRotatingLog(path, content, options = {}, fsOps = REAL_FS_OPS) {
   const maxBytes = options.maxBytes ?? positiveIntFromEnv("AGENTBRIDGE_LOG_MAX_BYTES", DEFAULT_MAX_BYTES);
   const keep = options.keep ?? positiveIntFromEnv("AGENTBRIDGE_LOG_ROTATE_KEEP", DEFAULT_KEEP);
-  if (!existsSync2(dirname(path)))
+  if (!fsOps.existsSync(dirname(path)))
     return;
-  rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep);
-  appendFileSync(path, content, "utf-8");
+  rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep, fsOps);
+  fsOps.appendFileSync(path, content, "utf-8");
 }
 function positiveIntFromEnv(name, fallback) {
   const value = process.env[name];
@@ -224,26 +225,48 @@ function positiveIntFromEnv(name, fallback) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
-function rotateIfNeeded(path, incomingBytes, maxBytes, keep) {
+function isEnoent(error) {
+  return !!error && error.code === "ENOENT";
+}
+function renameIfPresent(from, to, fsOps) {
+  try {
+    fsOps.renameSync(from, to);
+  } catch (error) {
+    if (!isEnoent(error))
+      throw error;
+  }
+}
+function unlinkIfPresent(path, fsOps) {
+  try {
+    fsOps.unlinkSync(path);
+  } catch (error) {
+    if (!isEnoent(error))
+      throw error;
+  }
+}
+function rotateIfNeeded(path, incomingBytes, maxBytes, keep, fsOps) {
   if (!Number.isFinite(maxBytes) || maxBytes <= 0 || keep <= 0)
     return;
-  if (!existsSync2(path))
-    return;
-  const size = statSync(path).size;
+  let size;
+  try {
+    size = fsOps.statSync(path).size;
+  } catch (error) {
+    if (isEnoent(error))
+      return;
+    throw error;
+  }
   if (size + incomingBytes <= maxBytes)
     return;
   for (let index = keep;index >= 1; index--) {
     const current = `${path}.${index}`;
     const next = `${path}.${index + 1}`;
-    if (!existsSync2(current))
-      continue;
     if (index === keep) {
-      unlinkSync(current);
+      unlinkIfPresent(current, fsOps);
     } else {
-      renameSync(current, next);
+      renameIfPresent(current, next, fsOps);
     }
   }
-  renameSync(path, `${path}.1`);
+  renameIfPresent(path, `${path}.1`, fsOps);
 }
 
 // src/process-log.ts

--- a/src/rotating-log.ts
+++ b/src/rotating-log.ts
@@ -4,10 +4,31 @@ import { dirname } from "node:path";
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
 const DEFAULT_KEEP = 3;
 
+/**
+ * The subset of node:fs the rotation path touches, behind an injectable seam.
+ *
+ * Production code always uses {@link REAL_FS_OPS} (the real node:fs functions).
+ * The seam exists ONLY so tests can deterministically inject the ENOENT that a
+ * concurrent cross-process writer would produce mid-rotation — a static ESM
+ * `import { renameSync }` binding cannot be monkey-patched after load, so a
+ * test reassigning `fs.renameSync` would never reach this code and would
+ * silently validate nothing. Default = real fs ⇒ no behavioral change.
+ */
+export interface FsOps {
+  statSync: typeof statSync;
+  renameSync: typeof renameSync;
+  unlinkSync: typeof unlinkSync;
+  appendFileSync: typeof appendFileSync;
+  existsSync: typeof existsSync;
+}
+
+const REAL_FS_OPS: FsOps = { statSync, renameSync, unlinkSync, appendFileSync, existsSync };
+
 export function appendRotatingLog(
   path: string,
   content: string,
   options: { maxBytes?: number; keep?: number } = {},
+  fsOps: FsOps = REAL_FS_OPS,
 ): void {
   const maxBytes = options.maxBytes ?? positiveIntFromEnv("AGENTBRIDGE_LOG_MAX_BYTES", DEFAULT_MAX_BYTES);
   const keep = options.keep ?? positiveIntFromEnv("AGENTBRIDGE_LOG_ROTATE_KEEP", DEFAULT_KEEP);
@@ -16,9 +37,19 @@ export function appendRotatingLog(
   // the pair was removed (abg pairs rm / prune) while this process survived.
   // The old unconditional mkdir resurrected removed pair dirs as unregistered
   // orphans on every log line. Best-effort logging drops the line instead.
-  if (!existsSync(dirname(path))) return;
-  rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep);
-  appendFileSync(path, content, "utf-8");
+  if (!fsOps.existsSync(dirname(path))) return;
+  // Crash-safe rotation race handling:
+  // The SAME agentbridge.log is appended by TWO cross-process writers (the
+  // daemon process and the foreground bridge process). Single-writer rotation
+  // is not safe here because the daemon does not own the file's growth — a
+  // foreground burst can blow past maxBytes between daemon writes. So instead
+  // we make the rotation ACTION race-tolerant: every step ignores ENOENT (the
+  // peer already moved that file), so a concurrent rotation can neither throw
+  // out of the append path nor skip/over-unlink a generation. No retry is
+  // needed: even if a peer rotated `path` away mid-flight, the appendFileSync
+  // below recreates it, so no log line is ever lost.
+  rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep, fsOps);
+  fsOps.appendFileSync(path, content, "utf-8");
 }
 
 function positiveIntFromEnv(name: string, fallback: number): number {
@@ -28,21 +59,62 @@ function positiveIntFromEnv(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
 
-function rotateIfNeeded(path: string, incomingBytes: number, maxBytes: number, keep: number): void {
+function isEnoent(error: unknown): boolean {
+  return !!error && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+/** rename that treats a vanished source as a benign no-op (peer already moved it). */
+function renameIfPresent(from: string, to: string, fsOps: FsOps): void {
+  try {
+    fsOps.renameSync(from, to);
+  } catch (error) {
+    // A concurrent writer rotated `from` out from under us. The generation it
+    // represents has already advanced; silently skipping keeps the cascade
+    // crash-safe without over-unlinking or throwing.
+    if (!isEnoent(error)) throw error;
+  }
+}
+
+/** unlink that treats a vanished target as a benign no-op (peer already removed it). */
+function unlinkIfPresent(path: string, fsOps: FsOps): void {
+  try {
+    fsOps.unlinkSync(path);
+  } catch (error) {
+    if (!isEnoent(error)) throw error;
+  }
+}
+
+function rotateIfNeeded(
+  path: string,
+  incomingBytes: number,
+  maxBytes: number,
+  keep: number,
+  fsOps: FsOps,
+): void {
   if (!Number.isFinite(maxBytes) || maxBytes <= 0 || keep <= 0) return;
-  if (!existsSync(path)) return;
-  const size = statSync(path).size;
+
+  let size: number;
+  try {
+    size = fsOps.statSync(path).size;
+  } catch (error) {
+    // No current log yet (or a peer just rotated it away): nothing to rotate.
+    if (isEnoent(error)) return;
+    throw error;
+  }
   if (size + incomingBytes <= maxBytes) return;
 
   for (let index = keep; index >= 1; index--) {
     const current = `${path}.${index}`;
     const next = `${path}.${index + 1}`;
-    if (!existsSync(current)) continue;
     if (index === keep) {
-      unlinkSync(current);
+      unlinkIfPresent(current, fsOps);
     } else {
-      renameSync(current, next);
+      renameIfPresent(current, next, fsOps);
     }
   }
-  renameSync(path, `${path}.1`);
+  // The head rename is the one that races hardest: two writers can both decide
+  // to rotate, and only the first `path -> path.1` wins. If our rename finds
+  // the head already gone (peer rotated it), that is success, not a lost line —
+  // the append below recreates `path` fresh.
+  renameIfPresent(path, `${path}.1`, fsOps);
 }

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -1,5 +1,9 @@
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
+
+/** Trace files older than this (by mtime) are pruned when a new day's file is created. */
+export const TRACE_RETENTION_DAYS = 7;
+const TRACE_FILE_RE = /^trace-\d{4}-\d{2}-\d{2}\.jsonl$/;
 
 const SECRET_KEY_RE = /(token|secret|password|passwd|api[_-]?key|auth|cookie|session)/i;
 const SECRET_ARG_RE = /^--?(?:token|secret|password|passwd|apikey|api-key|api_key|auth|cookie|session)(?:=.*)?$/i;
@@ -86,9 +90,49 @@ export function appendTraceEvent(input: TraceEventInput): string {
     ...(input.data ? { data: redactData(input.data) } : {}),
   };
 
-  mkdirSync(join(input.cwd, ".agentbridge", "logs"), { recursive: true });
+  const logsDir = join(input.cwd, ".agentbridge", "logs");
+  // Built-in retention: trace-<day>.jsonl files have no maxBytes and accumulate
+  // one per day forever. We prune only when a NEW day's file is about to be
+  // created (a cheap, self-limiting trigger that runs at most once per UTC day
+  // per process), deleting same-dir trace files whose mtime predates the
+  // retention window. `now` is derived from the event timestamp so callers can
+  // drive deterministic tests.
+  const isNewDayFile = !existsSync(path);
+  mkdirSync(logsDir, { recursive: true });
+  if (isNewDayFile) {
+    pruneOldTraceLogs(logsDir, path, Date.parse(timestamp));
+  }
   appendFileSync(path, JSON.stringify(event) + "\n", "utf-8");
   return path;
+}
+
+/**
+ * Delete trace-*.jsonl files in `logsDir` whose mtime is older than
+ * TRACE_RETENTION_DAYS relative to `nowMs`. Best-effort: never throws (it runs
+ * inside the best-effort logging path). The just-created file (`keepPath`) and
+ * any non-trace file are always left untouched.
+ */
+function pruneOldTraceLogs(logsDir: string, keepPath: string, nowMs: number): void {
+  if (!Number.isFinite(nowMs)) return;
+  const cutoff = nowMs - TRACE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  let entries: string[];
+  try {
+    entries = readdirSync(logsDir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (!TRACE_FILE_RE.test(name)) continue;
+    const filePath = join(logsDir, name);
+    if (filePath === keepPath) continue;
+    try {
+      if (statSync(filePath).mtimeMs < cutoff) {
+        unlinkSync(filePath);
+      }
+    } catch {
+      // A peer process may have removed it first, or stat raced — ignore.
+    }
+  }
 }
 
 /** A `data` field that is an env snapshot (key ends in "env", value is a plain object). */

--- a/src/unit-test/rotating-log.test.ts
+++ b/src/unit-test/rotating-log.test.ts
@@ -1,8 +1,28 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { appendRotatingLog } from "../rotating-log";
+import { type FsOps, appendRotatingLog } from "../rotating-log";
+
+/**
+ * Real fs ops wired through the production injection seam. Tests clone this and
+ * override a single op to inject the exact ENOENT a concurrent cross-process
+ * writer produces mid-rotation. (A static ESM `import { renameSync }` binding
+ * cannot be monkey-patched after load, so reassigning `fs.renameSync` would
+ * never reach the production code — hence the seam.)
+ */
+const realFsOps: FsOps = { statSync, renameSync, unlinkSync, appendFileSync, existsSync };
 
 describe("appendRotatingLog", () => {
   test("rotates when appending would exceed max bytes", () => {
@@ -30,6 +50,161 @@ describe("appendRotatingLog", () => {
 
       expect(readFileSync(path, "utf-8")).toBe("next\n");
       expect(readFileSync(`${path}.1`, "utf-8")).toBe("oversized\n");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps exactly `keep` rotated generations and drops the oldest (no regression)", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-log-"));
+    try {
+      const path = join(root, "agentbridge.log");
+      // keep=3 → at most path.1, path.2, path.3 survive; the 4th generation is dropped.
+      appendRotatingLog(path, "g1\n", { maxBytes: 4, keep: 3 });
+      appendRotatingLog(path, "g2\n", { maxBytes: 4, keep: 3 });
+      appendRotatingLog(path, "g3\n", { maxBytes: 4, keep: 3 });
+      appendRotatingLog(path, "g4\n", { maxBytes: 4, keep: 3 });
+      appendRotatingLog(path, "g5\n", { maxBytes: 4, keep: 3 });
+
+      expect(readFileSync(path, "utf-8")).toBe("g5\n");
+      expect(readFileSync(`${path}.1`, "utf-8")).toBe("g4\n");
+      expect(readFileSync(`${path}.2`, "utf-8")).toBe("g3\n");
+      expect(readFileSync(`${path}.3`, "utf-8")).toBe("g2\n");
+      expect(existsSync(`${path}.4`)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("ENOENT during the head rename does not throw and does not lose the line", () => {
+    // Simulate the cross-process interleaving where a PEER writer rotates the
+    // current log away in the gap between our oversize check and our head
+    // rename. The append must still land (no lost line) and must not throw.
+    //
+    // The injected renameSync models the peer winning the `path -> path.1` race:
+    // it performs the real move (the peer's effect) and then throws ENOENT — the
+    // error OUR own rename would observe finding the source already gone. The
+    // production code must swallow that ENOENT and let appendFileSync recreate
+    // `path`. If the ENOENT-tolerance is reverted, the throw escapes and this
+    // test FAILS — that is what makes it non-vacuous.
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-log-"));
+    try {
+      const path = join(root, "agentbridge.log");
+      writeFileSync(path, "oversized-current\n", "utf-8");
+
+      let armed = true;
+      const fsOps: FsOps = {
+        ...realFsOps,
+        renameSync: ((from: string, to: string) => {
+          if (armed && from === path) {
+            armed = false;
+            // Peer already moved `path` to `path.1`; our rename now races ENOENT.
+            renameSync(from, to);
+            const err: NodeJS.ErrnoException = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+            throw err;
+          }
+          return renameSync(from, to);
+        }) as typeof renameSync,
+      };
+
+      expect(() =>
+        appendRotatingLog(path, "new-line\n", { maxBytes: 8, keep: 3 }, fsOps),
+      ).not.toThrow();
+
+      // The injected ENOENT must actually have fired — guards against a future
+      // refactor silently bypassing the head rename and re-vacuating the test.
+      expect(armed).toBe(false);
+
+      // No line lost: the peer's rotated copy AND our fresh append both survive.
+      expect(readFileSync(path, "utf-8")).toBe("new-line\n");
+      expect(readFileSync(`${path}.1`, "utf-8")).toBe("oversized-current\n");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("concurrent interleaved appends to the same file keep every line and skip no generation", () => {
+    // Model two cross-process writers (A=daemon, B=foreground) appending to the
+    // SAME log, each independently calling appendRotatingLog. Interleave them so
+    // both repeatedly cross the rotation threshold. On a deterministic subset of
+    // rotations we inject the peer-already-rotated ENOENT at BOTH the head rename
+    // (`path -> path.1`) and an intermediate rename (`path.1 -> path.2`): the
+    // mock performs the real move (the peer's effect) and then throws ENOENT —
+    // exactly what our own racing op observes once the source is gone. The
+    // production cascade must swallow those ENOENTs and never throw out of the
+    // append path, never lose a line, and never skip a generation. Reverting the
+    // ENOENT-tolerance lets the injected throw escape ⇒ the `not.toThrow()`
+    // assertion below fails, proving the test is non-vacuous.
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-log-"));
+    try {
+      const path = join(root, "agentbridge.log");
+      const keep = 3;
+      const maxBytes = 16;
+      const head = path;
+      const firstRotated = `${path}.1`;
+
+      let injectedHead = 0;
+      let injectedIntermediate = 0;
+      // Inject on a fixed cadence so the peer-race branch is hit repeatedly and
+      // deterministically across the 30 writes.
+      let rotationRound = 0;
+      const fsOps: FsOps = {
+        ...realFsOps,
+        renameSync: ((from: string, to: string) => {
+          // Tie the injection cadence to head renames (one per rotation round).
+          if (from === head) {
+            rotationRound++;
+            if (rotationRound % 2 === 0) {
+              renameSync(from, to);
+              injectedHead++;
+              throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+            }
+          } else if (from === firstRotated && rotationRound % 3 === 0) {
+            // Intermediate generation also races a peer on some rounds.
+            renameSync(from, to);
+            injectedIntermediate++;
+            throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+          }
+          return renameSync(from, to);
+        }) as typeof renameSync,
+      };
+
+      const written: string[] = [];
+      // 30 small writes, alternating "writers". Each line is unique so we can
+      // verify presence/loss precisely.
+      for (let i = 0; i < 30; i++) {
+        const writer = i % 2 === 0 ? "A" : "B";
+        const line = `${writer}-${i}\n`;
+        written.push(line);
+        expect(() => appendRotatingLog(path, line, { maxBytes, keep }, fsOps)).not.toThrow();
+      }
+
+      // The injected peer-race ENOENT must actually have fired (otherwise the
+      // test would silently degrade to the ordinary rotation path and validate
+      // nothing about the crash-safe cascade).
+      expect(injectedHead).toBeGreaterThan(0);
+      expect(injectedIntermediate).toBeGreaterThan(0);
+
+      // Reconstruct everything still on disk (current + rotated generations).
+      const files = readdirSync(root).filter((name) => name.startsWith("agentbridge.log"));
+      const onDisk = files.map((name) => readFileSync(join(root, name), "utf-8")).join("");
+
+      // The most recent line must always be present (just appended, never rotated out).
+      expect(onDisk).toContain(written[written.length - 1]!);
+
+      // Generation invariant: never more than keep rotated files (path.1..path.keep).
+      const rotated = files.filter((name) => /\.\d+$/.test(name));
+      expect(rotated.length).toBeLessThanOrEqual(keep);
+
+      // The lines that survived must be a contiguous suffix of the write order
+      // (rotation drops oldest-first; it must not punch holes / skip a
+      // generation in the middle).
+      const present = written.map((line) => onDisk.includes(line));
+      const firstPresent = present.indexOf(true);
+      expect(firstPresent).toBeGreaterThanOrEqual(0);
+      for (let i = firstPresent; i < present.length; i++) {
+        expect(present[i]).toBe(true);
+      }
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/unit-test/trace-log.test.ts
+++ b/src/unit-test/trace-log.test.ts
@@ -1,8 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  TRACE_RETENTION_DAYS,
   appendTraceEvent,
   pickRelevantEnv,
   redactArgv,
@@ -152,5 +161,96 @@ describe("trace log", () => {
     expect(serialized).not.toContain("SUPERSECRETPW");
     expect(serialized).not.toContain("sentry.io");
     expect(serialized).not.toContain("DATABASE_URL");
+  });
+});
+
+describe("trace log retention", () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  function logsDirFor(cwd: string): string {
+    const dir = join(cwd, ".agentbridge", "logs");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  /** Create a trace file with a specific mtime (ageDays in the past relative to `nowMs`). */
+  function seedTraceFile(logsDir: string, name: string, nowMs: number, ageDays: number): string {
+    const filePath = join(logsDir, name);
+    writeFileSync(filePath, '{"seed":true}\n', "utf-8");
+    const mtimeSec = (nowMs - ageDays * DAY_MS) / 1000;
+    utimesSync(filePath, mtimeSec, mtimeSec);
+    return filePath;
+  }
+
+  test("creating a new day's file prunes only trace files older than the retention window", () => {
+    const cwd = tempCwd();
+    const logsDir = logsDirFor(cwd);
+    const now = Date.parse("2026-06-11T00:00:00.000Z");
+
+    // Older than the window → must be deleted.
+    const stale = seedTraceFile(logsDir, "trace-2026-05-01.jsonl", now, TRACE_RETENTION_DAYS + 1);
+    // Inside the window → must be kept.
+    const recent = seedTraceFile(logsDir, "trace-2026-06-08.jsonl", now, TRACE_RETENTION_DAYS - 1);
+    // Just inside the boundary (younger than the cutoff) → kept. We back off a
+    // fraction of a day so second-precision mtime rounding cannot flip it.
+    const boundary = seedTraceFile(logsDir, "trace-2026-06-04.jsonl", now, TRACE_RETENTION_DAYS - 0.5);
+    // A non-trace file must never be touched, even if ancient.
+    const unrelated = join(logsDir, "agentbridge.log");
+    writeFileSync(unrelated, "keep me\n", "utf-8");
+    utimesSync(unrelated, (now - 999 * DAY_MS) / 1000, (now - 999 * DAY_MS) / 1000);
+
+    // Trigger: write the FIRST event of a brand-new day.
+    const todayPath = appendTraceEvent({
+      cwd,
+      event: "bridge.start",
+      timestamp: "2026-06-11T09:00:00.000Z",
+    });
+
+    expect(existsSync(stale)).toBe(false);
+    expect(existsSync(recent)).toBe(true);
+    expect(existsSync(boundary)).toBe(true);
+    expect(existsSync(unrelated)).toBe(true);
+    expect(existsSync(todayPath)).toBe(true);
+  });
+
+  test("does not prune the just-created day's file even if its own mtime looks old", () => {
+    const cwd = tempCwd();
+    const logsDir = logsDirFor(cwd);
+    const now = Date.parse("2026-06-11T00:00:00.000Z");
+
+    // Pre-create today's file with an ancient mtime, then append (existing file
+    // → not a new-day write → no prune runs, and the file is preserved).
+    const todayPath = join(logsDir, "trace-2026-06-11.jsonl");
+    writeFileSync(todayPath, '{"pre":true}\n', "utf-8");
+    utimesSync(todayPath, (now - 999 * DAY_MS) / 1000, (now - 999 * DAY_MS) / 1000);
+
+    const returned = appendTraceEvent({
+      cwd,
+      event: "bridge.start",
+      timestamp: "2026-06-11T09:00:00.000Z",
+    });
+
+    expect(returned).toBe(todayPath);
+    expect(existsSync(todayPath)).toBe(true);
+    // Append preserved prior content (no truncation) and added the new event.
+    const lines = readFileSync(todayPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+  });
+
+  test("appending to an existing day file does not trigger pruning", () => {
+    const cwd = tempCwd();
+    const logsDir = logsDirFor(cwd);
+    const now = Date.parse("2026-06-11T00:00:00.000Z");
+    const stale = seedTraceFile(logsDir, "trace-2026-05-01.jsonl", now, TRACE_RETENTION_DAYS + 5);
+
+    // First write of the day → creates file → prunes stale.
+    appendTraceEvent({ cwd, event: "first", timestamp: "2026-06-11T08:00:00.000Z" });
+    expect(existsSync(stale)).toBe(false);
+
+    // Re-seed a stale file, then append again to the SAME (now existing) day
+    // file — this must NOT prune (trigger is new-day-file creation only).
+    const stale2 = seedTraceFile(logsDir, "trace-2026-05-02.jsonl", now, TRACE_RETENTION_DAYS + 5);
+    appendTraceEvent({ cwd, event: "second", timestamp: "2026-06-11T08:05:00.000Z" });
+    expect(existsSync(stale2)).toBe(true);
   });
 });


### PR DESCRIPTION
## 摘要
审视报告 P1：rotating-log 轮转裸序列无并发防护，agentbridge.log 由 daemon + 前台 bridge 两进程跨进程并发追加——同时越 maxBytes 时后到者 rename 抛 ENOENT 该行静默吞，更糟的交错把一代日志提前顶掉。trace 无保留策略。

## 变更
- rotation crash-safe cascade：每步容忍 ENOENT（peer 已移走），最终 appendFileSync 重建 path → 不丢行、不错代
- trace retention：新天文件创建时删同目录 mtime>7天的 trace-*.jsonl
- 可注入 fsOps seam（默认 REAL_FS_OPS）让测试确定性驱动 production ENOENT 分支；签名字节不变

## 测试
- [x] 749 pass；ci:local 绿；cross-review R1 抓测试 vacuous（静态 named import 无法 monkey-patch）→ 改注入 seam → **R2 双 0 REAL（mutation 复证：neuter→2 测试 fail，restore→pass）**