### PR TITLE
feat: abg pairs prune 条目级回收（失效注册条目）/ registry entry-level prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ After modifying AgentBridge source code, re-run `agentbridge dev` to sync change
 | `abg claude [args...]` | Start Claude Code with push channel enabled. **Runs with `--dangerously-skip-permissions` by default** (opt out: `--safe` or `AGENTBRIDGE_SAFE=1`). Clears any killed sentinel from a previous `kill`. Pass-through args are forwarded to `claude` |
 | `abg codex [args...]` | Start Codex TUI connected to AgentBridge daemon. **Bare `abg codex` auto-resumes the pair's last thread; use `abg codex --new` for a fresh thread. TUI launches run with `--yolo` by default** (opt out: `--safe` or `AGENTBRIDGE_SAFE=1`; non-TUI subcommands like `exec` are never touched). Manages TUI process lifecycle (pid tracking, cleanup). Pass-through args forwarded to `codex` |
 | `abg resume [claude\|codex]` | No target: print the resume commands for this directory's last Claude Code session and this pair's current Codex thread. With a target: resume that side directly (delegates to `abg claude --resume <id>` / `abg codex resume-current`) |
-| `abg pairs` | List registered pairs; `abg pairs rm <name\|id>` removes one, `abg pairs prune` deletes orphan state dirs |
+| `abg pairs` | List registered pairs; `abg pairs rm <name\|id>` removes one; `abg pairs prune` previews reclaimable orphan dirs + stranded registry entries (cwd-gone, dead, >1 day), `abg pairs prune --apply` deletes them |
 | `abg doctor [--json]` | Read-only diagnosis: env, daemon health/readiness, build drift, artifact alignment, TUI attachment, logs |
 | `abg budget [--json]` | Both agents' subscription quota snapshot (5h/weekly windows, drift, pause state) |
 | `abg kill` | Gracefully stop this pair's daemon and managed Codex TUI, write killed sentinel; `abg kill --all` stops every pair |

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13839,9 +13839,6 @@ class StateDirResolver {
   get statusFile() {
     return join(this.stateDir, "status.json");
   }
-  get portsFile() {
-    return join(this.stateDir, "ports.json");
-  }
   get currentThreadFile() {
     return join(this.stateDir, "current-thread.json");
   }
@@ -14274,7 +14271,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("c817916", "source"),
+  commit: defineString("9195031", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -15316,6 +15313,7 @@ import { basename, join as join3, resolve, sep } from "path";
 var PAIR_BASE_PORT = 4500;
 var PAIR_SLOT_STRIDE = 10;
 var PAIR_ID_REGEX = /^[A-Za-z0-9._-]{1,64}$/;
+var RECLAIMABLE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 var REGISTRY_FILE_NAME = "registry.json";
 class PairError extends Error {
   code;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("c817916", "source"),
+  commit: defineString("9195031", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -83,9 +83,6 @@ class StateDirResolver {
   }
   get statusFile() {
     return join(this.stateDir, "status.json");
-  }
-  get portsFile() {
-    return join(this.stateDir, "ports.json");
   }
   get currentThreadFile() {
     return join(this.stateDir, "current-thread.json");
@@ -4480,6 +4477,7 @@ function formatWaitingForCodexTuiMessage(options) {
 // src/pair-registry.ts
 var PAIR_BASE_PORT = 4500;
 var PAIR_SLOT_STRIDE = 10;
+var RECLAIMABLE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 var MAX_PAIR_SLOT = Math.floor((65535 - 2 - PAIR_BASE_PORT) / PAIR_SLOT_STRIDE);
 
 // src/liveness-probe.ts

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -150,8 +150,9 @@ Commands:
                      No target: print resume commands for this directory's last
                      Claude session + this pair's current Codex thread.
                      With target: resume that side directly.
-  pairs [rm <name|id> | prune [--dry-run]]
-                     List pairs; remove one (rm), or delete orphan state dirs (prune)
+  pairs [rm <name|id> | prune [--apply]]
+                     List pairs; remove one (rm), or reclaim orphan dirs + stranded
+                     entries (prune previews by default; --apply to delete)
   doctor [--json]    Diagnose env, daemon, build drift, logs, and current thread
   doctor resume-pollution [--apply]  Find/fix old AgentBridge kickoff metadata
   budget [--json]    Show both agents' subscription quota snapshot (5h/weekly, drift, pause state)
@@ -202,8 +203,8 @@ Examples:
   abg --pair work logs         # Tail the "work" pair's daemon log
   abg pairs rm work            # Stop this directory's "work" pair and free its slot
   abg pairs rm work-1a2b3c4d   # ...or by its full id (from that pair's directory)
-  abg pairs prune --dry-run    # Preview orphan pair dirs (no registry entry, not live)
-  abg pairs prune              # ...delete those orphan state directories
+  abg pairs prune              # Preview reclaimable: orphan dirs + stranded entries (cwd-gone, dead, >1d)
+  abg pairs prune --apply      # ...actually delete the previewed dirs + entries
   abg --pair work kill         # Stop only this directory's "work" pair
   abg kill                     # Stop this directory's pairs (+ any legacy-root daemon)
   abg kill all                 # Stop every pair in every directory (+ legacy-root)

--- a/src/cli/pairs.ts
+++ b/src/cli/pairs.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { DaemonLifecycle } from "../daemon-lifecycle";
 import {
+  classifyReclaimableEntries,
   detectLegacyRootDaemon,
   listPairDirs,
   pairDirDaemonAlive,
@@ -9,6 +10,7 @@ import {
   validatePairId,
   type PairEntry,
   type PairPorts,
+  type ReclaimableEntry,
 } from "../pair-registry";
 import {
   computeBaseDir,
@@ -50,7 +52,7 @@ export async function runPairs(args: string[] = []) {
   if (command && command !== "list" && command !== "--json" && command !== "--threads") {
     console.error(`Unknown pairs command: ${command}`);
     console.error(
-      "Usage: abg pairs [--json] [--threads] | abg pairs rm <name|id> | abg pairs prune [--dry-run]",
+      "Usage: abg pairs [--json] [--threads] | abg pairs rm <name|id> | abg pairs prune [--apply]",
     );
     process.exit(1);
   }
@@ -134,23 +136,71 @@ async function runRemove(args: string[]) {
 }
 
 /**
- * `abg pairs prune [--dry-run]` — remove orphan pair state directories left under
- * `<base>/pairs` that have no registry entry and no live daemon. These accumulate
- * from older builds (and `abg pairs rm` before this change) that dropped the
- * registry entry without deleting the directory. Registered or live dirs are
- * never touched; `--dry-run` reports what would be removed without deleting.
+ * `abg pairs prune [--apply]` — reclaim two kinds of registry leak:
+ *
+ *   1. ORPHAN DIRS — a state dir under `<base>/pairs` with NO registry entry and
+ *      no live daemon (older builds / pre-B1 `abg pairs rm` dropped the entry but
+ *      left the dir). Reclaimed via removeUnregisteredPairDir.
+ *   2. RECLAIMABLE ENTRIES (P1 #9) — a registry entry that is permanently invalid:
+ *      its cwd is gone, no live daemon owns it, and it is older than
+ *      RECLAIMABLE_MIN_AGE_MS. The canonical case is a double-hash-bug strand that
+ *      permanently occupies a slot/port range. Reclaimed (entry + dir together)
+ *      via removePairEntryAndDir.
+ *
+ * DRY RUN IS THE DEFAULT — the command only ever reports what it WOULD reclaim.
+ * `--apply` is required to actually delete. Registered-and-valid, live, or
+ * too-young entries/dirs are never touched.
  */
 async function runPrune(args: string[]) {
-  const dryRun = args.includes("--dry-run");
+  // Dry run is the default; deletion requires an explicit --apply. `--dry-run` is
+  // still accepted as an explicit no-op alias for the default so older muscle
+  // memory / scripts keep working.
+  const apply = args.includes("--apply");
   for (const arg of args) {
-    if (arg !== "--dry-run") {
+    if (arg !== "--apply" && arg !== "--dry-run") {
       console.error(`Unknown prune argument: ${arg}`);
-      console.error("Usage: abg pairs prune [--dry-run]");
+      console.error("Usage: abg pairs prune [--apply]");
       process.exit(1);
     }
   }
+  if (apply && args.includes("--dry-run")) {
+    console.error("Error: --apply and --dry-run are mutually exclusive.");
+    console.error("Usage: abg pairs prune [--apply]");
+    process.exit(1);
+  }
 
   const base = computeBaseDir();
+
+  // Classify reclaimable entries up front so the orphan-dir pass can SKIP the
+  // dirs that the entry pass will reclaim — otherwise a stranded entry's dir is
+  // double-reported (once as "registered" in Kept, once as a reclaimed entry).
+  const reclaimable = classifyReclaimableEntries(base);
+  const reclaimableIds = new Set(reclaimable.map((c) => c.entry.pairId.toLowerCase()));
+
+  const dirResult = pruneOrphanDirs(base, apply, reclaimableIds);
+  const entryResult = await pruneReclaimableEntries(reclaimable, base, apply);
+  // The orphan-dir prune may itself perform locked deletes; await it after we
+  // have its (synchronously-built) plan so both passes report coherently.
+  const resolvedDirResult = await dirResult;
+
+  printPruneSummary(resolvedDirResult, entryResult, apply);
+}
+
+interface OrphanDirResult {
+  removed: string[];
+  kept: Array<{ name: string; reason: string }>;
+}
+
+/**
+ * Reclaim orphan pair state dirs (dir exists, no registry entry, not live).
+ * `reclaimableIds` are the lowercased pairIds the ENTRY pass will reclaim — their
+ * dirs are skipped here so they are not also reported as "registered" Kept dirs.
+ */
+async function pruneOrphanDirs(
+  base: string,
+  apply: boolean,
+  reclaimableIds: ReadonlySet<string>,
+): Promise<OrphanDirResult> {
   const registered = new Set(listPairs(base).map((pair) => pair.pairId.toLowerCase()));
   const removed: string[] = [];
   const kept: Array<{ name: string; reason: string }> = [];
@@ -170,18 +220,23 @@ async function runPrune(args: string[]) {
       kept.push({ name, reason: "directory name is not a canonical pair id" });
       continue;
     }
+    // The entry pass owns this dir (it will reclaim the entry + dir together) —
+    // don't report it here at all.
+    if (reclaimableIds.has(id.toLowerCase())) {
+      continue;
+    }
     if (registered.has(id.toLowerCase())) {
       kept.push({ name, reason: "registered — use `abg pairs rm`" });
       continue;
     }
     // Cheap pre-filter using the SAME conservative liveness probe as the
-    // authoritative in-lock gate (pairDirDaemonAlive), so a --dry-run preview
+    // authoritative in-lock gate (pairDirDaemonAlive), so the dry-run preview
     // matches what a real prune would do and the pid logic lives in one place.
     if (pairDirDaemonAlive(base, id)) {
       kept.push({ name, reason: "daemon still alive" });
       continue;
     }
-    if (dryRun) {
+    if (!apply) {
       removed.push(name);
       continue;
     }
@@ -205,30 +260,114 @@ async function runPrune(args: string[]) {
     }
   }
 
-  printPruneSummary(removed, kept, dryRun);
+  return { removed, kept };
 }
 
-function printPruneSummary(
-  removed: string[],
-  kept: Array<{ name: string; reason: string }>,
-  dryRun: boolean,
-) {
-  if (removed.length === 0 && kept.length === 0) {
-    console.log("No pair directories found.");
+interface EntryReclaimResult {
+  /** Entries reclaimed (--apply) or that WOULD be reclaimed (default dry run). */
+  reclaimed: Array<{ pairId: string; slot: number; reason: string }>;
+  /** Entries skipped at apply time because a concurrent relaunch made them live. */
+  kept: Array<{ pairId: string; reason: string }>;
+}
+
+/**
+ * Reclaim permanently-invalid registry entries (cwd-gone + dead + old).
+ *
+ * `candidates` is the read-only classification from `classifyReclaimableEntries`,
+ * which also builds the dry-run preview. Under `--apply` each candidate is deleted
+ * via `removePairEntryAndDir`, whose in-lock liveness gate is the authoritative
+ * check: if a relaunch made the pair live between classify and delete, it is kept
+ * (keptLive), never destroyed.
+ */
+async function pruneReclaimableEntries(
+  candidates: ReclaimableEntry[],
+  base: string,
+  apply: boolean,
+): Promise<EntryReclaimResult> {
+  const reclaimed: Array<{ pairId: string; slot: number; reason: string }> = [];
+  const kept: Array<{ pairId: string; reason: string }> = [];
+
+  for (const candidate of candidates) {
+    const reason = describeReclaimReason(candidate);
+    if (!apply) {
+      reclaimed.push({ pairId: candidate.entry.pairId, slot: candidate.entry.slot, reason });
+      continue;
+    }
+    try {
+      const res = await removePairEntryAndDir(base, candidate.entry.pairId);
+      if (res.keptLive) {
+        kept.push({ pairId: candidate.entry.pairId, reason: "became live during prune" });
+      } else {
+        reclaimed.push({ pairId: candidate.entry.pairId, slot: candidate.entry.slot, reason });
+      }
+    } catch (err) {
+      kept.push({
+        pairId: candidate.entry.pairId,
+        reason: `error: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+
+  return { reclaimed, kept };
+}
+
+/** Human-readable reason string for a reclaimable entry (cwd-gone, dead, age). */
+function describeReclaimReason(candidate: ReclaimableEntry): string {
+  const { signals } = candidate;
+  const age = signals.ageMs === null ? "age?" : `age ${formatAgeDays(signals.ageMs)}`;
+  return `cwd-gone, dead, ${age}`;
+}
+
+/** Format a millisecond age as a compact "Nd" / "N.Nd" day count for the reason line. */
+function formatAgeDays(ageMs: number): string {
+  const days = ageMs / (24 * 60 * 60 * 1000);
+  return days >= 10 ? `${Math.round(days)}d` : `${days.toFixed(1)}d`;
+}
+
+function printPruneSummary(dirResult: OrphanDirResult, entryResult: EntryReclaimResult, apply: boolean) {
+  const { removed: dirsRemoved, kept: dirsKept } = dirResult;
+  const { reclaimed: entriesReclaimed, kept: entriesKept } = entryResult;
+
+  const nothingFound =
+    dirsRemoved.length === 0 &&
+    dirsKept.length === 0 &&
+    entriesReclaimed.length === 0 &&
+    entriesKept.length === 0;
+  if (nothingFound) {
+    console.log("Nothing to prune: no orphan pair directories or reclaimable entries found.");
     return;
   }
-  if (removed.length > 0) {
-    console.log(dryRun ? "Would remove orphan pair directories:" : "Removed orphan pair directories:");
-    for (const name of removed) console.log(`  ${name}`);
-  } else {
-    console.log(dryRun ? "No orphan pair directories to remove." : "No orphan pair directories removed.");
+
+  // --- Orphan dirs ---
+  if (dirsRemoved.length > 0) {
+    console.log(apply ? "Removed orphan pair directories:" : "Would remove orphan pair directories:");
+    for (const name of dirsRemoved) console.log(`  ${name}`);
   }
-  if (kept.length > 0) {
+
+  // --- Reclaimable entries ---
+  if (entriesReclaimed.length > 0) {
+    console.log(apply ? "Reclaimed registry entries:" : "Would reclaim registry entries:");
+    for (const { pairId, slot, reason } of entriesReclaimed) {
+      console.log(`  ${pairId} (slot ${slot}) — ${reason}`);
+    }
+  }
+
+  if (dirsRemoved.length === 0 && entriesReclaimed.length === 0) {
+    console.log(apply ? "Nothing was reclaimed." : "Nothing to reclaim.");
+  }
+
+  // --- Kept (skipped) ---
+  const keptLines = [
+    ...dirsKept.map(({ name, reason }) => `  ${name} (${reason})`),
+    ...entriesKept.map(({ pairId, reason }) => `  ${pairId} (${reason})`),
+  ];
+  if (keptLines.length > 0) {
     console.log("Kept:");
-    for (const { name, reason } of kept) console.log(`  ${name} (${reason})`);
+    for (const line of keptLines) console.log(line);
   }
-  if (dryRun) {
-    console.log("\n(dry run — nothing was deleted. Re-run without --dry-run to apply.)");
+
+  if (!apply) {
+    console.log("\n(dry run — nothing was deleted. Re-run with --apply to reclaim.)");
   }
 }
 

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -738,6 +738,20 @@ describe("E2E: CLI surface", () => {
     });
   }, 20000);
 
+  test("agentbridge --help documents the prune dry-run-by-default / --apply contract", async () => {
+    // Regression guard: #9 inverted the prune contract (bare prune previews,
+    // --apply deletes). The help text must match — a destructive command whose
+    // safety story is "dry-run default" cannot have help that says bare prune
+    // deletes (the old, now-false wording) or omits --apply.
+    await withHarness(async (harness) => {
+      const result = await harness.runCli(["--help"]);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("prune [--apply]");
+      expect(result.stdout).toContain("--apply");
+      expect(result.stdout).not.toContain("delete those orphan state directories");
+    });
+  }, 20000);
+
   test("agentbridge kill rejects unknown flags without stopping a running daemon", async () => {
     await withHarness(async (harness) => {
       await harness.startManagedFakeDaemon();
@@ -908,8 +922,9 @@ describe("E2E: CLI surface", () => {
       try {
         const baseEnv = { AGENTBRIDGE_BASE_DIR: harness.baseDir };
 
-        // Dry run lists the orphans but deletes nothing.
-        const dry = await harness.runCliWithEnv(["pairs", "prune", "--dry-run"], baseEnv);
+        // Bare `prune` is now a DRY RUN (the safe default): it lists the orphans
+        // but deletes nothing. `--dry-run` stays accepted as an explicit alias.
+        const dry = await harness.runCliWithEnv(["pairs", "prune"], baseEnv);
         expect(dry.code).toBe(0);
         expect(dry.stdout).toContain("main-aaaa0001");
         expect(dry.stdout).toContain("main-bbbb0002");
@@ -917,8 +932,8 @@ describe("E2E: CLI surface", () => {
         expect(existsSync(orphanNoPid)).toBe(true);
         expect(existsSync(orphanDead)).toBe(true);
 
-        // Real prune deletes only the dead orphans.
-        const run = await harness.runCliWithEnv(["pairs", "prune"], baseEnv);
+        // --apply deletes only the dead orphans; live and registered are kept.
+        const run = await harness.runCliWithEnv(["pairs", "prune", "--apply"], baseEnv);
         expect(run.code).toBe(0);
         expect(existsSync(orphanNoPid)).toBe(false);
         expect(existsSync(orphanDead)).toBe(false);
@@ -929,6 +944,134 @@ describe("E2E: CLI surface", () => {
           liveChild.kill("SIGKILL");
         } catch {}
       }
+    });
+  }, 20000);
+
+  test("agentbridge pairs prune reclaims a stranded entry (cwd-gone + dead + old) only with --apply (P1 #9)", async () => {
+    await withHarness(async (harness) => {
+      const pairsRoot = join(harness.baseDir, "pairs");
+      mkdirSync(pairsRoot, { recursive: true });
+
+      // A stranded entry: its cwd does NOT exist, no daemon, created long ago.
+      // This mirrors the real double-hash-bug residue that permanently squats a slot.
+      const strandedId = "main-deadbeef";
+      const strandedDir = join(pairsRoot, strandedId);
+      mkdirSync(strandedDir, { recursive: true });
+      writeFileSync(join(strandedDir, "agentbridge.log"), "x", "utf-8");
+      const goneCwd = join(harness.rootDir, "vanished-project"); // never created on disk
+      const oldCreatedAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+      // A valid current-cwd entry that must NEVER be reclaimed (cwd exists).
+      const liveId = derivePairId(harness.projectDir, "work");
+      const liveDir = join(pairsRoot, liveId);
+      mkdirSync(liveDir, { recursive: true });
+
+      writeFileSync(
+        join(pairsRoot, "registry.json"),
+        JSON.stringify(
+          {
+            version: 1,
+            pairs: [
+              { pairId: strandedId, slot: 1, cwd: goneCwd, name: "main", source: "cwd", createdAt: oldCreatedAt },
+              {
+                pairId: liveId,
+                slot: 2,
+                cwd: harness.projectDir,
+                name: "work",
+                source: "flag",
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      );
+
+      const baseEnv = { AGENTBRIDGE_BASE_DIR: harness.baseDir };
+
+      // Dry run (default): lists the stranded entry, deletes nothing.
+      const dry = await harness.runCliWithEnv(["pairs", "prune"], baseEnv);
+      expect(dry.code).toBe(0);
+      expect(dry.stdout).toContain("Would reclaim registry entries:");
+      expect(dry.stdout).toContain(strandedId);
+      expect(dry.stdout).toContain("cwd-gone, dead");
+      expect(dry.stdout).toContain("dry run");
+      // Nothing deleted yet.
+      expect(existsSync(strandedDir)).toBe(true);
+      // The valid entry is NOT listed for reclamation.
+      expect(dry.stdout).not.toContain(`Would reclaim registry entries:\n  ${liveId}`);
+
+      // --apply reclaims the stranded entry + dir; the valid entry stays.
+      const apply = await harness.runCliWithEnv(["pairs", "prune", "--apply"], baseEnv);
+      expect(apply.code).toBe(0);
+      expect(apply.stdout).toContain("Reclaimed registry entries:");
+      expect(apply.stdout).toContain(strandedId);
+      expect(existsSync(strandedDir)).toBe(false);
+      expect(existsSync(liveDir)).toBe(true);
+
+      // The registry now contains only the valid entry.
+      const reg = JSON.parse(readFileSync(join(pairsRoot, "registry.json"), "utf-8")) as {
+        pairs: Array<{ pairId: string }>;
+      };
+      expect(reg.pairs.map((p) => p.pairId)).toEqual([liveId]);
+    });
+  }, 20000);
+
+  test("agentbridge pairs prune combined: one orphan dir + one reclaimable entry, --apply cleans both (P1 #9)", async () => {
+    await withHarness(async (harness) => {
+      const pairsRoot = join(harness.baseDir, "pairs");
+      mkdirSync(pairsRoot, { recursive: true });
+
+      // (1) Orphan dir: a dir with NO registry entry, no daemon → dir-orphan prune.
+      const orphanDir = join(pairsRoot, "main-orph0001");
+      mkdirSync(orphanDir, { recursive: true });
+
+      // (2) Reclaimable entry: cwd-gone + dead + old → entry-level reclaim.
+      const strandedId = "main-strand02";
+      const strandedDir = join(pairsRoot, strandedId);
+      mkdirSync(strandedDir, { recursive: true });
+      const goneCwd = join(harness.rootDir, "no-such-dir");
+      const oldCreatedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+
+      writeFileSync(
+        join(pairsRoot, "registry.json"),
+        JSON.stringify(
+          {
+            version: 1,
+            pairs: [
+              { pairId: strandedId, slot: 3, cwd: goneCwd, name: "main", source: "cwd", createdAt: oldCreatedAt },
+            ],
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      );
+
+      const baseEnv = { AGENTBRIDGE_BASE_DIR: harness.baseDir };
+
+      // Dry run reports BOTH kinds without deleting.
+      const dry = await harness.runCliWithEnv(["pairs", "prune"], baseEnv);
+      expect(dry.code).toBe(0);
+      expect(dry.stdout).toContain("Would remove orphan pair directories:");
+      expect(dry.stdout).toContain("main-orph0001");
+      expect(dry.stdout).toContain("Would reclaim registry entries:");
+      expect(dry.stdout).toContain(strandedId);
+      expect(existsSync(orphanDir)).toBe(true);
+      expect(existsSync(strandedDir)).toBe(true);
+
+      // --apply cleans BOTH.
+      const apply = await harness.runCliWithEnv(["pairs", "prune", "--apply"], baseEnv);
+      expect(apply.code).toBe(0);
+      expect(existsSync(orphanDir)).toBe(false);
+      expect(existsSync(strandedDir)).toBe(false);
+
+      const reg = JSON.parse(readFileSync(join(pairsRoot, "registry.json"), "utf-8")) as {
+        pairs: Array<{ pairId: string }>;
+      };
+      expect(reg.pairs).toHaveLength(0);
     });
   }, 20000);
 

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -44,6 +44,17 @@ export const PAIR_ID_REGEX = /^[A-Za-z0-9._-]{1,64}$/;
 /** Friendly pair name used when no `--pair <name>` is given. Scoped to the cwd. */
 export const DEFAULT_PAIR_NAME = "main";
 
+/**
+ * Minimum age a registry entry must reach before `abg pairs prune` will consider
+ * it for entry-level reclamation (cwd-gone + dead daemon). This guards against a
+ * just-created pair whose cwd is briefly unavailable (e.g. an unmounted volume, a
+ * transient rename) being reaped before the user has even used it — see
+ * {@link isEntryReclaimable}. One day is deliberately conservative: reclaiming a
+ * permanently-stranded entry a day late is harmless, reaping a live workflow's
+ * entry is not.
+ */
+export const RECLAIMABLE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+
 const LOCK_FILE_NAME = ".registry.lock";
 const REGISTRY_FILE_NAME = "registry.json";
 const LOCK_DEADLINE_MS = 10_000;
@@ -1000,4 +1011,94 @@ export async function removeUnregisteredPairDir(
     }
     return { removed: removePairDir(base, pairId) };
   });
+}
+
+// ---------------------------------------------------------------------------
+// Entry-level reclamation (P1 #9)
+//
+// The dir-orphan prune above reclaims "dir exists but NO registry entry". The
+// reverse leak — "entry exists but is permanently invalid" — is reclaimed here.
+// The canonical example is a stranded entry left by the old double-hash bug: the
+// code was fixed (resolvePair's three-tier match) but the DATA residue persists,
+// permanently occupying a slot/port range that pickLowestFreeSlot still reads.
+// ---------------------------------------------------------------------------
+
+/** Why an entry is (or is not) reclaimable. Display-only; surfaced in the dry run. */
+export interface EntryReclaimSignals {
+  /** The entry's cwd no longer exists on disk (statSync ENOENT). */
+  cwdGone: boolean;
+  /** No live daemon is associated with the entry's pair dir (pairDirDaemonAlive=false). */
+  dead: boolean;
+  /** createdAt is older than {@link RECLAIMABLE_MIN_AGE_MS} relative to `now`. */
+  old: boolean;
+  /** Age of the entry in ms (now - createdAt), clamped to ≥0; null when createdAt is unparseable. */
+  ageMs: number | null;
+}
+
+export interface ReclaimableEntry {
+  entry: PairEntry;
+  signals: EntryReclaimSignals;
+}
+
+/**
+ * Pure reclaim predicate. An entry is RECLAIMABLE only when ALL three guards
+ * hold: its cwd is gone, no live daemon owns it, and it is older than the
+ * minimum age. Any one of "cwd exists" / "daemon alive" / "too young" vetoes
+ * reclamation — the safety rails are conjunctive on purpose.
+ *
+ * Kept signal-only (no fs/clock access) so it is trivially unit-testable; the
+ * caller gathers the live signals via {@link classifyReclaimableEntries}.
+ */
+export function isEntryReclaimable(signals: EntryReclaimSignals): boolean {
+  return signals.cwdGone && signals.dead && signals.old;
+}
+
+/**
+ * Whether an entry's cwd no longer exists. Returns true ONLY on ENOENT (the path
+ * is genuinely gone). Any other stat error (EACCES, EPERM, a transient I/O error)
+ * is treated as "present/unknown" so we never reap an entry whose cwd we merely
+ * cannot inspect — failing closed protects a live workflow.
+ */
+function cwdMissing(cwd: string): boolean {
+  try {
+    statSync(cwd);
+    return false;
+  } catch (err: any) {
+    return err?.code === "ENOENT";
+  }
+}
+
+/** Parse an ISO createdAt into epoch ms; null when missing/unparseable (treated as NOT old). */
+function parseCreatedAtMs(createdAt: string | undefined): number | null {
+  if (typeof createdAt !== "string") return null;
+  const ms = Date.parse(createdAt);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Gather reclaim signals for every registry entry (read-only — no lock, no
+ * deletes). Used by `abg pairs prune` to BOTH build the dry-run preview and pick
+ * which entries to hand to {@link removePairEntryAndDir} under `--apply`.
+ *
+ * Reads the registry once; per entry it stats the cwd and probes liveness with
+ * the SAME `pairDirDaemonAlive` the in-lock delete gate uses, so the preview
+ * matches the eventual action. `now` is injectable for deterministic tests.
+ */
+export function classifyReclaimableEntries(base: string, now: number = Date.now()): ReclaimableEntry[] {
+  const reg = readRegistry(base);
+  const out: ReclaimableEntry[] = [];
+  for (const entry of reg.pairs) {
+    const createdMs = parseCreatedAtMs(entry.createdAt);
+    const ageMs = createdMs === null ? null : Math.max(0, now - createdMs);
+    const signals: EntryReclaimSignals = {
+      cwdGone: cwdMissing(entry.cwd),
+      dead: !pairDirDaemonAlive(base, entry.pairId),
+      // A null/unparseable createdAt is treated as NOT old, so a malformed entry
+      // is never reaped on age grounds — it stays visible for manual `pairs rm`.
+      old: ageMs !== null && ageMs >= RECLAIMABLE_MIN_AGE_MS,
+      ageMs,
+    };
+    if (isEntryReclaimable(signals)) out.push({ entry, signals });
+  }
+  return out;
 }

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -9,7 +9,7 @@ import { homedir, platform } from "node:os";
  * Linux:  ${XDG_STATE_HOME:-~/.local/state}/agentbridge
  * Override: AGENTBRIDGE_STATE_DIR env var
  *
- * This directory stores daemon pid, managed TUI pid, lock, status, ports, and logs.
+ * This directory stores daemon pid, managed TUI pid, lock, status, and logs.
  * It is NOT for project-level config (that lives in .agentbridge/).
  */
 export class StateDirResolver {
@@ -62,10 +62,6 @@ export class StateDirResolver {
 
   get statusFile(): string {
     return join(this.stateDir, "status.json");
-  }
-
-  get portsFile(): string {
-    return join(this.stateDir, "ports.json");
   }
 
   get currentThreadFile(): string {

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -13,10 +13,12 @@ import { createServer, type Server } from "node:net";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  classifyReclaimableEntries,
   DEFAULT_PAIR_NAME,
   derivePairId,
   derivePairIdFromCwd,
   detectLegacyRootDaemon,
+  isEntryReclaimable,
   listPairDirs,
   MAX_PAIR_SLOT,
   pairDirPath,
@@ -26,6 +28,7 @@ import {
   portsForSlot,
   probePortFree,
   readRegistry,
+  RECLAIMABLE_MIN_AGE_MS,
   removePairDir,
   removePairEntry,
   removePairEntryAndDir,
@@ -33,6 +36,7 @@ import {
   resolvePair,
   validatePairId,
   writeRegistry,
+  type EntryReclaimSignals,
   type PairEntry,
   type RegistryFile,
 } from "../pair-registry";
@@ -836,5 +840,178 @@ describe("removePairEntryAndDir / removeUnregisteredPairDir — locked atomic cl
 
     expect(await removeUnregisteredPairDir(base, live)).toEqual({ removed: false, reason: "live" });
     expect(existsSync(join(base, "pairs", live))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Entry-level reclamation (P1 #9)
+// ---------------------------------------------------------------------------
+
+describe("isEntryReclaimable — pure reclaim predicate (P1 #9)", () => {
+  const signals = (over: Partial<EntryReclaimSignals> = {}): EntryReclaimSignals => ({
+    cwdGone: true,
+    dead: true,
+    old: true,
+    ageMs: RECLAIMABLE_MIN_AGE_MS,
+    ...over,
+  });
+
+  test("cwd-gone + dead + old → reclaimable", () => {
+    expect(isEntryReclaimable(signals())).toBe(true);
+  });
+
+  test("cwd still exists → NOT reclaimable", () => {
+    expect(isEntryReclaimable(signals({ cwdGone: false }))).toBe(false);
+  });
+
+  test("daemon alive (not dead) → NOT reclaimable", () => {
+    expect(isEntryReclaimable(signals({ dead: false }))).toBe(false);
+  });
+
+  test("too young (not old) → NOT reclaimable", () => {
+    expect(isEntryReclaimable(signals({ old: false }))).toBe(false);
+  });
+
+  test("only ALL three guards together reclaim — any single veto blocks it", () => {
+    // Exhaustively: any one false flag must veto.
+    expect(isEntryReclaimable(signals({ cwdGone: false, dead: true, old: true }))).toBe(false);
+    expect(isEntryReclaimable(signals({ cwdGone: true, dead: false, old: true }))).toBe(false);
+    expect(isEntryReclaimable(signals({ cwdGone: true, dead: true, old: false }))).toBe(false);
+  });
+});
+
+describe("classifyReclaimableEntries — signal gathering over the registry (P1 #9)", () => {
+  let base: string;
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-reclaim-"));
+  });
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  // A createdAt comfortably older than the min age (used by the "old" cases).
+  const oldCreatedAt = new Date(Date.now() - 5 * RECLAIMABLE_MIN_AGE_MS).toISOString();
+  // Now used for deterministic age math in the assertions below.
+  const fixedNow = Date.now();
+
+  function entryWith(over: Partial<PairEntry>): PairEntry {
+    return {
+      pairId: over.pairId ?? "main-aaaa0001",
+      slot: over.slot ?? 1,
+      cwd: over.cwd ?? join(base, "gone-project"),
+      name: over.name ?? "main",
+      source: over.source ?? "cwd",
+      createdAt: over.createdAt ?? oldCreatedAt,
+    };
+  }
+
+  test("cwd-gone + dead + old entry is classified reclaimable", () => {
+    const e = entryWith({ pairId: "main-deadbeef", cwd: join(base, "vanished") });
+    writeRegistry(base, { version: 1, pairs: [e] });
+
+    const out = classifyReclaimableEntries(base, fixedNow);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.entry.pairId).toBe("main-deadbeef");
+    expect(out[0]!.signals).toMatchObject({ cwdGone: true, dead: true, old: true });
+  });
+
+  test("entry whose cwd still EXISTS is not reclaimable", () => {
+    const livingCwd = join(base, "still-here");
+    mkdirSync(livingCwd, { recursive: true });
+    writeRegistry(base, { version: 1, pairs: [entryWith({ pairId: "main-exist001", cwd: livingCwd })] });
+
+    expect(classifyReclaimableEntries(base, fixedNow)).toHaveLength(0);
+  });
+
+  test("entry with a LIVE daemon is not reclaimable even if cwd is gone", () => {
+    const id = "main-alive001";
+    mkdirSync(join(base, "pairs", id), { recursive: true });
+    // process.pid is alive → pairDirDaemonAlive=true → dead=false → vetoed.
+    writeFileSync(join(base, "pairs", id, "daemon.pid"), `${process.pid}\n`, "utf-8");
+    writeRegistry(base, { version: 1, pairs: [entryWith({ pairId: id, cwd: join(base, "vanished") })] });
+
+    expect(classifyReclaimableEntries(base, fixedNow)).toHaveLength(0);
+  });
+
+  test("entry younger than RECLAIMABLE_MIN_AGE_MS is not reclaimable", () => {
+    // Created 1 hour ago → well under the 1-day floor.
+    const fresh = new Date(fixedNow - 60 * 60 * 1000).toISOString();
+    writeRegistry(base, {
+      version: 1,
+      pairs: [entryWith({ pairId: "main-fresh001", cwd: join(base, "vanished"), createdAt: fresh })],
+    });
+
+    expect(classifyReclaimableEntries(base, fixedNow)).toHaveLength(0);
+  });
+
+  test("age boundary: exactly RECLAIMABLE_MIN_AGE_MS old is reclaimable; one ms younger is not", () => {
+    const atFloor = new Date(fixedNow - RECLAIMABLE_MIN_AGE_MS).toISOString();
+    writeRegistry(base, {
+      version: 1,
+      pairs: [entryWith({ pairId: "main-floor001", cwd: join(base, "vanished"), createdAt: atFloor })],
+    });
+    expect(classifyReclaimableEntries(base, fixedNow)).toHaveLength(1);
+
+    // Re-evaluate the SAME entry against a `now` one ms earlier than the floor.
+    const justUnderNow = fixedNow - 1;
+    expect(classifyReclaimableEntries(base, justUnderNow)).toHaveLength(0);
+  });
+
+  test("malformed/unparseable createdAt is treated as NOT old (never reaped on age)", () => {
+    writeRegistry(base, {
+      version: 1,
+      pairs: [entryWith({ pairId: "main-badtime1", cwd: join(base, "vanished"), createdAt: "not-a-date" })],
+    });
+    const out = classifyReclaimableEntries(base, fixedNow);
+    expect(out).toHaveLength(0);
+  });
+
+  test("classifies a mix: only the cwd-gone + dead + old entry is selected", () => {
+    const goneId = "main-gone0001";
+    const liveCwd = join(base, "live-cwd");
+    mkdirSync(liveCwd, { recursive: true });
+    writeRegistry(base, {
+      version: 1,
+      pairs: [
+        entryWith({ pairId: goneId, slot: 1, cwd: join(base, "vanished") }), // reclaimable
+        entryWith({ pairId: "main-keepcwd1", slot: 2, cwd: liveCwd }), // cwd exists → kept
+        entryWith({ pairId: "main-young001", slot: 3, cwd: join(base, "vanished"), createdAt: new Date(fixedNow).toISOString() }), // too young → kept
+      ],
+    });
+
+    const out = classifyReclaimableEntries(base, fixedNow);
+    expect(out.map((c) => c.entry.pairId)).toEqual([goneId]);
+  });
+});
+
+describe("pruneReclaimableEntries via removePairEntryAndDir — apply deletes entry + dir (P1 #9)", () => {
+  let base: string;
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-reclaim-apply-"));
+  });
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("removePairEntryAndDir on a reclaimable entry removes BOTH the entry and its dir", async () => {
+    const id = "main-strand01";
+    const oldCreatedAt = new Date(Date.now() - 5 * RECLAIMABLE_MIN_AGE_MS).toISOString();
+    const dir = join(base, "pairs", id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "agentbridge.log"), "x", "utf-8");
+    writeRegistry(base, {
+      version: 1,
+      pairs: [{ pairId: id, slot: 1, cwd: join(base, "vanished"), name: "main", source: "cwd", createdAt: oldCreatedAt }],
+    });
+
+    // Sanity: classify flags it as reclaimable.
+    expect(classifyReclaimableEntries(base).map((c) => c.entry.pairId)).toEqual([id]);
+
+    const res = await removePairEntryAndDir(base, id);
+    expect(res.keptLive).toBe(false);
+    expect(res.dirRemoved).toBe(true);
+    expect(res.entry?.pairId).toBe(id);
+    expect(existsSync(dir)).toBe(false);
+    expect(readRegistry(base).pairs.some((p) => p.pairId === id)).toBe(false);
   });
 });

--- a/src/unit-test/state-dir.test.ts
+++ b/src/unit-test/state-dir.test.ts
@@ -26,7 +26,6 @@ describe("StateDirResolver", () => {
     expect(resolver.tuiPidFile).toBe(join(tempDir, "codex-tui.pid"));
     expect(resolver.lockFile).toBe(join(tempDir, "daemon.lock"));
     expect(resolver.statusFile).toBe(join(tempDir, "status.json"));
-    expect(resolver.portsFile).toBe(join(tempDir, "ports.json"));
     expect(resolver.logFile).toBe(join(tempDir, "agentbridge.log"));
     expect(resolver.updateCheckFile).toBe(join(tempDir, "update-check.json"));
   });


### PR DESCRIPTION
审视报告 P1：现有 prune 只回收孤儿目录，「条目存在但永久失效」无人回收（本机实测残留双-hash 时代条目永占端口段）。新增条目级回收：cwd-gone(ENOENT) + daemon-dead + createdAt>1天 → 可回收；**dry-run 默认，--apply 实删**；删 portsFile 死访问器；修 double-report bug。契约文档 help/README 同步 + e2e 回归测试。964 pass；cross-review R1（核心安全双 0 REAL + 1 文档 HIGH）→ R2 双 0 REAL。