### PR TITLE
refactor: 统一原子写到共享 atomic-json helper（tmp+fsync+rename）/ unify atomic writes via shared atomic-json helper

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14271,7 +14271,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("3f14d41", "source"),
+  commit: defineString("ef0c291", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14549,8 +14549,43 @@ class DaemonClient extends EventEmitter2 {
 
 // src/daemon-lifecycle.ts
 import { spawn } from "child_process";
-import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync2, writeFileSync, openSync, closeSync, constants } from "fs";
+import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync2, openSync as openSync2, closeSync as closeSync2, constants } from "fs";
 import { fileURLToPath } from "url";
+
+// src/atomic-json.ts
+import * as fs from "fs";
+import { randomUUID as randomUUID2 } from "crypto";
+import { dirname as dirname2 } from "path";
+function tmpPathFor(targetPath) {
+  return `${targetPath}.tmp.${process.pid}.${randomUUID2()}`;
+}
+function atomicWriteText(path, content, options = {}) {
+  fs.mkdirSync(dirname2(path), { recursive: true });
+  const tmp = tmpPathFor(path);
+  let renamed = false;
+  const fd = fs.openSync(tmp, "w");
+  try {
+    try {
+      fs.writeFileSync(fd, content, "utf-8");
+      if (options.fsync)
+        fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmp, path);
+    renamed = true;
+  } finally {
+    if (!renamed) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {}
+    }
+  }
+}
+function atomicWriteJson(path, value, options = {}) {
+  atomicWriteText(path, JSON.stringify(value, null, 2) + `
+`, options);
+}
 
 // src/env-utils.ts
 function parsePositiveIntEnv(name, fallback, log = () => {}, env = process.env) {
@@ -14825,9 +14860,7 @@ class DaemonLifecycle {
     }
   }
   writeStatus(status) {
-    this.stateDir.ensure();
-    writeFileSync(this.stateDir.statusFile, JSON.stringify(status, null, 2) + `
-`, "utf-8");
+    atomicWriteJson(this.stateDir.statusFile, status);
   }
   readPid() {
     try {
@@ -14841,28 +14874,27 @@ class DaemonLifecycle {
     }
   }
   writePid(pid) {
-    this.stateDir.ensure();
-    writeFileSync(this.stateDir.pidFile, `${pid ?? process.pid}
-`, "utf-8");
+    atomicWriteText(this.stateDir.pidFile, `${pid ?? process.pid}
+`);
   }
   removePidFile() {
     try {
-      unlinkSync2(this.stateDir.pidFile);
+      unlinkSync3(this.stateDir.pidFile);
     } catch {}
   }
   removeStatusFile() {
     try {
-      unlinkSync2(this.stateDir.statusFile);
+      unlinkSync3(this.stateDir.statusFile);
     } catch {}
   }
   markKilled() {
     this.stateDir.ensure();
-    writeFileSync(this.stateDir.killedFile, `${Date.now()}
+    writeFileSync2(this.stateDir.killedFile, `${Date.now()}
 `, "utf-8");
   }
   clearKilled() {
     try {
-      unlinkSync2(this.stateDir.killedFile);
+      unlinkSync3(this.stateDir.killedFile);
     } catch {}
   }
   wasKilled() {
@@ -14929,15 +14961,15 @@ class DaemonLifecycle {
     this.stateDir.ensure();
     let fd = null;
     try {
-      fd = openSync(this.stateDir.lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
-      writeFileSync(fd, `${process.pid}
+      fd = openSync2(this.stateDir.lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
+      writeFileSync2(fd, `${process.pid}
 `);
-      closeSync(fd);
+      closeSync2(fd);
       return true;
     } catch (err) {
       if (fd !== null && err.code !== "EEXIST") {
         try {
-          closeSync(fd);
+          closeSync2(fd);
         } catch {}
         this.releaseLock();
       }
@@ -14974,7 +15006,7 @@ class DaemonLifecycle {
   }
   releaseLock() {
     try {
-      unlinkSync2(this.stateDir.lockFile);
+      unlinkSync3(this.stateDir.lockFile);
     } catch {}
   }
   async kill(gracefulTimeoutMs = 3000, pidOverride) {
@@ -15033,7 +15065,7 @@ async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, existsSync as existsSync4 } from "fs";
+import { readFileSync as readFileSync2, mkdirSync as mkdirSync3, existsSync as existsSync4 } from "fs";
 import { join as join2 } from "path";
 var DEFAULT_BUDGET_CONFIG = {
   enabled: true,
@@ -15267,9 +15299,7 @@ class ConfigService {
     };
   }
   save(config2) {
-    this.ensureConfigDir();
-    writeFileSync2(this.configPath, JSON.stringify(config2, null, 2) + `
-`, "utf-8");
+    atomicWriteJson(this.configPath, config2);
   }
   initDefaults() {
     this.ensureConfigDir();
@@ -15285,7 +15315,7 @@ class ConfigService {
   }
   ensureConfigDir() {
     if (!existsSync4(this.configDir)) {
-      mkdirSync2(this.configDir, { recursive: true });
+      mkdirSync3(this.configDir, { recursive: true });
     }
   }
 }
@@ -15307,23 +15337,19 @@ function isCliName(value) {
 
 // src/pair-registry.ts
 import {
-  closeSync as closeSync2,
   existsSync as existsSync5,
-  fsyncSync,
   linkSync,
   lstatSync,
-  mkdirSync as mkdirSync3,
-  openSync as openSync2,
+  mkdirSync as mkdirSync4,
   readdirSync,
   readFileSync as readFileSync3,
   realpathSync,
-  renameSync as renameSync2,
   rmSync,
   statSync as statSync3,
-  unlinkSync as unlinkSync3,
+  unlinkSync as unlinkSync4,
   writeFileSync as writeFileSync3
 } from "fs";
-import { createHash, randomUUID as randomUUID2 } from "crypto";
+import { createHash, randomUUID as randomUUID3 } from "crypto";
 import { basename as basename2, join as join3, resolve, sep } from "path";
 var PAIR_BASE_PORT = 4500;
 var PAIR_SLOT_STRIDE = 10;
@@ -15513,7 +15539,7 @@ function nonEmpty(value) {
 }
 
 // src/trace-log.ts
-import { appendFileSync as appendFileSync2, existsSync as existsSync6, mkdirSync as mkdirSync4, readdirSync as readdirSync2, statSync as statSync4, unlinkSync as unlinkSync4 } from "fs";
+import { appendFileSync as appendFileSync2, existsSync as existsSync6, mkdirSync as mkdirSync5, readdirSync as readdirSync2, statSync as statSync4, unlinkSync as unlinkSync5 } from "fs";
 import { join as join4 } from "path";
 var TRACE_RETENTION_DAYS = 7;
 var TRACE_FILE_RE = /^trace-\d{4}-\d{2}-\d{2}\.jsonl$/;
@@ -15570,7 +15596,7 @@ function appendTraceEvent(input) {
   };
   const logsDir = join4(input.cwd, ".agentbridge", "logs");
   const isNewDayFile = !existsSync6(path);
-  mkdirSync4(logsDir, { recursive: true });
+  mkdirSync5(logsDir, { recursive: true });
   if (isNewDayFile) {
     pruneOldTraceLogs(logsDir, path, Date.parse(timestamp));
   }
@@ -15596,7 +15622,7 @@ function pruneOldTraceLogs(logsDir, keepPath, nowMs) {
       continue;
     try {
       if (statSync4(filePath).mtimeMs < cutoff) {
-        unlinkSync4(filePath);
+        unlinkSync5(filePath);
       }
     } catch {}
   }

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("3f14d41", "source"),
+  commit: defineString("ef0c291", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2454,8 +2454,43 @@ class TuiConnectionState {
 
 // src/daemon-lifecycle.ts
 import { spawn as spawn2 } from "child_process";
-import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync2, writeFileSync, openSync, closeSync, constants } from "fs";
+import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync2, openSync as openSync2, closeSync as closeSync2, constants } from "fs";
 import { fileURLToPath } from "url";
+
+// src/atomic-json.ts
+import * as fs from "fs";
+import { randomUUID } from "crypto";
+import { dirname as dirname2 } from "path";
+function tmpPathFor(targetPath) {
+  return `${targetPath}.tmp.${process.pid}.${randomUUID()}`;
+}
+function atomicWriteText(path, content, options = {}) {
+  fs.mkdirSync(dirname2(path), { recursive: true });
+  const tmp = tmpPathFor(path);
+  let renamed = false;
+  const fd = fs.openSync(tmp, "w");
+  try {
+    try {
+      fs.writeFileSync(fd, content, "utf-8");
+      if (options.fsync)
+        fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmp, path);
+    renamed = true;
+  } finally {
+    if (!renamed) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {}
+    }
+  }
+}
+function atomicWriteJson(path, value, options = {}) {
+  atomicWriteText(path, JSON.stringify(value, null, 2) + `
+`, options);
+}
 
 // src/process-lifecycle.ts
 import { execFileSync as execFileSync2 } from "child_process";
@@ -2717,9 +2752,7 @@ class DaemonLifecycle {
     }
   }
   writeStatus(status) {
-    this.stateDir.ensure();
-    writeFileSync(this.stateDir.statusFile, JSON.stringify(status, null, 2) + `
-`, "utf-8");
+    atomicWriteJson(this.stateDir.statusFile, status);
   }
   readPid() {
     try {
@@ -2733,28 +2766,27 @@ class DaemonLifecycle {
     }
   }
   writePid(pid) {
-    this.stateDir.ensure();
-    writeFileSync(this.stateDir.pidFile, `${pid ?? process.pid}
-`, "utf-8");
+    atomicWriteText(this.stateDir.pidFile, `${pid ?? process.pid}
+`);
   }
   removePidFile() {
     try {
-      unlinkSync2(this.stateDir.pidFile);
+      unlinkSync3(this.stateDir.pidFile);
     } catch {}
   }
   removeStatusFile() {
     try {
-      unlinkSync2(this.stateDir.statusFile);
+      unlinkSync3(this.stateDir.statusFile);
     } catch {}
   }
   markKilled() {
     this.stateDir.ensure();
-    writeFileSync(this.stateDir.killedFile, `${Date.now()}
+    writeFileSync2(this.stateDir.killedFile, `${Date.now()}
 `, "utf-8");
   }
   clearKilled() {
     try {
-      unlinkSync2(this.stateDir.killedFile);
+      unlinkSync3(this.stateDir.killedFile);
     } catch {}
   }
   wasKilled() {
@@ -2821,15 +2853,15 @@ class DaemonLifecycle {
     this.stateDir.ensure();
     let fd = null;
     try {
-      fd = openSync(this.stateDir.lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
-      writeFileSync(fd, `${process.pid}
+      fd = openSync2(this.stateDir.lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
+      writeFileSync2(fd, `${process.pid}
 `);
-      closeSync(fd);
+      closeSync2(fd);
       return true;
     } catch (err) {
       if (fd !== null && err.code !== "EEXIST") {
         try {
-          closeSync(fd);
+          closeSync2(fd);
         } catch {}
         this.releaseLock();
       }
@@ -2866,7 +2898,7 @@ class DaemonLifecycle {
   }
   releaseLock() {
     try {
-      unlinkSync2(this.stateDir.lockFile);
+      unlinkSync3(this.stateDir.lockFile);
     } catch {}
   }
   async kill(gracefulTimeoutMs = 3000, pidOverride) {
@@ -2925,7 +2957,7 @@ async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, existsSync as existsSync4 } from "fs";
+import { readFileSync as readFileSync2, mkdirSync as mkdirSync4, existsSync as existsSync4 } from "fs";
 import { join as join3 } from "path";
 var DEFAULT_BUDGET_CONFIG = {
   enabled: true,
@@ -3175,9 +3207,7 @@ class ConfigService {
     };
   }
   save(config) {
-    this.ensureConfigDir();
-    writeFileSync2(this.configPath, JSON.stringify(config, null, 2) + `
-`, "utf-8");
+    atomicWriteJson(this.configPath, config);
   }
   initDefaults() {
     this.ensureConfigDir();
@@ -3193,7 +3223,7 @@ class ConfigService {
   }
   ensureConfigDir() {
     if (!existsSync4(this.configDir)) {
-      mkdirSync3(this.configDir, { recursive: true });
+      mkdirSync4(this.configDir, { recursive: true });
     }
   }
 }
@@ -4332,14 +4362,11 @@ class ReplyRequiredTracker {
 // src/thread-state.ts
 import {
   existsSync as existsSync6,
-  mkdirSync as mkdirSync4,
   readdirSync,
-  readFileSync as readFileSync3,
-  renameSync as renameSync2,
-  writeFileSync as writeFileSync3
+  readFileSync as readFileSync3
 } from "fs";
 import { homedir as homedir3 } from "os";
-import { basename as basename2, dirname as dirname2, join as join5 } from "path";
+import { basename as basename2, join as join5 } from "path";
 function nowIso() {
   return new Date().toISOString();
 }
@@ -4349,13 +4376,6 @@ function threadTag(identity) {
 }
 function codexHome(env = process.env) {
   return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join5(homedir3(), ".codex");
-}
-function atomicWriteJson(path, value) {
-  mkdirSync4(dirname2(path), { recursive: true });
-  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
-  writeFileSync3(tmp, JSON.stringify(value, null, 2) + `
-`, "utf-8");
-  renameSync2(tmp, path);
 }
 function readRawCurrentThread(stateDir) {
   try {

--- a/src/atomic-json.ts
+++ b/src/atomic-json.ts
@@ -1,0 +1,43 @@
+import * as fs from "node:fs";
+import { randomUUID } from "node:crypto";
+import { dirname } from "node:path";
+
+export interface AtomicWriteOptions {
+  /**
+   * fsync the temp file before rename. Use for shared registry files where the
+   * extra syscall is worth the stronger durability; ordinary status/cache files
+   * can use the default tmp+rename path.
+   */
+  fsync?: boolean;
+}
+
+function tmpPathFor(targetPath: string): string {
+  return `${targetPath}.tmp.${process.pid}.${randomUUID()}`;
+}
+
+export function atomicWriteText(path: string, content: string, options: AtomicWriteOptions = {}): void {
+  fs.mkdirSync(dirname(path), { recursive: true });
+  const tmp = tmpPathFor(path);
+  let renamed = false;
+  const fd = fs.openSync(tmp, "w");
+  try {
+    try {
+      fs.writeFileSync(fd, content, "utf-8");
+      if (options.fsync) fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmp, path);
+    renamed = true;
+  } finally {
+    if (!renamed) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {}
+    }
+  }
+}
+
+export function atomicWriteJson(path: string, value: unknown, options: AtomicWriteOptions = {}): void {
+  atomicWriteText(path, JSON.stringify(value, null, 2) + "\n", options);
+}

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -1,5 +1,6 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
+import { atomicWriteJson } from "./atomic-json";
 import type { BudgetConfig, CodexTierMap, CodexTurnOverrides } from "./budget/types";
 
 /** Machine-readable project config schema. */
@@ -477,8 +478,7 @@ export class ConfigService {
 
   /** Save project config. */
   save(config: AgentBridgeConfig): void {
-    this.ensureConfigDir();
-    writeFileSync(this.configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+    atomicWriteJson(this.configPath, config);
   }
 
   /** Generate default config files if they don't exist. Returns list of created files. */

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { atomicWriteJson, atomicWriteText } from "./atomic-json";
 import { BUILD_INFO, compatibleContractVersion, formatBuildInfo, sameRuntimeContract } from "./build-info";
 import { StateDirResolver } from "./state-dir";
 import { parsePositiveIntEnv } from "./env-utils";
@@ -351,8 +352,7 @@ export class DaemonLifecycle {
 
   /** Write daemon status to status.json. */
   writeStatus(status: Record<string, unknown>): void {
-    this.stateDir.ensure();
-    writeFileSync(this.stateDir.statusFile, JSON.stringify(status, null, 2) + "\n", "utf-8");
+    atomicWriteJson(this.stateDir.statusFile, status);
   }
 
   /** Read daemon PID from pid file. */
@@ -369,8 +369,7 @@ export class DaemonLifecycle {
 
   /** Write daemon PID to pid file. */
   writePid(pid?: number): void {
-    this.stateDir.ensure();
-    writeFileSync(this.stateDir.pidFile, `${pid ?? process.pid}\n`, "utf-8");
+    atomicWriteText(this.stateDir.pidFile, `${pid ?? process.pid}\n`);
   }
 
   /** Remove stale pid file. */

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -1,16 +1,12 @@
 import { execFileSync } from "node:child_process";
 import {
-  closeSync,
   existsSync,
-  fsyncSync,
   linkSync,
   lstatSync,
   mkdirSync,
-  openSync,
   readdirSync,
   readFileSync,
   realpathSync,
-  renameSync,
   rmSync,
   statSync,
   unlinkSync,
@@ -20,6 +16,7 @@ import { createServer } from "node:net";
 import { createHash, randomUUID } from "node:crypto";
 import { hostname, userInfo } from "node:os";
 import { basename, join, resolve, sep } from "node:path";
+import { atomicWriteJson } from "./atomic-json";
 import { isAgentBridgeDaemon, pidLooksAlive } from "./process-lifecycle";
 
 /**
@@ -318,18 +315,7 @@ export function readRegistry(base: string): RegistryFile {
 
 /** Atomically replace the registry file (temp + fsync + rename). */
 export function writeRegistry(base: string, reg: RegistryFile): void {
-  mkdirSync(pairsDir(base), { recursive: true });
-  const target = registryPath(base);
-  const tmp = `${target}.tmp.${process.pid}`;
-  const data = JSON.stringify(reg, null, 2) + "\n";
-  const fd = openSync(tmp, "w");
-  try {
-    writeFileSync(fd, data);
-    fsyncSync(fd);
-  } finally {
-    closeSync(fd);
-  }
-  renameSync(tmp, target);
+  atomicWriteJson(registryPath(base), reg, { fsync: true });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/thread-state.ts
+++ b/src/thread-state.ts
@@ -1,13 +1,11 @@
 import {
   existsSync,
-  mkdirSync,
   readdirSync,
   readFileSync,
-  renameSync,
-  writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, join } from "node:path";
+import { atomicWriteJson } from "./atomic-json";
 import type { StateDirResolver } from "./state-dir";
 
 export type CurrentThreadStatus = "pending" | "current";
@@ -44,13 +42,6 @@ function threadTag(identity: ThreadIdentity): string {
 
 export function codexHome(env: NodeJS.ProcessEnv = process.env): string {
   return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join(homedir(), ".codex");
-}
-
-function atomicWriteJson(path: string, value: unknown): void {
-  mkdirSync(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
-  writeFileSync(tmp, JSON.stringify(value, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path);
 }
 
 export function readRawCurrentThread(stateDir: StateDirResolver): CurrentThreadState | null {

--- a/src/unit-test/atomic-json.test.ts
+++ b/src/unit-test/atomic-json.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { atomicWriteJson, atomicWriteText } from "../atomic-json";
+
+const tmpDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "abg-atomic-json-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("atomic-json", () => {
+  test("writes formatted JSON that is immediately readable", () => {
+    const dir = tempDir();
+    const path = join(dir, "state", "status.json");
+
+    atomicWriteJson(path, { pid: 123, ok: true });
+
+    expect(JSON.parse(readFileSync(path, "utf-8"))).toEqual({ pid: 123, ok: true });
+    expect(readFileSync(path, "utf-8")).toEndWith("\n");
+    expect(readdirSync(join(dir, "state")).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+
+  test("writes plain text atomically for pid-style files", () => {
+    const dir = tempDir();
+    const path = join(dir, "daemon.pid");
+
+    atomicWriteText(path, "456\n");
+
+    expect(readFileSync(path, "utf-8")).toBe("456\n");
+  });
+
+  test("concurrent writers use unique temp files and leave a valid final JSON file", async () => {
+    const dir = tempDir();
+    const target = join(dir, "shared.json");
+    const atomicModuleUrl = pathToFileURL(join(process.cwd(), "src", "atomic-json.ts")).href;
+    const script = join(dir, "writer.mjs");
+    writeFileSync(
+      script,
+      [
+        `import { atomicWriteJson } from ${JSON.stringify(atomicModuleUrl)};`,
+        "const [target, id] = process.argv.slice(2);",
+        "atomicWriteJson(target, { id: Number(id), payload: 'x'.repeat(1024) });",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const children = Array.from({ length: 8 }, (_, index) =>
+      Bun.spawn([process.execPath, script, target, String(index)], {
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+    );
+    const results = await Promise.all(children.map(async (child) => ({
+      code: await child.exited,
+      stderr: await new Response(child.stderr).text(),
+    })));
+
+    expect(results).toEqual(results.map(() => ({ code: 0, stderr: "" })));
+    const parsed = JSON.parse(readFileSync(target, "utf-8")) as { id: number; payload: string };
+    expect(parsed.id).toBeGreaterThanOrEqual(0);
+    expect(parsed.id).toBeLessThan(8);
+    expect(parsed.payload).toHaveLength(1024);
+    expect(readdirSync(dir).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+
+  test("fsync option fsyncs the temp file before rename", () => {
+    const dir = tempDir();
+    const fsyncSpy = spyOn(fs, "fsyncSync");
+    try {
+      atomicWriteJson(join(dir, "registry.json"), { version: 1 }, { fsync: true });
+      expect(fsyncSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      fsyncSpy.mockRestore();
+    }
+  });
+
+  test("a failed rename leaves the previous target intact", () => {
+    const dir = tempDir();
+    const path = join(dir, "status.json");
+    atomicWriteJson(path, { pid: 111 });
+    const renameSpy = spyOn(fs, "renameSync").mockImplementationOnce(() => {
+      throw new Error("rename failed");
+    });
+    try {
+      expect(() => atomicWriteJson(path, { pid: 222 })).toThrow("rename failed");
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(JSON.parse(readFileSync(path, "utf-8"))).toEqual({ pid: 111 });
+    expect(readdirSync(dir).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+});

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { describe, expect, spyOn, test, beforeEach, afterEach } from "bun:test";
+import * as fs from "node:fs";
 import {
   existsSync,
   mkdirSync,
@@ -12,6 +13,7 @@ import {
 import { createServer, type Server } from "node:net";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { DaemonLifecycle } from "../daemon-lifecycle";
 import {
   classifyReclaimableEntries,
   DEFAULT_PAIR_NAME,
@@ -40,6 +42,7 @@ import {
   type PairEntry,
   type RegistryFile,
 } from "../pair-registry";
+import { StateDirResolver } from "../state-dir";
 
 // Helper: build a minimal PairEntry with a given slot (other fields are
 // irrelevant for slot-allocation logic).
@@ -840,6 +843,30 @@ describe("removePairEntryAndDir / removeUnregisteredPairDir — locked atomic cl
 
     expect(await removeUnregisteredPairDir(base, live)).toEqual({ removed: false, reason: "live" });
     expect(existsSync(join(base, "pairs", live))).toBe(true);
+  });
+
+  test("a failed status update cannot expose a torn status that lets prune delete a live pair", async () => {
+    const live = "main-live0004";
+    const dir = join(base, "pairs", live);
+    mkdirSync(dir, { recursive: true });
+    const lifecycle = new DaemonLifecycle({
+      stateDir: new StateDirResolver(dir),
+      controlPort: portsForSlot(0).controlPort,
+      log: () => {},
+    });
+    lifecycle.writeStatus({ pid: process.pid });
+
+    const renameSpy = spyOn(fs, "renameSync").mockImplementationOnce(() => {
+      throw new Error("rename failed");
+    });
+    try {
+      expect(() => lifecycle.writeStatus({ pid: 2147483646 })).toThrow("rename failed");
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(await removeUnregisteredPairDir(base, live)).toEqual({ removed: false, reason: "live" });
+    expect(existsSync(dir)).toBe(true);
   });
 });
 

--- a/src/update-notifier.ts
+++ b/src/update-notifier.ts
@@ -21,7 +21,8 @@
  * CLI (`npm i -g`) and plugin (`/plugin marketplace update`) upgrade paths.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { atomicWriteJson } from "./atomic-json";
 import { StateDirResolver } from "./state-dir";
 import { isStableUpgrade, isStableVersion } from "./version-utils";
 import { parsePositiveIntEnv } from "./env-utils";
@@ -91,8 +92,7 @@ function readCache(stateDir: StateDirResolver): UpdateCache | null {
 
 function writeCache(stateDir: StateDirResolver, cache: UpdateCache): void {
   try {
-    stateDir.ensure();
-    writeFileSync(stateDir.updateCheckFile, JSON.stringify(cache, null, 2) + "\n", "utf-8");
+    atomicWriteJson(stateDir.updateCheckFile, cache);
   } catch {
     // best-effort; a failed cache write just means we recheck next time
   }


### PR DESCRIPTION
## 摘要 / Summary

arch-review P1 #7：把分散在各处的「写 JSON/文本」收敛到一个共享原子写 helper，杜绝并发读到半写文件、并统一失败清理。

- **`src/atomic-json.ts`（新）**：`atomicWriteText` / `atomicWriteJson` —— `mkdir -p` 目标目录、写唯一 tmp（`${target}.tmp.${pid}.${uuid}`）、可选 `fsync` tmp body、`renameSync` 覆盖目标、失败时 outer `finally` `unlink` tmp。`rename` 为 POSIX 原子操作，目标只被一次替换，读者只会看到旧 inode 或新 inode，永不半写。
- **五处写入收敛**：`pair-registry`（`fsync:true`）/ `thread-state` / `daemon-lifecycle`（`writeStatus`/`writePid`）/ `config-service`（`save`）/ `update-notifier`。各站点保持原签名、字节格式（缩进 2 + 末尾换行）与错误契约；`update-notifier` 仍 `try/catch`，写失败不抛进命令热路径。

Consolidates scattered JSON/text writes behind one shared atomic-write helper (tmp + optional fsync + atomic rename), preventing torn reads and unifying failure cleanup.

## 测试 / Test plan

- `bun run typecheck` ✅ exit 0
- `bun test src` ✅ **996 pass / 0 fail**
- `bun run verify:plugin-sync` ✅ bundles in sync
- 新增 `atomic-json.test.ts`：原子写、并发 tmp 不冲突、fsync 档位、rename 失败保留旧文件、status 写失败不暴露半 JSON；`pair-registry.test.ts`：prune 不回收活 pair dir（失败的 status rename 保留旧 status）。
- Cross-review gate：**2 轮各 2 独立 reviewer**（correctness/integration + durability/migration）连续 **0 REAL**。唯一 suspect（rename 后未 fsync 父目录）经实证为与旧 `writeRegistry` **同等行为（pre-existing parity）**，降级为 RECOMMEND。

## 备注 / Notes

- 攒批发布：`release-on-merge` 暂禁用，本 PR 合并不 bump；与 #21（PR #130）一起在统一 release（v0.1.13）发布。
- 已 rebase 到 `#129`（registry prune），pair-registry 三方自动合并无冲突。