### PR TITLE
feat: 统一 CLI 调用名渲染（abg/agentbridge）+ init 依赖检查收集后报告 / unify CLI invocation-name rendering + collect-then-report init deps

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14271,7 +14271,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("9195031", "source"),
+  commit: defineString("3f14d41", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -15290,6 +15290,21 @@ class ConfigService {
   }
 }
 
+// src/cli-invocation.ts
+import { basename } from "path";
+var CLI_NAMES = ["abg", "agentbridge"];
+var DEFAULT_CLI_NAME = "abg";
+function cliInvocationName(argv = process.argv) {
+  const raw = argv[1];
+  if (typeof raw !== "string" || raw.length === 0)
+    return DEFAULT_CLI_NAME;
+  const name = basename(raw).replace(/\.(ts|js|mjs|cjs)$/, "");
+  return isCliName(name) ? name : DEFAULT_CLI_NAME;
+}
+function isCliName(value) {
+  return CLI_NAMES.includes(value);
+}
+
 // src/pair-registry.ts
 import {
   closeSync as closeSync2,
@@ -15309,7 +15324,7 @@ import {
   writeFileSync as writeFileSync3
 } from "fs";
 import { createHash, randomUUID as randomUUID2 } from "crypto";
-import { basename, join as join3, resolve, sep } from "path";
+import { basename as basename2, join as join3, resolve, sep } from "path";
 var PAIR_BASE_PORT = 4500;
 var PAIR_SLOT_STRIDE = 10;
 var PAIR_ID_REGEX = /^[A-Za-z0-9._-]{1,64}$/;
@@ -15390,10 +15405,10 @@ function findPair(base, pairId) {
 }
 
 // src/pair-command.ts
-function pairScopedCommand(cmd) {
+function pairScopedCommand(cmd, name = cliInvocationName()) {
   const pairId = process.env.AGENTBRIDGE_PAIR_ID;
   if (!pairId)
-    return `agentbridge ${cmd}`;
+    return `${name} ${cmd}`;
   let selector = process.env.AGENTBRIDGE_PAIR_NAME;
   if (!selector) {
     try {
@@ -15402,7 +15417,7 @@ function pairScopedCommand(cmd) {
       selector = pairId;
     }
   }
-  return `agentbridge --pair ${selector} ${cmd}`;
+  return `${name} --pair ${selector} ${cmd}`;
 }
 
 // src/bridge-disabled-state.ts
@@ -15418,7 +15433,7 @@ function disabledReplyError(reason) {
     case "auto_recovery_exhausted":
       return `AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${claudeCmd}\`.`;
     case "killed":
-      return `AgentBridge is disabled by \`agentbridge kill\`. Restart Claude Code (\`${claudeCmd}\`), switch to a new conversation, or run \`/resume\` to reconnect.`;
+      return `AgentBridge is disabled by \`${pairScopedCommand("kill")}\`. Restart Claude Code (\`${claudeCmd}\`), switch to a new conversation, or run \`/resume\` to reconnect.`;
   }
 }
 
@@ -15757,7 +15772,7 @@ daemonClient.on("rejected", async (code) => {
 claude.on("ready", async () => {
   log("MCP server ready (push delivery) \u2014 ensuring AgentBridge daemon...");
   if (daemonLifecycle.wasKilled()) {
-    await enterDisabledState("Killed sentinel found \u2014 bridge staying idle", `\u26D4 AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`);
+    await enterDisabledState("Killed sentinel found \u2014 bridge staying idle", `\u26D4 AgentBridge was stopped by \`${pairScopedCommand("kill")}\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`);
     return;
   }
   try {
@@ -15819,7 +15834,7 @@ var reconnectTask = null;
 async function notifyIfDaemonKilled(logMessage) {
   if (!daemonLifecycle.wasKilled())
     return false;
-  await enterDisabledState(logMessage, `\u26D4 AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`);
+  await enterDisabledState(logMessage, `\u26D4 AgentBridge was stopped by \`${pairScopedCommand("kill")}\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`);
   return true;
 }
 async function notifyIfPairRemoved(logMessage) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("9195031", "source"),
+  commit: defineString("3f14d41", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/src/bridge-disabled-state.ts
+++ b/src/bridge-disabled-state.ts
@@ -22,6 +22,6 @@ export function disabledReplyError(reason: BridgeDisabledReason): string {
     case "auto_recovery_exhausted":
       return `AgentBridge auto-recovery gave up after exhausting its retry budget for the in-flight liveness probe contention. Retry manually with \`${claudeCmd}\`.`;
     case "killed":
-      return `AgentBridge is disabled by \`agentbridge kill\`. Restart Claude Code (\`${claudeCmd}\`), switch to a new conversation, or run \`/resume\` to reconnect.`;
+      return `AgentBridge is disabled by \`${pairScopedCommand("kill")}\`. Restart Claude Code (\`${claudeCmd}\`), switch to a new conversation, or run \`/resume\` to reconnect.`;
   }
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -228,7 +228,7 @@ claude.on("ready", async () => {
   if (daemonLifecycle.wasKilled()) {
     await enterDisabledState(
       "Killed sentinel found — bridge staying idle",
-      `⛔ AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`,
+      `⛔ AgentBridge was stopped by \`${pairScopedCommand("kill")}\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`,
     );
     return;
   }
@@ -320,7 +320,7 @@ async function notifyIfDaemonKilled(logMessage: string) {
 
   await enterDisabledState(
     logMessage,
-    `⛔ AgentBridge was stopped by \`agentbridge kill\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`,
+    `⛔ AgentBridge was stopped by \`${pairScopedCommand("kill")}\`. Bridge is staying idle. Restart Claude Code (\`${pairScopedCommand("claude")}\`), switch to a new conversation, or run \`/resume\` to reconnect.`,
   );
   return true;
 }

--- a/src/cli-invocation.ts
+++ b/src/cli-invocation.ts
@@ -1,0 +1,48 @@
+/**
+ * Single source of truth for the CLI invocation name.
+ *
+ * The binary is published under two names — `abg` (short) and `agentbridge`
+ * (full) — and user-facing guidance strings (kill's restart hint, budget's
+ * "run X first", doctor's daemon hints, the `--pair`-scoped command suggestions)
+ * used to hardcode one or the other inconsistently. That meant a user who typed
+ * `abg kill` could be told to restart with `agentbridge claude`, and vice versa.
+ *
+ * `cliInvocationName()` echoes back whichever name the user actually invoked, by
+ * inspecting `process.argv[1]`. Routing every guidance string through it keeps
+ * the whole journey (start → diagnose → kill → restart) phrased in one name.
+ */
+
+import { basename } from "node:path";
+
+/** The two names the CLI binary is published under. */
+export const CLI_NAMES = ["abg", "agentbridge"] as const;
+export type CliName = (typeof CLI_NAMES)[number];
+
+/** Fallback when the basename of argv[1] is neither published name. */
+export const DEFAULT_CLI_NAME: CliName = "abg";
+
+/**
+ * Resolve the name the CLI was invoked as from `process.argv[1]`.
+ *
+ * - basename "abg"  → "abg"
+ * - basename "agentbridge" → "agentbridge"
+ * - anything else (a test runner path, `bun src/cli.ts`, `cli.js`, an unset
+ *   argv[1]) → DEFAULT_CLI_NAME ("abg")
+ *
+ * The strip of a trailing `.ts`/`.js`/`.mjs`/`.cjs` extension lets a
+ * source/dev launcher (`agentbridge.ts`) still resolve to the published name;
+ * a generic `cli.js` bundle name still falls back, which is the safe default.
+ *
+ * @param argv defaults to `process.argv`; passed explicitly only in tests.
+ */
+export function cliInvocationName(argv: readonly string[] = process.argv): CliName {
+  const raw = argv[1];
+  if (typeof raw !== "string" || raw.length === 0) return DEFAULT_CLI_NAME;
+  // Strip a single known script extension so `agentbridge.ts` / `abg.js` match.
+  const name = basename(raw).replace(/\.(ts|js|mjs|cjs)$/, "");
+  return isCliName(name) ? name : DEFAULT_CLI_NAME;
+}
+
+function isCliName(value: string): value is CliName {
+  return (CLI_NAMES as readonly string[]).includes(value);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,8 @@
  *   agentbridge kill        — Force kill all AgentBridge processes
  */
 
+import { cliInvocationName } from "./cli-invocation";
+
 // Marketplace name constant (shared with plugin)
 export const MARKETPLACE_NAME = "agentbridge";
 export const PLUGIN_NAME = "agentbridge";
@@ -133,6 +135,10 @@ async function main(command: string | undefined, restArgs: string[]) {
 }
 
 function printHelp() {
+  // The Usage block deliberately shows BOTH names (teaching that the binary is
+  // published twice). Everything action-oriented — the Examples below — echoes
+  // whichever name the user actually invoked, via cliInvocationName().
+  const cli = cliInvocationName();
   console.log(`
 AgentBridge — Multi-agent collaboration bridge
 
@@ -184,30 +190,30 @@ Multi-pair:
   contesting it — pick another --pair name (or kill the live one first).
 
 Examples:
-  abg init                     # First-time setup
-  abg claude                   # Start the "main" pair for this directory
-  abg codex                    # Connect Codex to this directory's "main" pair
-  abg resume                   # Print resume commands for both sides
-  abg resume claude            # Resume the last Claude Code session here
-  abg resume codex             # Resume this pair's current Codex thread
-  abg claude --safe            # One launch without the max-permission default
-  abg --pair work claude       # Start a named pair "work" (this directory)
-  abg --pair work codex        # Connect Codex to the "work" pair
-  abg --pair review claude     # A second, parallel pair
-  abg pairs                    # List all pairs and their ports/status
-  abg pairs --threads          # Include current thread mapping
-  abg doctor --json            # Emit a structured diagnostics report
-  abg logs                     # Tail the last 100 lines of this pair's daemon log
-  abg logs -f -n 200           # Follow the log, starting from the last 200 lines
-  abg logs --codex             # Tail the codex wrapper log instead
-  abg --pair work logs         # Tail the "work" pair's daemon log
-  abg pairs rm work            # Stop this directory's "work" pair and free its slot
-  abg pairs rm work-1a2b3c4d   # ...or by its full id (from that pair's directory)
-  abg pairs prune              # Preview reclaimable: orphan dirs + stranded entries (cwd-gone, dead, >1d)
-  abg pairs prune --apply      # ...actually delete the previewed dirs + entries
-  abg --pair work kill         # Stop only this directory's "work" pair
-  abg kill                     # Stop this directory's pairs (+ any legacy-root daemon)
-  abg kill all                 # Stop every pair in every directory (+ legacy-root)
+  ${cli} init                     # First-time setup
+  ${cli} claude                   # Start the "main" pair for this directory
+  ${cli} codex                    # Connect Codex to this directory's "main" pair
+  ${cli} resume                   # Print resume commands for both sides
+  ${cli} resume claude            # Resume the last Claude Code session here
+  ${cli} resume codex             # Resume this pair's current Codex thread
+  ${cli} claude --safe            # One launch without the max-permission default
+  ${cli} --pair work claude       # Start a named pair "work" (this directory)
+  ${cli} --pair work codex        # Connect Codex to the "work" pair
+  ${cli} --pair review claude     # A second, parallel pair
+  ${cli} pairs                    # List all pairs and their ports/status
+  ${cli} pairs --threads          # Include current thread mapping
+  ${cli} doctor --json            # Emit a structured diagnostics report
+  ${cli} logs                     # Tail the last 100 lines of this pair's daemon log
+  ${cli} logs -f -n 200           # Follow the log, starting from the last 200 lines
+  ${cli} logs --codex             # Tail the codex wrapper log instead
+  ${cli} --pair work logs         # Tail the "work" pair's daemon log
+  ${cli} pairs rm work            # Stop this directory's "work" pair and free its slot
+  ${cli} pairs rm work-1a2b3c4d   # ...or by its full id (from that pair's directory)
+  ${cli} pairs prune              # Preview reclaimable: orphan dirs + stranded entries (cwd-gone, dead, >1d)
+  ${cli} pairs prune --apply      # ...actually delete the previewed dirs + entries
+  ${cli} --pair work kill         # Stop only this directory's "work" pair
+  ${cli} kill                     # Stop this directory's pairs (+ any legacy-root daemon)
+  ${cli} kill all                 # Stop every pair in every directory (+ legacy-root)
 `.trim());
 }
 

--- a/src/cli/budget.ts
+++ b/src/cli/budget.ts
@@ -6,12 +6,16 @@
  * two surfaces to stay consistent).
  */
 
+import { cliInvocationName } from "../cli-invocation";
 import { fetchDaemonStatus } from "../daemon-status";
 import { parsePairFlag, type ReadOnlyPairResolution, resolvePairReadOnly } from "../pair-resolver";
 import { renderBudgetSnapshot, BUDGET_UNAVAILABLE_TEXT } from "../budget/render";
 
 export async function runBudget(args: string[]) {
   const json = args.includes("--json");
+  // Echo whichever name the user invoked (abg | agentbridge) in the "run X first"
+  // hints, so they match the kill/doctor guidance — see cli-invocation.ts.
+  const cli = cliInvocationName();
   const { pairFlag } = parsePairFlag(args.filter((arg) => arg !== "--json"));
   let resolution: ReadOnlyPairResolution;
   try {
@@ -32,7 +36,7 @@ export async function runBudget(args: string[]) {
     if (json) {
       console.log(JSON.stringify({ ok: false, error: "pair_not_registered" }));
     } else {
-      console.error("该目录尚无 pair，先运行 abg claude");
+      console.error(`该目录尚无 pair，先运行 ${cli} claude`);
     }
     process.exit(1);
     return;
@@ -45,7 +49,7 @@ export async function runBudget(args: string[]) {
     } else {
       console.error(
         `AgentBridge daemon 未运行（pair ${pair.pairId}，控制端口 ${pair.ports.controlPort}）。` +
-          "先运行 `abg claude` 启动会话。",
+          `先运行 \`${cli} claude\` 启动会话。`,
       );
     }
     process.exit(1);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "n
 import { join } from "node:path";
 import { pluginCacheRoot } from "./plugin-cache";
 import { BUILD_INFO, formatBuildInfo, sameRuntimeContract } from "../build-info";
+import { cliInvocationName } from "../cli-invocation";
 import { ConfigService } from "../config-service";
 import { fetchDaemonStatus } from "../daemon-status";
 import { inspectAgentBridgeEnv } from "../env-guard";
@@ -157,6 +158,9 @@ function runResumePollution(args: string[]) {
 
 async function buildDoctorReport(pair: PairResolution, registered: boolean): Promise<DoctorReport> {
   const cwd = process.cwd();
+  // Echo whichever name the user invoked (abg | agentbridge) in every actionable
+  // hint, so doctor's guidance matches kill/budget — see cli-invocation.ts.
+  const cli = cliInvocationName();
   const env = inspectAgentBridgeEnv({ cwd, env: process.env });
   const [health, ready] = registered
     ? await Promise.all([
@@ -195,7 +199,7 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
       : `not registered yet — would be ${pair.pairId} (created on first launch)`,
     hint: registered
       ? undefined
-      : "该目录还没有注册过 pair：运行 `agentbridge claude` 即会创建。以下检查按未启动状态解读。",
+      : `该目录还没有注册过 pair：运行 \`${cli} claude\` 即会创建。以下检查按未启动状态解读。`,
   });
   checks.push({
     name: "env",
@@ -203,9 +207,9 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
     detail: env.ok ? "AgentBridge env matches cwd" : env.reasons.join("; "),
     hint: env.ok
       ? undefined
-      : "环境变量与当前目录不匹配：请在正确的项目目录里重新运行 `agentbridge claude`，不要复用其他目录的会话环境。",
+      : `环境变量与当前目录不匹配：请在正确的项目目录里重新运行 \`${cli} claude\`，不要复用其他目录的会话环境。`,
   });
-  checks.push(configParseabilityCheck(cwd));
+  checks.push(configParseabilityCheck(cwd, cli));
   checks.push({
     name: "daemon health",
     status: health ? "ok" : "warn",
@@ -214,7 +218,7 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
       : registered
         ? `no daemon reachable on :${pair.ports.controlPort}`
         : "n/a — pair not registered",
-    hint: health ? undefined : "daemon 未运行。运行 `agentbridge claude`（或 `agentbridge codex`）会自动启动它。",
+    hint: health ? undefined : `daemon 未运行。运行 \`${cli} claude\`（或 \`${cli} codex\`）会自动启动它。`,
   });
   // Daemon-dependent checks collapse to skip when the daemon is not running:
   // one root cause must not stack three WARNs.
@@ -262,7 +266,7 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
     hint:
       buildDrift === true
         ? "daemon 运行的是旧构建（通常由旧版 CLI 或未重开的 Claude Code 窗口启动）。" +
-          "没有进行中的 Codex 会话时，运行 `abg kill` 后重新 `agentbridge claude` 即可对齐；" +
+          `没有进行中的 Codex 会话时，运行 \`${cli} kill\` 后重新 \`${cli} claude\` 即可对齐；` +
           "有活跃会话则等收尾后再重启——版本差异不会强杀活跃会话，可以继续用。"
         : undefined,
   });
@@ -283,7 +287,7 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
       ? undefined
       : rawThread
         ? "通常无害：线程还没有产生首条回应、或 rollout 文件尚未落盘。" +
-          "仅当 `abg codex`（resume）失败时才需要处理：用 `abg codex --new` 开新线程。"
+          `仅当 \`${cli} codex\`（resume）失败时才需要处理：用 \`${cli} codex --new\` 开新线程。`
         : registered
           ? "尚无线程记录：连接 Codex 后建立首个线程时会自动写入，无需处理。"
           : undefined,
@@ -316,7 +320,7 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
     hint:
       attachedHere.length > 0
         ? undefined
-        : "另开一个终端、在同一目录运行 `agentbridge codex` 连接本 pair。",
+        : `另开一个终端、在同一目录运行 \`${cli} codex\` 连接本 pair。`,
   });
   checks.push({
     name: "codex tui (other pairs)",
@@ -328,7 +332,7 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
         : "no managed Codex TUI attached to another pair",
     hint:
       attachedElsewhere.length > 0
-        ? "这些 TUI 属于其他目录的 pair，不影响本 pair；它们不会桥接到这里。如不再需要，去对应目录运行 `abg kill`。"
+        ? `这些 TUI 属于其他目录的 pair，不影响本 pair；它们不会桥接到这里。如不再需要，去对应目录运行 \`${cli} kill\`。`
         : undefined,
   });
 
@@ -336,7 +340,7 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
     ["daemon log", pair.stateDir.logFile],
     ["codex wrapper log", pair.stateDir.codexWrapperLogFile],
   ] as const) {
-    checks.push(logCheck(name, path));
+    checks.push(logCheck(name, path, cli));
   }
 
   return {
@@ -431,7 +435,7 @@ function extractBundleCommit(path: string): string | null {
  * defaults at startup (P1); surface that loudly here so doctor — run by someone
  * already stuck — can see it instead of chasing why their thresholds "don't work".
  */
-function configParseabilityCheck(cwd: string): DoctorCheck {
+function configParseabilityCheck(cwd: string, cli: string): DoctorCheck {
   const desc = new ConfigService(cwd).describeConfig();
   if (desc.state === "absent") {
     return {
@@ -447,7 +451,7 @@ function configParseabilityCheck(cwd: string): DoctorCheck {
       detail: `unparseable at ${desc.path} (${desc.reason}) — custom thresholds NOT in effect, using defaults`,
       hint:
         "config.json 损坏或字段类型错误：bridge 已回退到默认阈值，你的自定义 budget/idle 设置未生效。" +
-        "修正该文件的 JSON 语法/字段类型后重启 `agentbridge claude` 即可重新生效。",
+        `修正该文件的 JSON 语法/字段类型后重启 \`${cli} claude\` 即可重新生效。`,
     };
   }
   return {
@@ -459,7 +463,7 @@ function configParseabilityCheck(cwd: string): DoctorCheck {
   };
 }
 
-function logCheck(name: string, path: string): DoctorCheck {
+function logCheck(name: string, path: string, cli: string): DoctorCheck {
   if (!existsSync(path)) {
     return {
       name,
@@ -475,7 +479,7 @@ function logCheck(name: string, path: string): DoctorCheck {
       status: "warn",
       detail:
         `${path} (${stat.size} bytes, oversized; stop the pair, rebuild/reinstall, then rotate or remove this log)`,
-      hint: "日志过大：`abg kill` 停止 pair 后删除该文件再重启即可。",
+      hint: `日志过大：\`${cli} kill\` 停止 pair 后删除该文件再重启即可。`,
     };
   }
   return { name, status: "ok", detail: `${path} (${stat.size} bytes)` };

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,6 +1,7 @@
 import { execSync, execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { cliInvocationName } from "../cli-invocation";
 import { ConfigService } from "../config-service";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import { findPackageRoot, registerMarketplace } from "./pkg-root";
@@ -15,14 +16,42 @@ import {
 
 const MIN_CLAUDE_VERSION = "2.1.80";
 
+/**
+ * Result of a single dependency probe. Mirrors doctor's DoctorCheck so the two
+ * surfaces read the same way (check line + ↳ hint) for the first-run journey.
+ *
+ * - "ok"   → present and acceptable
+ * - "warn" → absent but NOT fatal (the second agent can be installed later)
+ * - "fail" → absent/too-old and fatal (a hard prerequisite for init to succeed)
+ */
+export interface DepCheck {
+  name: string;
+  status: "ok" | "warn" | "fail";
+  detail: string;
+  /** Actionable next step for a non-OK check (install URL / upgrade command). */
+  hint?: string;
+}
+
 export async function runInit() {
   console.log("AgentBridge Init\n");
+  const cli = cliInvocationName();
 
-  // Step 1: Check dependencies
+  // Step 1: Check dependencies. Collect ALL results first, then report them
+  // together — the old flow exited on the FIRST missing dep, so a user missing
+  // both claude and codex only ever saw the claude error and fixed things one
+  // round-trip at a time. We now check all three, print a doctor-style summary,
+  // and only THEN decide whether to abort.
   console.log("Checking dependencies...");
-  checkBun();
-  checkClaude();
-  checkCodex();
+  const depChecks = [checkBun(), checkClaude(), checkCodex()];
+  for (const line of formatDepChecks(depChecks, cli)) {
+    console.log(line);
+  }
+  // bun/claude are hard prerequisites (runtime + plugin host); a missing codex
+  // is only a WARN — see checkCodex(). Abort only on a real FAIL, after the user
+  // has seen the full picture.
+  if (depChecks.some((check) => check.status === "fail")) {
+    process.exit(1);
+  }
   console.log("");
 
   // Step 2: Generate project config
@@ -66,7 +95,7 @@ export async function runInit() {
     // Detect context independently here so a findPackageRoot() failure above
     // (no package.json) is still treated as "not a repo" → marketplace steps.
     console.log("  Plugin install skipped (marketplace registration or install failed).");
-    for (const line of pluginInstallFallbackGuidance(detectRepoCheckout())) {
+    for (const line of pluginInstallFallbackGuidance(detectRepoCheckout(), cli)) {
       console.log(line);
     }
   }
@@ -82,8 +111,8 @@ export async function runInit() {
   }
   console.log("Next steps:");
   console.log("  1. If Claude Code is already running, execute /reload-plugins in your session");
-  console.log("  2. Start Claude Code:  agentbridge claude");
-  console.log("  3. Start Codex TUI:    agentbridge codex");
+  console.log(`  2. Start Claude Code:  ${cli} claude`);
+  console.log(`  3. Start Codex TUI:    ${cli} codex`);
 }
 
 /**
@@ -101,15 +130,20 @@ function detectRepoCheckout(): boolean {
 
 /**
  * Guidance lines printed when step-4 plugin install fails. Repo checkouts can
- * recover with `abg dev`; global npm installs cannot (the published package
+ * recover with `<cli> dev`; global npm installs cannot (the published package
  * ships no build scripts), so those users get the README marketplace steps.
  * Pure + exported for unit testing.
+ *
+ * @param cli the resolved invocation name; defaults to cliInvocationName().
  */
-export function pluginInstallFallbackGuidance(insideRepo: boolean): string[] {
+export function pluginInstallFallbackGuidance(
+  insideRepo: boolean,
+  cli: string = cliInvocationName(),
+): string[] {
   if (insideRepo) {
     return [
       "  You can install it later with:",
-      "    abg dev   # registers marketplace and installs plugin",
+      `    ${cli} dev   # registers marketplace and installs plugin`,
     ];
   }
   return [
@@ -118,49 +152,91 @@ export function pluginInstallFallbackGuidance(insideRepo: boolean): string[] {
   ];
 }
 
-function checkBun() {
+/**
+ * Render dependency checks in doctor's "check line + ↳ hint" style, then a
+ * closing line that links the first-run journey to diagnostics. Pure (no I/O)
+ * so the exact shape is unit-testable.
+ *
+ * Format matches formatDoctorReport: `STATUS name: detail`, with a `     ↳ hint`
+ * line under any non-OK check.
+ */
+export function formatDepChecks(checks: DepCheck[], cli: string): string[] {
+  const lines: string[] = [];
+  for (const check of checks) {
+    lines.push(`  ${check.status.toUpperCase().padEnd(4)} ${check.name}: ${check.detail}`);
+    if ((check.status === "warn" || check.status === "fail") && check.hint) {
+      lines.push(`       ↳ ${check.hint}`);
+    }
+  }
+  // Tie the first-run journey to ongoing diagnostics: after install, `doctor`
+  // is where the user verifies env/daemon/build health.
+  lines.push(`  验证安装: ${cli} doctor`);
+  return lines;
+}
+
+/** bun is the runtime — its absence is fatal. */
+function checkBun(): DepCheck {
   try {
     const version = execSync("bun --version", { encoding: "utf-8" }).trim();
-    console.log(`  bun: ${version}`);
+    return { name: "bun", status: "ok", detail: version };
   } catch {
-    console.error("  ERROR: bun not found in PATH.");
-    console.error("  Install Bun: https://bun.sh");
-    process.exit(1);
+    return {
+      name: "bun",
+      status: "fail",
+      detail: "not found in PATH",
+      hint: "Install Bun: https://bun.sh",
+    };
   }
 }
 
-function checkClaude() {
+/** claude hosts the plugin and is the primary agent — absence/too-old is fatal. */
+function checkClaude(): DepCheck {
+  let versionOutput: string;
   try {
-    const versionOutput = execSync("claude --version", { encoding: "utf-8" }).trim();
-    // Extract version number (may be in format "claude v2.1.80" or just "2.1.80")
-    const match = versionOutput.match(/(\d+\.\d+\.\d+)/);
-    if (match) {
-      const version = match[1];
-      console.log(`  claude: ${version}`);
-      if (compareVersions(version, MIN_CLAUDE_VERSION) < 0) {
-        console.error(`  ERROR: Claude Code version ${version} is too old.`);
-        console.error(`  Channels require >= ${MIN_CLAUDE_VERSION}.`);
-        console.error("  Update: npm update -g @anthropic-ai/claude-code");
-        process.exit(1);
-      }
-    } else {
-      console.log(`  claude: ${versionOutput} (version check skipped)`);
-    }
+    versionOutput = execSync("claude --version", { encoding: "utf-8" }).trim();
   } catch {
-    console.error("  ERROR: claude not found in PATH.");
-    console.error("  Install Claude Code: npm install -g @anthropic-ai/claude-code");
-    process.exit(1);
+    return {
+      name: "claude",
+      status: "fail",
+      detail: "not found in PATH",
+      hint: "Install Claude Code: npm install -g @anthropic-ai/claude-code",
+    };
   }
+  // Extract version number (may be in format "claude v2.1.80" or just "2.1.80").
+  const match = versionOutput.match(/(\d+\.\d+\.\d+)/);
+  if (!match) {
+    return { name: "claude", status: "ok", detail: `${versionOutput} (version check skipped)` };
+  }
+  const version = match[1]!;
+  if (compareVersions(version, MIN_CLAUDE_VERSION) < 0) {
+    return {
+      name: "claude",
+      status: "fail",
+      detail: `${version} is too old (channels require >= ${MIN_CLAUDE_VERSION})`,
+      hint: "Update: npm update -g @anthropic-ai/claude-code",
+    };
+  }
+  return { name: "claude", status: "ok", detail: version };
 }
 
-function checkCodex() {
+/**
+ * codex is the SECOND agent. A user may legitimately set up the Claude side
+ * first and install/connect Codex later, so a missing codex is a non-fatal
+ * WARN: init still installs the plugin, writes config, and completes. The old
+ * flow hard-exited here, which blocked the entire setup over an optional-at-init
+ * dependency — `agentbridge codex` will surface the same hint when actually used.
+ */
+function checkCodex(): DepCheck {
   try {
     const version = execSync("codex --version", { encoding: "utf-8" }).trim();
-    console.log(`  codex: ${version}`);
+    return { name: "codex", status: "ok", detail: version };
   } catch {
-    console.error("  ERROR: codex not found in PATH.");
-    console.error("  Install Codex: https://github.com/openai/codex");
-    process.exit(1);
+    return {
+      name: "codex",
+      status: "warn",
+      detail: "not found in PATH (the Codex side will be unavailable until installed)",
+      hint: "Install Codex when you want to pair: https://github.com/openai/codex",
+    };
   }
 }
 

--- a/src/cli/kill.ts
+++ b/src/cli/kill.ts
@@ -1,5 +1,6 @@
 import { readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
+import { cliInvocationName } from "../cli-invocation";
 import { DaemonLifecycle } from "../daemon-lifecycle";
 import { PairError, detectLegacyRootDaemon, listPairDirs, type PairEntry, type PairPorts } from "../pair-registry";
 import {
@@ -56,8 +57,11 @@ export async function runKill(args: string[] = []) {
   const base = computeBaseDir();
   console.log("AgentBridge Kill — stopping AgentBridge pair processes\n");
 
+  // Echo back whichever name the user invoked (abg | agentbridge) so the whole
+  // stop → restart journey reads consistently — see cli-invocation.ts.
+  const cli = cliInvocationName();
   const results: StopResult[] = [];
-  let restartCommand = "agentbridge claude";
+  let restartCommand = `${cli} claude`;
   if (parsed.pairFlag !== undefined) {
     // The friendly name is scoped to the current directory (same name elsewhere
     // is a different pair); findPairForFlag composes it with the cwd, falling
@@ -74,7 +78,7 @@ export async function runKill(args: string[] = []) {
       printKnownPairs(base);
       return;
     }
-    restartCommand = `agentbridge --pair ${pair.name ?? parsed.pairFlag} claude`;
+    restartCommand = `${cli} --pair ${pair.name ?? parsed.pairFlag} claude`;
     results.push(await stopPairEntry(base, pair));
   } else if (parsed.all) {
     // The registry is exactly the state that gets corrupted when things go
@@ -119,7 +123,7 @@ export async function runKill(args: string[] = []) {
       const message = error instanceof Error ? error.message : String(error);
       console.log(
         `⚠️  pair registry 不可读（${message}）——无法按目录定位 pair。` +
-          "运行 `abg kill --all` 可降级为全盘状态目录扫描，停止所有能找到的 pair。",
+          `运行 \`${cli} kill --all\` 可降级为全盘状态目录扫描，停止所有能找到的 pair。`,
       );
       process.exitCode = 2;
     }
@@ -136,7 +140,7 @@ export async function runKill(args: string[] = []) {
     }
     if (results.length === 0) {
       console.log(`No AgentBridge pairs registered for current directory: ${process.cwd()}`);
-      console.log("Use `abg kill all` or `abg kill --all` to stop pairs from every directory.");
+      console.log(`Use \`${cli} kill all\` or \`${cli} kill --all\` to stop pairs from every directory.`);
       return;
     }
   }
@@ -336,13 +340,17 @@ export function formatKillReport(
   lines.push("");
 
   if (stopped.length > 0) {
+    // Keep the sibling `codex` hint phrased in the SAME binary name the caller
+    // built restartCommand from (its leading token), so kill never mixes
+    // `abg claude` with `agentbridge codex`.
+    const cliName = restartCommand.split(" ")[0] ?? "abg";
     lines.push("AgentBridge stopped.");
     lines.push(
       `Please restart Claude Code (\`${restartCommand}\`), switch to a new conversation, or run \`/resume\` to fully disconnect.`,
     );
     lines.push(
       "ℹ️  已写入 killed 哨兵：被停止的 pair 不会被自动复活；" +
-        `下次 \`${restartCommand}\` / \`agentbridge codex\` 会清除哨兵并用当前安装版本启动全新 daemon。`,
+        `下次 \`${restartCommand}\` / \`${cliName} codex\` 会清除哨兵并用当前安装版本启动全新 daemon。`,
     );
   } else {
     lines.push("No running AgentBridge daemon or managed Codex TUI found.");

--- a/src/e2e-cli.test.ts
+++ b/src/e2e-cli.test.ts
@@ -601,7 +601,10 @@ describe("E2E: CLI surface", () => {
 
       expect(result.code).toBe(0);
       expect(result.stdout).toContain("AgentBridge stopped.");
-      expect(result.stdout).toContain("Please restart Claude Code (`agentbridge claude`), switch to a new conversation, or run `/resume` to fully disconnect.");
+      // The restart hint echoes the invocation name (cliInvocationName); the
+      // harness launches via `bun run cli.ts`, so argv[1]'s basename is neither
+      // published name → the "abg" fallback.
+      expect(result.stdout).toContain("Please restart Claude Code (`abg claude`), switch to a new conversation, or run `/resume` to fully disconnect.");
       await waitFor(() => (pid ? !isProcessAlive(pid) : true), 60, 50);
       await waitFor(() => (tuiPid ? !isProcessAlive(tuiPid) : true), 60, 50);
       await waitFor(() => codexProc.child.exitCode !== null, 60, 50);
@@ -714,8 +717,10 @@ describe("E2E: CLI surface", () => {
 
         expect(result.code).toBe(0);
         expect(result.stdout).toContain("AgentBridge stopped.");
-        expect(result.stdout).toContain("Please restart Claude Code (`agentbridge --pair work claude`)");
-        expect(result.stdout).not.toContain("Please restart Claude Code (`agentbridge claude`)");
+        // Invocation name is the "abg" fallback here (launched via `bun run cli.ts`);
+        // the --pair scope must still ride along with it.
+        expect(result.stdout).toContain("Please restart Claude Code (`abg --pair work claude`)");
+        expect(result.stdout).not.toContain("Please restart Claude Code (`abg claude`)");
       } finally {
         await stopProcess(trackedDaemon);
       }

--- a/src/pair-command.ts
+++ b/src/pair-command.ts
@@ -1,24 +1,30 @@
+import { cliInvocationName } from "./cli-invocation";
 import { computeBaseDir, findPair } from "./pair-resolver";
 
 /**
- * Render a user-facing `agentbridge` command suggestion scoped to the current
- * pair.
+ * Render a user-facing command suggestion scoped to the current pair.
+ *
+ * The leading binary name echoes whichever name the user invoked the CLI as
+ * (`abg` or `agentbridge`), via `cliInvocationName()` — see cli-invocation.ts.
  *
  * In multi-pair mode the resolver sets `AGENTBRIDGE_PAIR_ID`, and that env is
  * inherited by the daemon, the plugin MCP server (bridge), and the codex
  * wrapper. User-facing hints ("start Codex with…", "restart with…", "run kill
  * to reset") MUST carry `--pair <id>` in that mode — otherwise a user following
  * the hint in a named-pair session would connect to a different (cwd-derived)
- * pair, or run a bare `agentbridge kill` that stops ALL pairs.
+ * pair, or run a bare kill that stops ALL pairs.
  *
  * In legacy/manual single-pair mode `AGENTBRIDGE_PAIR_ID` is unset, so the bare
  * command is returned (unchanged behaviour).
  *
  * @param cmd the subcommand + its own args, e.g. "codex" or "claude --resume".
+ * @param name the resolved invocation name; defaults to cliInvocationName().
+ *             Passed explicitly only in tests (the test runner's argv[1] is a
+ *             test path, so the live default would always be the fallback).
  */
-export function pairScopedCommand(cmd: string): string {
+export function pairScopedCommand(cmd: string, name: string = cliInvocationName()): string {
   const pairId = process.env.AGENTBRIDGE_PAIR_ID;
-  if (!pairId) return `agentbridge ${cmd}`;
+  if (!pairId) return `${name} ${cmd}`;
   // Prefer the friendly, cwd-scoped name (e.g. "main") — it is what the user types.
   let selector = process.env.AGENTBRIDGE_PAIR_NAME;
   if (!selector) {
@@ -37,5 +43,5 @@ export function pairScopedCommand(cmd: string): string {
     }
   }
   // `--pair <name>` goes BEFORE the subcommand (the supported position).
-  return `agentbridge --pair ${selector} ${cmd}`;
+  return `${name} --pair ${selector} ${cmd}`;
 }

--- a/src/unit-test/bridge-disabled-state.test.ts
+++ b/src/unit-test/bridge-disabled-state.test.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { disabledReplyError } from "../bridge-disabled-state";
 
 describe("bridge disabled-state messaging", () => {
-  // These assert the bare `agentbridge claude` / `agentbridge kill` hint
-  // substrings, i.e. manual/no-pair mode. Clear any pair env that may have
-  // leaked from another test so pairScopedCommand renders the bare command.
+  // These assert the bare hint substrings, i.e. manual/no-pair mode. The leading
+  // binary name now comes from cliInvocationName() (see cli-invocation.ts); in
+  // the test runner argv[1] is a test path, so it resolves to the "abg" fallback
+  // — hence the hints read `abg claude` / `abg kill` here. Clear any pair env
+  // that may have leaked so pairScopedCommand renders the bare command.
   let savedId: string | undefined;
   let savedName: string | undefined;
   beforeEach(() => {
@@ -21,7 +23,7 @@ describe("bridge disabled-state messaging", () => {
   });
 
   test("kill-disabled sessions explain how to reconnect", () => {
-    expect(disabledReplyError("killed")).toContain("disabled by `agentbridge kill`");
+    expect(disabledReplyError("killed")).toContain("disabled by `abg kill`");
     expect(disabledReplyError("killed")).toContain("/resume");
   });
 
@@ -29,7 +31,7 @@ describe("bridge disabled-state messaging", () => {
     const message = disabledReplyError("rejected");
     expect(message).toContain("rejected this session");
     expect(message).toContain("another Claude Code session is already connected");
-    expect(message).toContain("agentbridge kill");
+    expect(message).toContain("abg kill");
     expect(message).not.toContain("/resume");
   });
 
@@ -37,7 +39,7 @@ describe("bridge disabled-state messaging", () => {
     const message = disabledReplyError("evicted");
     expect(message).toContain("evicted this session");
     expect(message).toContain("liveness probes");
-    expect(message).toContain("agentbridge claude");
+    expect(message).toContain("abg claude");
     // Evicted is not the same as "another session connected" — must not reuse that wording
     expect(message).not.toContain("another Claude Code session is already connected");
   });
@@ -46,16 +48,16 @@ describe("bridge disabled-state messaging", () => {
     const message = disabledReplyError("probe_in_progress");
     expect(message).toContain("liveness probe");
     expect(message).toContain("Retry");
-    expect(message).toContain("agentbridge claude");
-    // Probe-in-progress is transient — must not tell the user to run `agentbridge kill`
-    expect(message).not.toContain("agentbridge kill");
+    expect(message).toContain("abg claude");
+    // Probe-in-progress is transient — must not tell the user to run a kill
+    expect(message).not.toContain("abg kill");
   });
 
   test("auto_recovery_exhausted explains the retry budget gave up, not 'another session'", () => {
     const message = disabledReplyError("auto_recovery_exhausted");
     expect(message).toContain("auto-recovery gave up");
     expect(message).toContain("retry budget");
-    expect(message).toContain("agentbridge claude");
+    expect(message).toContain("abg claude");
     // Must NOT borrow the misleading "another session connected" wording from
     // the bare "rejected" reason — the cause here is exhausted retries, not
     // an active competing session.

--- a/src/unit-test/cli-invocation.test.ts
+++ b/src/unit-test/cli-invocation.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cliInvocationName, CLI_NAMES, DEFAULT_CLI_NAME } from "../cli-invocation";
+import { pairScopedCommand } from "../pair-command";
+
+describe("cliInvocationName", () => {
+  test("returns 'abg' when argv[1] basename is 'abg'", () => {
+    expect(cliInvocationName(["bun", "/usr/local/bin/abg", "kill"])).toBe("abg");
+  });
+
+  test("returns 'agentbridge' when argv[1] basename is 'agentbridge'", () => {
+    expect(cliInvocationName(["bun", "/opt/homebrew/bin/agentbridge", "doctor"])).toBe("agentbridge");
+  });
+
+  test("falls back to 'abg' for any other basename (e.g. a test runner path)", () => {
+    expect(cliInvocationName(["bun", "/private/tmp/some.test.ts"])).toBe("abg");
+    expect(cliInvocationName(["node", "/repo/src/cli.ts", "init"])).toBe("abg");
+    expect(cliInvocationName(["bun", "/repo/dist/cli.js"])).toBe("abg");
+    expect(DEFAULT_CLI_NAME).toBe("abg");
+  });
+
+  test("strips a known script extension so a source/dev launcher still matches", () => {
+    // `agentbridge.ts` / `abg.js` (source or wrapper) resolve to the published name.
+    expect(cliInvocationName(["bun", "/repo/bin/agentbridge.ts"])).toBe("agentbridge");
+    expect(cliInvocationName(["bun", "/repo/bin/abg.js"])).toBe("abg");
+    // A generic bundle name still falls back — the safe default.
+    expect(cliInvocationName(["bun", "/repo/dist/cli.mjs"])).toBe("abg");
+  });
+
+  test("handles a missing / empty argv[1] without throwing", () => {
+    expect(cliInvocationName(["bun"])).toBe("abg");
+    expect(cliInvocationName(["bun", ""])).toBe("abg");
+    expect(cliInvocationName([])).toBe("abg");
+  });
+
+  test("only the two published names are accepted", () => {
+    expect([...CLI_NAMES].sort()).toEqual(["abg", "agentbridge"]);
+    // A near-miss (substring / superstring) is NOT a match.
+    expect(cliInvocationName(["bun", "/bin/agentbridgex"])).toBe("abg");
+    expect(cliInvocationName(["bun", "/bin/ab"])).toBe("abg");
+  });
+});
+
+describe("cliInvocationName is the single source threaded into guidance", () => {
+  // pairScopedCommand defaults its name to cliInvocationName(); swapping
+  // process.argv[1] under it proves both echo the SAME name (no second source
+  // of truth). This stands in for "kill restart hint / budget hint / doctor
+  // daemon hint echo the invoked name consistently" — they all resolve the
+  // name through this one helper.
+  let savedArgv1: string | undefined;
+  let savedPairId: string | undefined;
+  let savedPairName: string | undefined;
+
+  beforeEach(() => {
+    savedArgv1 = process.argv[1];
+    savedPairId = process.env.AGENTBRIDGE_PAIR_ID;
+    savedPairName = process.env.AGENTBRIDGE_PAIR_NAME;
+    delete process.env.AGENTBRIDGE_PAIR_ID;
+    delete process.env.AGENTBRIDGE_PAIR_NAME;
+  });
+
+  afterEach(() => {
+    if (savedArgv1 === undefined) process.argv.length = Math.min(process.argv.length, 1);
+    else process.argv[1] = savedArgv1;
+    if (savedPairId === undefined) delete process.env.AGENTBRIDGE_PAIR_ID;
+    else process.env.AGENTBRIDGE_PAIR_ID = savedPairId;
+    if (savedPairName === undefined) delete process.env.AGENTBRIDGE_PAIR_NAME;
+    else process.env.AGENTBRIDGE_PAIR_NAME = savedPairName;
+  });
+
+  test("under argv[1]='agentbridge', the helper AND pairScopedCommand agree", () => {
+    process.argv[1] = "/opt/homebrew/bin/agentbridge";
+    expect(cliInvocationName()).toBe("agentbridge");
+    // pairScopedCommand defaults to cliInvocationName() — so it echoes the same name.
+    expect(pairScopedCommand("claude")).toBe("agentbridge claude");
+  });
+
+  test("under argv[1]='abg', the helper AND pairScopedCommand agree", () => {
+    process.argv[1] = "/usr/local/bin/abg";
+    expect(cliInvocationName()).toBe("abg");
+    expect(pairScopedCommand("claude")).toBe("abg claude");
+  });
+});

--- a/src/unit-test/init-deps.test.ts
+++ b/src/unit-test/init-deps.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { formatDepChecks, type DepCheck } from "../cli/init";
+
+describe("init: formatDepChecks", () => {
+  test("renders doctor-style 'STATUS name: detail' lines with padded status", () => {
+    const lines = formatDepChecks(
+      [
+        { name: "bun", status: "ok", detail: "1.3.11" },
+        { name: "claude", status: "ok", detail: "2.1.80" },
+        { name: "codex", status: "ok", detail: "0.20.0" },
+      ],
+      "abg",
+    );
+    // padEnd(4): "OK  " is 4 chars wide, matching formatDoctorReport's column.
+    expect(lines).toContain("  OK   bun: 1.3.11");
+    expect(lines).toContain("  OK   claude: 2.1.80");
+    expect(lines).toContain("  OK   codex: 0.20.0");
+  });
+
+  test("prints a ↳ hint line under a non-OK check (warn and fail)", () => {
+    const lines = formatDepChecks(
+      [
+        { name: "claude", status: "fail", detail: "not found in PATH", hint: "Install Claude Code: npm ..." },
+        { name: "codex", status: "warn", detail: "not found in PATH", hint: "Install Codex: https://..." },
+      ],
+      "abg",
+    );
+    const text = lines.join("\n");
+    expect(text).toContain("  FAIL claude: not found in PATH");
+    expect(text).toContain("       ↳ Install Claude Code: npm ...");
+    expect(text).toContain("  WARN codex: not found in PATH");
+    expect(text).toContain("       ↳ Install Codex: https://...");
+  });
+
+  test("an OK check never emits a ↳ hint line", () => {
+    const lines = formatDepChecks([{ name: "bun", status: "ok", detail: "1.3.11", hint: "should not show" }], "abg");
+    expect(lines.join("\n")).not.toContain("↳");
+  });
+
+  test("closes with a '验证安装: <cli> doctor' line echoing the invocation name", () => {
+    expect(formatDepChecks([], "abg")).toContain("  验证安装: abg doctor");
+    expect(formatDepChecks([], "agentbridge")).toContain("  验证安装: agentbridge doctor");
+  });
+});
+
+describe("init: dependency-check fatal semantics", () => {
+  // Mirrors the abort decision in runInit: `depChecks.some(c => c.status === "fail")`.
+  const isFatal = (checks: DepCheck[]) => checks.some((c) => c.status === "fail");
+
+  test("a missing codex is a WARN, not a FAIL — init must NOT abort on it", () => {
+    const checks: DepCheck[] = [
+      { name: "bun", status: "ok", detail: "1.3.11" },
+      { name: "claude", status: "ok", detail: "2.1.80" },
+      { name: "codex", status: "warn", detail: "not found in PATH", hint: "Install Codex later" },
+    ];
+    expect(isFatal(checks)).toBe(false);
+  });
+
+  test("a missing bun or claude IS fatal — init aborts", () => {
+    expect(isFatal([{ name: "bun", status: "fail", detail: "not found" }])).toBe(true);
+    expect(isFatal([{ name: "claude", status: "fail", detail: "too old" }])).toBe(true);
+  });
+
+  test("all three checks are reported even when an early one fails (collect-then-report)", () => {
+    // The formatter renders every check it is given — the runner collects all
+    // three before deciding, so the user sees the full picture in one pass.
+    const lines = formatDepChecks(
+      [
+        { name: "bun", status: "ok", detail: "1.3.11" },
+        { name: "claude", status: "fail", detail: "not found in PATH", hint: "install claude" },
+        { name: "codex", status: "warn", detail: "not found in PATH", hint: "install codex" },
+      ],
+      "abg",
+    );
+    const text = lines.join("\n");
+    expect(text).toContain("bun:");
+    expect(text).toContain("claude:");
+    expect(text).toContain("codex:");
+  });
+});

--- a/src/unit-test/pair-command.test.ts
+++ b/src/unit-test/pair-command.test.ts
@@ -38,35 +38,51 @@ describe("pairScopedCommand", () => {
     rmSync(base, { recursive: true, force: true });
   });
 
-  test("legacy/manual mode (no AGENTBRIDGE_PAIR_ID) → bare command", () => {
-    expect(pairScopedCommand("codex")).toBe("agentbridge codex");
-    expect(pairScopedCommand("claude")).toBe("agentbridge claude");
-    expect(pairScopedCommand("kill")).toBe("agentbridge kill");
+  // The leading binary name now comes from cliInvocationName(); in the test
+  // runner argv[1] is a test path, so the live default resolves to "abg". The
+  // explicit-name overload is exercised separately below to prove either name
+  // flows through.
+  test("legacy/manual mode (no AGENTBRIDGE_PAIR_ID) → bare command (default name)", () => {
+    expect(pairScopedCommand("codex")).toBe("abg codex");
+    expect(pairScopedCommand("claude")).toBe("abg claude");
+    expect(pairScopedCommand("kill")).toBe("abg kill");
   });
 
   test("pair mode → puts --pair <selector> BEFORE the subcommand", () => {
     process.env.AGENTBRIDGE_PAIR_ID = "work-1a2b3c4d";
     process.env.AGENTBRIDGE_PAIR_NAME = "work";
-    expect(pairScopedCommand("codex")).toBe("agentbridge --pair work codex");
-    expect(pairScopedCommand("claude")).toBe("agentbridge --pair work claude");
-    expect(pairScopedCommand("kill")).toBe("agentbridge --pair work kill");
+    expect(pairScopedCommand("codex")).toBe("abg --pair work codex");
+    expect(pairScopedCommand("claude")).toBe("abg --pair work claude");
+    expect(pairScopedCommand("kill")).toBe("abg --pair work kill");
+  });
+
+  test("echoes the explicit invocation name (abg vs agentbridge)", () => {
+    process.env.AGENTBRIDGE_PAIR_ID = "work-1a2b3c4d";
+    process.env.AGENTBRIDGE_PAIR_NAME = "work";
+    expect(pairScopedCommand("codex", "agentbridge")).toBe("agentbridge --pair work codex");
+    expect(pairScopedCommand("codex", "abg")).toBe("abg --pair work codex");
+    // Bare (legacy) form also threads the name through.
+    delete process.env.AGENTBRIDGE_PAIR_ID;
+    delete process.env.AGENTBRIDGE_PAIR_NAME;
+    expect(pairScopedCommand("claude", "agentbridge")).toBe("agentbridge claude");
+    expect(pairScopedCommand("claude", "abg")).toBe("abg claude");
   });
 
   test("prefers the friendly name over the composite pairId", () => {
     process.env.AGENTBRIDGE_PAIR_ID = "main-deadbeef";
     process.env.AGENTBRIDGE_PAIR_NAME = "main";
-    expect(pairScopedCommand("codex")).toBe("agentbridge --pair main codex");
+    expect(pairScopedCommand("codex", "agentbridge")).toBe("agentbridge --pair main codex");
   });
 
   test("--pair precedes the subcommand's own extra args", () => {
     process.env.AGENTBRIDGE_PAIR_ID = "review-1a2b3c4d";
     process.env.AGENTBRIDGE_PAIR_NAME = "review";
-    expect(pairScopedCommand("claude --resume")).toBe("agentbridge --pair review claude --resume");
+    expect(pairScopedCommand("claude --resume", "agentbridge")).toBe("agentbridge --pair review claude --resume");
   });
 
   test("an empty-string AGENTBRIDGE_PAIR_ID is treated as unset (no --pair)", () => {
     process.env.AGENTBRIDGE_PAIR_ID = "";
-    expect(pairScopedCommand("codex")).toBe("agentbridge codex");
+    expect(pairScopedCommand("codex", "agentbridge")).toBe("agentbridge codex");
   });
 
   // Conservative C: when AGENTBRIDGE_PAIR_NAME is missing (e.g. an OLD bridge
@@ -80,13 +96,13 @@ describe("pairScopedCommand", () => {
         { pairId: "myproj-1a2b3c4d", slot: 3, cwd: "/some/dir", name: "myproj", source: "cwd", createdAt: "2026-01-01T00:00:00.000Z" },
       ],
     });
-    expect(pairScopedCommand("codex")).toBe("agentbridge --pair myproj codex");
+    expect(pairScopedCommand("codex", "agentbridge")).toBe("agentbridge --pair myproj codex");
   });
 
   test("falls back to the composite pairId when PAIR_NAME unset AND no registry match", () => {
     process.env.AGENTBRIDGE_PAIR_ID = "myproj-1a2b3c4d";
     writeRegistry(base, { version: 1, pairs: [] });
-    expect(pairScopedCommand("codex")).toBe("agentbridge --pair myproj-1a2b3c4d codex");
+    expect(pairScopedCommand("codex", "agentbridge")).toBe("agentbridge --pair myproj-1a2b3c4d codex");
   });
 
   // best-effort: a corrupt/unreadable registry must NOT throw while rendering a
@@ -96,7 +112,7 @@ describe("pairScopedCommand", () => {
     process.env.AGENTBRIDGE_PAIR_ID = "ghost-deadbeef";
     mkdirSync(join(base, "pairs"), { recursive: true });
     writeFileSync(join(base, "pairs", "registry.json"), "{ this is not valid json", "utf-8");
-    expect(() => pairScopedCommand("codex")).not.toThrow();
-    expect(pairScopedCommand("codex")).toBe("agentbridge --pair ghost-deadbeef codex");
+    expect(() => pairScopedCommand("codex", "agentbridge")).not.toThrow();
+    expect(pairScopedCommand("codex", "agentbridge")).toBe("agentbridge --pair ghost-deadbeef codex");
   });
 });


### PR DESCRIPTION
## 摘要 / Summary

arch-review P1 #21：把用户面命令名（`abg` vs `agentbridge`）统一从实际调用名渲染，消除同一条消息里 `abg X` 与 `agentbridge Y` 的 within-string 混用；并把 `init` 依赖检查重构为 collect-then-report。

- **`src/cli-invocation.ts`（新）**：从 `argv[1]` basename 解析用户实际调用名 —— 扩展名剥离 + 双名白名单（abg/agentbridge）+ `'abg'` 回退；`pairScopedCommand` 仅对非空 pair 前置 `--pair`。
- **guidance 串统一**：`cli.ts` / `cli/budget.ts` / `cli/doctor.ts` / `cli/kill.ts` / `bridge.ts` / `bridge-disabled-state.ts` 全部经 `cliInvocationName`/`pairScopedCommand` 渲染；`kill.ts` 的 codex 提示名从 `restartCommand` 首 token 派生，不再硬编码。
- **`init.ts` collect-then-report**：`bun`/`claude` 缺失或过旧仍 **fatal abort（exit 1）**；`codex` 缺失降级为可见 **WARN**（不阻断、不 false-green）；plugin 安装失败独立置 exitCode。

Unifies how the user-facing command name (`abg` vs `agentbridge`) is rendered — derived from the actual invocation — eliminating within-string `abg`/`agentbridge` mixing, plus a collect-then-report refactor of `init` dependency checks.

## 测试 / Test plan

- `bun run typecheck` ✅ exit 0
- `bun test src` ✅ **1006 pass / 0 fail**（含新增 `cli-invocation.test.ts` 边界 + `init-deps.test.ts` + `pair-command`/`bridge-disabled-state`/`e2e-cli` 断言对齐真实渲染）
- `bun run verify:plugin-sync` ✅ bundles in sync
- Cross-review gate：2 轮独立 reviewer（logic/integration + within-string mix 复核）连续 **0 REAL**

## 备注 / Notes

- 已 rebase 到 `#129`（registry prune），help 示例的 prune 语义采用 #129 的 `prune`=预览 / `--apply`=删除。
- 攒批发布：`release-on-merge` 暂禁用，本 PR 合并不 bump；与 #7 等第二波一起在统一 release（v0.1.13）发布。