### PR TITLE
refactor: DaemonLifecycle 轮询节奏可注入 + self-heal 测试提速 20× / injectable DaemonLifecycle cadence + 20× faster self-heal tests

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14271,7 +14271,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("ef0c291", "source"),
+  commit: defineString("20991c3", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14641,6 +14641,8 @@ var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 var REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES", 12);
 var REUSE_READY_DELAY_MS = 250;
+var WAIT_READY_RETRIES = 40;
+var WAIT_READY_DELAY_MS = 250;
 var HEALTH_FETCH_TIMEOUT_MS = 500;
 var LOCK_IDENTITY_GRACE_MS = parsePositiveIntEnv("AGENTBRIDGE_LOCK_IDENTITY_GRACE_MS", 120000);
 function isReuseVerdict(verdict) {
@@ -14685,15 +14687,25 @@ function classifyDaemon(expectedPairId, status, buildInfo) {
   }
   return { verdict: "reuse", reason: "daemon pair and runtime contract match" };
 }
+function resolveTiming(timing) {
+  return {
+    reuseReadyRetries: timing?.reuseReadyRetries ?? REUSE_READY_RETRIES,
+    reuseReadyDelayMs: timing?.reuseReadyDelayMs ?? REUSE_READY_DELAY_MS,
+    waitReadyRetries: timing?.waitReadyRetries ?? WAIT_READY_RETRIES,
+    waitReadyDelayMs: timing?.waitReadyDelayMs ?? WAIT_READY_DELAY_MS
+  };
+}
 
 class DaemonLifecycle {
   stateDir;
   controlPort;
   log;
+  timing;
   constructor(opts) {
     this.stateDir = opts.stateDir;
     this.controlPort = opts.controlPort;
     this.log = opts.log;
+    this.timing = resolveTiming(opts.timing);
   }
   get healthUrl() {
     return `http://127.0.0.1:${this.controlPort}/healthz`;
@@ -14750,7 +14762,7 @@ class DaemonLifecycle {
           break;
       }
       try {
-        await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+        await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
         return;
       } catch {
         this.log(`Daemon on control port ${this.controlPort} is healthy but not ready within reuse window \u2014 replacing`);
@@ -14763,7 +14775,7 @@ class DaemonLifecycle {
       if (isProcessAlive(existingPid)) {
         if (isAgentBridgeDaemon(existingPid)) {
           try {
-            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
             return;
           } catch {
             this.log(`Existing daemon process ${existingPid} never became ready \u2014 replacing`);
@@ -14791,7 +14803,7 @@ class DaemonLifecycle {
           await this.kill(3000, status?.pid);
         } else {
           try {
-            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
             return;
           } catch {
             this.log(`Daemon on control port ${this.controlPort} is healthy but not ready under startup lock \u2014 replacing`);
@@ -14800,7 +14812,7 @@ class DaemonLifecycle {
         }
       }
       this.launch();
-      await this.waitForReady();
+      await this.waitForReady(this.timing.waitReadyRetries, this.timing.waitReadyDelayMs);
     });
   }
   async isHealthy() {
@@ -14827,7 +14839,7 @@ class DaemonLifecycle {
       return false;
     }
   }
-  async waitForReady(maxRetries = 40, delayMs = 250) {
+  async waitForReady(maxRetries = WAIT_READY_RETRIES, delayMs = WAIT_READY_DELAY_MS) {
     for (let attempt = 0;attempt < maxRetries; attempt++) {
       if (await this.isReady())
         return;
@@ -14835,7 +14847,7 @@ class DaemonLifecycle {
     }
     throw new Error(`Timed out waiting for AgentBridge daemon readiness on ${this.readyUrl}`);
   }
-  async waitForReadyAndOurs(maxRetries = 40, delayMs = 250) {
+  async waitForReadyAndOurs(maxRetries = WAIT_READY_RETRIES, delayMs = WAIT_READY_DELAY_MS) {
     for (let attempt = 0;attempt < maxRetries; attempt++) {
       if (await this.isReady()) {
         const status = await this.fetchStatus();
@@ -14933,7 +14945,7 @@ class DaemonLifecycle {
         }
         if (isReuseVerdict(classification.verdict)) {
           try {
-            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
             return;
           } catch {}
         }
@@ -14941,12 +14953,12 @@ class DaemonLifecycle {
       this.log(`Killing unhealthy daemon on control port ${this.controlPort} and relaunching`);
       await this.kill(3000, statusPid);
       this.launch();
-      await this.waitForReady();
+      await this.waitForReady(this.timing.waitReadyRetries, this.timing.waitReadyDelayMs);
     });
   }
   async waitForContendedStartupLock() {
     this.log("Another process holds the startup lock, waiting for readiness+identity...");
-    await this.waitForReadyAndOurs();
+    await this.waitForReadyAndOurs(this.timing.waitReadyRetries, this.timing.waitReadyDelayMs);
   }
   async withStartupLockStrict(fn) {
     const locked = this.acquireLockStrict();

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("ef0c291", "source"),
+  commit: defineString("20991c3", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2533,6 +2533,8 @@ var DAEMON_ENTRY = process.env.AGENTBRIDGE_DAEMON_ENTRY || DEFAULT_DAEMON_ENTRY;
 var DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 var REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES", 12);
 var REUSE_READY_DELAY_MS = 250;
+var WAIT_READY_RETRIES = 40;
+var WAIT_READY_DELAY_MS = 250;
 var HEALTH_FETCH_TIMEOUT_MS = 500;
 var LOCK_IDENTITY_GRACE_MS = parsePositiveIntEnv("AGENTBRIDGE_LOCK_IDENTITY_GRACE_MS", 120000);
 function isReuseVerdict(verdict) {
@@ -2577,15 +2579,25 @@ function classifyDaemon(expectedPairId, status, buildInfo) {
   }
   return { verdict: "reuse", reason: "daemon pair and runtime contract match" };
 }
+function resolveTiming(timing) {
+  return {
+    reuseReadyRetries: timing?.reuseReadyRetries ?? REUSE_READY_RETRIES,
+    reuseReadyDelayMs: timing?.reuseReadyDelayMs ?? REUSE_READY_DELAY_MS,
+    waitReadyRetries: timing?.waitReadyRetries ?? WAIT_READY_RETRIES,
+    waitReadyDelayMs: timing?.waitReadyDelayMs ?? WAIT_READY_DELAY_MS
+  };
+}
 
 class DaemonLifecycle {
   stateDir;
   controlPort;
   log;
+  timing;
   constructor(opts) {
     this.stateDir = opts.stateDir;
     this.controlPort = opts.controlPort;
     this.log = opts.log;
+    this.timing = resolveTiming(opts.timing);
   }
   get healthUrl() {
     return `http://127.0.0.1:${this.controlPort}/healthz`;
@@ -2642,7 +2654,7 @@ class DaemonLifecycle {
           break;
       }
       try {
-        await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+        await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
         return;
       } catch {
         this.log(`Daemon on control port ${this.controlPort} is healthy but not ready within reuse window \u2014 replacing`);
@@ -2655,7 +2667,7 @@ class DaemonLifecycle {
       if (isProcessAlive(existingPid)) {
         if (isAgentBridgeDaemon(existingPid)) {
           try {
-            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
             return;
           } catch {
             this.log(`Existing daemon process ${existingPid} never became ready \u2014 replacing`);
@@ -2683,7 +2695,7 @@ class DaemonLifecycle {
           await this.kill(3000, status?.pid);
         } else {
           try {
-            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
             return;
           } catch {
             this.log(`Daemon on control port ${this.controlPort} is healthy but not ready under startup lock \u2014 replacing`);
@@ -2692,7 +2704,7 @@ class DaemonLifecycle {
         }
       }
       this.launch();
-      await this.waitForReady();
+      await this.waitForReady(this.timing.waitReadyRetries, this.timing.waitReadyDelayMs);
     });
   }
   async isHealthy() {
@@ -2719,7 +2731,7 @@ class DaemonLifecycle {
       return false;
     }
   }
-  async waitForReady(maxRetries = 40, delayMs = 250) {
+  async waitForReady(maxRetries = WAIT_READY_RETRIES, delayMs = WAIT_READY_DELAY_MS) {
     for (let attempt = 0;attempt < maxRetries; attempt++) {
       if (await this.isReady())
         return;
@@ -2727,7 +2739,7 @@ class DaemonLifecycle {
     }
     throw new Error(`Timed out waiting for AgentBridge daemon readiness on ${this.readyUrl}`);
   }
-  async waitForReadyAndOurs(maxRetries = 40, delayMs = 250) {
+  async waitForReadyAndOurs(maxRetries = WAIT_READY_RETRIES, delayMs = WAIT_READY_DELAY_MS) {
     for (let attempt = 0;attempt < maxRetries; attempt++) {
       if (await this.isReady()) {
         const status = await this.fetchStatus();
@@ -2825,7 +2837,7 @@ class DaemonLifecycle {
         }
         if (isReuseVerdict(classification.verdict)) {
           try {
-            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
             return;
           } catch {}
         }
@@ -2833,12 +2845,12 @@ class DaemonLifecycle {
       this.log(`Killing unhealthy daemon on control port ${this.controlPort} and relaunching`);
       await this.kill(3000, statusPid);
       this.launch();
-      await this.waitForReady();
+      await this.waitForReady(this.timing.waitReadyRetries, this.timing.waitReadyDelayMs);
     });
   }
   async waitForContendedStartupLock() {
     this.log("Another process holds the startup lock, waiting for readiness+identity...");
-    await this.waitForReadyAndOurs();
+    await this.waitForReadyAndOurs(this.timing.waitReadyRetries, this.timing.waitReadyDelayMs);
   }
   async withStartupLockStrict(fn) {
     const locked = this.acquireLockStrict();

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -22,6 +22,11 @@ const DAEMON_PATH = fileURLToPath(new URL(DAEMON_ENTRY, import.meta.url));
 // healthz-OK/readyz-503 zombie so we replace it instead of hanging the full ~10s.
 const REUSE_READY_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_REUSE_READY_RETRIES", 12);
 const REUSE_READY_DELAY_MS = 250;
+// Full readiness wait (fresh launch + contended-lock branches). ~10s (40×250ms):
+// the historical waitForReady() / waitForReadyAndOurs() signature defaults, now
+// named so DaemonLifecycleTiming can override them without touching the prod path.
+const WAIT_READY_RETRIES = 40;
+const WAIT_READY_DELAY_MS = 250;
 const HEALTH_FETCH_TIMEOUT_MS = 500;
 // A legitimate startup-lock hold lasts seconds (launch + waitForReady, plus a
 // 3s graceful kill during a replace). Only locks far older than that get the
@@ -93,10 +98,52 @@ export function classifyDaemon(
   return { verdict: "reuse", reason: "daemon pair and runtime contract match" };
 }
 
+/**
+ * Polling cadence for the readiness loops. Injectable so tests can drive the
+ * self-heal contract at 10-20ms instead of paying the real ~3s reuse window /
+ * ~10s wait. PRODUCTION DEFAULTS (resolveTiming below) must stay bit-for-bit
+ * identical to the historical hardcoded constants — daemon-lifecycle.test pins
+ * them so the injection seam can never silently drift the shipped cadence.
+ */
+export interface DaemonLifecycleTiming {
+  /** Retries for the reuse-validation readiness window (REUSE_READY_RETRIES). */
+  reuseReadyRetries?: number;
+  /** Delay between reuse-validation probes (REUSE_READY_DELAY_MS). */
+  reuseReadyDelayMs?: number;
+  /** Retries for the full waitForReady / waitForReadyAndOurs loops. */
+  waitReadyRetries?: number;
+  /** Delay between full readiness probes. */
+  waitReadyDelayMs?: number;
+}
+
+export interface ResolvedTiming {
+  reuseReadyRetries: number;
+  reuseReadyDelayMs: number;
+  waitReadyRetries: number;
+  waitReadyDelayMs: number;
+}
+
+/**
+ * Resolve the timing knobs, falling back to the historical production constants
+ * for any field left undefined. Keep these fallbacks in lockstep with the
+ * module-level constants — they are the shipped daemon cadence. Exported so a
+ * lock-down test can pin the production defaults against the injection seam.
+ */
+export function resolveTiming(timing?: DaemonLifecycleTiming): ResolvedTiming {
+  return {
+    reuseReadyRetries: timing?.reuseReadyRetries ?? REUSE_READY_RETRIES,
+    reuseReadyDelayMs: timing?.reuseReadyDelayMs ?? REUSE_READY_DELAY_MS,
+    waitReadyRetries: timing?.waitReadyRetries ?? WAIT_READY_RETRIES,
+    waitReadyDelayMs: timing?.waitReadyDelayMs ?? WAIT_READY_DELAY_MS,
+  };
+}
+
 export interface DaemonLifecycleOptions {
   stateDir: StateDirResolver;
   controlPort: number;
   log: (msg: string) => void;
+  /** Optional polling cadence override; defaults to production constants. */
+  timing?: DaemonLifecycleTiming;
 }
 
 /**
@@ -107,11 +154,13 @@ export class DaemonLifecycle {
   private readonly stateDir: StateDirResolver;
   private readonly controlPort: number;
   private readonly log: (msg: string) => void;
+  private readonly timing: ResolvedTiming;
 
   constructor(opts: DaemonLifecycleOptions) {
     this.stateDir = opts.stateDir;
     this.controlPort = opts.controlPort;
     this.log = opts.log;
+    this.timing = resolveTiming(opts.timing);
   }
 
   get healthUrl(): string {
@@ -199,7 +248,7 @@ export class DaemonLifecycle {
       }
       try {
         // Short window: a sane daemon (or a legit slow boot) reports ready within ~3s.
-        await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+        await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
         return; // healthy + ready → reuse
       } catch {
         // healthz-OK but never ready within the reuse window → bad/zombie daemon
@@ -219,7 +268,7 @@ export class DaemonLifecycle {
         // Verify the live process is actually our daemon, not an OS-reused PID
         if (isAgentBridgeDaemon(existingPid)) {
           try {
-            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
             return;
           } catch {
             // Live daemon process but control port never became ready → replace it
@@ -257,7 +306,7 @@ export class DaemonLifecycle {
           await this.kill(3000, status?.pid);
         } else {
           try {
-            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
             return;
           } catch {
             this.log(
@@ -268,7 +317,7 @@ export class DaemonLifecycle {
         }
       }
       this.launch();
-      await this.waitForReady();
+      await this.waitForReady(this.timing.waitReadyRetries, this.timing.waitReadyDelayMs);
     });
   }
 
@@ -302,7 +351,7 @@ export class DaemonLifecycle {
   }
 
   /** Wait for daemon to become ready. */
-  async waitForReady(maxRetries = 40, delayMs = 250): Promise<void> {
+  async waitForReady(maxRetries = WAIT_READY_RETRIES, delayMs = WAIT_READY_DELAY_MS): Promise<void> {
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       if (await this.isReady()) return;
       await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -317,7 +366,7 @@ export class DaemonLifecycle {
    * other pair repairing their own daemon). In manual mode (no expected pairId) this
    * is equivalent to waitForReady.
    */
-  async waitForReadyAndOurs(maxRetries = 40, delayMs = 250): Promise<void> {
+  async waitForReadyAndOurs(maxRetries = WAIT_READY_RETRIES, delayMs = WAIT_READY_DELAY_MS): Promise<void> {
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       if (await this.isReady()) {
         const status = await this.fetchStatus();
@@ -449,7 +498,7 @@ export class DaemonLifecycle {
         }
         if (isReuseVerdict(classification.verdict)) {
           try {
-            await this.waitForReady(REUSE_READY_RETRIES, REUSE_READY_DELAY_MS);
+            await this.waitForReady(this.timing.reuseReadyRetries, this.timing.reuseReadyDelayMs);
             return; // someone else already fixed it — don't kill
           } catch {
             // still not ready → fall through to kill + relaunch
@@ -459,7 +508,7 @@ export class DaemonLifecycle {
       this.log(`Killing unhealthy daemon on control port ${this.controlPort} and relaunching`);
       await this.kill(3000, statusPid);
       this.launch();
-      await this.waitForReady();
+      await this.waitForReady(this.timing.waitReadyRetries, this.timing.waitReadyDelayMs);
     });
   }
 
@@ -470,7 +519,7 @@ export class DaemonLifecycle {
     // that is BOTH ready AND ours — a foreign daemon becoming ready behind the
     // lock holder is the other pair repairing their own daemon; adopting it
     // would squat the wrong pair.
-    await this.waitForReadyAndOurs();
+    await this.waitForReadyAndOurs(this.timing.waitReadyRetries, this.timing.waitReadyDelayMs);
   }
 
   /**

--- a/src/unit-test/daemon-lifecycle.test.ts
+++ b/src/unit-test/daemon-lifecycle.test.ts
@@ -4,7 +4,7 @@ import { createServer } from "node:net";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { StateDirResolver } from "../state-dir";
-import { classifyDaemon, DaemonLifecycle, isProcessAlive } from "../daemon-lifecycle";
+import { classifyDaemon, DaemonLifecycle, isProcessAlive, resolveTiming } from "../daemon-lifecycle";
 import { BUILD_INFO, type AgentBridgeBuildInfo } from "../build-info";
 import type { DaemonStatus } from "../control-protocol";
 
@@ -345,4 +345,33 @@ describe("DaemonLifecycle", () => {
     expect(killed).toBe(false);
     expect(launched).toBe(false);
   }, 15000);
+});
+
+// Lock-down test for arch-review P1 #435: the timing injection seam must default to
+// the EXACT historical production cadence. Hard-coded literals (not the module
+// constants) so a future edit that lowers the shipped reuse/wait window — e.g. a
+// test-tuning value leaking into resolveTiming's fallback — fails here loudly.
+describe("resolveTiming production defaults (injection seam guard)", () => {
+  // NOTE: REUSE_READY_RETRIES is captured ONCE from AGENTBRIDGE_REUSE_READY_RETRIES at
+  // module load — the 12 below is the shipped default observed with that env unset (the
+  // normal case for the test runner and CI). If a future env-leak ever set that var at
+  // load time, this assertion would surface it as a failure, which is the intent: it
+  // pins what the daemon actually ships, not what a runtime mutation could fake.
+  test("undefined timing yields the historical hardcoded cadence", () => {
+    expect(resolveTiming(undefined)).toEqual({
+      reuseReadyRetries: 12, // REUSE_READY_RETRIES default → ~3s reuse window (12×250ms)
+      reuseReadyDelayMs: 250, // REUSE_READY_DELAY_MS
+      waitReadyRetries: 40, // WAIT_READY_RETRIES → ~10s full wait (40×250ms)
+      waitReadyDelayMs: 250, // WAIT_READY_DELAY_MS
+    });
+  });
+
+  test("partial timing overrides only the supplied fields, rest fall back to prod defaults", () => {
+    expect(resolveTiming({ reuseReadyDelayMs: 10, waitReadyRetries: 3 })).toEqual({
+      reuseReadyRetries: 12, // untouched → prod default
+      reuseReadyDelayMs: 10, // overridden
+      waitReadyRetries: 3, // overridden
+      waitReadyDelayMs: 250, // untouched → prod default
+    });
+  });
 });

--- a/src/unit-test/daemon-self-heal.test.ts
+++ b/src/unit-test/daemon-self-heal.test.ts
@@ -67,8 +67,22 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  // Fake control server with a mutable readyz status + reported pairId.
-  function fakeDaemon(port: number, state: { readyzStatus: number; pairId: string | null; pid?: number }) {
+  // Fake control server with a mutable readyz status + reported pairId. `state.readyzHits`
+  // (when present) counts every /readyz probe — lets tests assert "we actually polled N
+  // times" against the fake server instead of a flaky wall-clock elapsed-ms threshold.
+  function fakeDaemon(
+    port: number,
+    state: {
+      readyzStatus: number;
+      pairId: string | null;
+      pid?: number;
+      readyzHits?: number;
+      // When set, /readyz returns 200 starting from this probe count (1-based) — a
+      // deterministic "slow boot" that becomes ready after N polls, independent of the
+      // wall clock (no setTimeout race against the polling cadence).
+      readyAtHit?: number;
+    },
+  ) {
     const s = Bun.serve({
       port,
       hostname: "127.0.0.1",
@@ -86,7 +100,12 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
           build: BUILD_INFO,
         };
         if (u.pathname === "/healthz") return Response.json(body);
-        if (u.pathname === "/readyz") return Response.json(body, { status: state.readyzStatus });
+        if (u.pathname === "/readyz") {
+          state.readyzHits = (state.readyzHits ?? 0) + 1;
+          const status =
+            state.readyAtHit != null && state.readyzHits >= state.readyAtHit ? 200 : state.readyzStatus;
+          return Response.json(body, { status });
+        }
         return new Response("ok");
       },
     });
@@ -94,8 +113,20 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
     return s;
   }
 
+  // Fast polling cadence so the self-heal contract is exercised in ms, not the real
+  // ~3s reuse window / ~10s full wait. Production defaults are pinned separately in
+  // daemon-lifecycle.test.ts ("resolveTiming production defaults"). Retry counts are
+  // kept generous (timeouts are reached by exhausting retries × tiny delay, not by
+  // shortening the budget) so the "we actually waited / polled" assertions stay valid.
+  const FAST_TIMING = {
+    reuseReadyRetries: 12,
+    reuseReadyDelayMs: 10,
+    waitReadyRetries: 40,
+    waitReadyDelayMs: 10,
+  };
+
   function lifecycle(port: number) {
-    return new DaemonLifecycle({ stateDir, controlPort: port, log: () => {} });
+    return new DaemonLifecycle({ stateDir, controlPort: port, log: () => {}, timing: FAST_TIMING });
   }
 
   test("reuses a healthy, ready, matching-pair daemon (no kill, no launch)", async () => {
@@ -342,16 +373,15 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
     await lc.ensureRunning();
     expect(killed).toBe(true);
     expect(launched).toBe(true);
-  }, 15000);
+  }, 5000);
 
   test("does NOT kill a healthy daemon that is merely slow to become ready", async () => {
     const port = await freePort();
-    const state = { readyzStatus: 503, pairId: null as string | null };
+    // Becomes ready on the 3rd /readyz probe — comfortably inside the reuseReadyRetries
+    // budget (12), so it's a legit slow boot, not a zombie. Probe-count based (not a
+    // setTimeout) so the "slow" window can't lose a race against the polling cadence.
+    const state = { readyzStatus: 503, pairId: null as string | null, readyAtHit: 3, readyzHits: 0 };
     fakeDaemon(port, state);
-    // Flip to ready well within the ~3s reuse window — a legit slow boot, not a zombie.
-    setTimeout(() => {
-      state.readyzStatus = 200;
-    }, 600);
     const lc = lifecycle(port);
     let killed = false;
     let launched = false;
@@ -365,7 +395,9 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
     await lc.ensureRunning();
     expect(killed).toBe(false);
     expect(launched).toBe(false);
-  }, 15000);
+    // Confirms reuse came from a late-readying probe, not an instant 200.
+    expect(state.readyzHits).toBeGreaterThanOrEqual(3);
+  }, 5000);
 
   test("acquireLockStrict returns false when a LIVE process holds the lock (no bypass)", () => {
     const lc = lifecycle(20001);
@@ -419,7 +451,7 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
     (lcB as any).launch = mockLaunch;
     await Promise.all([lcA.ensureRunning(), lcB.ensureRunning()]);
     expect(launchCount).toBe(1); // strict lock → only one launcher replaces; the other waits
-  }, 25000);
+  }, 5000);
 
   // Regression guard for cross-review HIGH-1: in a contended-lock branch the launcher
   // losing the race must wait for ready+OURS, not just ready. A foreign-pair daemon
@@ -432,27 +464,30 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
     process.env.AGENTBRIDGE_PAIR_ID = "mine-aaaa0000";
     const port = await freePort();
     // Foreign daemon: ready 200 from the start, but reports a DIFFERENT pairId.
-    fakeDaemon(port, { readyzStatus: 200, pairId: "other-bbbb1111", pid: 99999 });
+    const state = { readyzStatus: 200, pairId: "other-bbbb1111" as string | null, pid: 99999, readyzHits: 0 };
+    fakeDaemon(port, state);
     // Pin the lock file from outside so acquireLockStrict returns false → ensureRunning
     // takes the `locked=false` branch inside withStartupLockStrict → waitForReadyAndOurs.
     writeFileSync(stateDir.lockFile, `${process.pid}\n`); // this test process holds the lock
     const lc = lifecycle(port);
     (lc as any).kill = async () => true;
     (lc as any).launch = () => {};
-    const start = Date.now();
     let rejected: Error | null = null;
     try {
       await lc.ensureRunning();
     } catch (err: any) {
       rejected = err;
     }
-    const elapsed = Date.now() - start;
-    // Must reject (timed out waiting for ready+identity) and must have ACTUALLY waited,
-    // not short-circuited because the foreign daemon is "ready".
+    // Must reject (timed out waiting for ready+identity) and must have ACTUALLY polled
+    // the full retry budget, not short-circuited because the foreign daemon is "ready".
+    // Counting real /readyz probes against the fake server is exact and flake-free —
+    // unlike the old wall-clock `elapsed >= 5000` threshold.
     expect(rejected).not.toBeNull();
     expect(rejected!.message).toMatch(/Timed out waiting for AgentBridge daemon readiness\+identity/);
-    expect(elapsed).toBeGreaterThanOrEqual(5000); // waitForReadyAndOurs default = 40×250ms=10s, ≥5s confirms we waited
-  }, 20000);
+    // waitForReadyAndOurs polls /readyz once per retry; a foreign daemon never matches
+    // identity, so the loop exhausts the full waitReadyRetries budget before timing out.
+    expect(state.readyzHits).toBe(FAST_TIMING.waitReadyRetries);
+  }, 5000);
 
   // Regression guard for cross-review HIGH-2: in pair mode, a missing/null reported
   // pairId is treated as FOREIGN (a hard-paired pair must not adopt a manual/old
@@ -476,5 +511,5 @@ describe("DaemonLifecycle self-heal (zombie / foreign daemon replacement)", () =
     await lc.ensureRunning();
     expect(killed).toBe(true);
     expect(launched).toBe(true);
-  }, 15000);
+  }, 5000);
 });


### PR DESCRIPTION
## 摘要 / Summary
arch-review P1 #435：把 DaemonLifecycle 的轮询节奏从模块级硬编码常量改为可注入 options，**生产节奏逐位不变**，让最慢的测试文件提速 20×。
- `DaemonLifecycleOptions.timing?: { reuseReadyRetries?, reuseReadyDelayMs?, waitReadyRetries?, waitReadyDelayMs? }`；`resolveTiming()` 各字段回退历史默认（reuse 12×250ms / wait 40×250ms）。7 处调用点统一读 `this.timing.*`。
- daemon-self-heal.test.ts 注入 10ms 节奏；"确实等待了" 的墙钟断言 → fakeDaemon `/readyz` 命中次数断言（`readyzHits===40`，更准更强、零 flake）：**23.05s → 1.13s**。
- 新增 `resolveTiming` 生产默认值锁死单测（硬字面量，防注入口误调漂移）。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1014 pass / 0 fail** / `bun run verify:plugin-sync` ✅
- Cross-review：2 独立 reviewer（default-equivalence + test-strength）round-1 **0 REAL**，经 `git show HEAD` 实证旧值=新默认、7 调用点全 trace、自检 5× 零 flake。
## 备注
攒批发布：release-on-merge 暂禁，本 PR 合并不 bump。ensureRunning 是回归最敏感路径——已确认默认值 bit-identical。