### PR TITLE
fix(security): claude_to_codex 注入加 attach 守卫 + 控制端能力令牌 / attach guard + capability token for turn injection

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14341,7 +14341,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("ccd2875", "source"),
+  commit: defineString("c8dba20", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14369,6 +14369,7 @@ var CLOSE_CODE_REPLACED = 4001;
 var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 var CLOSE_CODE_PAIR_MISMATCH = 4004;
+var CLOSE_CODE_TOKEN_MISMATCH = 4005;
 
 // src/interrupt-timing.ts
 var CLIENT_REPLY_TIMEOUT_MS = 15000;
@@ -14430,10 +14431,15 @@ class DaemonClient extends EventEmitter2 {
     });
   }
   attachClaude() {
+    const identity = this.resolveIdentity();
     this.send({
       type: "claude_connect",
-      ...this.options.identity ? { identity: this.options.identity } : {}
+      ...identity ? { identity } : {}
     });
+  }
+  resolveIdentity() {
+    const opt = this.options.identity;
+    return typeof opt === "function" ? opt() : opt;
   }
   async attachClaudeAndWaitForStatus(timeoutMs = 1000) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
@@ -14589,7 +14595,7 @@ class DaemonClient extends EventEmitter2 {
       if (isCurrent) {
         this.ws = null;
         this.rejectPendingReplies("AgentBridge daemon disconnected.");
-        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE || event.code === CLOSE_CODE_PROBE_IN_PROGRESS || event.code === CLOSE_CODE_PAIR_MISMATCH) {
+        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE || event.code === CLOSE_CODE_PROBE_IN_PROGRESS || event.code === CLOSE_CODE_PAIR_MISMATCH || event.code === CLOSE_CODE_TOKEN_MISMATCH) {
           this.emit("rejected", event.code);
         } else {
           this.emit("disconnect");
@@ -14633,7 +14639,7 @@ function atomicWriteText(path, content, options = {}) {
   fs.mkdirSync(dirname2(path), { recursive: true });
   const tmp = tmpPathFor(path);
   let renamed = false;
-  const fd = fs.openSync(tmp, "w");
+  const fd = fs.openSync(tmp, "w", options.mode ?? 438);
   try {
     try {
       fs.writeFileSync(fd, content, "utf-8");
@@ -15620,9 +15626,25 @@ function nonEmpty(value) {
   return value && value.length > 0 ? value : null;
 }
 
+// src/control-token.ts
+import { chmodSync, readFileSync as readFileSync4 } from "fs";
+import { join as join4 } from "path";
+var CONTROL_TOKEN_FILENAME = "control-token";
+function resolveControlTokenPath(stateDir) {
+  return join4(stateDir, CONTROL_TOKEN_FILENAME);
+}
+function readControlToken(path) {
+  try {
+    const raw = readFileSync4(path, "utf-8").trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
 // src/trace-log.ts
 import { appendFileSync as appendFileSync2, existsSync as existsSync6, mkdirSync as mkdirSync5, readdirSync as readdirSync2, statSync as statSync4, unlinkSync as unlinkSync5 } from "fs";
-import { join as join4 } from "path";
+import { join as join5 } from "path";
 var TRACE_RETENTION_DAYS = 7;
 var TRACE_FILE_RE = /^trace-\d{4}-\d{2}-\d{2}\.jsonl$/;
 var SECRET_KEY_RE = /(token|secret|password|passwd|api[_-]?key|auth|cookie|session)/i;
@@ -15662,7 +15684,7 @@ function redactArgv(argv) {
 }
 function traceLogPath(cwd, timestamp) {
   const day = timestamp.slice(0, 10);
-  return join4(cwd, ".agentbridge", "logs", `trace-${day}.jsonl`);
+  return join5(cwd, ".agentbridge", "logs", `trace-${day}.jsonl`);
 }
 function appendTraceEvent(input) {
   const timestamp = input.timestamp ?? new Date().toISOString();
@@ -15676,7 +15698,7 @@ function appendTraceEvent(input) {
     ...input.env ? { env: pickRelevantEnv(input.env) } : {},
     ...input.data ? { data: redactData(input.data) } : {}
   };
-  const logsDir = join4(input.cwd, ".agentbridge", "logs");
+  const logsDir = join5(input.cwd, ".agentbridge", "logs");
   const isNewDayFile = !existsSync6(path);
   mkdirSync5(logsDir, { recursive: true });
   if (isNewDayFile) {
@@ -15699,7 +15721,7 @@ function pruneOldTraceLogs(logsDir, keepPath, nowMs) {
   for (const name of entries) {
     if (!TRACE_FILE_RE.test(name))
       continue;
-    const filePath = join4(logsDir, name);
+    const filePath = join5(logsDir, name);
     if (filePath === keepPath)
       continue;
     try {
@@ -15754,7 +15776,7 @@ var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 var claude = new ClaudeAdapter(stateDir.logFile);
-var daemonClient = new DaemonClient(CONTROL_WS_URL, { identity: currentClientIdentity() });
+var daemonClient = new DaemonClient(CONTROL_WS_URL, { identity: currentClientIdentity });
 var shuttingDown = false;
 var daemonDisabled = false;
 var daemonDisabledReason = null;
@@ -15860,6 +15882,11 @@ daemonClient.on("rejected", async (code) => {
       reason = "rejected";
       notificationId = "system_bridge_pair_mismatch";
       notificationContent = `\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 pair/cwd identity mismatch (this daemon belongs to a different pair or directory). Do NOT kill it; start Claude Code from the pair's own directory, or pick another pair name with \`agentbridge --pair <name> claude\`. AgentBridge \u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014pair/\u76EE\u5F55\u8EAB\u4EFD\u4E0D\u5339\u914D\uFF08\u8BE5 daemon \u5C5E\u4E8E\u5176\u4ED6 pair \u6216\u76EE\u5F55\uFF09\u3002\u65E0\u9700 kill\uFF1B\u8BF7\u5230\u5BF9\u5E94\u76EE\u5F55\u542F\u52A8\uFF0C\u6216\u6362\u4E00\u4E2A pair \u540D\uFF1A\`agentbridge --pair <\u540D\u5B57> claude\`\u3002`;
+      break;
+    case CLOSE_CODE_TOKEN_MISMATCH:
+      reason = "rejected";
+      notificationId = "system_bridge_token_mismatch";
+      notificationContent = `\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 control token mismatch (the daemon likely restarted and rotated its token). Start a fresh session with \`${pairScopedCommand("claude")}\` to pick up the current token. AgentBridge \u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u63A7\u5236\u4EE4\u724C\u4E0D\u5339\u914D\uFF08daemon \u53EF\u80FD\u5DF2\u91CD\u542F\u5E76\u8F6E\u6362\u4EE4\u724C\uFF09\u3002\u8BF7\u7528 \`${pairScopedCommand("claude")}\` \u91CD\u65B0\u542F\u52A8\u4EE5\u83B7\u53D6\u6700\u65B0\u4EE4\u724C\u3002`;
       break;
     default:
       reason = "rejected";
@@ -16104,6 +16131,7 @@ function systemMessage(idPrefix, content) {
   };
 }
 function currentClientIdentity() {
+  const controlToken = readControlToken(resolveControlTokenPath(stateDir.dir));
   return {
     pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
     pairName: process.env.AGENTBRIDGE_PAIR_NAME ?? null,
@@ -16111,7 +16139,8 @@ function currentClientIdentity() {
     baseDir: process.env.AGENTBRIDGE_BASE_DIR ?? null,
     stateDir: stateDir.dir,
     clientPid: process.pid,
-    contractVersion: BUILD_INFO.contractVersion
+    contractVersion: BUILD_INFO.contractVersion,
+    ...controlToken ? { controlToken } : {}
   };
 }
 function shutdown(reason) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env bun
 // @bun
 
+// src/daemon.ts
+import { rmSync as rmSync2 } from "fs";
+
 // src/contract-version.ts
 var CONTRACT_VERSION = 1;
 
@@ -18,7 +21,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("ccd2875", "source"),
+  commit: defineString("c8dba20", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2247,9 +2250,98 @@ var CLOSE_CODE_REPLACED = 4001;
 var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 var CLOSE_CODE_PAIR_MISMATCH = 4004;
+var CLOSE_CODE_TOKEN_MISMATCH = 4005;
+
+// src/control-token.ts
+import { chmodSync as chmodSync2, readFileSync } from "fs";
+import { join as join3 } from "path";
+import { randomUUID as randomUUID2 } from "crypto";
+
+// src/atomic-json.ts
+import * as fs from "fs";
+import { randomUUID } from "crypto";
+import { dirname as dirname2 } from "path";
+function tmpPathFor(targetPath) {
+  return `${targetPath}.tmp.${process.pid}.${randomUUID()}`;
+}
+function atomicWriteText(path, content, options = {}) {
+  fs.mkdirSync(dirname2(path), { recursive: true });
+  const tmp = tmpPathFor(path);
+  let renamed = false;
+  const fd = fs.openSync(tmp, "w", options.mode ?? 438);
+  try {
+    try {
+      fs.writeFileSync(fd, content, "utf-8");
+      if (options.fsync)
+        fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmp, path);
+    renamed = true;
+  } finally {
+    if (!renamed) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {}
+    }
+  }
+}
+function atomicWriteJson(path, value, options = {}) {
+  atomicWriteText(path, JSON.stringify(value, null, 2) + `
+`, options);
+}
+
+// src/control-token.ts
+var CONTROL_TOKEN_FILENAME = "control-token";
+function resolveControlTokenPath(stateDir) {
+  return join3(stateDir, CONTROL_TOKEN_FILENAME);
+}
+function generateControlToken() {
+  return randomUUID2();
+}
+function writeControlToken(path, token) {
+  atomicWriteText(path, token, { mode: 384 });
+  chmodSync2(path, 384);
+}
+function validateControlToken(input) {
+  const { expectedToken } = input;
+  if (expectedToken == null || expectedToken.length === 0) {
+    return { ok: true };
+  }
+  const provided = input.providedToken;
+  if (provided == null || provided.length === 0) {
+    return { ok: false, reason: "missing control token" };
+  }
+  if (!constantTimeEquals(provided, expectedToken)) {
+    return { ok: false, reason: "control token mismatch" };
+  }
+  return { ok: true };
+}
+function constantTimeEquals(a, b) {
+  const len = Math.max(a.length, b.length);
+  let diff = a.length ^ b.length;
+  for (let i = 0;i < len; i++) {
+    diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  }
+  return diff === 0;
+}
 
 // src/daemon-identity.ts
 function validateClaudeClientIdentity(input) {
+  if (input.expectedControlToken && input.identity) {
+    const tokenResult = validateControlToken({
+      expectedToken: input.expectedControlToken,
+      providedToken: input.identity.controlToken
+    });
+    if (!tokenResult.ok) {
+      return {
+        ok: false,
+        closeCode: CLOSE_CODE_TOKEN_MISMATCH,
+        reason: tokenResult.reason
+      };
+    }
+  }
   if (!input.expectedPairId)
     return { ok: true };
   if (!input.identity) {
@@ -2270,6 +2362,16 @@ function validateClaudeClientIdentity(input) {
     };
   }
   return { ok: true };
+}
+function evaluateInjectionAttachGuard(attachedSocket, requestingSocket) {
+  if (attachedSocket != null && attachedSocket === requestingSocket) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    code: "not_attached",
+    reason: "This socket is not the attached Claude session. Send `claude_connect` " + "(with a valid control token) and win the attach slot before injecting a turn."
+  };
 }
 
 // src/message-filter.ts
@@ -2454,43 +2556,8 @@ class TuiConnectionState {
 
 // src/daemon-lifecycle.ts
 import { spawn as spawn2 } from "child_process";
-import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync2, openSync as openSync2, closeSync as closeSync2, constants } from "fs";
+import { existsSync as existsSync3, readFileSync as readFileSync2, statSync as statSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync2, openSync as openSync2, closeSync as closeSync2, constants } from "fs";
 import { fileURLToPath } from "url";
-
-// src/atomic-json.ts
-import * as fs from "fs";
-import { randomUUID } from "crypto";
-import { dirname as dirname2 } from "path";
-function tmpPathFor(targetPath) {
-  return `${targetPath}.tmp.${process.pid}.${randomUUID()}`;
-}
-function atomicWriteText(path, content, options = {}) {
-  fs.mkdirSync(dirname2(path), { recursive: true });
-  const tmp = tmpPathFor(path);
-  let renamed = false;
-  const fd = fs.openSync(tmp, "w");
-  try {
-    try {
-      fs.writeFileSync(fd, content, "utf-8");
-      if (options.fsync)
-        fs.fsyncSync(fd);
-    } finally {
-      fs.closeSync(fd);
-    }
-    fs.renameSync(tmp, path);
-    renamed = true;
-  } finally {
-    if (!renamed) {
-      try {
-        fs.unlinkSync(tmp);
-      } catch {}
-    }
-  }
-}
-function atomicWriteJson(path, value, options = {}) {
-  atomicWriteText(path, JSON.stringify(value, null, 2) + `
-`, options);
-}
 
 // src/process-lifecycle.ts
 import { execFileSync as execFileSync2 } from "child_process";
@@ -2757,7 +2824,7 @@ class DaemonLifecycle {
   }
   readStatus() {
     try {
-      const raw = readFileSync(this.stateDir.statusFile, "utf-8");
+      const raw = readFileSync2(this.stateDir.statusFile, "utf-8");
       return JSON.parse(raw);
     } catch {
       return null;
@@ -2768,7 +2835,7 @@ class DaemonLifecycle {
   }
   readPid() {
     try {
-      const raw = readFileSync(this.stateDir.pidFile, "utf-8").trim();
+      const raw = readFileSync2(this.stateDir.pidFile, "utf-8").trim();
       if (!raw)
         return null;
       const pid = Number.parseInt(raw, 10);
@@ -2881,7 +2948,7 @@ class DaemonLifecycle {
         if (reclaimed)
           return false;
         try {
-          const holderPid = Number.parseInt(readFileSync(this.stateDir.lockFile, "utf-8").trim(), 10);
+          const holderPid = Number.parseInt(readFileSync2(this.stateDir.lockFile, "utf-8").trim(), 10);
           if (Number.isFinite(holderPid) && !isProcessAlive(holderPid)) {
             this.log(`Stale startup lock from dead process ${holderPid}, reclaiming`);
             this.releaseLock();
@@ -2969,8 +3036,8 @@ async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, mkdirSync as mkdirSync4, existsSync as existsSync4 } from "fs";
-import { join as join3 } from "path";
+import { readFileSync as readFileSync3, mkdirSync as mkdirSync4, existsSync as existsSync4 } from "fs";
+import { join as join4 } from "path";
 var DEFAULT_BUDGET_CONFIG = {
   enabled: true,
   pollSeconds: 300,
@@ -3157,8 +3224,8 @@ class ConfigService {
   configPath;
   constructor(projectRoot) {
     const root = projectRoot ?? process.cwd();
-    this.configDir = join3(root, CONFIG_DIR);
-    this.configPath = join3(this.configDir, CONFIG_FILE);
+    this.configDir = join4(root, CONFIG_DIR);
+    this.configPath = join4(this.configDir, CONFIG_FILE);
   }
   hasConfig() {
     return existsSync4(this.configPath);
@@ -3166,7 +3233,7 @@ class ConfigService {
   load() {
     let raw;
     try {
-      raw = readFileSync2(this.configPath, "utf-8");
+      raw = readFileSync3(this.configPath, "utf-8");
     } catch (err) {
       if (err?.code === "ENOENT") {
         return { state: "absent" };
@@ -3909,7 +3976,7 @@ class BudgetCoordinator {
 import { execFile } from "child_process";
 import { existsSync as existsSync5 } from "fs";
 import { homedir as homedir2 } from "os";
-import { basename, join as join4 } from "path";
+import { basename, join as join5 } from "path";
 var DEFAULT_TIMEOUT_MS = 1e4;
 var MAX_BUFFER = 1024 * 1024;
 function defaultRunner(command, args, options) {
@@ -4157,11 +4224,11 @@ class QuotaSource {
       add(command, commandKind(command));
       return candidates;
     }
-    const binDir = join4(this.homeDir, ".budget-guard/bin");
-    const installedBudgetProbe = join4(binDir, "budget-probe");
+    const binDir = join5(this.homeDir, ".budget-guard/bin");
+    const installedBudgetProbe = join5(binDir, "budget-probe");
     if (existsSync5(installedBudgetProbe))
       add(installedBudgetProbe, "budget-probe");
-    const installedProbeMjs = join4(binDir, "probe.mjs");
+    const installedProbeMjs = join5(binDir, "probe.mjs");
     if (existsSync5(installedProbeMjs))
       add(installedProbeMjs, "probe-mjs");
     return candidates;
@@ -4375,10 +4442,10 @@ class ReplyRequiredTracker {
 import {
   existsSync as existsSync6,
   readdirSync,
-  readFileSync as readFileSync3
+  readFileSync as readFileSync4
 } from "fs";
 import { homedir as homedir3 } from "os";
-import { basename as basename2, join as join5 } from "path";
+import { basename as basename2, join as join6 } from "path";
 function nowIso() {
   return new Date().toISOString();
 }
@@ -4387,11 +4454,11 @@ function threadTag(identity) {
   return `abg:${name}:${identity.cwd}`;
 }
 function codexHome(env = process.env) {
-  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join5(homedir3(), ".codex");
+  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join6(homedir3(), ".codex");
 }
 function readRawCurrentThread(stateDir) {
   try {
-    const parsed = JSON.parse(readFileSync3(stateDir.currentThreadFile, "utf-8"));
+    const parsed = JSON.parse(readFileSync4(stateDir.currentThreadFile, "utf-8"));
     if (parsed?.version === 1 && typeof parsed.threadId === "string" && parsed.threadId.length > 0 && (parsed.status === "pending" || parsed.status === "current") && typeof parsed.cwd === "string") {
       return parsed;
     }
@@ -4399,7 +4466,7 @@ function readRawCurrentThread(stateDir) {
   return null;
 }
 function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
-  const sessionsDir = join5(codexHome(env), "sessions");
+  const sessionsDir = join6(codexHome(env), "sessions");
   if (!threadId || !existsSync6(sessionsDir))
     return null;
   const exactName = `rollout-${threadId}.jsonl`;
@@ -4415,7 +4482,7 @@ function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
     }
     for (const entry of entries) {
       visited++;
-      const path = join5(dir, entry.name);
+      const path = join6(dir, entry.name);
       if (entry.isDirectory()) {
         stack.push(path);
         continue;
@@ -4585,6 +4652,15 @@ class BoundedMessageBuffer {
 var stateDir = new StateDirResolver;
 stateDir.ensure();
 var processLogger = createProcessLogger({ component: "AgentBridgeDaemon", logFile: stateDir.logFile });
+var controlTokenPath = resolveControlTokenPath(stateDir.dir);
+var controlToken = null;
+try {
+  controlToken = generateControlToken();
+  writeControlToken(controlTokenPath, controlToken);
+} catch (err) {
+  controlToken = null;
+  processLogger.log(`Failed to write control token (${controlTokenPath}): ${err?.message ?? err} \u2014 ` + `token layer DISABLED for this daemon (attach guard + Origin guard still active)`);
+}
 var configService = new ConfigService;
 var config = configService.loadOrDefault(processLogger.log);
 var CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.codex.appPort), 10);
@@ -4943,7 +5019,8 @@ function handleControlMessage(ws, raw) {
         expectedPairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
         daemonCwd: process.cwd(),
         identity: message.identity,
-        allowIdentityless: ALLOW_IDENTITYLESS_CLIENT
+        allowIdentityless: ALLOW_IDENTITYLESS_CLIENT,
+        expectedControlToken: controlToken
       });
       if (!admission.ok) {
         log(`Rejecting Claude frontend #${ws.data.clientId}: ${admission.reason}`);
@@ -5022,6 +5099,16 @@ function waitForInterruptOutcome(turnIds) {
   });
 }
 async function handleClaudeToCodex(ws, message) {
+  const attachGuard = evaluateInjectionAttachGuard(attachedClaude, ws);
+  if (!attachGuard.allowed) {
+    log(`Rejecting claude_to_codex from non-attached socket #${ws.data.clientId} ` + `(request ${message.requestId}, attached=${attachedClaude ? "#" + attachedClaude.data.clientId : "none"})`);
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: attachGuard.code,
+      error: attachGuard.reason
+    });
+    return;
+  }
   if (message.message.source !== "claude") {
     sendClaudeToCodexResult(ws, message.requestId, {
       success: false,
@@ -5559,7 +5646,13 @@ function shutdown(reason, exitCode = 0) {
   codex.stop();
   removePidFile();
   removeStatusFile();
+  removeControlToken();
   process.exit(exitCode);
+}
+function removeControlToken() {
+  try {
+    rmSync2(controlTokenPath, { force: true });
+  } catch {}
 }
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
@@ -5567,6 +5660,7 @@ process.on("exit", () => {
   codex.forceKillAppServerSync();
   removePidFile();
   removeStatusFile();
+  removeControlToken();
 });
 process.on("uncaughtException", (err) => {
   processLogger.fatal("UNCAUGHT EXCEPTION", err);

--- a/src/atomic-json.ts
+++ b/src/atomic-json.ts
@@ -9,6 +9,14 @@ export interface AtomicWriteOptions {
    * can use the default tmp+rename path.
    */
   fsync?: boolean;
+  /**
+   * Permission mode for the temp file (and therefore the renamed target). When
+   * set, the temp file is created with this mode FROM THE START, closing the
+   * brief world-readable window a post-rename chmod would otherwise leave open
+   * (CWE-732). e.g. pass 0o600 for secrets. Subject to the process umask, which
+   * can only further restrict — never widen — these bits. Defaults to 0o666.
+   */
+  mode?: number;
 }
 
 function tmpPathFor(targetPath: string): string {
@@ -19,7 +27,7 @@ export function atomicWriteText(path: string, content: string, options: AtomicWr
   fs.mkdirSync(dirname(path), { recursive: true });
   const tmp = tmpPathFor(path);
   let renamed = false;
-  const fd = fs.openSync(tmp, "w");
+  const fd = fs.openSync(tmp, "w", options.mode ?? 0o666);
   try {
     try {
       fs.writeFileSync(fd, content, "utf-8");

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -10,12 +10,14 @@ import { ConfigService } from "./config-service";
 import { disabledReplyError, type BridgeDisabledReason } from "./bridge-disabled-state";
 import { guardAgentBridgeEnv, normalizeEnvGuardMode } from "./env-guard";
 import { pairScopedCommand } from "./pair-command";
+import { readControlToken, resolveControlTokenPath } from "./control-token";
 import { appendTraceEvent, pickRelevantEnv } from "./trace-log";
 import { createProcessLogger } from "./process-log";
 import {
   CLOSE_CODE_EVICTED_STALE,
   CLOSE_CODE_PAIR_MISMATCH,
   CLOSE_CODE_PROBE_IN_PROGRESS,
+  CLOSE_CODE_TOKEN_MISMATCH,
 } from "./control-protocol";
 import type { ControlClientIdentity } from "./control-protocol";
 import type { BridgeMessage } from "./types";
@@ -43,7 +45,10 @@ const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_POR
 const CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 
 const claude = new ClaudeAdapter(stateDir.logFile);
-const daemonClient = new DaemonClient(CONTROL_WS_URL, { identity: currentClientIdentity() });
+// Pass the identity RESOLVER (not a snapshot) so the control token is read from
+// disk on each attach: the daemon may not have written it when bridge.ts starts,
+// and a daemon restart rotates the token (arch-review P1 #283).
+const daemonClient = new DaemonClient(CONTROL_WS_URL, { identity: currentClientIdentity });
 
 let shuttingDown = false;
 let daemonDisabled = false;
@@ -199,6 +204,15 @@ daemonClient.on("rejected", async (code: number) => {
       reason = "rejected";
       notificationId = "system_bridge_pair_mismatch";
       notificationContent = `⚠️ AgentBridge daemon rejected this session — pair/cwd identity mismatch (this daemon belongs to a different pair or directory). Do NOT kill it; start Claude Code from the pair's own directory, or pick another pair name with \`agentbridge --pair <name> claude\`. AgentBridge 拒绝了此会话——pair/目录身份不匹配（该 daemon 属于其他 pair 或目录）。无需 kill；请到对应目录启动，或换一个 pair 名：\`agentbridge --pair <名字> claude\`。`;
+      break;
+    case CLOSE_CODE_TOKEN_MISMATCH:
+      // The control token we presented was missing/stale — almost always the
+      // daemon restarted and rotated its token while this session held an old
+      // one. A fresh launch re-reads the current token and recovers. Distinct
+      // message so the user does not chase a phantom "another session" conflict.
+      reason = "rejected";
+      notificationId = "system_bridge_token_mismatch";
+      notificationContent = `⚠️ AgentBridge daemon rejected this session — control token mismatch (the daemon likely restarted and rotated its token). Start a fresh session with \`${pairScopedCommand("claude")}\` to pick up the current token. AgentBridge 拒绝了此会话——控制令牌不匹配（daemon 可能已重启并轮换令牌）。请用 \`${pairScopedCommand("claude")}\` 重新启动以获取最新令牌。`;
       break;
     default:
       reason = "rejected";
@@ -549,6 +563,10 @@ function systemMessage(idPrefix: string, content: string): BridgeMessage {
 }
 
 function currentClientIdentity(): ControlClientIdentity {
+  // Read the control token fresh on every attach (arch-review P1 #283). null
+  // when the daemon hasn't written it yet or wrote it with the token layer
+  // disabled — the daemon then admits us on pair/cwd alone (compat-degraded).
+  const controlToken = readControlToken(resolveControlTokenPath(stateDir.dir));
   return {
     pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
     pairName: process.env.AGENTBRIDGE_PAIR_NAME ?? null,
@@ -557,6 +575,7 @@ function currentClientIdentity(): ControlClientIdentity {
     stateDir: stateDir.dir,
     clientPid: process.pid,
     contractVersion: BUILD_INFO.contractVersion,
+    ...(controlToken ? { controlToken } : {}),
   };
 }
 

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -11,6 +11,14 @@ export interface ControlClientIdentity {
   stateDir?: string | null;
   clientPid?: number;
   contractVersion?: number;
+  /**
+   * Capability token (arch-review P1 #283). The daemon writes a random token to
+   * `<stateDir>/control-token` (0600) at startup; a legitimate same-machine
+   * frontend reads it and echoes it here. The daemon enforces it at
+   * `claude_connect` (see control-token.ts). Absent against an older client or
+   * when the daemon has no token loaded (compat-degraded).
+   */
+  controlToken?: string | null;
 }
 
 /**
@@ -159,3 +167,12 @@ export const CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 
 /** WebSocket close code reserved for pair/cwd identity mismatch enforcement. */
 export const CLOSE_CODE_PAIR_MISMATCH = 4004;
+
+/**
+ * WebSocket close code sent when a Claude frontend's `claude_connect` carries a
+ * missing/incorrect control-port capability token (arch-review P1 #283). Distinct
+ * from CLOSE_CODE_PAIR_MISMATCH so the frontend can tell "wrong directory" apart
+ * from "stale/absent token" — the latter usually means a daemon restarted and
+ * rotated its token, and a fresh `claude` launch (re-reading the token) recovers.
+ */
+export const CLOSE_CODE_TOKEN_MISMATCH = 4005;

--- a/src/control-token.ts
+++ b/src/control-token.ts
@@ -1,0 +1,130 @@
+/**
+ * Control-port capability token (arch-review P1 #283).
+ *
+ * The daemon's control WebSocket binds 127.0.0.1 and gates browser pages with
+ * the WS Origin guard (ws-origin-guard.ts), but a non-browser local process can
+ * still open `ws://127.0.0.1:<port>/ws` and — before this token existed — send
+ * `claude_connect`/`claude_to_codex` to inject a turn into Codex. In multi-pair
+ * mode the pairId is `sha256(realpath(cwd)).slice(0,8)`, derivable from a known
+ * project path, so it is a ROUTING identifier, not a secret.
+ *
+ * This module adds a capability token as a second, independent layer of defense
+ * (alongside attach-convergence and the Origin guard):
+ *
+ *   - The daemon generates a random token at startup and writes it to
+ *     `<stateDir>/control-token` with owner-only (0600) permissions.
+ *   - A legitimate same-machine frontend (bridge.ts) reads that file and echoes
+ *     the token in its `claude_connect` identity; the daemon compares it.
+ *   - A browser page cannot read the local filesystem, so it cannot present the
+ *     token — token + Origin guard form defense in depth.
+ *
+ * TRUST BOUNDARY (intentional, documented): any local process running as the
+ * same OS user CAN read the 0600 token file. That is an accepted boundary — the
+ * threat model here is a remote/browser origin and accidental cross-pair
+ * cross-talk, not a same-user local attacker (who could read the token, attach
+ * to the codex socket directly, or sign your commits regardless).
+ */
+
+import { chmodSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { atomicWriteText } from "./atomic-json";
+
+/** File name (under the pair's state dir) holding the control-port token. */
+export const CONTROL_TOKEN_FILENAME = "control-token";
+
+/** Resolve the absolute path to the control-token file for a given state dir. */
+export function resolveControlTokenPath(stateDir: string): string {
+  return join(stateDir, CONTROL_TOKEN_FILENAME);
+}
+
+/** Generate a fresh random capability token (128-bit UUID, hex+dashes). */
+export function generateControlToken(): string {
+  return randomUUID();
+}
+
+/**
+ * Write the token to `path` with owner-only (0600) permissions.
+ *
+ * atomicWriteText now creates the temp file at mode 0600 FROM THE START (via the
+ * `mode` option), so the renamed token is owner-only with no world-readable
+ * window between rename and any post-hoc chmod (CWE-732). We STILL chmod 0600
+ * explicitly afterwards as belt-and-suspenders: it re-tightens even if a prior
+ * (looser) file was somehow left at the target path, and makes the 0600
+ * guarantee independent of the helper's internals.
+ */
+export function writeControlToken(path: string, token: string): void {
+  // No trailing newline: the file content IS the token. readControlToken trims
+  // defensively, but keeping the on-disk bytes exact avoids any ambiguity.
+  // mode 0600: the temp file is owner-only before the rename — no exposure window.
+  atomicWriteText(path, token, { mode: 0o600 });
+  // Best-effort would be wrong here: if we cannot enforce 0600 the token is
+  // exposed, so fail loud (the daemon's startup will surface it) rather than
+  // silently ship a world-readable secret.
+  chmodSync(path, 0o600);
+}
+
+/**
+ * Read the token from `path`, returning null when the file is absent or
+ * unreadable. Trims trailing whitespace/newline so a token written by any
+ * version (with or without a trailing newline) compares equal.
+ */
+export function readControlToken(path: string): string | null {
+  try {
+    const raw = readFileSync(path, "utf-8").trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export type ControlTokenValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * Compare a client-provided token against the daemon's expected token.
+ *
+ * Compatibility / enforcement policy:
+ *   - `expectedToken == null` (daemon has no token loaded, e.g. an older daemon
+ *     or a token-file write/read failure) → token check is DISABLED; pass. The
+ *     attach-convergence guard and Origin guard still apply, so this degrades to
+ *     pre-token behavior rather than locking out every client.
+ *   - `expectedToken` present, `providedToken` missing → reject (a token-aware
+ *     daemon expects token-aware clients; same-version bridge always sends it).
+ *   - both present → constant-time-ish exact compare.
+ */
+export function validateControlToken(input: {
+  expectedToken: string | null;
+  providedToken?: string | null;
+}): ControlTokenValidationResult {
+  const { expectedToken } = input;
+  if (expectedToken == null || expectedToken.length === 0) {
+    // No token to enforce — token layer disabled (compat / degraded).
+    return { ok: true };
+  }
+  const provided = input.providedToken;
+  if (provided == null || provided.length === 0) {
+    return { ok: false, reason: "missing control token" };
+  }
+  if (!constantTimeEquals(provided, expectedToken)) {
+    return { ok: false, reason: "control token mismatch" };
+  }
+  return { ok: true };
+}
+
+/**
+ * Length-independent constant-time string comparison. Avoids leaking the token
+ * via early-exit timing. Both inputs are local strings, so this is belt-and-
+ * suspenders, but cheap and correct.
+ */
+function constantTimeEquals(a: string, b: string): boolean {
+  // Comparing lengths first would leak length via timing; instead fold length
+  // mismatch into the accumulator and always scan the longer string.
+  const len = Math.max(a.length, b.length);
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < len; i++) {
+    diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  }
+  return diff === 0;
+}

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -5,6 +5,7 @@ import {
   CLOSE_CODE_EVICTED_STALE,
   CLOSE_CODE_PROBE_IN_PROGRESS,
   CLOSE_CODE_PAIR_MISMATCH,
+  CLOSE_CODE_TOKEN_MISMATCH,
 } from "./control-protocol";
 import type { ControlClientIdentity, ControlClientMessage, ControlServerMessage, DaemonStatus, TurnPhase } from "./control-protocol";
 import { CLIENT_REPLY_TIMEOUT_MS } from "./interrupt-timing";
@@ -35,7 +36,15 @@ interface DaemonClientEvents {
 let nextSocketId = 0;
 
 export interface DaemonClientOptions {
-  identity?: ControlClientIdentity;
+  /**
+   * Client identity sent in `claude_connect`. Either a fixed object or a
+   * resolver evaluated on EACH attach. A resolver is required for the
+   * capability token (arch-review P1 #283): the token file is written by the
+   * daemon and may not exist when the client is constructed, so it must be read
+   * lazily at attach time, AND re-read on reconnect after a daemon restart
+   * rotates the token.
+   */
+  identity?: ControlClientIdentity | (() => ControlClientIdentity);
 }
 
 export class DaemonClient extends EventEmitter<DaemonClientEvents> {
@@ -98,10 +107,22 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   }
 
   attachClaude() {
+    const identity = this.resolveIdentity();
     this.send({
       type: "claude_connect",
-      ...(this.options.identity ? { identity: this.options.identity } : {}),
+      ...(identity ? { identity } : {}),
     });
+  }
+
+  /**
+   * Resolve the identity for this attach. A function option is evaluated NOW
+   * (lazily, per attach) so the capability token is read fresh from disk —
+   * critical because the daemon may not have written the token when this client
+   * was constructed, and a daemon restart rotates it (arch-review P1 #283).
+   */
+  private resolveIdentity(): ControlClientIdentity | undefined {
+    const opt = this.options.identity;
+    return typeof opt === "function" ? opt() : opt;
   }
 
   async attachClaudeAndWaitForStatus(timeoutMs = 1000): Promise<DaemonStatus | null> {
@@ -306,7 +327,8 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
           event.code === CLOSE_CODE_REPLACED ||
           event.code === CLOSE_CODE_EVICTED_STALE ||
           event.code === CLOSE_CODE_PROBE_IN_PROGRESS ||
-          event.code === CLOSE_CODE_PAIR_MISMATCH
+          event.code === CLOSE_CODE_PAIR_MISMATCH ||
+          event.code === CLOSE_CODE_TOKEN_MISMATCH
         ) {
           this.emit("rejected", event.code);
         } else {

--- a/src/daemon-identity.ts
+++ b/src/daemon-identity.ts
@@ -1,13 +1,22 @@
 import {
   CLOSE_CODE_PAIR_MISMATCH,
+  CLOSE_CODE_TOKEN_MISMATCH,
   type ControlClientIdentity,
 } from "./control-protocol";
+import { validateControlToken } from "./control-token";
 
 export interface ClaudeIdentityValidationInput {
   expectedPairId: string | null;
   daemonCwd: string;
   identity?: ControlClientIdentity;
   allowIdentityless?: boolean;
+  /**
+   * The daemon's control-port capability token (arch-review P1 #283). When set,
+   * the client's identity MUST echo it. null disables the token layer (older
+   * daemon / token write+read failure) — admission then degrades to the
+   * pre-token pair/cwd checks plus the attach-convergence guard at injection.
+   */
+  expectedControlToken?: string | null;
 }
 
 export type ClaudeIdentityValidationResult =
@@ -17,6 +26,39 @@ export type ClaudeIdentityValidationResult =
 export function validateClaudeClientIdentity(
   input: ClaudeIdentityValidationInput,
 ): ClaudeIdentityValidationResult {
+  // Capability-token gate (P1 #283) runs FIRST and INDEPENDENTLY of pair mode:
+  // even a legacy/manual single-pair daemon (no pairId enforcement) writes a
+  // token, so an identity-carrying socket that did not read the 0600 token file
+  // is rejected here before any pair/cwd reasoning. Compat is two-fold:
+  //
+  //   1. expectedControlToken null (older daemon / token write+read failure) →
+  //      gate disabled, behavior unchanged.
+  //   2. NO identity object on the message → gate skipped, and the request is
+  //      handled by the identityless policy below. This preserves the two
+  //      legacy admit paths verbatim: pure legacy mode (no pairId) admits an
+  //      identityless client, and AGENTBRIDGE_COMPAT_IDENTITYLESS admits one in
+  //      pair mode. A client that CANNOT carry a token (sends no identity at
+  //      all) must not be force-rejected by the token layer — the attach guard
+  //      + Origin guard remain its defense. EVERY real frontend (bridge.ts)
+  //      sends an identity and therefore IS held to the token.
+  //
+  // Consequence: as soon as a socket presents an identity, it must present the
+  // right token — a foreign/browser socket cannot read the file, so it cannot
+  // forge a passing identity here.
+  if (input.expectedControlToken && input.identity) {
+    const tokenResult = validateControlToken({
+      expectedToken: input.expectedControlToken,
+      providedToken: input.identity.controlToken,
+    });
+    if (!tokenResult.ok) {
+      return {
+        ok: false,
+        closeCode: CLOSE_CODE_TOKEN_MISMATCH,
+        reason: tokenResult.reason,
+      };
+    }
+  }
+
   if (!input.expectedPairId) return { ok: true };
   if (!input.identity) {
     return input.allowIdentityless
@@ -38,4 +80,38 @@ export function validateClaudeClientIdentity(
     };
   }
   return { ok: true };
+}
+
+export type InjectionAttachGuardResult =
+  | { allowed: true }
+  | { allowed: false; code: "not_attached"; reason: string };
+
+/**
+ * Attach-convergence guard for claude_to_codex injection (arch-review P1 #283,
+ * defense layer 1). ONLY the socket that currently holds the attach slot — i.e.
+ * the one that passed `claude_connect` admission (pair/cwd + capability token)
+ * and has not been detached/evicted/replaced — may inject a turn into Codex.
+ *
+ * Pure + reference-identity based so it is unit-testable without a live
+ * WebSocket: pass the daemon's `attachedClaude` and the requesting socket; the
+ * decision is exactly their identity comparison. `null`/`undefined` attached
+ * (no live frontend) always rejects.
+ *
+ * Generic over the socket type (compared by reference) to avoid importing Bun's
+ * ServerWebSocket here; the daemon passes its real sockets, tests pass sentinels.
+ */
+export function evaluateInjectionAttachGuard<T>(
+  attachedSocket: T | null | undefined,
+  requestingSocket: T,
+): InjectionAttachGuardResult {
+  if (attachedSocket != null && attachedSocket === requestingSocket) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    code: "not_attached",
+    reason:
+      "This socket is not the attached Claude session. Send `claude_connect` " +
+      "(with a valid control token) and win the attach slot before injecting a turn.",
+  };
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 
 import type { ServerWebSocket } from "bun";
+import { rmSync } from "node:fs";
 import { daemonStatusBuildInfo } from "./build-info";
 import { CodexAdapter } from "./codex-adapter";
-import { validateClaudeClientIdentity } from "./daemon-identity";
+import { validateClaudeClientIdentity, evaluateInjectionAttachGuard } from "./daemon-identity";
 import {
   REPLY_REQUIRED_INSTRUCTION,
   StatusBuffer,
@@ -23,6 +24,11 @@ import {
 } from "./control-protocol";
 import { parsePositiveIntEnv } from "./env-utils";
 import { isAllowedWsUpgrade, wsOriginRejectedResponse } from "./ws-origin-guard";
+import {
+  generateControlToken,
+  resolveControlTokenPath,
+  writeControlToken,
+} from "./control-token";
 import { IdempotencyTracker, type IdempotencyDuplicate } from "./idempotency-tracker";
 import { ReplyRequiredTracker } from "./reply-required-tracker";
 import { persistCurrentThreadWithRolloutRetry } from "./thread-state";
@@ -61,6 +67,26 @@ interface ControlSocketData {
 const stateDir = new StateDirResolver();
 stateDir.ensure();
 const processLogger = createProcessLogger({ component: "AgentBridgeDaemon", logFile: stateDir.logFile });
+
+// Control-port capability token (arch-review P1 #283). Generated fresh on every
+// daemon start and written 0600 to the pair's state dir BEFORE the control server
+// accepts any socket, so a legitimate same-machine frontend can read it and echo
+// it in `claude_connect`. A write/chmod failure degrades the token layer to OFF
+// (null) — the attach-convergence guard + Origin guard still apply — rather than
+// bricking the daemon. Per-pair isolation is automatic: each pair has its own
+// state dir, hence its own token.
+const controlTokenPath = resolveControlTokenPath(stateDir.dir);
+let controlToken: string | null = null;
+try {
+  controlToken = generateControlToken();
+  writeControlToken(controlTokenPath, controlToken);
+} catch (err: any) {
+  controlToken = null;
+  processLogger.log(
+    `Failed to write control token (${controlTokenPath}): ${err?.message ?? err} — ` +
+    `token layer DISABLED for this daemon (attach guard + Origin guard still active)`,
+  );
+}
 const configService = new ConfigService();
 // Thread the daemon logger so a corrupt config.json fails loud (to log + stderr)
 // instead of silently reverting custom budget/idle thresholds to defaults.
@@ -684,6 +710,7 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
         daemonCwd: process.cwd(),
         identity: message.identity,
         allowIdentityless: ALLOW_IDENTITYLESS_CLIENT,
+        expectedControlToken: controlToken,
       });
       if (!admission.ok) {
         log(`Rejecting Claude frontend #${ws.data.clientId}: ${admission.reason}`);
@@ -803,6 +830,31 @@ async function handleClaudeToCodex(
   ws: ServerWebSocket<ControlSocketData>,
   message: Extract<ControlClientMessage, { type: "claude_to_codex" }>,
 ): Promise<void> {
+  // Attach-convergence guard (arch-review P1 #283, defense layer 1). ONLY the
+  // socket that passed `claude_connect` admission (and thus the pair/cwd + token
+  // gate) and currently holds the attach slot may inject a turn into Codex. A
+  // socket that connected to /ws but never attached — or one that lost the slot
+  // to a newer session — is rejected here, BEFORE any thread/budget reasoning.
+  // This cannot misfire on the normal reply path: the bridge sends every
+  // claude_to_codex over the same socket it attached with, so attachedClaude===ws
+  // holds for every legitimate reply (verified against the attach/detach
+  // lifecycle: attachClaude sets attachedClaude=ws, detachClaude/eviction clear
+  // it, and a replaced socket is closed). Decision extracted to a pure helper so
+  // it is unit-testable without a live WebSocket.
+  const attachGuard = evaluateInjectionAttachGuard(attachedClaude, ws);
+  if (!attachGuard.allowed) {
+    log(
+      `Rejecting claude_to_codex from non-attached socket #${ws.data.clientId} ` +
+      `(request ${message.requestId}, attached=${attachedClaude ? "#" + attachedClaude.data.clientId : "none"})`,
+    );
+    sendClaudeToCodexResult(ws, message.requestId, {
+      success: false,
+      code: attachGuard.code,
+      error: attachGuard.reason,
+    });
+    return;
+  }
+
   if (message.message.source !== "claude") {
     sendClaudeToCodexResult(ws, message.requestId, {
       success: false,
@@ -1635,7 +1687,20 @@ function shutdown(reason: string, exitCode = 0) {
   codex.stop();
   removePidFile();
   removeStatusFile();
+  removeControlToken();
   process.exit(exitCode);
+}
+
+/**
+ * Best-effort removal of the control-token file. The token is a per-start
+ * secret; leaving a stale file behind would let a NEXT daemon's pre-write window
+ * (or a crashed daemon) expose an old token, and a same-version restart writes a
+ * fresh one anyway. Never throws — removal failure must not block shutdown.
+ */
+function removeControlToken() {
+  try {
+    rmSync(controlTokenPath, { force: true });
+  } catch {}
 }
 
 process.on("SIGINT", () => shutdown("SIGINT"));
@@ -1649,6 +1714,7 @@ process.on("exit", () => {
   codex.forceKillAppServerSync();
   removePidFile();
   removeStatusFile();
+  removeControlToken();
 });
 process.on("uncaughtException", (err) => {
   processLogger.fatal("UNCAUGHT EXCEPTION", err);

--- a/src/unit-test/atomic-json.test.ts
+++ b/src/unit-test/atomic-json.test.ts
@@ -84,6 +84,21 @@ describe("atomic-json", () => {
     }
   });
 
+  test("mode option creates the file owner-only with no world/group window (CWE-732)", () => {
+    const dir = tempDir();
+    const path = join(dir, "secret-token");
+
+    atomicWriteText(path, "s3cr3t", { mode: 0o600 });
+
+    const mode = fs.statSync(path).mode & 0o777;
+    // The security-relevant property: no group/other permission bits are ever set,
+    // so the secret is never world/group readable — not even for the temp-file
+    // instant before a post-rename chmod would run.
+    expect(mode & 0o077).toBe(0);
+    expect(mode & 0o400).toBe(0o400); // owner can still read it
+    expect(readFileSync(path, "utf-8")).toBe("s3cr3t");
+  });
+
   test("a failed rename leaves the previous target intact", () => {
     const dir = tempDir();
     const path = join(dir, "status.json");

--- a/src/unit-test/control-token.test.ts
+++ b/src/unit-test/control-token.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CONTROL_TOKEN_FILENAME,
+  generateControlToken,
+  readControlToken,
+  resolveControlTokenPath,
+  validateControlToken,
+  writeControlToken,
+} from "../control-token";
+
+describe("control-token", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "abg-control-token-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("resolveControlTokenPath nests the token under the state dir", () => {
+    expect(resolveControlTokenPath(dir)).toBe(join(dir, CONTROL_TOKEN_FILENAME));
+  });
+
+  test("generateControlToken produces a non-trivial, unique-per-call token", () => {
+    const a = generateControlToken();
+    const b = generateControlToken();
+    expect(a.length).toBeGreaterThanOrEqual(16);
+    expect(a).not.toBe(b); // randomUUID collision is astronomically unlikely
+  });
+
+  test("writeControlToken writes the token and round-trips via readControlToken", () => {
+    const path = resolveControlTokenPath(dir);
+    const token = generateControlToken();
+    writeControlToken(path, token);
+    expect(readControlToken(path)).toBe(token);
+    // On-disk bytes are exactly the token (no trailing newline added).
+    expect(readFileSync(path, "utf-8")).toBe(token);
+  });
+
+  test("writeControlToken enforces 0600 owner-only permissions", () => {
+    const path = resolveControlTokenPath(dir);
+    writeControlToken(path, generateControlToken());
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("writeControlToken re-tightens a pre-existing world-readable file to 0600", () => {
+    const path = resolveControlTokenPath(dir);
+    // Simulate a stale, loosely-permissioned token left behind by an old build.
+    writeFileSync(path, "stale-token", { mode: 0o644 });
+    expect(statSync(path).mode & 0o777).toBe(0o644);
+
+    const fresh = generateControlToken();
+    writeControlToken(path, fresh);
+    expect(readControlToken(path)).toBe(fresh);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  test("readControlToken returns null for a missing file", () => {
+    expect(readControlToken(resolveControlTokenPath(dir))).toBeNull();
+    expect(existsSync(resolveControlTokenPath(dir))).toBe(false);
+  });
+
+  test("readControlToken trims trailing whitespace/newline so any writer compares equal", () => {
+    const path = resolveControlTokenPath(dir);
+    writeFileSync(path, "tok-with-newline\n");
+    expect(readControlToken(path)).toBe("tok-with-newline");
+  });
+
+  test("readControlToken returns null for an empty/whitespace-only file", () => {
+    const path = resolveControlTokenPath(dir);
+    writeFileSync(path, "   \n");
+    expect(readControlToken(path)).toBeNull();
+  });
+});
+
+describe("validateControlToken", () => {
+  test("disabled (no expected token) always passes — compat / degraded", () => {
+    expect(validateControlToken({ expectedToken: null, providedToken: undefined }).ok).toBe(true);
+    expect(validateControlToken({ expectedToken: "", providedToken: "anything" }).ok).toBe(true);
+    // Even a wrong/absent provided token passes when enforcement is off.
+    expect(validateControlToken({ expectedToken: null, providedToken: "wrong" }).ok).toBe(true);
+  });
+
+  test("expected token present but provided missing → reject", () => {
+    const r1 = validateControlToken({ expectedToken: "secret", providedToken: undefined });
+    expect(r1.ok).toBe(false);
+    if (!r1.ok) expect(r1.reason).toBe("missing control token");
+
+    const r2 = validateControlToken({ expectedToken: "secret", providedToken: "" });
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) expect(r2.reason).toBe("missing control token");
+
+    const r3 = validateControlToken({ expectedToken: "secret", providedToken: null });
+    expect(r3.ok).toBe(false);
+  });
+
+  test("mismatched provided token → reject", () => {
+    const r = validateControlToken({ expectedToken: "secret", providedToken: "guess" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("control token mismatch");
+  });
+
+  test("a near-miss (prefix / length-off) token → reject", () => {
+    expect(validateControlToken({ expectedToken: "secret", providedToken: "secre" }).ok).toBe(false);
+    expect(validateControlToken({ expectedToken: "secret", providedToken: "secretx" }).ok).toBe(false);
+    expect(validateControlToken({ expectedToken: "secret", providedToken: "Secret" }).ok).toBe(false);
+  });
+
+  test("exact match → pass", () => {
+    const token = generateControlToken();
+    expect(validateControlToken({ expectedToken: token, providedToken: token }).ok).toBe(true);
+  });
+});

--- a/src/unit-test/daemon-identity.test.ts
+++ b/src/unit-test/daemon-identity.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { CLOSE_CODE_PAIR_MISMATCH } from "../control-protocol";
-import { validateClaudeClientIdentity } from "../daemon-identity";
+import { CLOSE_CODE_PAIR_MISMATCH, CLOSE_CODE_TOKEN_MISMATCH } from "../control-protocol";
+import {
+  evaluateInjectionAttachGuard,
+  validateClaudeClientIdentity,
+} from "../daemon-identity";
 
 describe("daemon Claude identity admission", () => {
   test("pair daemon rejects identity-less Claude clients by default", async () => {
@@ -48,5 +51,153 @@ describe("daemon Claude identity admission", () => {
       identity: undefined,
       allowIdentityless: true,
     }).ok).toBe(true);
+  });
+});
+
+describe("control-token admission gate (arch-review P1 #283)", () => {
+  const goodIdentity = (controlToken?: string | null) => ({
+    pairId: "main-12345678",
+    cwd: "/tmp/project",
+    ...(controlToken !== undefined ? { controlToken } : {}),
+  });
+
+  test("token correct + identity correct → admitted", () => {
+    const result = validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: goodIdentity("the-secret-token"),
+      allowIdentityless: false,
+      expectedControlToken: "the-secret-token",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("token missing while the daemon expects one → rejected with TOKEN_MISMATCH (4005)", () => {
+    const result = validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: goodIdentity(undefined), // pair/cwd correct, but NO token
+      allowIdentityless: false,
+      expectedControlToken: "the-secret-token",
+    });
+    expect(result).toEqual({
+      ok: false,
+      closeCode: CLOSE_CODE_TOKEN_MISMATCH,
+      reason: "missing control token",
+    });
+  });
+
+  test("token wrong → rejected with TOKEN_MISMATCH even when pair/cwd are correct", () => {
+    const result = validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: goodIdentity("attacker-guess"),
+      allowIdentityless: false,
+      expectedControlToken: "the-secret-token",
+    });
+    expect(result).toEqual({
+      ok: false,
+      closeCode: CLOSE_CODE_TOKEN_MISMATCH,
+      reason: "control token mismatch",
+    });
+  });
+
+  test("token gate runs BEFORE pair/cwd — a wrong token is rejected as TOKEN_MISMATCH", () => {
+    // Even with a wrong pairId, the token gate (first) decides the close code, so
+    // the failure is unambiguously attributable to the token.
+    const result = validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: { pairId: "other-aaaaaaaa", cwd: "/tmp/elsewhere", controlToken: "wrong" },
+      allowIdentityless: false,
+      expectedControlToken: "the-secret-token",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.closeCode).toBe(CLOSE_CODE_TOKEN_MISMATCH);
+  });
+
+  test("token enforced even in legacy mode (no expectedPairId) — arbitrary socket without token is rejected", () => {
+    const result = validateClaudeClientIdentity({
+      expectedPairId: null,
+      daemonCwd: "/tmp/project",
+      identity: { controlToken: undefined }, // no token presented
+      allowIdentityless: false,
+      expectedControlToken: "legacy-secret",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.closeCode).toBe(CLOSE_CODE_TOKEN_MISMATCH);
+
+    // The legitimate legacy client that read the token is admitted.
+    expect(validateClaudeClientIdentity({
+      expectedPairId: null,
+      daemonCwd: "/tmp/project",
+      identity: { controlToken: "legacy-secret" },
+      allowIdentityless: false,
+      expectedControlToken: "legacy-secret",
+    }).ok).toBe(true);
+  });
+
+  test("expectedControlToken null disables the gate (older daemon / write failure) — compat", () => {
+    const result = validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: goodIdentity(undefined),
+      allowIdentityless: false,
+      expectedControlToken: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("identityless compat escape hatch bypasses the token gate", () => {
+    // AGENTBRIDGE_COMPAT_IDENTITYLESS: no identity object means no token can be
+    // carried; the explicit operator opt-out must still admit.
+    const result = validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: undefined,
+      allowIdentityless: true,
+      expectedControlToken: "the-secret-token",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("an identity-CARRYING client under the compat flag still must present the right token", () => {
+    // The escape hatch only bypasses when identity is ABSENT. A client that sends
+    // an identity (so it could carry a token) is held to the token gate.
+    const result = validateClaudeClientIdentity({
+      expectedPairId: "main-12345678",
+      daemonCwd: "/tmp/project",
+      identity: { pairId: "main-12345678", cwd: "/tmp/project", controlToken: "wrong" },
+      allowIdentityless: true,
+      expectedControlToken: "the-secret-token",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.closeCode).toBe(CLOSE_CODE_TOKEN_MISMATCH);
+  });
+});
+
+describe("injection attach-convergence guard (arch-review P1 #283)", () => {
+  // Reference-identity sentinels stand in for the daemon's ServerWebSockets.
+  const attached = { id: "attached" };
+  const other = { id: "other" };
+
+  test("the attached socket is allowed to inject", () => {
+    expect(evaluateInjectionAttachGuard(attached, attached)).toEqual({ allowed: true });
+  });
+
+  test("a different (non-attached) socket is rejected with not_attached", () => {
+    const result = evaluateInjectionAttachGuard(attached, other);
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.code).toBe("not_attached");
+      expect(result.reason).toContain("not the attached Claude session");
+    }
+  });
+
+  test("no live frontend attached (null/undefined) rejects every injection", () => {
+    expect(evaluateInjectionAttachGuard(null, other).allowed).toBe(false);
+    expect(evaluateInjectionAttachGuard(undefined, other).allowed).toBe(false);
+    // Even the socket itself cannot inject if it is not the recorded attached one.
+    expect(evaluateInjectionAttachGuard(null, attached).allowed).toBe(false);
   });
 });

--- a/src/unit-test/daemon-wiring.test.ts
+++ b/src/unit-test/daemon-wiring.test.ts
@@ -16,6 +16,7 @@ import { createServer, connect, type Socket } from "node:net";
 import type { BridgeMessage } from "../types";
 import type { ControlServerMessage, DaemonStatus } from "../control-protocol";
 import { portsForSlot, type PairPorts } from "../pair-registry";
+import { readControlToken, resolveControlTokenPath } from "../control-token";
 
 const DAEMON_PATH = join(process.cwd(), "src", "daemon.ts");
 const DEFAULT_TEST_SLOT_START = 2500 + (process.pid % 500);
@@ -893,6 +894,152 @@ describe("daemon wiring", () => {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
   }, 60000);
+
+  // --- Security: attach-convergence guard + capability token (arch-review P1 #283) ---
+
+  test("attach guard: a NON-attached socket's claude_to_codex is rejected with not_attached, even with a valid token", async () => {
+    const harness = await startHarness({ pairId: "main-attachgrd", pairName: "main" });
+
+    // Legit frontend attaches + a ready thread exists, so the ONLY thing that can
+    // reject the second socket below is the attach guard (not no_thread/busy).
+    await harness.attachClaude();
+    await harness.connectTui();
+
+    // A SECOND control socket that connects to /ws but never wins the attach slot.
+    // It even presents the correct capability token (so token admission would
+    // pass) — proving the attach guard is an INDEPENDENT second layer: passing
+    // the token gate is not sufficient to inject; you must also hold the slot.
+    const intruder = await connectControlSocket(harness.controlPort);
+    const intruderResults: ControlServerMessage[] = [];
+    intruder.onmessage = (event) => {
+      const raw = typeof event.data === "string" ? event.data : event.data.toString();
+      intruderResults.push(JSON.parse(raw) as ControlServerMessage);
+    };
+
+    // Deliberately do NOT send claude_connect on the intruder — it is an
+    // unattached socket trying to inject a turn straight into Codex.
+    intruder.send(JSON.stringify({
+      type: "claude_to_codex",
+      requestId: "req-intruder-1",
+      message: { id: "req-intruder-1", source: "claude", content: "inject without attaching", timestamp: Date.now() },
+    }));
+
+    await waitFor(
+      () => intruderResults.some(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === "req-intruder-1",
+      ),
+      "claude_to_codex_result for the intruder socket",
+    );
+    const rejected = intruderResults.find(
+      (m) => m.type === "claude_to_codex_result" && m.requestId === "req-intruder-1",
+    ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }>;
+    expect(rejected.success).toBe(false);
+    expect(rejected.code).toBe("not_attached");
+    expect(rejected.error).toContain("not the attached Claude session");
+
+    // The attached frontend's own reply on the SAME pair still works — the guard
+    // does not misfire on the legitimate path (attachedClaude === its socket).
+    harness.sendClaudeToCodex("req-legit-1", "legitimate reply from the attached session");
+    await waitFor(
+      () => harness.statusMessages.some(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === "req-legit-1",
+      ),
+      "claude_to_codex_result for the attached session's reply",
+    );
+    const accepted = harness.statusMessages.find(
+      (m) => m.type === "claude_to_codex_result" && m.requestId === "req-legit-1",
+    ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }>;
+    expect(accepted.success).toBe(true);
+
+    try { intruder.close(); } catch {}
+  }, 30000);
+
+  test("token gate: claude_connect with a WRONG control token is rejected and the socket is closed (4005)", async () => {
+    const harness = await startHarness({ pairId: "main-tokengate", pairName: "main" });
+
+    const ws = await connectControlSocket(harness.controlPort);
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      ws.onclose = (event) => resolve({ code: event.code, reason: event.reason });
+    });
+
+    // Present a SYNTACTICALLY valid identity (correct pair/cwd) but a bogus token —
+    // a browser/foreign socket that cannot read the 0600 token file.
+    ws.send(JSON.stringify({
+      type: "claude_connect",
+      identity: {
+        pairId: "main-tokengate",
+        pairName: "main",
+        cwd: harness.cwd,
+        stateDir: harness.stateDir,
+        clientPid: process.pid,
+        contractVersion: 1,
+        controlToken: "totally-wrong-token",
+      },
+    }));
+
+    const result = await Promise.race([
+      closed,
+      sleep(4000).then(() => null),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.code).toBe(4005); // CLOSE_CODE_TOKEN_MISMATCH
+    expect(result!.reason).toContain("token");
+
+    // The daemon did NOT attach this socket: a follow-up status request from a
+    // fresh, properly-tokened socket still reports no live frontend interference.
+    // (The wrong-token socket is closed, so it cannot have become attachedClaude.)
+    const healthz = await fetch(`http://127.0.0.1:${harness.controlPort}/healthz`);
+    expect(healthz.ok).toBe(true);
+  }, 30000);
+
+  test("token gate: claude_connect MISSING the control token is rejected (4005)", async () => {
+    const harness = await startHarness({ pairId: "main-tokenmiss", pairName: "main" });
+
+    const ws = await connectControlSocket(harness.controlPort);
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      ws.onclose = (event) => resolve({ code: event.code, reason: event.reason });
+    });
+
+    // Correct pair/cwd but NO token at all (a pre-token client, or an attacker
+    // who never read the file). The token-aware daemon rejects it.
+    ws.send(JSON.stringify({
+      type: "claude_connect",
+      identity: {
+        pairId: "main-tokenmiss",
+        pairName: "main",
+        cwd: harness.cwd,
+        stateDir: harness.stateDir,
+        clientPid: process.pid,
+        contractVersion: 1,
+      },
+    }));
+
+    const result = await Promise.race([closed, sleep(4000).then(() => null)]);
+    expect(result).not.toBeNull();
+    expect(result!.code).toBe(4005);
+    expect(result!.reason).toContain("missing control token");
+  }, 30000);
+
+  test("token gate: a correctly-tokened claude_connect attaches and can inject (end-to-end happy path)", async () => {
+    const harness = await startHarness({ pairId: "main-tokenok12", pairName: "main" });
+
+    // harness.attachClaude() reads the real token from the state dir and presents
+    // it — the daemon admits it. Then a reply must flow through to a ready thread.
+    await harness.attachClaude();
+    await harness.connectTui();
+
+    harness.sendClaudeToCodex("req-ok-1", "hello with a valid token");
+    await waitFor(
+      () => harness.statusMessages.some(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === "req-ok-1",
+      ),
+      "claude_to_codex_result for the tokened reply",
+    );
+    const accepted = harness.statusMessages.find(
+      (m) => m.type === "claude_to_codex_result" && m.requestId === "req-ok-1",
+    ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }>;
+    expect(accepted.success).toBe(true);
+  }, 30000);
 });
 
 async function startHarness(opts: {
@@ -992,6 +1139,10 @@ async function startHarness(opts: {
           harness.messages.push(message.message);
         }
       };
+      // Mirror the real frontend (bridge.ts): read the daemon's capability token
+      // from the pair state dir and echo it in the identity (arch-review P1 #283).
+      // The daemon is readyz-200 here, so the token file already exists.
+      const controlToken = readControlToken(resolveControlTokenPath(stateDir));
       ws.send(JSON.stringify({
         type: "claude_connect",
         identity: {
@@ -1001,6 +1152,7 @@ async function startHarness(opts: {
           stateDir,
           clientPid: process.pid,
           contractVersion: 1,
+          ...(controlToken ? { controlToken } : {}),
         },
       }));
     },


### PR DESCRIPTION
## 摘要 / Summary
arch-review P1 #283（安全）：把「注入一个 turn 进 Codex」的权限从「任意连上 /ws 的 socket」收敛为「已通过 admission 且持有能力令牌的那条 attached socket」，与既有 WS Origin 校验形成纵深防御。
- **attach 守卫**：`handleClaudeToCodex` 注入前要求 `attachedClaude===ws`（纯函数 `evaluateInjectionAttachGuard`），未附着直接失败。
- **能力令牌**：daemon 启动随机生成 token，**0600 原子写**入 state dir（`atomic-json` 新增 `mode` 选项，temp 从一开始就 0600，消除 rename→chmod 间世界可读窗口，CWE-732）；bridge 懒读 token 进 identity，daemon `claude_connect` 比对；不匹配/缺失 → 新 `CLOSE_CODE_TOKEN_MISMATCH(4005)`，bridge rejected 给清晰重启指引。
- **兼容**：令牌门仅在客户端携带 identity 时强制（`expectedToken=null` 或 identityless/`COMPAT_IDENTITYLESS` 跳过），不破坏 legacy / e2e-reconnect；production bridge 始终发 identity 故始终受保护。token 在 shutdown/exit 清理；pairId 退回纯路由标识。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1041 pass / 0 fail** / `verify:plugin-sync` ✅
- 新增 `src/control-token.ts` + 测试；`daemon-identity` / `daemon-wiring` 安全测试矩阵（未 attach 拒绝 / token 正确通过 / token 错误 / 缺 token / attached reply 不误杀）。
- Cross-review：R1 安全镜头 **0 bug**；compat 镜头发现 1 LOW（token 文件 rename→chmod 间亚毫秒世界可读窗口，CWE-732）→ **已修**（atomic-json `mode` 选项 + 单测锁 `mode & 0o077 === 0`）；R2 复核。

## 备注
攒批发布：release-on-merge 暂禁。CLOSE code 分配：4005=TOKEN_MISMATCH（本 PR）；后续 #303 契约版本用 4006。