### PR TITLE
refactor: daemon.ts 有界投递缓冲收敛为 BoundedMessageBuffer / extract BoundedMessageBuffer from daemon.ts

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14271,7 +14271,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("20991c3", "source"),
+  commit: defineString("56a5f87", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("20991c3", "source"),
+  commit: defineString("56a5f87", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -4540,6 +4540,47 @@ async function probeLiveness(target, options) {
   return target.pongCount > baseline;
 }
 
+// src/delivery-buffer.ts
+class BoundedMessageBuffer {
+  messages = [];
+  cap;
+  overflowLabel;
+  overflowNoun;
+  log;
+  constructor(options) {
+    this.cap = options.cap;
+    this.overflowLabel = options.overflowLabel;
+    this.overflowNoun = options.overflowNoun ?? "message(s)";
+    this.log = options.log;
+  }
+  get length() {
+    return this.messages.length;
+  }
+  push(message) {
+    this.messages.push(message);
+    this.enforceCap();
+  }
+  unshiftMany(messages) {
+    if (messages.length === 0)
+      return;
+    this.messages.unshift(...messages);
+    this.enforceCap();
+  }
+  drainAll() {
+    return this.messages.splice(0, this.messages.length);
+  }
+  clear() {
+    this.messages.length = 0;
+  }
+  enforceCap() {
+    if (this.messages.length > this.cap) {
+      const dropped = this.messages.length - this.cap;
+      this.messages.splice(0, dropped);
+      this.log(`${this.overflowLabel}: dropped ${dropped} oldest ${this.overflowNoun}, ${this.cap} remaining`);
+    }
+  }
+}
+
 // src/daemon.ts
 var stateDir = new StateDirResolver;
 stateDir.ensure();
@@ -4583,7 +4624,19 @@ var ATTACH_STATUS_COOLDOWN_MS = 30000;
 var LIVENESS_PROBE_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS", 3000, log);
 var LIVENESS_PROBE_POLL_MS = 50;
 var challengeInProgress = false;
-var bufferedMessages = [];
+var bufferedMessages = new BoundedMessageBuffer({
+  cap: MAX_BUFFERED_MESSAGES,
+  overflowLabel: "Message buffer overflow",
+  log
+});
+function createPendingBackpressureBuffer() {
+  return new BoundedMessageBuffer({
+    cap: MAX_BUFFERED_MESSAGES,
+    overflowLabel: "Backpressure overflow",
+    overflowNoun: "tracked message(s)",
+    log
+  });
+}
 var budgetCoordinator = null;
 function ensureBudgetCoordinatorStarted() {
   if (!BUDGET_CONFIG.enabled)
@@ -4836,7 +4889,7 @@ function startControlServer() {
           log("Rejected WS upgrade on control port: Origin header present (possible CSWSH)");
           return wsOriginRejectedResponse();
         }
-        if (server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: [] } })) {
+        if (server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: createPendingBackpressureBuffer() } })) {
           return;
         }
       }
@@ -4848,7 +4901,7 @@ function startControlServer() {
       open: (ws) => {
         ws.data.clientId = ++nextControlClientId;
         ws.data.lastPongAt = Date.now();
-        ws.data.pendingBackpressure = [];
+        ws.data.pendingBackpressure = createPendingBackpressureBuffer();
         log(`Frontend socket opened (#${ws.data.clientId})`);
       },
       close: (ws, code, reason) => {
@@ -4866,7 +4919,7 @@ function startControlServer() {
       },
       drain: (ws) => {
         if (ws.data.pendingBackpressure.length > 0 && ws.getBufferedAmount() === 0) {
-          ws.data.pendingBackpressure = [];
+          ws.data.pendingBackpressure.clear();
         }
         if (ws === attachedClaude && bufferedMessages.length > 0) {
           flushBufferedMessages(ws);
@@ -5191,14 +5244,9 @@ function detachClaude(ws, reason) {
   ws.data.attached = false;
   log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
   if (ws.data.pendingBackpressure.length > 0) {
-    bufferedMessages.unshift(...ws.data.pendingBackpressure);
-    log(`Re-buffered ${ws.data.pendingBackpressure.length} backpressured message(s) for redelivery on reconnect`);
-    ws.data.pendingBackpressure = [];
-    if (bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
-      const dropped = bufferedMessages.length - MAX_BUFFERED_MESSAGES;
-      bufferedMessages.splice(0, dropped);
-      log(`Message buffer overflow: dropped ${dropped} oldest message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
-    }
+    const reBuffered = ws.data.pendingBackpressure.drainAll();
+    log(`Re-buffered ${reBuffered.length} backpressured message(s) for redelivery on reconnect`);
+    bufferedMessages.unshiftMany(reBuffered);
   }
   scheduleClaudeDisconnectNotification(ws.data.clientId);
   scheduleIdleShutdown();
@@ -5321,11 +5369,6 @@ function emitToClaude(message) {
     log("Send to Claude failed, buffering message for retry on reconnect");
   }
   bufferedMessages.push(message);
-  if (bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
-    const dropped = bufferedMessages.length - MAX_BUFFERED_MESSAGES;
-    bufferedMessages.splice(0, dropped);
-    log(`Message buffer overflow: dropped ${dropped} oldest message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
-  }
 }
 function trySendBridgeMessage(ws, message) {
   try {
@@ -5336,11 +5379,6 @@ function trySendBridgeMessage(ws, message) {
     }
     if (typeof result === "number" && result === -1) {
       ws.data.pendingBackpressure.push(message);
-      if (ws.data.pendingBackpressure.length > MAX_BUFFERED_MESSAGES) {
-        const dropped = ws.data.pendingBackpressure.length - MAX_BUFFERED_MESSAGES;
-        ws.data.pendingBackpressure.splice(0, dropped);
-        log(`Backpressure overflow: dropped ${dropped} oldest tracked message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
-      }
     }
     return true;
   } catch (err) {
@@ -5349,11 +5387,11 @@ function trySendBridgeMessage(ws, message) {
   }
 }
 function flushBufferedMessages(ws) {
-  const messages = bufferedMessages.splice(0, bufferedMessages.length);
+  const messages = bufferedMessages.drainAll();
   for (let i = 0;i < messages.length; i++) {
     if (!trySendBridgeMessage(ws, messages[i])) {
       const remaining = messages.slice(i);
-      bufferedMessages.unshift(...remaining);
+      bufferedMessages.unshiftMany(remaining);
       log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
       return;
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -38,6 +38,7 @@ import type {
 } from "./control-protocol";
 import type { BridgeMessage } from "./types";
 import { probeLiveness as probeLivenessImpl } from "./liveness-probe";
+import { BoundedMessageBuffer } from "./delivery-buffer";
 
 interface ControlSocketData {
   clientId: number;
@@ -54,7 +55,7 @@ interface ControlSocketData {
    * redelivery on reconnect (at-least-once: a pre-close partial flush can
    * produce a duplicate; silent loss cannot).
    */
-  pendingBackpressure: BridgeMessage[];
+  pendingBackpressure: BoundedMessageBuffer;
 }
 
 const stateDir = new StateDirResolver();
@@ -147,7 +148,25 @@ const LIVENESS_PROBE_TIMEOUT_MS = parsePositiveIntEnv(
 const LIVENESS_PROBE_POLL_MS = 50;
 let challengeInProgress = false;
 
-const bufferedMessages: BridgeMessage[] = [];
+// Module-level delivery backlog: messages that could not be sent while Claude
+// was detached / a send failed, awaiting the next attach or drain.
+const bufferedMessages = new BoundedMessageBuffer({
+  cap: MAX_BUFFERED_MESSAGES,
+  overflowLabel: "Message buffer overflow",
+  log,
+});
+
+// Per-socket backpressure tracker (ws.send returned -1): bounded the same way
+// so a never-draining socket can't accumulate unboundedly. Distinct overflow
+// label/noun keeps the log line bit-exact with the prior inline code.
+function createPendingBackpressureBuffer(): BoundedMessageBuffer {
+  return new BoundedMessageBuffer({
+    cap: MAX_BUFFERED_MESSAGES,
+    overflowLabel: "Backpressure overflow",
+    overflowNoun: "tracked message(s)",
+    log,
+  });
+}
 
 // --- Budget coordination (plan v2.3 P1) ---
 // Constructed lazily on the first codex "ready" and kept for the daemon's lifetime.
@@ -596,7 +615,7 @@ function startControlServer() {
           log("Rejected WS upgrade on control port: Origin header present (possible CSWSH)");
           return wsOriginRejectedResponse();
         }
-        if (server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: [] } })) {
+        if (server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: createPendingBackpressureBuffer() } })) {
           return undefined;
         }
       }
@@ -609,7 +628,7 @@ function startControlServer() {
       open: (ws: ServerWebSocket<ControlSocketData>) => {
         ws.data.clientId = ++nextControlClientId;
         ws.data.lastPongAt = Date.now();
-        ws.data.pendingBackpressure = [];
+        ws.data.pendingBackpressure = createPendingBackpressureBuffer();
         log(`Frontend socket opened (#${ws.data.clientId})`);
       },
       close: (ws: ServerWebSocket<ControlSocketData>, code: number, reason: string) => {
@@ -636,7 +655,7 @@ function startControlServer() {
         // OS buffer means the bytes reached the transport — the same
         // delivery guarantee a plain successful send has.
         if (ws.data.pendingBackpressure.length > 0 && ws.getBufferedAmount() === 0) {
-          ws.data.pendingBackpressure = [];
+          ws.data.pendingBackpressure.clear();
         }
         // Deliver anything that buffered while the socket was congested
         // instead of waiting for the next reattach.
@@ -1150,16 +1169,11 @@ function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
   // Prepend (they predate anything buffered after the send started failing)
   // and re-apply the cap.
   if (ws.data.pendingBackpressure.length > 0) {
-    bufferedMessages.unshift(...ws.data.pendingBackpressure);
+    const reBuffered = ws.data.pendingBackpressure.drainAll();
     log(
-      `Re-buffered ${ws.data.pendingBackpressure.length} backpressured message(s) for redelivery on reconnect`,
+      `Re-buffered ${reBuffered.length} backpressured message(s) for redelivery on reconnect`,
     );
-    ws.data.pendingBackpressure = [];
-    if (bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
-      const dropped = bufferedMessages.length - MAX_BUFFERED_MESSAGES;
-      bufferedMessages.splice(0, dropped);
-      log(`Message buffer overflow: dropped ${dropped} oldest message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
-    }
+    bufferedMessages.unshiftMany(reBuffered);
   }
 
   scheduleClaudeDisconnectNotification(ws.data.clientId);
@@ -1337,11 +1351,6 @@ function emitToClaude(message: BridgeMessage) {
   }
 
   bufferedMessages.push(message);
-  if (bufferedMessages.length > MAX_BUFFERED_MESSAGES) {
-    const dropped = bufferedMessages.length - MAX_BUFFERED_MESSAGES;
-    bufferedMessages.splice(0, dropped);
-    log(`Message buffer overflow: dropped ${dropped} oldest message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
-  }
 }
 
 function trySendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: BridgeMessage): boolean {
@@ -1361,11 +1370,6 @@ function trySendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: B
       // Same cap as bufferedMessages — a never-draining socket must not
       // accumulate unboundedly (bounded, logged loss beats OOM).
       ws.data.pendingBackpressure.push(message);
-      if (ws.data.pendingBackpressure.length > MAX_BUFFERED_MESSAGES) {
-        const dropped = ws.data.pendingBackpressure.length - MAX_BUFFERED_MESSAGES;
-        ws.data.pendingBackpressure.splice(0, dropped);
-        log(`Backpressure overflow: dropped ${dropped} oldest tracked message(s), ${MAX_BUFFERED_MESSAGES} remaining`);
-      }
     }
     return true;
   } catch (err: any) {
@@ -1375,14 +1379,16 @@ function trySendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: B
 }
 
 function flushBufferedMessages(ws: ServerWebSocket<ControlSocketData>) {
-  const messages = bufferedMessages.splice(0, bufferedMessages.length);
+  const messages = bufferedMessages.drainAll();
   for (let i = 0; i < messages.length; i++) {
     if (!trySendBridgeMessage(ws, messages[i]!)) {
       // Re-buffer this and all remaining messages on failure. Positional index,
       // not indexOf: identity lookup breaks the count if a message object is
-      // ever enqueued twice.
+      // ever enqueued twice. The buffer is empty here (just drained, and
+      // trySend only touches pendingBackpressure), so re-applying the cap on
+      // prepend is a provable no-op — count is preserved bit-exactly.
       const remaining = messages.slice(i);
-      bufferedMessages.unshift(...remaining);
+      bufferedMessages.unshiftMany(remaining);
       log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
       return;
     }

--- a/src/delivery-buffer.ts
+++ b/src/delivery-buffer.ts
@@ -1,0 +1,97 @@
+import type { BridgeMessage } from "./types";
+
+/**
+ * Bounded FIFO buffer for bridge messages awaiting delivery to Claude.
+ *
+ * Encapsulates the "append / prepend, then trim to cap and log the overflow"
+ * pattern that #101 hardened across three daemon call sites (the module-level
+ * delivery backlog, the detach re-buffer, and the per-socket backpressure
+ * tracker). Centralising it here means the not-lost-but-bounded invariant is
+ * stated once and can be unit-tested directly instead of only through a
+ * live-WS harness.
+ *
+ * Semantics (bit-exact with the prior inline daemon code):
+ *  - cap defaults to MAX_BUFFERED_MESSAGES; when the buffer grows past cap the
+ *    OLDEST messages are dropped (splice from the front) and a single overflow
+ *    line is logged with the per-instance label + dropped count + remaining cap.
+ *  - `push` appends to the tail (newest), `unshiftMany` prepends to the head
+ *    (these messages predate everything already buffered) — both re-apply cap.
+ *  - `drainAll` removes and returns every message in order, leaving the buffer
+ *    empty.
+ *
+ * The class is pure aside from the injected `log` sink, so tests can assert the
+ * exact overflow text and counts without a daemon/WS.
+ */
+export interface BoundedMessageBufferOptions {
+  /** Max retained messages; overflow drops the oldest. */
+  cap: number;
+  /**
+   * Prefix for the overflow log line, e.g. "Message buffer overflow" or
+   * "Backpressure overflow".
+   */
+  overflowLabel: string;
+  /**
+   * Noun phrase describing the dropped items. Defaults to "message(s)";
+   * the backpressure tracker uses "tracked message(s)" to keep its log
+   * line bit-exact with the prior inline code.
+   */
+  overflowNoun?: string;
+  /** Log sink (injected for testability). */
+  log: (msg: string) => void;
+}
+
+export class BoundedMessageBuffer {
+  private readonly messages: BridgeMessage[] = [];
+  private readonly cap: number;
+  private readonly overflowLabel: string;
+  private readonly overflowNoun: string;
+  private readonly log: (msg: string) => void;
+
+  constructor(options: BoundedMessageBufferOptions) {
+    this.cap = options.cap;
+    this.overflowLabel = options.overflowLabel;
+    this.overflowNoun = options.overflowNoun ?? "message(s)";
+    this.log = options.log;
+  }
+
+  /** Current retained message count. */
+  get length(): number {
+    return this.messages.length;
+  }
+
+  /** Append one message to the tail (newest), then enforce the cap. */
+  push(message: BridgeMessage): void {
+    this.messages.push(message);
+    this.enforceCap();
+  }
+
+  /**
+   * Prepend messages to the head (they predate everything already buffered),
+   * preserving their relative order, then enforce the cap.
+   */
+  unshiftMany(messages: BridgeMessage[]): void {
+    if (messages.length === 0) return;
+    this.messages.unshift(...messages);
+    this.enforceCap();
+  }
+
+  /** Remove and return every message in FIFO order, leaving the buffer empty. */
+  drainAll(): BridgeMessage[] {
+    return this.messages.splice(0, this.messages.length);
+  }
+
+  /** Discard all messages without returning them (drain-confirmation path). */
+  clear(): void {
+    this.messages.length = 0;
+  }
+
+  private enforceCap(): void {
+    if (this.messages.length > this.cap) {
+      const dropped = this.messages.length - this.cap;
+      this.messages.splice(0, dropped);
+      this.log(
+        `${this.overflowLabel}: dropped ${dropped} oldest ${this.overflowNoun}, ${this.cap} remaining`,
+      );
+    }
+  }
+}

--- a/src/unit-test/delivery-buffer.test.ts
+++ b/src/unit-test/delivery-buffer.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import { BoundedMessageBuffer } from "../delivery-buffer";
+import type { BridgeMessage } from "../types";
+
+function msg(id: string): BridgeMessage {
+  return { id, source: "codex", content: `c-${id}`, timestamp: 0 };
+}
+
+function ids(messages: BridgeMessage[]): string[] {
+  return messages.map((m) => m.id);
+}
+
+/**
+ * Build a buffer with a captured log sink so overflow text/counts can be
+ * asserted exactly (the daemon depends on these log lines bit-for-bit).
+ */
+function makeBuffer(
+  cap: number,
+  overrides: Partial<{ overflowLabel: string; overflowNoun: string }> = {},
+) {
+  const logs: string[] = [];
+  const buffer = new BoundedMessageBuffer({
+    cap,
+    overflowLabel: overrides.overflowLabel ?? "Message buffer overflow",
+    overflowNoun: overrides.overflowNoun,
+    log: (line) => logs.push(line),
+  });
+  return { buffer, logs };
+}
+
+describe("BoundedMessageBuffer", () => {
+  test("push retains messages in FIFO order up to cap with no overflow log", () => {
+    const { buffer, logs } = makeBuffer(3);
+    buffer.push(msg("a"));
+    buffer.push(msg("b"));
+    buffer.push(msg("c"));
+    expect(buffer.length).toBe(3);
+    expect(logs).toEqual([]);
+    expect(ids(buffer.drainAll())).toEqual(["a", "b", "c"]);
+  });
+
+  test("push over cap drops the OLDEST and logs one overflow line per excess push", () => {
+    const { buffer, logs } = makeBuffer(2);
+    buffer.push(msg("a"));
+    buffer.push(msg("b"));
+    expect(logs).toEqual([]);
+
+    buffer.push(msg("c")); // overflow by 1: drop "a"
+    expect(buffer.length).toBe(2);
+    expect(logs).toEqual([
+      "Message buffer overflow: dropped 1 oldest message(s), 2 remaining",
+    ]);
+    // Newest survive, oldest evicted.
+    expect(ids(buffer.drainAll())).toEqual(["b", "c"]);
+  });
+
+  test("overflow drops exactly the excess count and keeps the newest tail", () => {
+    const { buffer } = makeBuffer(2);
+    buffer.push(msg("a"));
+    buffer.push(msg("b"));
+    buffer.push(msg("c"));
+    buffer.push(msg("d"));
+    // cap=2, only the two newest survive in order.
+    expect(ids(buffer.drainAll())).toEqual(["c", "d"]);
+  });
+
+  test("unshiftMany prepends preserving relative order (predates buffered tail)", () => {
+    const { buffer, logs } = makeBuffer(5);
+    buffer.push(msg("c"));
+    buffer.push(msg("d"));
+    buffer.unshiftMany([msg("a"), msg("b")]);
+    expect(logs).toEqual([]);
+    // a,b are older than c,d and keep their own order.
+    expect(ids(buffer.drainAll())).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("unshiftMany over cap drops the oldest (the just-prepended head) + logs", () => {
+    const { buffer, logs } = makeBuffer(3);
+    buffer.push(msg("x"));
+    buffer.push(msg("y"));
+    buffer.push(msg("z")); // [x,y,z], at cap
+    // Prepend 2 → [a,b,x,y,z] length 5, cap 3 → drop 2 oldest (a,b).
+    buffer.unshiftMany([msg("a"), msg("b")]);
+    expect(buffer.length).toBe(3);
+    expect(logs).toEqual([
+      "Message buffer overflow: dropped 2 oldest message(s), 3 remaining",
+    ]);
+    expect(ids(buffer.drainAll())).toEqual(["x", "y", "z"]);
+  });
+
+  test("unshiftMany with empty array is a no-op (no cap check, no log)", () => {
+    const { buffer, logs } = makeBuffer(1);
+    buffer.push(msg("a"));
+    buffer.unshiftMany([]);
+    expect(buffer.length).toBe(1);
+    expect(logs).toEqual([]);
+    expect(ids(buffer.drainAll())).toEqual(["a"]);
+  });
+
+  test("drainAll returns everything in order and leaves the buffer empty", () => {
+    const { buffer } = makeBuffer(10);
+    buffer.push(msg("a"));
+    buffer.push(msg("b"));
+    const drained = buffer.drainAll();
+    expect(ids(drained)).toEqual(["a", "b"]);
+    expect(buffer.length).toBe(0);
+    // Second drain on an empty buffer yields nothing.
+    expect(buffer.drainAll()).toEqual([]);
+  });
+
+  test("clear empties without returning (drain-confirmation path)", () => {
+    const { buffer } = makeBuffer(10);
+    buffer.push(msg("a"));
+    buffer.push(msg("b"));
+    buffer.clear();
+    expect(buffer.length).toBe(0);
+    expect(buffer.drainAll()).toEqual([]);
+  });
+
+  test("custom overflow label + noun matches the backpressure log line verbatim", () => {
+    const { buffer, logs } = makeBuffer(1, {
+      overflowLabel: "Backpressure overflow",
+      overflowNoun: "tracked message(s)",
+    });
+    buffer.push(msg("a"));
+    buffer.push(msg("b")); // overflow by 1
+    expect(logs).toEqual([
+      "Backpressure overflow: dropped 1 oldest tracked message(s), 1 remaining",
+    ]);
+  });
+
+  test("detach re-buffer sequence: prepend backpressured ahead of existing backlog", () => {
+    // Mirrors detachClaude: existing backlog [m3] + re-buffered [m1,m2] (older)
+    // → prepend keeps m1,m2 before m3, preserving global timeline.
+    const { buffer } = makeBuffer(10);
+    buffer.push(msg("m3"));
+    const pending = [msg("m1"), msg("m2")];
+    buffer.unshiftMany(pending);
+    expect(ids(buffer.drainAll())).toEqual(["m1", "m2", "m3"]);
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary
arch-review P1 #465：把 daemon.ts 里逐字重复三遍的 "append + cap-trim + overflow-log" 模式（detachClaude / emitToClaude / trySendBridgeMessage）收敛为一个纯类 `BoundedMessageBuffer`，并让刚硬化的 #101 投递不变量可被直接单测锁住。
- **新增 `src/delivery-buffer.ts`**：`BoundedMessageBuffer`（push/unshiftMany/drainAll/clear/length，内化 cap + 统一 overflow 日志，注入 log）。
- `pendingBackpressure`：`BridgeMessage[]` → per-socket 实例；`bufferedMessages` → 单例。所有读写迁移到类 API，**行为逐位等价**。
- **#101 "不静默丢消息" 不变量 bit-exact**：detach drainAll+unshiftMany 头插保序、drain 确认清空、cap 丢最旧 + overflow 计数/文案逐字一致（含 backpressure 的 "tracked message(s)"）。
- **新增 `src/unit-test/delivery-buffer.test.ts`（10 测试）** 直接锁投递不变量。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1022 pass / 0 fail** / `verify:plugin-sync` ✅
- Cross-review：2 独立 reviewer（bit-equivalence + array→class blast-radius）round-1 **0 REAL**，独立 grep 枚举全部引用、端到端 trace #101 路径、确认无静默丢失窗口 + per-socket 隔离 + 状态计数等价。
## 备注
攒批发布：release-on-merge 暂禁，本 PR 合并不 bump。daemon.ts 主战场，与 #283 等后续 daemon.ts PR 串行 rebase。