### PR TITLE
perf: budget snapshot 广播双定时器合一 / snapshot broadcast timer consolidation

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14274,7 +14274,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("eec6018", "source"),
+  commit: defineString("c817916", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("eec6018", "source"),
+  commit: defineString("c817916", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -3522,6 +3522,7 @@ class BudgetCoordinator {
   config;
   emit;
   onPauseChange;
+  onSnapshot;
   now;
   scheduler;
   log;
@@ -3542,6 +3543,7 @@ class BudgetCoordinator {
     this.config = options.config;
     this.emit = options.emit;
     this.onPauseChange = options.onPauseChange;
+    this.onSnapshot = options.onSnapshot ?? (() => {});
     this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
     this.scheduler = options.scheduler ?? REAL_BUDGET_POLL_SCHEDULER;
     this.log = options.log ?? (() => {});
@@ -3619,7 +3621,7 @@ class BudgetCoordinator {
     }
     if (!usage) {
       if (!this.isPaused())
-        this.latestSnapshot = null;
+        this.setSnapshot(null);
       return;
     }
     if (!this.running) {
@@ -3628,7 +3630,11 @@ class BudgetCoordinator {
     const state = computeBudgetState(usage.claude, usage.codex, this.config, this.now());
     this.updatePendingOverrides(state.effort.codexTier);
     this.applyState(state);
-    this.latestSnapshot = this.toSnapshot(state);
+    this.setSnapshot(this.toSnapshot(state));
+  }
+  setSnapshot(snapshot) {
+    this.latestSnapshot = snapshot;
+    this.onSnapshot(snapshot);
   }
   applyState(state) {
     const previousSide = this.pauseSide();
@@ -4549,7 +4555,6 @@ var LIVENESS_PROBE_POLL_MS = 50;
 var challengeInProgress = false;
 var bufferedMessages = [];
 var budgetCoordinator = null;
-var budgetStatusTimer = null;
 function ensureBudgetCoordinatorStarted() {
   if (!BUDGET_CONFIG.enabled)
     return;
@@ -4560,27 +4565,18 @@ function ensureBudgetCoordinatorStarted() {
       config: BUDGET_CONFIG,
       emit: (id, content) => {
         emitToClaude(systemMessage(id, content));
-        queueMicrotask(() => broadcastStatus());
       },
       onPauseChange: (paused) => {
         log(`Budget intervention ${paused ? "ACTIVE" : "CLEARED"} ` + `(gate ${budgetCoordinator?.isGateClosed() ? "CLOSED" : "OPEN"})`);
-        queueMicrotask(() => broadcastStatus());
       },
+      onSnapshot: () => broadcastStatus(),
       log
     });
   }
   budgetCoordinator.start();
-  if (!budgetStatusTimer) {
-    budgetStatusTimer = setInterval(() => broadcastStatus(), BUDGET_CONFIG.pollSeconds * 1000);
-    budgetStatusTimer.unref?.();
-  }
 }
 function stopBudgetCoordinator() {
   budgetCoordinator?.stop();
-  if (budgetStatusTimer) {
-    clearInterval(budgetStatusTimer);
-    budgetStatusTimer = null;
-  }
 }
 function budgetPauseGateError() {
   const snapshot = budgetCoordinator?.getSnapshot() ?? null;

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -54,6 +54,7 @@ export interface BudgetCoordinatorOptions {
   config: BudgetConfig;
   emit: (id: string, content: string) => void;
   onPauseChange: (paused: boolean) => void;
+  onSnapshot?: (snapshot: BudgetSnapshot | null) => void;
   now?: () => number;
   scheduler?: BudgetPollScheduler;
   log?: (message: string) => void;
@@ -150,6 +151,7 @@ export class BudgetCoordinator {
   private readonly config: BudgetConfig;
   private readonly emit: (id: string, content: string) => void;
   private readonly onPauseChange: (paused: boolean) => void;
+  private readonly onSnapshot: (snapshot: BudgetSnapshot | null) => void;
   private readonly now: () => number;
   private readonly scheduler: BudgetPollScheduler;
   private readonly log: (message: string) => void;
@@ -172,6 +174,7 @@ export class BudgetCoordinator {
     this.config = options.config;
     this.emit = options.emit;
     this.onPauseChange = options.onPauseChange;
+    this.onSnapshot = options.onSnapshot ?? (() => {});
     this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
     this.scheduler = options.scheduler ?? REAL_BUDGET_POLL_SCHEDULER;
     this.log = options.log ?? (() => {});
@@ -264,7 +267,7 @@ export class BudgetCoordinator {
     }
 
     if (!usage) {
-      if (!this.isPaused()) this.latestSnapshot = null;
+      if (!this.isPaused()) this.setSnapshot(null);
       return;
     }
 
@@ -275,7 +278,12 @@ export class BudgetCoordinator {
     const state = computeBudgetState(usage.claude, usage.codex, this.config, this.now());
     this.updatePendingOverrides(state.effort.codexTier);
     this.applyState(state);
-    this.latestSnapshot = this.toSnapshot(state);
+    this.setSnapshot(this.toSnapshot(state));
+  }
+
+  private setSnapshot(snapshot: BudgetSnapshot | null): void {
+    this.latestSnapshot = snapshot;
+    this.onSnapshot(snapshot);
   }
 
   private applyState(state: BudgetState): void {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -154,7 +154,6 @@ const bufferedMessages: BridgeMessage[] = [];
 // The coordinator owns polling/dedup/pause-hysteresis; the daemon owns the
 // claude_to_codex pause gate and snapshot exposure via DaemonStatus.budget.
 let budgetCoordinator: BudgetCoordinator | null = null;
-let budgetStatusTimer: ReturnType<typeof setInterval> | null = null;
 
 function ensureBudgetCoordinatorStarted() {
   if (!BUDGET_CONFIG.enabled) return;
@@ -175,10 +174,6 @@ function ensureBudgetCoordinatorStarted() {
       config: BUDGET_CONFIG,
       emit: (id, content) => {
         emitToClaude(systemMessage(id, content));
-        // Defer one microtask: the coordinator writes latestSnapshot AFTER its
-        // applyState() callbacks return, so an immediate broadcast would push
-        // the previous poll's snapshot on directive edges.
-        queueMicrotask(() => broadcastStatus());
       },
       onPauseChange: (paused) => {
         // v2.4: paused = R4 intervention active (handoff OR pause); the reply
@@ -187,26 +182,16 @@ function ensureBudgetCoordinatorStarted() {
           `Budget intervention ${paused ? "ACTIVE" : "CLEARED"} ` +
           `(gate ${budgetCoordinator?.isGateClosed() ? "CLOSED" : "OPEN"})`,
         );
-        queueMicrotask(() => broadcastStatus());
       },
+      onSnapshot: () => broadcastStatus(),
       log,
     });
   }
   void budgetCoordinator.start();
-  // Keep DaemonStatus.budget (and the bridge's get_budget cache) fresh between
-  // directives: snapshots change every poll even when no directive fires.
-  if (!budgetStatusTimer) {
-    budgetStatusTimer = setInterval(() => broadcastStatus(), BUDGET_CONFIG.pollSeconds * 1000);
-    budgetStatusTimer.unref?.();
-  }
 }
 
 function stopBudgetCoordinator() {
   budgetCoordinator?.stop();
-  if (budgetStatusTimer) {
-    clearInterval(budgetStatusTimer);
-    budgetStatusTimer = null;
-  }
 }
 
 function budgetPauseGateError(): string {

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -118,6 +118,33 @@ async function waitFor(condition: () => boolean, timeoutMs = 250): Promise<void>
 }
 
 describe("BudgetCoordinator", () => {
+  test("calls onSnapshot after latestSnapshot is updated", async () => {
+    const source = new FakeSource([{ claude: usage(), codex: usage({ gateUtil: 25, warnUtil: 25 }) }]);
+    let coordinator: BudgetCoordinator;
+    const snapshots: Array<{
+      snapshot: ReturnType<BudgetCoordinator["getSnapshot"]>;
+      current: ReturnType<BudgetCoordinator["getSnapshot"]>;
+    }> = [];
+    coordinator = new BudgetCoordinator({
+      source,
+      config: CONFIG,
+      emit: () => {},
+      onPauseChange: () => {},
+      now: () => NOW,
+      onSnapshot: (snapshot) => {
+        snapshots.push({ snapshot, current: coordinator.getSnapshot() });
+      },
+    });
+
+    await coordinator.start();
+    coordinator.stop();
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]!.snapshot).toBe(coordinator.getSnapshot());
+    expect(snapshots[0]!.current).toBe(snapshots[0]!.snapshot);
+    expect(snapshots[0]!.snapshot).toMatchObject({ codex: { gateUtil: 25 } });
+  });
+
   test("adaptive poll delay uses longer intervals far from thresholds", () => {
     const config = longPollConfig();
 

--- a/src/unit-test/daemon-wiring.test.ts
+++ b/src/unit-test/daemon-wiring.test.ts
@@ -482,6 +482,84 @@ describe("daemon wiring", () => {
     }
   }, 60000);
 
+  test("budget status broadcasts follow coordinator snapshot polls, not the daemon interval", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-budget-snapshot-fixture-"));
+    const probePath = join(fixtureRoot, "probe.sh");
+    const writeUsage = (agent: "claude" | "codex", gateUtil: number, resetOffsetSec: number) => {
+      writeFileSync(
+        join(fixtureRoot, `usage-${agent}.json`),
+        JSON.stringify({
+          ok: true,
+          util: gateUtil,
+          warn_util: gateUtil,
+          fetched_at: Math.floor(Date.now() / 1000),
+          buckets: [
+            {
+              id: "five_hour",
+              util: gateUtil,
+              reset_epoch: Math.floor(Date.now() / 1000) + resetOffsetSec,
+            },
+          ],
+        }),
+      );
+    };
+    const writeBoth = (gateUtil: number, resetOffsetSec: number) => {
+      writeUsage("claude", gateUtil, resetOffsetSec);
+      writeUsage("codex", gateUtil, resetOffsetSec);
+    };
+    writeBoth(10, 1);
+    writeFileSync(probePath, `#!/bin/sh\ncat "${fixtureRoot}/usage-$2.json"\n`, "utf-8");
+    chmodSync(probePath, 0o755);
+
+    try {
+      const harness = await startHarness({
+        pairId: "main-budsnap1",
+        pairName: "main",
+        projectConfig: {
+          version: "1.0",
+          budget: {
+            codexTierControl: true,
+            codexTiers: { full: { effort: "high" } },
+          },
+        },
+        extraEnv: {
+          AGENTBRIDGE_BUDGET_ENABLED: "1",
+          AGENTBRIDGE_QUOTA_PROBE: probePath,
+          AGENTBRIDGE_BUDGET_POLL_SECONDS: "300",
+        },
+      });
+
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      await waitFor(async () => {
+        try {
+          const res = await fetch(`http://127.0.0.1:${harness.controlPort}/healthz`);
+          if (!res.ok) return false;
+          const status = (await res.json()) as DaemonStatus;
+          return status.budget?.codexTier === "full";
+        } catch {
+          return false;
+        }
+      }, "initial full budget snapshot", 100, 100);
+
+      const statusCount = harness.statusMessages.length;
+      writeBoth(85, 3600);
+
+      await waitFor(
+        () =>
+          harness.statusMessages
+            .slice(statusCount)
+            .some((message) => message.type === "status" && message.status.budget?.codexTier === "eco"),
+        "budget status broadcast from coordinator snapshot callback",
+        140,
+        100,
+      );
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 30000);
+
   test("on_busy=steer feeds the message into a running turn via turn/steer (protocol v2 B0)", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-steer-fixture-"));
     const steerLog = join(fixtureRoot, "turnsteer.jsonl");


### PR DESCRIPTION
## 摘要
审视报告 P1（Codex 实现）：daemon budgetStatusTimer 与 coordinator 同周期但相位不同步，广播 snapshot 最坏陈旧近一周期。

## 变更
- BudgetCoordinator 增 onSnapshot（setSnapshot 保证写后回调序）；daemon 用 onSnapshot 广播，删影子 interval + 两处 queueMicrotask
- snapshot 新鲜度变「poll 完成即广播」确定性时序，与 #11 自适应节奏兼容

## 测试
- [x] 964 pass；ci:local 绿；cross-review **双 0 REAL**（无丢失广播枚举 + 写后回调序 + scope 干净）