### PR TITLE
feat: Codex 拦截面协议版本感知 / codex protocol version awareness

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14274,7 +14274,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("5840cb3", "source"),
+  commit: defineString("eec6018", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("5840cb3", "source"),
+  commit: defineString("eec6018", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -363,6 +363,16 @@ var APP_SERVER_NOTIFICATION_METHODS = [
 var TRACKED_REQUEST_METHOD_SET = new Set(APP_SERVER_TRACKED_REQUEST_METHODS);
 var SERVER_REQUEST_METHOD_SET = new Set(APP_SERVER_SERVER_REQUEST_METHODS);
 var NOTIFICATION_METHOD_SET = new Set(APP_SERVER_NOTIFICATION_METHODS);
+function parseAppServerVersion(userAgent) {
+  if (typeof userAgent !== "string")
+    return null;
+  const match = userAgent.match(/\/([^\s]+)/);
+  return match ? match[1] : null;
+}
+var APP_SERVER_RATE_LIMIT_ERROR_CODES = new Set([
+  -32603,
+  -32600
+]);
 function isObjectRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -715,6 +725,10 @@ class CodexAdapter extends EventEmitter {
   static OUTAGE_TIMEOUT_MS = 1e4;
   lastInitializeRaw = null;
   lastInitializedRaw = null;
+  pendingInitializeProxyIds = new Set;
+  appServerInfo = null;
+  warnedAppServerVersions = new Set;
+  warnedFragileRateLimitMessages = new Set;
   sessionRestoreInProgress = false;
   replayPending = new Map;
   static SESSION_REPLAY_TIMEOUT_MS = 5000;
@@ -733,6 +747,9 @@ class CodexAdapter extends EventEmitter {
   }
   get activeThreadId() {
     return this.threadId;
+  }
+  get capturedAppServerInfo() {
+    return this.appServerInfo;
   }
   async start() {
     this.intentionalDisconnect = false;
@@ -1549,6 +1566,9 @@ class CodexAdapter extends EventEmitter {
         const proxyId = this.nextProxyId++;
         this.upstreamToClient.set(proxyId, { connId, clientId: parsed.id });
         this.trackPendingRequest(parsed, connId, proxyId);
+        if (parsed.method === "initialize") {
+          this.pendingInitializeProxyIds.add(proxyId);
+        }
         parsed.id = proxyId;
         forwarded = JSON.stringify(parsed);
       } else {
@@ -1701,6 +1721,9 @@ class CodexAdapter extends EventEmitter {
     const mapping = !isNaN(numericId) ? this.upstreamToClient.get(numericId) : undefined;
     if (mapping) {
       this.upstreamToClient.delete(numericId);
+      if (!isNaN(numericId) && this.pendingInitializeProxyIds.delete(numericId)) {
+        this.captureAppServerInfo(parsed.result);
+      }
       if (mapping.connId !== this.tuiConnId) {
         this.log(`Dropping stale response (upstream id ${responseId}, from conn #${mapping.connId}, current #${this.tuiConnId})`);
         return null;
@@ -1751,11 +1774,40 @@ class CodexAdapter extends EventEmitter {
     this.log(`Dropping unmatched app-server response id ${String(responseId)}`);
     return null;
   }
+  captureAppServerInfo(result) {
+    const init = typeof result === "object" && result !== null ? result : {};
+    const userAgent = typeof init.userAgent === "string" ? init.userAgent : null;
+    const version = parseAppServerVersion(userAgent);
+    const info = {
+      version,
+      userAgent,
+      platformFamily: typeof init.platformFamily === "string" ? init.platformFamily : null,
+      platformOs: typeof init.platformOs === "string" ? init.platformOs : null
+    };
+    this.appServerInfo = info;
+    this.log(`Captured app-server initialize: version=${version ?? "unknown"} ` + `userAgent=${userAgent ?? "none"} platform=${info.platformOs ?? "?"}/${info.platformFamily ?? "?"}`);
+    if (version === null) {
+      const dedupKey = userAgent ?? "<missing-userAgent>";
+      if (!this.warnedAppServerVersions.has(dedupKey)) {
+        this.warnedAppServerVersions.add(dedupKey);
+        this.log(`WARNING: app-server initialize response carried no parseable version ` + `(userAgent=${userAgent ?? "missing"}). The proxy's intercept points assume a ` + `known protocol snapshot \u2014 verify the version-coupling checklist if Codex was upgraded.`);
+      }
+    }
+  }
   patchResponse(parsed, raw) {
     if (isAppServerResponseMessage(parsed) && parsed.error && parsed.id !== undefined) {
       const errMsg = parsed.error.message ?? "";
-      if (errMsg.includes("rate limits") || errMsg.includes("rateLimits")) {
-        this.log(`Patching rateLimits error \u2192 mock success (id: ${parsed.id})`);
+      const errCode = parsed.error.code;
+      const textMatchesRateLimit = errMsg.includes("rate limits") || errMsg.includes("rateLimits");
+      const codeRecognized = typeof errCode === "number" && APP_SERVER_RATE_LIMIT_ERROR_CODES.has(errCode);
+      const structuredMatch = codeRecognized && textMatchesRateLimit;
+      if (structuredMatch || textMatchesRateLimit) {
+        if (structuredMatch) {
+          this.log(`Patching rateLimits error \u2192 mock success via structured code ${errCode} (id: ${parsed.id})`);
+        } else {
+          this.warnFragileRateLimitMatch(errMsg, errCode);
+          this.log(`Patching rateLimits error \u2192 mock success via fragile text fallback (id: ${parsed.id})`);
+        }
         return JSON.stringify({
           id: parsed.id,
           result: {
@@ -1773,6 +1825,12 @@ class CodexAdapter extends EventEmitter {
       }
     }
     return raw;
+  }
+  warnFragileRateLimitMatch(errMsg, errCode) {
+    if (this.warnedFragileRateLimitMessages.has(errMsg))
+      return;
+    this.warnedFragileRateLimitMessages.add(errMsg);
+    this.log(`WARNING: fragile-match \u2014 patched a rate-limit error by human-readable text ` + `(code=${errCode ?? "none"} not in the recognized set). If Codex changed the ` + `error wording or code, update patchResponse / APP_SERVER_RATE_LIMIT_ERROR_CODES. ` + `Message: ${errMsg.slice(0, 120)}`);
   }
   interceptServerMessage(msg, connId) {
     this.handleTrackedResponse(msg, connId);
@@ -2136,6 +2194,7 @@ class CodexAdapter extends EventEmitter {
   clearTransientResponseTrackingState() {
     this.pendingRequests.clear();
     this.upstreamToClient.clear();
+    this.pendingInitializeProxyIds.clear();
     for (const timer of this.staleProxyIds.values()) {
       clearTimeout(timer);
     }
@@ -5312,7 +5371,8 @@ function currentStatus() {
     budget: budgetCoordinator?.getSnapshot() ?? undefined,
     turnInProgress: codex.turnInProgress,
     turnPhase: codex.turnPhase,
-    attentionWindowActive: inAttentionWindow
+    attentionWindowActive: inAttentionWindow,
+    appServerInfo: codex.capturedAppServerInfo
   };
 }
 function currentWaitingMessage() {
@@ -5357,7 +5417,8 @@ function writeStatusFile() {
     build: daemonStatusBuildInfo(),
     turnInProgress: codex.turnInProgress,
     turnPhase: codex.turnPhase,
-    attentionWindowActive: inAttentionWindow
+    attentionWindowActive: inAttentionWindow,
+    appServerInfo: codex.capturedAppServerInfo
   });
 }
 function removeStatusFile() {

--- a/src/app-server-protocol.ts
+++ b/src/app-server-protocol.ts
@@ -132,6 +132,76 @@ export interface TurnStartResponse {
   [key: string]: unknown;
 }
 
+/**
+ * `initialize` response (codex-rs app-server-protocol v1 InitializeResponse).
+ *
+ * Verified against codex-rs at
+ * codex-rs/app-server-protocol/src/protocol/v1.rs:61-71 (camelCase on the wire
+ * via `#[serde(rename_all = "camelCase")]`) and its construction site
+ * codex-rs/app-server/src/request_processors/initialize_processor.rs:141-146.
+ *
+ * The app-server does NOT expose a dedicated top-level `version` field or a
+ * server-side `capabilities` object; the version is embedded in `userAgent`
+ * (built by get_codex_user_agent — codex-rs/login/src/auth/default_client.rs:133,
+ * format `"{originator}/{version} ({OsType} {os_version}; {arch}) {ua}"`).
+ *
+ * All fields are typed optional here so a future protocol that drops one
+ * surfaces as a captured-null (a drift signal) rather than a crash.
+ */
+export interface AppServerInitializeResponse {
+  /** e.g. "codex_cli_rs/0.139.0 (Mac OS 15.1; arm64) ...". Carries the version. */
+  userAgent?: string;
+  /** Absolute path to the server's $CODEX_HOME directory. */
+  codexHome?: string;
+  /** Platform family, e.g. "unix" / "windows". */
+  platformFamily?: string;
+  /** Operating system, e.g. "macos" / "linux" / "windows". */
+  platformOs?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Captured app-server identity, derived from the `initialize` response. Exposed
+ * on DaemonStatus so `abg doctor` / /healthz can show which app-server build the
+ * proxy is actually coupled to, and the adapter can WARN when it drifts from the
+ * assumptions baked into the intercept points (see codex-adapter.ts).
+ */
+export interface AppServerInfo {
+  /** Version token parsed out of `userAgent` (e.g. "0.139.0"); null if unparseable. */
+  version: string | null;
+  /** Raw `userAgent` string as received. */
+  userAgent: string | null;
+  /** Platform family ("unix" / "windows" / …) if present. */
+  platformFamily: string | null;
+  /** Operating system ("macos" / "linux" / "windows" / …) if present. */
+  platformOs: string | null;
+}
+
+/**
+ * Parse the version token out of an app-server `userAgent`. The wire format is
+ * `"{originator}/{version} (…)"` — the version is the run of characters after
+ * the FIRST "/" up to the first whitespace. Returns null when the string does
+ * not match that shape (a drift signal worth a WARNING at the call site).
+ */
+export function parseAppServerVersion(userAgent: string | null | undefined): string | null {
+  if (typeof userAgent !== "string") return null;
+  const match = userAgent.match(/\/([^\s]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * JSON-RPC error codes the app-server's rate-limits read path is known to use
+ * (codex-rs/app-server/src/error_code.rs + account_processor.rs:967-990). These
+ * are GENERIC codes (not rate-limit-specific), so they alone do not identify a
+ * rate-limit error — patchResponse pairs them with the message text. Modeling
+ * them as a named set documents the structured signal we DO have and gives the
+ * fragile-text fallback a clear "structured-recognized vs not" boundary.
+ */
+export const APP_SERVER_RATE_LIMIT_ERROR_CODES: ReadonlySet<number> = new Set([
+  -32603, // INTERNAL_ERROR_CODE — "failed to fetch codex rate limits: …"
+  -32600, // INVALID_REQUEST_ERROR_CODE — "chatgpt authentication required to read rate limits"
+]);
+
 export interface AppServerRequest<M extends string = string, P = unknown> {
   jsonrpc?: "2.0";
   id: AppServerJsonRpcId;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -231,6 +231,23 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
         ? "daemon 在运行但 codex app-server 尚未就绪；稍候片刻重试，持续不就绪请查看下方 daemon log。"
         : undefined,
   });
+  // P1 #5: surface the captured Codex app-server identity (version/platform).
+  // null until the first initialize handshake — informational, never a failure.
+  const appServerInfo = health?.appServerInfo ?? null;
+  checks.push({
+    name: "codex app-server",
+    status: health ? "ok" : "skip",
+    detail: !health
+      ? "n/a — daemon not running"
+      : appServerInfo
+        ? `version=${appServerInfo.version ?? "unknown"}` +
+          (appServerInfo.platformOs ? ` platform=${appServerInfo.platformOs}` : "")
+        : "not captured yet — connect Codex (initialize handshake) to populate",
+    hint:
+      health && appServerInfo && appServerInfo.version === null
+        ? "app-server 未返回可解析的版本号（userAgent 异常）。若刚升级过 Codex，请核对 codex-adapter 的 version-coupling checklist。"
+        : undefined,
+  });
   checks.push({
     name: "build drift",
     status: buildDrift === false ? "ok" : buildDrift === true ? "fail" : "skip",

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -18,10 +18,14 @@ import { createProcessLogger, type ProcessLogger } from "./process-log";
 import type { BridgeMessage } from "./types";
 import type { ServerWebSocket } from "bun";
 import {
+  APP_SERVER_RATE_LIMIT_ERROR_CODES,
   isAppServerNotification,
   isAppServerRequestMessage,
   isAppServerResponseMessage,
   isTrackedAppServerRequestMethod,
+  parseAppServerVersion,
+  type AppServerInfo,
+  type AppServerInitializeResponse,
   type AppServerItem,
   type AppServerNotification,
   type AppServerRequest,
@@ -90,6 +94,34 @@ interface PendingRequest {
   threadSwitchSeq?: number;
 }
 
+/**
+ * ── Codex app-server PROTOCOL-VERSION-COUPLING CHECKLIST (P1 #5) ────────────
+ *
+ * The proxy intercepts and rewrites the Codex app-server protocol at a handful
+ * of points. Every one of them encodes assumptions about a SPECIFIC protocol
+ * snapshot — an upstream bump can silently break them. When bumping the
+ * supported codex version, re-verify EACH site against codex-rs:
+ *
+ *   1. initialize capture — captureAppServerInfo() / handleAppServerResponse.
+ *      Reads InitializeResponse.userAgent (codex-rs v1.rs:61-71). If the field
+ *      set changes, the captured AppServerInfo / drift WARNING must follow.
+ *   2. agentMessage aggregation — handleServerNotification (item/started +
+ *      item/agentMessage/delta + item/completed). Coupled to the item/* event
+ *      names and the `agentMessage` item type.
+ *   3. turn lifecycle — turn/started + turn/completed notifications drive
+ *      turnPhase, the inactivity watchdog, and busy-guard injection.
+ *   4. rate-limit patch — patchResponse(). Matches the `account/rateLimits/read`
+ *      error and hand-writes a GetAccountRateLimitsResponse-shaped mock
+ *      (rateLimits / rateLimitsByLimitId). Coupled to BOTH the error shape and
+ *      the success result shape (codex-rs v2/account.rs:254-258).
+ *   5. thread/closed sniff — handleAppServerPayload. String-matches the
+ *      `thread/closed` notification method to explain a silent TUI exit(0).
+ *
+ * The captured app-server version (exposed via `appServerInfo` →
+ * DaemonStatus → /healthz + `abg doctor`) lets an operator see, at a glance,
+ * whether the running server drifted from the version these sites were written
+ * against.
+ */
 export class CodexAdapter extends EventEmitter {
   private static readonly RESPONSE_TRACKING_TTL_MS = 30000;
 
@@ -212,6 +244,21 @@ export class CodexAdapter extends EventEmitter {
   // unintentional reconnect. See handleSessionRestoreAfterReconnect.
   private lastInitializeRaw: string | null = null;
   private lastInitializedRaw: string | null = null;
+  // P1 #5: protocol-version awareness. Proxy ids of in-flight `initialize`
+  // requests (TUI → app-server), so the matching RESPONSE can be recognized and
+  // its InitializeResponse captured at the handleAppServerResponse funnel.
+  private pendingInitializeProxyIds = new Set<number>();
+  // Captured app-server identity (version / platform) from the last initialize
+  // response. null until the first handshake completes. Surfaced on
+  // DaemonStatus.appServerInfo via the getter below.
+  private appServerInfo: AppServerInfo | null = null;
+  // Fire the "unknown app-server version" WARNING at most once per distinct
+  // captured version string, so a stable-but-unrecognized server does not spam
+  // the log on every reconnect/initialize.
+  private warnedAppServerVersions = new Set<string>();
+  // Fire the patchResponse fragile-text-match WARNING at most once per distinct
+  // error message, so a repeated legacy rate-limit error does not spam the log.
+  private warnedFragileRateLimitMessages = new Set<string>();
   private sessionRestoreInProgress = false;
   private replayPending = new Map<number | string, {
     method: string;
@@ -232,6 +279,13 @@ export class CodexAdapter extends EventEmitter {
   get appServerUrl() { return `ws://127.0.0.1:${this.appPort}`; }
   get proxyUrl() { return `ws://127.0.0.1:${this.proxyPort}`; }
   get activeThreadId() { return this.threadId; }
+  /**
+   * Captured Codex app-server identity (P1 #5). null until the first
+   * `initialize` handshake response is observed. Read by the daemon's status
+   * builder so /healthz + status.json + `abg doctor` can surface which
+   * app-server build the proxy is coupled to.
+   */
+  get capturedAppServerInfo(): AppServerInfo | null { return this.appServerInfo; }
 
   // ── Lifecycle ──────────────────────────────────────────────
 
@@ -1445,6 +1499,13 @@ export class CodexAdapter extends EventEmitter {
         const proxyId = this.nextProxyId++;
         this.upstreamToClient.set(proxyId, { connId, clientId: parsed.id });
         this.trackPendingRequest(parsed, connId, proxyId);
+        // P1 #5: remember initialize request proxy ids so the matching response
+        // can be recognized in handleAppServerResponse and its InitializeResponse
+        // captured (version / platform). Bounded: cleared on capture and on
+        // response-tracking resets.
+        if (parsed.method === "initialize") {
+          this.pendingInitializeProxyIds.add(proxyId);
+        }
         parsed.id = proxyId;
         forwarded = JSON.stringify(parsed);
       } else {
@@ -1674,6 +1735,14 @@ export class CodexAdapter extends EventEmitter {
     if (mapping) {
       this.upstreamToClient.delete(numericId);
 
+      // P1 #5: capture the initialize response (version / platform) BEFORE the
+      // staleness drop below — the server identity is connection-independent, so
+      // even a response to a now-superseded conn still tells us the truth about
+      // the app-server we're proxying. Always clears the pending-id bookkeeping.
+      if (!isNaN(numericId) && this.pendingInitializeProxyIds.delete(numericId)) {
+        this.captureAppServerInfo(parsed.result);
+      }
+
       if (mapping.connId !== this.tuiConnId) {
         this.log(`Dropping stale response (upstream id ${responseId}, from conn #${mapping.connId}, current #${this.tuiConnId})`);
         return null;
@@ -1760,11 +1829,71 @@ export class CodexAdapter extends EventEmitter {
     return null;
   }
 
+  /**
+   * P1 #5: capture the app-server identity from an `initialize` response result
+   * (version / platform) and expose it on the status getter. Logs the captured
+   * identity, and WARNs once-per-distinct-version when the userAgent is missing
+   * or its version is unparseable — a signal the app-server drifted from the
+   * shape these intercept points were written against (see the class-level
+   * version-coupling checklist).
+   *
+   * Behavior-preserving: capture-only, never mutates the forwarded payload.
+   */
+  private captureAppServerInfo(result: unknown): void {
+    const init = (typeof result === "object" && result !== null ? result : {}) as AppServerInitializeResponse;
+    const userAgent = typeof init.userAgent === "string" ? init.userAgent : null;
+    const version = parseAppServerVersion(userAgent);
+    const info: AppServerInfo = {
+      version,
+      userAgent,
+      platformFamily: typeof init.platformFamily === "string" ? init.platformFamily : null,
+      platformOs: typeof init.platformOs === "string" ? init.platformOs : null,
+    };
+    this.appServerInfo = info;
+    this.log(
+      `Captured app-server initialize: version=${version ?? "unknown"} ` +
+        `userAgent=${userAgent ?? "none"} platform=${info.platformOs ?? "?"}/${info.platformFamily ?? "?"}`,
+    );
+    if (version === null) {
+      // Key the at-most-once dedup on the raw userAgent (or a sentinel) so a
+      // stable-but-unparseable server warns once, not on every reconnect.
+      const dedupKey = userAgent ?? "<missing-userAgent>";
+      if (!this.warnedAppServerVersions.has(dedupKey)) {
+        this.warnedAppServerVersions.add(dedupKey);
+        this.log(
+          `WARNING: app-server initialize response carried no parseable version ` +
+            `(userAgent=${userAgent ?? "missing"}). The proxy's intercept points assume a ` +
+            `known protocol snapshot — verify the version-coupling checklist if Codex was upgraded.`,
+        );
+      }
+    }
+  }
+
   private patchResponse(parsed: AppServerNotification | AppServerResponse | Record<string, unknown>, raw: string): string {
     if (isAppServerResponseMessage(parsed) && parsed.error && parsed.id !== undefined) {
       const errMsg: string = parsed.error.message ?? "";
-      if (errMsg.includes("rate limits") || errMsg.includes("rateLimits")) {
-        this.log(`Patching rateLimits error → mock success (id: ${parsed.id})`);
+      const errCode = parsed.error.code;
+      const textMatchesRateLimit = errMsg.includes("rate limits") || errMsg.includes("rateLimits");
+      // P1 #5: structured-code-FIRST. The app-server's rate-limit read path uses
+      // GENERIC JSON-RPC error codes (no rate-limit-specific code exists —
+      // codex-rs error_code.rs + account_processor.rs:967-990), so the
+      // structured signal we DO have is "the error code is one of the recognized
+      // codes that path emits". When the code is recognized AND the text agrees,
+      // we patch via the structured path with NO fragile-match warning. When the
+      // code is absent/unrecognized but the legacy text still matches, we keep
+      // patching (behavior-preserving) but log a once-per-message 'fragile-match'
+      // warning so an upstream wording change becomes visible instead of silent.
+      const codeRecognized =
+        typeof errCode === "number" && APP_SERVER_RATE_LIMIT_ERROR_CODES.has(errCode);
+      const structuredMatch = codeRecognized && textMatchesRateLimit;
+
+      if (structuredMatch || textMatchesRateLimit) {
+        if (structuredMatch) {
+          this.log(`Patching rateLimits error → mock success via structured code ${errCode} (id: ${parsed.id})`);
+        } else {
+          this.warnFragileRateLimitMatch(errMsg, errCode);
+          this.log(`Patching rateLimits error → mock success via fragile text fallback (id: ${parsed.id})`);
+        }
         return JSON.stringify({
           id: parsed.id,
           result: {
@@ -1784,6 +1913,21 @@ export class CodexAdapter extends EventEmitter {
       // WS on each TUI `initialize` request, giving it a fresh connection scope.
     }
     return raw;
+  }
+
+  /**
+   * P1 #5: emit the 'fragile-match' warning at most once per distinct error
+   * message, so a repeated legacy rate-limit error does not spam the log.
+   */
+  private warnFragileRateLimitMatch(errMsg: string, errCode: number | undefined): void {
+    if (this.warnedFragileRateLimitMessages.has(errMsg)) return;
+    this.warnedFragileRateLimitMessages.add(errMsg);
+    this.log(
+      `WARNING: fragile-match — patched a rate-limit error by human-readable text ` +
+        `(code=${errCode ?? "none"} not in the recognized set). If Codex changed the ` +
+        `error wording or code, update patchResponse / APP_SERVER_RATE_LIMIT_ERROR_CODES. ` +
+        `Message: ${errMsg.slice(0, 120)}`,
+    );
   }
 
   // ── Server Message Interception (for Bridge) ───────────────
@@ -2286,6 +2430,11 @@ export class CodexAdapter extends EventEmitter {
   private clearTransientResponseTrackingState() {
     this.pendingRequests.clear();
     this.upstreamToClient.clear();
+    // P1 #5: pending initialize ids share upstreamToClient's lifecycle — a proxy
+    // id dropped from upstreamToClient can never match a response, so clear here
+    // to avoid an unbounded leak of orphaned ids. The captured appServerInfo
+    // itself PERSISTS (it is a fact about the server, not a transient mapping).
+    this.pendingInitializeProxyIds.clear();
 
     for (const timer of this.staleProxyIds.values()) {
       clearTimeout(timer);

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -1,6 +1,7 @@
 import type { BridgeMessage } from "./types";
 import type { AgentBridgeBuildInfo } from "./build-info";
 import type { BudgetSnapshot } from "./budget/types";
+import type { AppServerInfo } from "./app-server-protocol";
 
 export interface ControlClientIdentity {
   pairId?: string | null;
@@ -53,6 +54,15 @@ export interface DaemonStatus {
    * of turnPhase.
    */
   attentionWindowActive?: boolean;
+  /**
+   * Captured Codex app-server identity (version / platform), derived from the
+   * `initialize` response (P1 #5). null until the first initialize handshake
+   * completes, or when the response carried no recognizable userAgent. Exposed
+   * so `abg doctor` / /healthz can show which app-server build the proxy is
+   * coupled to — the version-coupling intercept points (rate-limit patch,
+   * thread/closed sniff, …) assume a particular protocol snapshot.
+   */
+  appServerInfo?: AppServerInfo | null;
 }
 
 export type ControlClientMessage =

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1460,6 +1460,9 @@ function currentStatus(): DaemonStatus {
     turnInProgress: codex.turnInProgress,
     turnPhase: codex.turnPhase,
     attentionWindowActive: inAttentionWindow,
+    // P1 #5: captured Codex app-server identity (version/platform) so /healthz +
+    // `abg doctor` can surface protocol drift. null until the first initialize.
+    appServerInfo: codex.capturedAppServerInfo,
   };
 }
 
@@ -1523,6 +1526,9 @@ function writeStatusFile() {
     // drift (protocol v2 PR A). Attention transitions also refresh this file.
     turnPhase: codex.turnPhase,
     attentionWindowActive: inAttentionWindow,
+    // P1 #5: keep app-server identity in step with /healthz so status.json and
+    // the control status stream cannot drift on this field either.
+    appServerInfo: codex.capturedAppServerInfo,
   });
 }
 

--- a/src/unit-test/app-server-protocol.test.ts
+++ b/src/unit-test/app-server-protocol.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  APP_SERVER_RATE_LIMIT_ERROR_CODES,
   APP_SERVER_SERVER_REQUEST_METHODS,
   APP_SERVER_TRACKED_REQUEST_METHODS,
   isAppServerNotification,
@@ -7,6 +8,7 @@ import {
   isAppServerResponseMessage,
   isAppServerServerRequest,
   isTrackedAppServerRequestMethod,
+  parseAppServerVersion,
 } from "../app-server-protocol";
 
 describe("app-server protocol subset", () => {
@@ -108,5 +110,35 @@ describe("app-server protocol subset", () => {
     expect(isAppServerResponseMessage("response")).toBe(false);
     expect(isAppServerResponseMessage(123)).toBe(false);
     expect(isAppServerResponseMessage([{ id: 1, result: {} }])).toBe(false);
+  });
+});
+
+describe("parseAppServerVersion (P1 #5)", () => {
+  test("extracts the version token after the first slash", () => {
+    // Real codex-rs userAgent shape: "{originator}/{version} ({os}; {arch}) {ua}"
+    // (codex-rs/login/src/auth/default_client.rs:133).
+    expect(parseAppServerVersion("codex_cli_rs/0.139.0 (Mac OS 15.1; arm64) reqwest/0.12")).toBe(
+      "0.139.0",
+    );
+    expect(parseAppServerVersion("codex/1.0")).toBe("1.0");
+    expect(parseAppServerVersion("codex/0.140.0-beta.2 (linux)")).toBe("0.140.0-beta.2");
+  });
+
+  test("returns null for unparseable / missing userAgent (a drift signal)", () => {
+    expect(parseAppServerVersion(null)).toBeNull();
+    expect(parseAppServerVersion(undefined)).toBeNull();
+    expect(parseAppServerVersion("")).toBeNull();
+    expect(parseAppServerVersion("garbage-no-slash")).toBeNull();
+    expect(parseAppServerVersion(123 as unknown as string)).toBeNull();
+  });
+});
+
+describe("APP_SERVER_RATE_LIMIT_ERROR_CODES (P1 #5)", () => {
+  test("models the generic JSON-RPC codes the rate-limits read path emits", () => {
+    // codex-rs/app-server/src/error_code.rs + account_processor.rs:967-990.
+    expect(APP_SERVER_RATE_LIMIT_ERROR_CODES.has(-32603)).toBe(true); // INTERNAL_ERROR_CODE
+    expect(APP_SERVER_RATE_LIMIT_ERROR_CODES.has(-32600)).toBe(true); // INVALID_REQUEST_ERROR_CODE
+    expect(APP_SERVER_RATE_LIMIT_ERROR_CODES.has(-32099)).toBe(false);
+    expect(APP_SERVER_RATE_LIMIT_ERROR_CODES.has(0)).toBe(false);
   });
 });

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -2231,6 +2231,176 @@ describe("CodexAdapter thread/closed diagnostic sniffer", () => {
   });
 });
 
+describe("CodexAdapter protocol-version awareness (P1 #5)", () => {
+  // Drive an initialize response through the real funnel: register the proxy-id
+  // mapping the way onTuiMessage would, mark it as a pending initialize, then
+  // feed the response. Mirrors the existing "initialize reconnect" test shape.
+  function feedInitializeResponse(
+    adapter: any,
+    proxyId: number,
+    result: unknown,
+    logs: string[],
+  ) {
+    adapter.tuiConnId = 1;
+    adapter.tuiWs = { send: () => {} } as any;
+    adapter.upstreamToClient.set(proxyId, { connId: 1, clientId: 1 });
+    adapter.pendingInitializeProxyIds.add(proxyId);
+    adapter.log = (m: string) => logs.push(m);
+    adapter.handleAppServerPayload(JSON.stringify({ id: proxyId, result }));
+  }
+
+  test("captures version / platform from an initialize response and exposes it", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    expect(adapter.capturedAppServerInfo).toBeNull(); // null before initialize
+
+    feedInitializeResponse(
+      adapter,
+      200001,
+      {
+        userAgent: "codex_cli_rs/0.139.0 (Mac OS 15.1; arm64) reqwest/0.12",
+        codexHome: "/Users/x/.codex",
+        platformFamily: "unix",
+        platformOs: "macos",
+      },
+      logs,
+    );
+
+    const info = adapter.capturedAppServerInfo;
+    expect(info).not.toBeNull();
+    expect(info.version).toBe("0.139.0");
+    expect(info.userAgent).toBe("codex_cli_rs/0.139.0 (Mac OS 15.1; arm64) reqwest/0.12");
+    expect(info.platformFamily).toBe("unix");
+    expect(info.platformOs).toBe("macos");
+    // Captured-info log line present; no unknown-version WARNING for a good UA.
+    expect(logs.some((l) => l.includes("Captured app-server initialize: version=0.139.0"))).toBe(true);
+    expect(logs.some((l) => l.includes("no parseable version"))).toBe(false);
+    // The pending-id bookkeeping is consumed.
+    expect(adapter.pendingInitializeProxyIds.has(200001)).toBe(false);
+  });
+
+  test("WARNs (once per distinct UA) when the initialize response has no parseable version", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+
+    // Missing userAgent entirely → version null, WARNING fires.
+    feedInitializeResponse(adapter, 200002, { platformOs: "linux" }, logs);
+    expect(adapter.capturedAppServerInfo.version).toBeNull();
+    const warns = logs.filter((l) => l.includes("no parseable version"));
+    expect(warns.length).toBe(1);
+
+    // A second initialize with the SAME (missing) UA must not re-warn.
+    feedInitializeResponse(adapter, 200003, { platformOs: "linux" }, logs);
+    expect(logs.filter((l) => l.includes("no parseable version")).length).toBe(1);
+
+    // A DIFFERENT unparseable UA warns again (distinct key).
+    feedInitializeResponse(adapter, 200004, { userAgent: "garbage-no-slash" }, logs);
+    expect(logs.filter((l) => l.includes("no parseable version")).length).toBe(2);
+  });
+
+  test("captures even when the response conn is stale (server identity is conn-independent)", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.tuiConnId = 5; // current primary differs from the mapped conn
+    adapter.upstreamToClient.set(200005, { connId: 2, clientId: 1 });
+    adapter.pendingInitializeProxyIds.add(200005);
+    adapter.log = (m: string) => logs.push(m);
+
+    const forwarded = adapter.handleAppServerPayload(
+      JSON.stringify({ id: 200005, result: { userAgent: "codex_cli_rs/0.140.0 (x)" } }),
+    );
+
+    // Stale response is dropped (not forwarded) ...
+    expect(forwarded).toBeNull();
+    // ... but the version was still captured.
+    expect(adapter.capturedAppServerInfo.version).toBe("0.140.0");
+  });
+
+  test("patchResponse patches a STRUCTURED-code rate-limit error with no fragile warning", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.log = (m: string) => logs.push(m);
+
+    const out = adapter.patchResponse(
+      {
+        jsonrpc: "2.0",
+        id: 7,
+        error: { code: -32603, message: "failed to fetch codex rate limits: timeout" },
+      },
+      "RAW",
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.id).toBe(7);
+    expect(parsed.result.rateLimits).toBeDefined();
+    expect(parsed.result.rateLimitsByLimitId).toBeNull();
+    expect(logs.some((l) => l.includes("via structured code -32603"))).toBe(true);
+    expect(logs.some((l) => l.includes("fragile-match"))).toBe(false);
+  });
+
+  test("patchResponse still patches a TEXT-only legacy rate-limit error via fallback + fragile WARNING", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.log = (m: string) => logs.push(m);
+
+    // Unrecognized code (not in the rate-limit set) but legacy text matches.
+    const out = adapter.patchResponse(
+      {
+        jsonrpc: "2.0",
+        id: 8,
+        error: { code: -32099, message: "could not read rate limits right now" },
+      },
+      "RAW",
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.id).toBe(8);
+    expect(parsed.result.rateLimits).toBeDefined(); // behavior preserved
+    const fragile = logs.filter((l) => l.includes("fragile-match"));
+    expect(fragile.length).toBe(1);
+    expect(logs.some((l) => l.includes("via fragile text fallback"))).toBe(true);
+
+    // Same message again → no second fragile warning (once per distinct message).
+    adapter.patchResponse(
+      {
+        jsonrpc: "2.0",
+        id: 9,
+        error: { code: -32099, message: "could not read rate limits right now" },
+      },
+      "RAW",
+    );
+    expect(logs.filter((l) => l.includes("fragile-match")).length).toBe(1);
+  });
+
+  test("patchResponse leaves a non-rate-limit error untouched", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    adapter.log = (m: string) => logs.push(m);
+
+    const RAW = JSON.stringify({ id: 10, error: { code: -32603, message: "disk full" } });
+    const out = adapter.patchResponse(
+      { jsonrpc: "2.0", id: 10, error: { code: -32603, message: "disk full" } },
+      RAW,
+    );
+
+    expect(out).toBe(RAW); // unchanged
+    expect(logs.some((l) => l.includes("Patching rateLimits"))).toBe(false);
+  });
+
+  test("clearTransientResponseTrackingState drops pending initialize ids but keeps captured info", () => {
+    const adapter = createAdapter();
+    const logs: string[] = [];
+    feedInitializeResponse(adapter, 200010, { userAgent: "codex_cli_rs/0.141.0 (x)" }, logs);
+    expect(adapter.capturedAppServerInfo.version).toBe("0.141.0");
+
+    adapter.pendingInitializeProxyIds.add(999999);
+    adapter.clearTransientResponseTrackingState();
+    expect(adapter.pendingInitializeProxyIds.size).toBe(0);
+    // Captured info is a fact about the server — it persists across the reset.
+    expect(adapter.capturedAppServerInfo.version).toBe("0.141.0");
+  });
+});
+
 describe("CodexAdapter.forceKillAppServerSync", () => {
   test("synchronously SIGKILLs the retained app-server pid", async () => {
     const adapter = createAdapter();

--- a/src/unit-test/doctor.test.ts
+++ b/src/unit-test/doctor.test.ts
@@ -92,6 +92,7 @@ describe("doctor command", () => {
         "config.json",
         "daemon health",
         "daemon readiness",
+        "codex app-server",
         "build drift",
         "artifact alignment",
         "current thread",


### PR DESCRIPTION
## 摘要
审视报告 P1：代理对 Codex app-server 协议耦合点全是无版本感知的硬编码。

## 变更
- 捕获 initialize 响应版本（userAgent token 派生——**实证 codex-rs 无顶层 version 字段**），透出 DaemonStatus + /healthz + doctor；未知 UA 一次性 WARNING
- patchResponse 优先结构化 error.code（rate-limit 复用通用码故 code+text 双门必需），text fallback 打 fragile-match WARNING
- 拦截点 checklist 注释

## 测试
- [x] 959 pass；ci:local 绿；cross-review **双 0 REAL**（codex-rs ground truth 全实证）