### PR TITLE
refactor: daemon 复用/替换判定表驱动化 classifyDaemon + manual-conflict lock-path 收口 / table-driven daemon classify

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14274,7 +14274,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("b0c8a46", "source"),
+  commit: defineString("5840cb3", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14611,6 +14611,48 @@ var REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES",
 var REUSE_READY_DELAY_MS = 250;
 var HEALTH_FETCH_TIMEOUT_MS = 500;
 var LOCK_IDENTITY_GRACE_MS = parsePositiveIntEnv("AGENTBRIDGE_LOCK_IDENTITY_GRACE_MS", 120000);
+function isReuseVerdict(verdict) {
+  return verdict === "reuse" || verdict === "reuse-despite-drift";
+}
+function classifyDaemon(expectedPairId, status, buildInfo) {
+  if (!status) {
+    return { verdict: "unreachable", reason: "daemon status is unavailable or unparseable" };
+  }
+  const reportedPairId = status.pairId;
+  if (!expectedPairId && reportedPairId != null) {
+    return {
+      verdict: "manual-conflict",
+      reason: `manual mode must not adopt registered pair ${reportedPairId}`
+    };
+  }
+  if (expectedPairId) {
+    if (reportedPairId == null) {
+      return {
+        verdict: "replace-foreign",
+        reason: `pair ${expectedPairId} found daemon without pair identity`
+      };
+    }
+    if (reportedPairId !== expectedPairId) {
+      return {
+        verdict: "replace-foreign",
+        reason: `pair ${expectedPairId} found daemon for pair ${reportedPairId}`
+      };
+    }
+  }
+  if (!sameRuntimeContract(status.build, buildInfo)) {
+    if (compatibleContractVersion(status.build, buildInfo) && status.tuiConnected === true) {
+      return {
+        verdict: "reuse-despite-drift",
+        reason: "runtime build drift has a compatible contract and a live Codex TUI is attached"
+      };
+    }
+    return {
+      verdict: "replace-drifted",
+      reason: `runtime build ${formatBuildInfo(status.build)} does not match launcher ${formatBuildInfo(buildInfo)}`
+    };
+  }
+  return { verdict: "reuse", reason: "daemon pair and runtime contract match" };
+}
 
 class DaemonLifecycle {
   stateDir;
@@ -14643,52 +14685,37 @@ class DaemonLifecycle {
       return null;
     }
   }
-  isForeignDaemon(status) {
-    const expected = this.expectedPairId;
-    if (!expected)
-      return false;
-    if (!status)
-      return false;
-    const reported = status.pairId;
-    if (reported == null)
-      return true;
-    return reported !== expected;
+  classifyDaemon(status) {
+    const classification = classifyDaemon(this.expectedPairId, status, BUILD_INFO);
+    if (process.env.AGENTBRIDGE_ALLOW_BUILD_DRIFT === "1" && (classification.verdict === "replace-drifted" || classification.verdict === "unreachable")) {
+      return { verdict: "reuse", reason: "build drift replacement disabled by AGENTBRIDGE_ALLOW_BUILD_DRIFT" };
+    }
+    return classification;
   }
-  isRegisteredPairDaemonInManualMode(status) {
-    return !this.expectedPairId && status?.pairId != null;
-  }
-  isBuildDrifted(status) {
-    if (process.env.AGENTBRIDGE_ALLOW_BUILD_DRIFT === "1")
-      return false;
-    const runtime = status?.build;
-    if (!runtime)
-      return true;
-    return !sameRuntimeContract(runtime, BUILD_INFO);
-  }
-  canReuseDespiteDrift(status) {
-    if (!compatibleContractVersion(status?.build, BUILD_INFO))
-      return false;
-    return status?.tuiConnected === true;
+  manualConflictError(status) {
+    return new Error(`Control port ${this.controlPort} is owned by registered pair ${status?.pairId}. ` + `This session has no pair identity (manual mode) and will not reuse or replace it \u2014 ` + `start with \`agentbridge claude\` from that pair's directory, or set AGENTBRIDGE_CONTROL_PORT to a free port.`);
   }
   async ensureRunning() {
     if (await this.isHealthy()) {
       const status = await this.fetchStatus();
-      if (this.isRegisteredPairDaemonInManualMode(status)) {
-        throw new Error(`Control port ${this.controlPort} is owned by registered pair ${status?.pairId}. ` + `This session has no pair identity (manual mode) and will not reuse or replace it \u2014 ` + `start with \`agentbridge claude\` from that pair's directory, or set AGENTBRIDGE_CONTROL_PORT to a free port.`);
-      }
-      if (this.isForeignDaemon(status)) {
-        this.log(`Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` + `but this pair is ${this.expectedPairId} \u2014 replacing foreign daemon`);
-        await this.replaceUnhealthyDaemon(status?.pid);
-        return;
-      }
-      if (this.isBuildDrifted(status)) {
-        if (this.canReuseDespiteDrift(status)) {
-          this.log(`Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` + `(launcher ${formatBuildInfo(BUILD_INFO)}) but a live Codex TUI is attached \u2014 reusing instead of ` + `replacing; the new build is picked up at the next restart (abg kill, then relaunch)`);
-        } else {
+      const classification = this.classifyDaemon(status);
+      switch (classification.verdict) {
+        case "manual-conflict":
+          throw this.manualConflictError(status);
+        case "replace-foreign":
+          this.log(`Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` + `but this pair is ${this.expectedPairId} \u2014 replacing foreign daemon`);
+          await this.replaceUnhealthyDaemon(status?.pid);
+          return;
+        case "replace-drifted":
+        case "unreachable":
           this.log(`Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` + `but launcher is ${formatBuildInfo(BUILD_INFO)} \u2014 replacing drifted daemon`);
           await this.replaceUnhealthyDaemon(status?.pid);
           return;
-        }
+        case "reuse-despite-drift":
+          this.log(`Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` + `(launcher ${formatBuildInfo(BUILD_INFO)}) but a live Codex TUI is attached \u2014 reusing instead of ` + `replacing; the new build is picked up at the next restart (abg kill, then relaunch)`);
+          break;
+        case "reuse":
+          break;
       }
       try {
         await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
@@ -14718,14 +14745,17 @@ class DaemonLifecycle {
     }
     await this.withStartupLockStrict(async (locked) => {
       if (!locked) {
-        this.log("Another process holds the startup lock, waiting for readiness+identity...");
-        await this.waitForReadyAndOurs();
+        await this.waitForContendedStartupLock();
         return;
       }
       if (await this.isHealthy()) {
         const status = await this.fetchStatus();
-        if (this.isForeignDaemon(status) || this.isBuildDrifted(status) && !this.canReuseDespiteDrift(status)) {
-          this.log(`Daemon on control port ${this.controlPort} is not reusable under startup lock ` + `(pair=${status?.pairId ?? "<none>"}, build=${formatBuildInfo(status?.build)}) \u2014 replacing`);
+        const classification = this.classifyDaemon(status);
+        if (classification.verdict === "manual-conflict") {
+          throw this.manualConflictError(status);
+        }
+        if (!isReuseVerdict(classification.verdict)) {
+          this.log(`Daemon on control port ${this.controlPort} is not reusable under startup lock ` + `(pair=${status?.pairId ?? "<none>"}, build=${formatBuildInfo(status?.build)}, ` + `reason=${classification.reason}) \u2014 replacing`);
           await this.kill(3000, status?.pid);
         } else {
           try {
@@ -14777,7 +14807,11 @@ class DaemonLifecycle {
     for (let attempt = 0;attempt < maxRetries; attempt++) {
       if (await this.isReady()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status) && (!this.isBuildDrifted(status) || this.canReuseDespiteDrift(status))) {
+        const classification = this.classifyDaemon(status);
+        if (classification.verdict === "manual-conflict") {
+          throw this.manualConflictError(status);
+        }
+        if (isReuseVerdict(classification.verdict)) {
           return;
         }
       }
@@ -14859,13 +14893,16 @@ class DaemonLifecycle {
   async replaceUnhealthyDaemon(statusPid) {
     await this.withStartupLockStrict(async (locked) => {
       if (!locked) {
-        this.log("Another process holds the startup lock, waiting for readiness+identity...");
-        await this.waitForReadyAndOurs();
+        await this.waitForContendedStartupLock();
         return;
       }
       if (await this.isHealthy()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status) && (!this.isBuildDrifted(status) || this.canReuseDespiteDrift(status))) {
+        const classification = this.classifyDaemon(status);
+        if (classification.verdict === "manual-conflict") {
+          throw this.manualConflictError(status);
+        }
+        if (isReuseVerdict(classification.verdict)) {
           try {
             await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
@@ -14877,6 +14914,10 @@ class DaemonLifecycle {
       this.launch();
       await this.waitForReady();
     });
+  }
+  async waitForContendedStartupLock() {
+    this.log("Another process holds the startup lock, waiting for readiness+identity...");
+    await this.waitForReadyAndOurs();
   }
   async withStartupLockStrict(fn) {
     const locked = this.acquireLockStrict();

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.11", "0.0.0-source"),
-  commit: defineString("b0c8a46", "source"),
+  commit: defineString("5840cb3", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2444,6 +2444,48 @@ var REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES",
 var REUSE_READY_DELAY_MS = 250;
 var HEALTH_FETCH_TIMEOUT_MS = 500;
 var LOCK_IDENTITY_GRACE_MS = parsePositiveIntEnv("AGENTBRIDGE_LOCK_IDENTITY_GRACE_MS", 120000);
+function isReuseVerdict(verdict) {
+  return verdict === "reuse" || verdict === "reuse-despite-drift";
+}
+function classifyDaemon(expectedPairId, status, buildInfo) {
+  if (!status) {
+    return { verdict: "unreachable", reason: "daemon status is unavailable or unparseable" };
+  }
+  const reportedPairId = status.pairId;
+  if (!expectedPairId && reportedPairId != null) {
+    return {
+      verdict: "manual-conflict",
+      reason: `manual mode must not adopt registered pair ${reportedPairId}`
+    };
+  }
+  if (expectedPairId) {
+    if (reportedPairId == null) {
+      return {
+        verdict: "replace-foreign",
+        reason: `pair ${expectedPairId} found daemon without pair identity`
+      };
+    }
+    if (reportedPairId !== expectedPairId) {
+      return {
+        verdict: "replace-foreign",
+        reason: `pair ${expectedPairId} found daemon for pair ${reportedPairId}`
+      };
+    }
+  }
+  if (!sameRuntimeContract(status.build, buildInfo)) {
+    if (compatibleContractVersion(status.build, buildInfo) && status.tuiConnected === true) {
+      return {
+        verdict: "reuse-despite-drift",
+        reason: "runtime build drift has a compatible contract and a live Codex TUI is attached"
+      };
+    }
+    return {
+      verdict: "replace-drifted",
+      reason: `runtime build ${formatBuildInfo(status.build)} does not match launcher ${formatBuildInfo(buildInfo)}`
+    };
+  }
+  return { verdict: "reuse", reason: "daemon pair and runtime contract match" };
+}
 
 class DaemonLifecycle {
   stateDir;
@@ -2476,52 +2518,37 @@ class DaemonLifecycle {
       return null;
     }
   }
-  isForeignDaemon(status) {
-    const expected = this.expectedPairId;
-    if (!expected)
-      return false;
-    if (!status)
-      return false;
-    const reported = status.pairId;
-    if (reported == null)
-      return true;
-    return reported !== expected;
+  classifyDaemon(status) {
+    const classification = classifyDaemon(this.expectedPairId, status, BUILD_INFO);
+    if (process.env.AGENTBRIDGE_ALLOW_BUILD_DRIFT === "1" && (classification.verdict === "replace-drifted" || classification.verdict === "unreachable")) {
+      return { verdict: "reuse", reason: "build drift replacement disabled by AGENTBRIDGE_ALLOW_BUILD_DRIFT" };
+    }
+    return classification;
   }
-  isRegisteredPairDaemonInManualMode(status) {
-    return !this.expectedPairId && status?.pairId != null;
-  }
-  isBuildDrifted(status) {
-    if (process.env.AGENTBRIDGE_ALLOW_BUILD_DRIFT === "1")
-      return false;
-    const runtime = status?.build;
-    if (!runtime)
-      return true;
-    return !sameRuntimeContract(runtime, BUILD_INFO);
-  }
-  canReuseDespiteDrift(status) {
-    if (!compatibleContractVersion(status?.build, BUILD_INFO))
-      return false;
-    return status?.tuiConnected === true;
+  manualConflictError(status) {
+    return new Error(`Control port ${this.controlPort} is owned by registered pair ${status?.pairId}. ` + `This session has no pair identity (manual mode) and will not reuse or replace it \u2014 ` + `start with \`agentbridge claude\` from that pair's directory, or set AGENTBRIDGE_CONTROL_PORT to a free port.`);
   }
   async ensureRunning() {
     if (await this.isHealthy()) {
       const status = await this.fetchStatus();
-      if (this.isRegisteredPairDaemonInManualMode(status)) {
-        throw new Error(`Control port ${this.controlPort} is owned by registered pair ${status?.pairId}. ` + `This session has no pair identity (manual mode) and will not reuse or replace it \u2014 ` + `start with \`agentbridge claude\` from that pair's directory, or set AGENTBRIDGE_CONTROL_PORT to a free port.`);
-      }
-      if (this.isForeignDaemon(status)) {
-        this.log(`Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` + `but this pair is ${this.expectedPairId} \u2014 replacing foreign daemon`);
-        await this.replaceUnhealthyDaemon(status?.pid);
-        return;
-      }
-      if (this.isBuildDrifted(status)) {
-        if (this.canReuseDespiteDrift(status)) {
-          this.log(`Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` + `(launcher ${formatBuildInfo(BUILD_INFO)}) but a live Codex TUI is attached \u2014 reusing instead of ` + `replacing; the new build is picked up at the next restart (abg kill, then relaunch)`);
-        } else {
+      const classification = this.classifyDaemon(status);
+      switch (classification.verdict) {
+        case "manual-conflict":
+          throw this.manualConflictError(status);
+        case "replace-foreign":
+          this.log(`Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` + `but this pair is ${this.expectedPairId} \u2014 replacing foreign daemon`);
+          await this.replaceUnhealthyDaemon(status?.pid);
+          return;
+        case "replace-drifted":
+        case "unreachable":
           this.log(`Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` + `but launcher is ${formatBuildInfo(BUILD_INFO)} \u2014 replacing drifted daemon`);
           await this.replaceUnhealthyDaemon(status?.pid);
           return;
-        }
+        case "reuse-despite-drift":
+          this.log(`Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` + `(launcher ${formatBuildInfo(BUILD_INFO)}) but a live Codex TUI is attached \u2014 reusing instead of ` + `replacing; the new build is picked up at the next restart (abg kill, then relaunch)`);
+          break;
+        case "reuse":
+          break;
       }
       try {
         await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
@@ -2551,14 +2578,17 @@ class DaemonLifecycle {
     }
     await this.withStartupLockStrict(async (locked) => {
       if (!locked) {
-        this.log("Another process holds the startup lock, waiting for readiness+identity...");
-        await this.waitForReadyAndOurs();
+        await this.waitForContendedStartupLock();
         return;
       }
       if (await this.isHealthy()) {
         const status = await this.fetchStatus();
-        if (this.isForeignDaemon(status) || this.isBuildDrifted(status) && !this.canReuseDespiteDrift(status)) {
-          this.log(`Daemon on control port ${this.controlPort} is not reusable under startup lock ` + `(pair=${status?.pairId ?? "<none>"}, build=${formatBuildInfo(status?.build)}) \u2014 replacing`);
+        const classification = this.classifyDaemon(status);
+        if (classification.verdict === "manual-conflict") {
+          throw this.manualConflictError(status);
+        }
+        if (!isReuseVerdict(classification.verdict)) {
+          this.log(`Daemon on control port ${this.controlPort} is not reusable under startup lock ` + `(pair=${status?.pairId ?? "<none>"}, build=${formatBuildInfo(status?.build)}, ` + `reason=${classification.reason}) \u2014 replacing`);
           await this.kill(3000, status?.pid);
         } else {
           try {
@@ -2610,7 +2640,11 @@ class DaemonLifecycle {
     for (let attempt = 0;attempt < maxRetries; attempt++) {
       if (await this.isReady()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status) && (!this.isBuildDrifted(status) || this.canReuseDespiteDrift(status))) {
+        const classification = this.classifyDaemon(status);
+        if (classification.verdict === "manual-conflict") {
+          throw this.manualConflictError(status);
+        }
+        if (isReuseVerdict(classification.verdict)) {
           return;
         }
       }
@@ -2692,13 +2726,16 @@ class DaemonLifecycle {
   async replaceUnhealthyDaemon(statusPid) {
     await this.withStartupLockStrict(async (locked) => {
       if (!locked) {
-        this.log("Another process holds the startup lock, waiting for readiness+identity...");
-        await this.waitForReadyAndOurs();
+        await this.waitForContendedStartupLock();
         return;
       }
       if (await this.isHealthy()) {
         const status = await this.fetchStatus();
-        if (!this.isForeignDaemon(status) && (!this.isBuildDrifted(status) || this.canReuseDespiteDrift(status))) {
+        const classification = this.classifyDaemon(status);
+        if (classification.verdict === "manual-conflict") {
+          throw this.manualConflictError(status);
+        }
+        if (isReuseVerdict(classification.verdict)) {
           try {
             await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return;
@@ -2710,6 +2747,10 @@ class DaemonLifecycle {
       this.launch();
       await this.waitForReady();
     });
+  }
+  async waitForContendedStartupLock() {
+    this.log("Another process holds the startup lock, waiting for readiness+identity...");
+    await this.waitForReadyAndOurs();
   }
   async withStartupLockStrict(fn) {
     const locked = this.acquireLockStrict();

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -6,6 +6,7 @@ import { StateDirResolver } from "./state-dir";
 import { parsePositiveIntEnv } from "./env-utils";
 import { isAgentBridgeDaemon, isAgentBridgeProcess, isProcessAlive } from "./process-lifecycle";
 import type { DaemonStatus } from "./control-protocol";
+import type { AgentBridgeBuildInfo } from "./build-info";
 
 // In source/dev mode this module is loaded from src/*.ts and can launch the
 // sibling daemon.ts directly. In bundled CLI/plugin mode it is loaded from a
@@ -25,6 +26,71 @@ const HEALTH_FETCH_TIMEOUT_MS = 500;
 // 3s graceful kill during a replace). Only locks far older than that get the
 // pid-recycling identity check — see acquireLockStrict.
 const LOCK_IDENTITY_GRACE_MS = parsePositiveIntEnv("AGENTBRIDGE_LOCK_IDENTITY_GRACE_MS", 120_000);
+
+export type DaemonClassificationVerdict =
+  | "reuse"
+  | "reuse-despite-drift"
+  | "replace-foreign"
+  | "replace-drifted"
+  | "manual-conflict"
+  | "unreachable";
+
+export interface DaemonClassification {
+  verdict: DaemonClassificationVerdict;
+  reason: string;
+}
+
+function isReuseVerdict(verdict: DaemonClassificationVerdict): boolean {
+  return verdict === "reuse" || verdict === "reuse-despite-drift";
+}
+
+export function classifyDaemon(
+  expectedPairId: string | null,
+  status: DaemonStatus | null,
+  buildInfo: AgentBridgeBuildInfo,
+): DaemonClassification {
+  if (!status) {
+    return { verdict: "unreachable", reason: "daemon status is unavailable or unparseable" };
+  }
+
+  const reportedPairId = status.pairId;
+  if (!expectedPairId && reportedPairId != null) {
+    return {
+      verdict: "manual-conflict",
+      reason: `manual mode must not adopt registered pair ${reportedPairId}`,
+    };
+  }
+
+  if (expectedPairId) {
+    if (reportedPairId == null) {
+      return {
+        verdict: "replace-foreign",
+        reason: `pair ${expectedPairId} found daemon without pair identity`,
+      };
+    }
+    if (reportedPairId !== expectedPairId) {
+      return {
+        verdict: "replace-foreign",
+        reason: `pair ${expectedPairId} found daemon for pair ${reportedPairId}`,
+      };
+    }
+  }
+
+  if (!sameRuntimeContract(status.build, buildInfo)) {
+    if (compatibleContractVersion(status.build, buildInfo) && status.tuiConnected === true) {
+      return {
+        verdict: "reuse-despite-drift",
+        reason: "runtime build drift has a compatible contract and a live Codex TUI is attached",
+      };
+    }
+    return {
+      verdict: "replace-drifted",
+      reason: `runtime build ${formatBuildInfo(status.build)} does not match launcher ${formatBuildInfo(buildInfo)}`,
+    };
+  }
+
+  return { verdict: "reuse", reason: "daemon pair and runtime contract match" };
+}
 
 export interface DaemonLifecycleOptions {
   stateDir: StateDirResolver;
@@ -75,61 +141,23 @@ export class DaemonLifecycle {
     }
   }
 
-  /**
-   * True when this pair expects a specific pairId and the live daemon is NOT ours —
-   * a foreign daemon squatting our control port. In pair mode (expected pairId set),
-   * a missing/null reported pairId is ALSO foreign: an old daemon built before pairId
-   * shipped, or a manual daemon, must not be silently reused by a named pair — that is
-   * exactly the squatting the hardening exists to prevent. In manual/legacy mode
-   * (no expected pairId), any reported pairId is acceptable.
-   */
-  private isForeignDaemon(status: DaemonStatus | null): boolean {
-    const expected = this.expectedPairId;
-    if (!expected) return false; // manual/legacy — no enforcement
-    if (!status) return false; // unreachable/unparseable status — don't force-replace
-    const reported = status.pairId;
-    if (reported == null) return true; // pair-mode + no reported identity = foreign
-    return reported !== expected;
+  private classifyDaemon(status: DaemonStatus | null): DaemonClassification {
+    const classification = classifyDaemon(this.expectedPairId, status, BUILD_INFO);
+    if (
+      process.env.AGENTBRIDGE_ALLOW_BUILD_DRIFT === "1" &&
+      (classification.verdict === "replace-drifted" || classification.verdict === "unreachable")
+    ) {
+      return { verdict: "reuse", reason: "build drift replacement disabled by AGENTBRIDGE_ALLOW_BUILD_DRIFT" };
+    }
+    return classification;
   }
 
-  /**
-   * A MANUAL-mode launcher (no AGENTBRIDGE_PAIR_ID) found a daemon that belongs
-   * to a REGISTERED pair on its control port. Manual mode waives the foreign
-   * check above, but adopting (or worse, drift-replacing) a registered pair's
-   * daemon is squatting: an unwrapped `claude` session defaults to the root
-   * control port, which aliases registered slot 0. Neither reuse nor replace is
-   * acceptable here — the caller must abort with guidance.
-   */
-  private isRegisteredPairDaemonInManualMode(status: DaemonStatus | null): boolean {
-    return !this.expectedPairId && status?.pairId != null;
-  }
-
-  private isBuildDrifted(status: DaemonStatus | null): boolean {
-    if (process.env.AGENTBRIDGE_ALLOW_BUILD_DRIFT === "1") return false;
-    const runtime = status?.build;
-    if (!runtime) return true;
-    // Compare the runtime CONTRACT (version/commit/contractVersion), NOT `bundle`:
-    // the dist CLI and the Claude Code plugin launch co-equal daemons from the same
-    // source for the same pair, so a bundle-kind difference must not trigger a
-    // destructive replace (that would replace-war the two launchers).
-    return !sameRuntimeContract(runtime, BUILD_INFO);
-  }
-
-  /**
-   * Can a build-drifted daemon be REUSED instead of replaced? Replacing a daemon
-   * is destructive: SIGTERM tears down the codex app-server proxy, which severs
-   * any attached Codex TUI mid-session (observed live: the TUI dies with
-   * "WebSocket protocol error: Connection reset without closing handshake").
-   * Commit/version drift alone is an upgrade-hygiene concern, never worth that:
-   *  - contractVersion mismatch → NOT reusable (the frontend cannot speak to it);
-   *  - same contract + live Codex TUI attached → reusable (warn; the new build is
-   *    picked up at the next natural restart instead of by killing live work);
-   *  - same contract + no TUI → not reusable (replace in the safe window, keeping
-   *    the auto-upgrade behavior when it costs nothing).
-   */
-  private canReuseDespiteDrift(status: DaemonStatus | null): boolean {
-    if (!compatibleContractVersion(status?.build, BUILD_INFO)) return false;
-    return status?.tuiConnected === true;
+  private manualConflictError(status: DaemonStatus | null): Error {
+    return new Error(
+      `Control port ${this.controlPort} is owned by registered pair ${status?.pairId}. ` +
+        `This session has no pair identity (manual mode) and will not reuse or replace it — ` +
+        `start with \`agentbridge claude\` from that pair's directory, or set AGENTBRIDGE_CONTROL_PORT to a free port.`,
+    );
   }
 
   /** Ensure daemon is running: reuse a healthy one, replace a bad/foreign one, else launch. */
@@ -139,37 +167,34 @@ export class DaemonLifecycle {
     // daemon belongs to THIS pair. Distinguish reuse-able from replace-able:
     if (await this.isHealthy()) {
       const status = await this.fetchStatus();
-      if (this.isRegisteredPairDaemonInManualMode(status)) {
-        throw new Error(
-          `Control port ${this.controlPort} is owned by registered pair ${status?.pairId}. ` +
-            `This session has no pair identity (manual mode) and will not reuse or replace it — ` +
-            `start with \`agentbridge claude\` from that pair's directory, or set AGENTBRIDGE_CONTROL_PORT to a free port.`,
-        );
-      }
-      if (this.isForeignDaemon(status)) {
-        this.log(
-          `Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` +
-            `but this pair is ${this.expectedPairId} — replacing foreign daemon`,
-        );
-        await this.replaceUnhealthyDaemon(status?.pid);
-        return;
-      }
-      if (this.isBuildDrifted(status)) {
-        if (this.canReuseDespiteDrift(status)) {
+      const classification = this.classifyDaemon(status);
+      switch (classification.verdict) {
+        case "manual-conflict":
+          throw this.manualConflictError(status);
+        case "replace-foreign":
           this.log(
-            `Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` +
-              `(launcher ${formatBuildInfo(BUILD_INFO)}) but a live Codex TUI is attached — reusing instead of ` +
-              `replacing; the new build is picked up at the next restart (abg kill, then relaunch)`,
+            `Control port ${this.controlPort} held by a daemon for pair ${status?.pairId ?? "<none>"}, ` +
+              `but this pair is ${this.expectedPairId} — replacing foreign daemon`,
           );
-          // fall through to the readiness check + reuse path below
-        } else {
+          await this.replaceUnhealthyDaemon(status?.pid);
+          return;
+        case "replace-drifted":
+        case "unreachable":
           this.log(
             `Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` +
               `but launcher is ${formatBuildInfo(BUILD_INFO)} — replacing drifted daemon`,
           );
           await this.replaceUnhealthyDaemon(status?.pid);
           return;
-        }
+        case "reuse-despite-drift":
+          this.log(
+            `Daemon on control port ${this.controlPort} is running build ${formatBuildInfo(status?.build)} ` +
+              `(launcher ${formatBuildInfo(BUILD_INFO)}) but a live Codex TUI is attached — reusing instead of ` +
+              `replacing; the new build is picked up at the next restart (abg kill, then relaunch)`,
+          );
+          break;
+        case "reuse":
+          break;
       }
       try {
         // Short window: a sane daemon (or a legit slow boot) reports ready within ~3s.
@@ -212,23 +237,21 @@ export class DaemonLifecycle {
     // Nothing usable running — launch a fresh daemon under the strict lock.
     await this.withStartupLockStrict(async (locked) => {
       if (!locked) {
-        // Another process holds the lock and is launching/replacing — just wait.
-        this.log("Another process holds the startup lock, waiting for readiness+identity...");
-        // Contended branch: the lock holder is doing the fix-up. Wait for a daemon
-        // that is BOTH ready AND ours — a foreign daemon becoming ready behind the
-        // lock holder is the other pair repairing their own daemon; adopting it
-        // would squat the wrong pair. Manual mode is handled by waitForReadyAndOurs
-        // (it short-circuits the identity check).
-        await this.waitForReadyAndOurs();
+        await this.waitForContendedStartupLock();
         return;
       }
       // Re-check under the lock: a concurrent launcher may have just started one.
       if (await this.isHealthy()) {
         const status = await this.fetchStatus();
-        if (this.isForeignDaemon(status) || (this.isBuildDrifted(status) && !this.canReuseDespiteDrift(status))) {
+        const classification = this.classifyDaemon(status);
+        if (classification.verdict === "manual-conflict") {
+          throw this.manualConflictError(status);
+        }
+        if (!isReuseVerdict(classification.verdict)) {
           this.log(
             `Daemon on control port ${this.controlPort} is not reusable under startup lock ` +
-              `(pair=${status?.pairId ?? "<none>"}, build=${formatBuildInfo(status?.build)}) — replacing`,
+              `(pair=${status?.pairId ?? "<none>"}, build=${formatBuildInfo(status?.build)}, ` +
+              `reason=${classification.reason}) — replacing`,
           );
           await this.kill(3000, status?.pid);
         } else {
@@ -301,10 +324,11 @@ export class DaemonLifecycle {
         // policy keeps alive — same contract with a live TUI). Without the latter,
         // this loop spins to a 10s timeout against a perfectly usable daemon
         // (observed live as "Timed out waiting for readiness+identity").
-        if (
-          !this.isForeignDaemon(status) &&
-          (!this.isBuildDrifted(status) || this.canReuseDespiteDrift(status))
-        ) {
+        const classification = this.classifyDaemon(status);
+        if (classification.verdict === "manual-conflict") {
+          throw this.manualConflictError(status);
+        }
+        if (isReuseVerdict(classification.verdict)) {
           return;
         }
       }
@@ -414,23 +438,17 @@ export class DaemonLifecycle {
   private async replaceUnhealthyDaemon(statusPid?: number): Promise<void> {
     await this.withStartupLockStrict(async (locked) => {
       if (!locked) {
-        // Another launcher holds the lock and will replace/launch — just wait.
-        this.log("Another process holds the startup lock, waiting for readiness+identity...");
-        // Contended branch: the lock holder is doing the fix-up. Wait for a daemon
-        // that is BOTH ready AND ours — a foreign daemon becoming ready behind the
-        // lock holder is the other pair repairing their own daemon; adopting it
-        // would squat the wrong pair. Manual mode is handled by waitForReadyAndOurs
-        // (it short-circuits the identity check).
-        await this.waitForReadyAndOurs();
+        await this.waitForContendedStartupLock();
         return;
       }
       // Re-check under the lock: the daemon may have readied or been replaced already.
       if (await this.isHealthy()) {
         const status = await this.fetchStatus();
-        if (
-          !this.isForeignDaemon(status) &&
-          (!this.isBuildDrifted(status) || this.canReuseDespiteDrift(status))
-        ) {
+        const classification = this.classifyDaemon(status);
+        if (classification.verdict === "manual-conflict") {
+          throw this.manualConflictError(status);
+        }
+        if (isReuseVerdict(classification.verdict)) {
           try {
             await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
             return; // someone else already fixed it — don't kill
@@ -444,6 +462,16 @@ export class DaemonLifecycle {
       this.launch();
       await this.waitForReady();
     });
+  }
+
+  private async waitForContendedStartupLock(): Promise<void> {
+    // Another launcher holds the lock and will replace/launch — just wait.
+    this.log("Another process holds the startup lock, waiting for readiness+identity...");
+    // Contended branch: the lock holder is doing the fix-up. Wait for a daemon
+    // that is BOTH ready AND ours — a foreign daemon becoming ready behind the
+    // lock holder is the other pair repairing their own daemon; adopting it
+    // would squat the wrong pair.
+    await this.waitForReadyAndOurs();
   }
 
   /**

--- a/src/unit-test/daemon-lifecycle.test.ts
+++ b/src/unit-test/daemon-lifecycle.test.ts
@@ -1,23 +1,170 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { createServer } from "node:net";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { StateDirResolver } from "../state-dir";
-import { DaemonLifecycle, isProcessAlive } from "../daemon-lifecycle";
+import { classifyDaemon, DaemonLifecycle, isProcessAlive } from "../daemon-lifecycle";
+import { BUILD_INFO, type AgentBridgeBuildInfo } from "../build-info";
+import type { DaemonStatus } from "../control-protocol";
+
+function status(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
+  return {
+    bridgeReady: true,
+    tuiConnected: false,
+    threadId: null,
+    queuedMessageCount: 0,
+    proxyUrl: "",
+    appServerUrl: "",
+    pid: 12345,
+    pairId: null,
+    build: BUILD_INFO,
+    ...overrides,
+  };
+}
+
+function build(overrides: Partial<AgentBridgeBuildInfo> = {}): AgentBridgeBuildInfo {
+  return { ...BUILD_INFO, ...overrides };
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+describe("classifyDaemon", () => {
+  const sameBuild = BUILD_INFO;
+  const bundleOnlyDrift = build({ bundle: BUILD_INFO.bundle === "plugin" ? "dist" : "plugin" });
+  const compatibleCommitDrift = build({ commit: "old-build" });
+  const incompatibleContract = build({ commit: "old-build", contractVersion: BUILD_INFO.contractVersion + 1 });
+
+  const cases: Array<{
+    name: string;
+    expectedPairId: string | null;
+    status: DaemonStatus | null;
+    expectedVerdict:
+      | "reuse"
+      | "reuse-despite-drift"
+      | "replace-foreign"
+      | "replace-drifted"
+      | "manual-conflict"
+      | "unreachable";
+  }> = [
+    {
+      name: "unreachable status cannot be reused",
+      expectedPairId: "mine",
+      status: null,
+      expectedVerdict: "unreachable",
+    },
+    {
+      name: "manual mode reuses legacy manual daemon",
+      expectedPairId: null,
+      status: status({ pairId: null, build: sameBuild, tuiConnected: false }),
+      expectedVerdict: "reuse",
+    },
+    {
+      name: "manual mode refuses a registered pair daemon",
+      expectedPairId: null,
+      status: status({ pairId: "registered", build: sameBuild, tuiConnected: true }),
+      expectedVerdict: "manual-conflict",
+    },
+    {
+      name: "pair mode treats missing pairId as foreign",
+      expectedPairId: "mine",
+      status: status({ pairId: null, build: sameBuild, tuiConnected: false }),
+      expectedVerdict: "replace-foreign",
+    },
+    {
+      name: "pair mode replaces mismatched pairId",
+      expectedPairId: "mine",
+      status: status({ pairId: "other", build: sameBuild, tuiConnected: true }),
+      expectedVerdict: "replace-foreign",
+    },
+    {
+      name: "same pair and same runtime contract reuses",
+      expectedPairId: "mine",
+      status: status({ pairId: "mine", build: sameBuild, tuiConnected: false }),
+      expectedVerdict: "reuse",
+    },
+    {
+      name: "bundle-only drift reuses because runtime contract matches",
+      expectedPairId: "mine",
+      status: status({ pairId: "mine", build: bundleOnlyDrift, tuiConnected: false }),
+      expectedVerdict: "reuse",
+    },
+    {
+      name: "compatible commit drift without TUI is replaced in the safe window",
+      expectedPairId: "mine",
+      status: status({ pairId: "mine", build: compatibleCommitDrift, tuiConnected: false }),
+      expectedVerdict: "replace-drifted",
+    },
+    {
+      name: "compatible commit drift with live TUI is reused",
+      expectedPairId: "mine",
+      status: status({ pairId: "mine", build: compatibleCommitDrift, tuiConnected: true }),
+      expectedVerdict: "reuse-despite-drift",
+    },
+    {
+      name: "contract mismatch is replaced even with live TUI",
+      expectedPairId: "mine",
+      status: status({ pairId: "mine", build: incompatibleContract, tuiConnected: true }),
+      expectedVerdict: "replace-drifted",
+    },
+    {
+      name: "missing build info is drifted and replaced",
+      expectedPairId: "mine",
+      status: status({ pairId: "mine", build: undefined, tuiConnected: true }),
+      expectedVerdict: "replace-drifted",
+    },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      const result = classifyDaemon(testCase.expectedPairId, testCase.status, BUILD_INFO);
+      expect(result.verdict).toBe(testCase.expectedVerdict);
+      expect(result.reason.length).toBeGreaterThan(0);
+    });
+  }
+
+  test("matrix covers every daemon lifecycle verdict", () => {
+    expect(new Set(cases.map((testCase) => testCase.expectedVerdict))).toEqual(new Set([
+      "reuse",
+      "reuse-despite-drift",
+      "replace-foreign",
+      "replace-drifted",
+      "manual-conflict",
+      "unreachable",
+    ]));
+  });
+});
 
 describe("DaemonLifecycle", () => {
   let tempDir: string;
   let stateDir: StateDirResolver;
   let logs: string[];
+  let savedPairId: string | undefined;
+  const servers: Array<{ stop: () => void | Promise<void> }> = [];
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), "agentbridge-lifecycle-test-"));
     stateDir = new StateDirResolver(tempDir);
     stateDir.ensure();
     logs = [];
+    savedPairId = process.env.AGENTBRIDGE_PAIR_ID;
+    delete process.env.AGENTBRIDGE_PAIR_ID;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    while (servers.length > 0) await servers.pop()!.stop();
+    if (savedPairId === undefined) delete process.env.AGENTBRIDGE_PAIR_ID;
+    else process.env.AGENTBRIDGE_PAIR_ID = savedPairId;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -27,6 +174,35 @@ describe("DaemonLifecycle", () => {
       controlPort: port,
       log: (msg) => logs.push(msg),
     });
+  }
+
+  function fakeDaemon(
+    port: number,
+    state: { healthzStatus: number; readyzStatus: number; pairId: string | null; pid?: number },
+  ) {
+    const server = Bun.serve({
+      port,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        const body = {
+          bridgeReady: state.readyzStatus >= 200 && state.readyzStatus < 300,
+          tuiConnected: false,
+          threadId: null,
+          queuedMessageCount: 0,
+          proxyUrl: "",
+          appServerUrl: "",
+          pid: state.pid ?? 99999,
+          pairId: state.pairId,
+          build: BUILD_INFO,
+        };
+        if (url.pathname === "/healthz") return Response.json(body, { status: state.healthzStatus });
+        if (url.pathname === "/readyz") return Response.json(body, { status: state.readyzStatus });
+        return new Response("ok");
+      },
+    });
+    servers.push(server);
+    return server;
   }
 
   test("healthUrl and controlWsUrl use correct port", () => {
@@ -127,4 +303,46 @@ describe("DaemonLifecycle", () => {
     const result = await lc.kill();
     expect(result).toBe(false);
   });
+
+  test("contended lock aborts immediately when manual mode sees a registered pair daemon", async () => {
+    delete process.env.AGENTBRIDGE_PAIR_ID;
+    const port = await freePort();
+    const daemonState = {
+      healthzStatus: 503,
+      readyzStatus: 503,
+      pairId: "registered-cccc2222",
+      pid: 99999,
+    };
+    fakeDaemon(port, daemonState);
+    writeFileSync(stateDir.lockFile, `${process.pid}\n`);
+    const lc = createLifecycle(port);
+    let killed = false;
+    let launched = false;
+    (lc as any).kill = async () => {
+      killed = true;
+      return true;
+    };
+    (lc as any).launch = () => {
+      launched = true;
+    };
+
+    setTimeout(() => {
+      daemonState.healthzStatus = 200;
+      daemonState.readyzStatus = 200;
+    }, 20);
+
+    const startedAt = Date.now();
+    let error: Error | null = null;
+    try {
+      await lc.ensureRunning();
+    } catch (err) {
+      error = err as Error;
+    }
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain("registered pair registered-cccc2222");
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+    expect(killed).toBe(false);
+    expect(launched).toBe(false);
+  }, 15000);
 });


### PR DESCRIPTION
## 摘要
审视报告 P1（Codex 实现）：复用/替换组合判定在 daemon-lifecycle.ts 出现 4 次散落形态，policy 改动须同步 4 处——PR#101 曾漏改一处致空转 10s。

## 变更
- 提取纯函数 `classifyDaemon → verdict`（6 态）；4 调用点改 switch；contended-lock wait 收敛为 waitForContendedStartupLock
- AGENTBRIDGE_ALLOW_BUILD_DRIFT 经 wrapper 保留（仅改写 drift→reuse，不碰 manual-conflict/foreign）
- **收口**：manual-conflict 在全 4 站点立即 throw（原 lock-path 会静默 squat 已注册 pair daemon → 现统一安全 abort）
- 矩阵测试覆盖全 6 verdict + lock-path 回归（RED 10s→GREEN 286ms）

## 测试
- [x] 828 pass；ci:local 绿；cross-review R1（抓 manual-conflict 行为变化）→精修→**R2 双 0 REAL**（mutation 复证 RED→GREEN）