### PR TITLE
feat: claude-adapter fallback 队列加字节上限 + 双上界有界化 / bound the MCP fallback queue by bytes as well as count

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13940,6 +13940,8 @@ function renderBudgetSnapshot(snapshot) {
 var BUDGET_UNAVAILABLE_TEXT = "\u9884\u7B97\u611F\u77E5\u4E0D\u53EF\u7528\uFF1A\u672A\u68C0\u6D4B\u5230 agent-quota-guard \u63A2\u9488\uFF08~/.budget-guard/bin/budget-probe\uFF09\u6216 budget \u529F\u80FD\u5DF2\u7981\u7528\u3002\u534F\u4F5C\u4E0D\u53D7\u5F71\u54CD\u3002";
 
 // src/claude-adapter.ts
+var DEFAULT_MAX_BUFFERED_MESSAGES = 100;
+var DEFAULT_MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
 var CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
   "",
@@ -13988,10 +13990,16 @@ class ClaudeAdapter extends EventEmitter {
   logFile;
   logger;
   pendingMessages = [];
+  pendingMessageByteSizes = [];
+  pendingMessageBytes = 0;
   maxBufferedMessages;
+  maxBufferedBytes;
   droppedMessageCount = 0;
+  oversizedMessageCount = 0;
+  oversizedMessageBytes = 0;
+  oversizedMessageSourceCounts = {};
   budgetSnapshot = null;
-  constructor(logFile = new StateDirResolver().logFile) {
+  constructor(logFile = new StateDirResolver().logFile, options = {}) {
     super();
     this.logFile = logFile;
     this.logger = createProcessLogger({ component: "ClaudeAdapter", logFile: this.logFile });
@@ -14002,7 +14010,8 @@ class ClaudeAdapter extends EventEmitter {
     if (process.env.AGENTBRIDGE_MODE) {
       this.log(`AGENTBRIDGE_MODE="${process.env.AGENTBRIDGE_MODE}" is no longer supported \u2014 ` + "pull mode was removed; push delivery (with per-message fallback queue) is always used.");
     }
-    this.maxBufferedMessages = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
+    this.maxBufferedMessages = positiveIntegerOr(options.maxBufferedMessages, parsePositiveIntegerEnv("AGENTBRIDGE_MAX_BUFFERED_MESSAGES", DEFAULT_MAX_BUFFERED_MESSAGES));
+    this.maxBufferedBytes = positiveIntegerOr(options.maxBufferedBytes, parsePositiveIntegerEnv("AGENTBRIDGE_MAX_BUFFERED_BYTES", DEFAULT_MAX_BUFFERED_BYTES));
     this.server = new Server({ name: "agentbridge", version: "0.1.0" }, {
       capabilities: {
         experimental: { "claude/channel": {} },
@@ -14056,32 +14065,61 @@ class ClaudeAdapter extends EventEmitter {
     }
   }
   queueFallbackMessage(message) {
-    if (this.pendingMessages.length >= this.maxBufferedMessages) {
-      this.pendingMessages.shift();
+    const messageBytes = utf8ByteLength(message.content);
+    if (messageBytes > this.maxBufferedBytes) {
+      this.oversizedMessageCount++;
+      this.oversizedMessageBytes += messageBytes;
+      this.oversizedMessageSourceCounts[message.source] = (this.oversizedMessageSourceCounts[message.source] ?? 0) + 1;
+      this.log(`Fallback queue omitted oversized ${message.source} message ` + `(${formatBytes(messageBytes)} > ${formatBytes(this.maxBufferedBytes)}; ` + `total oversized: ${this.oversizedMessageCount})`);
+      return;
+    }
+    let dropped = 0;
+    while (this.pendingMessages.length >= this.maxBufferedMessages || this.pendingMessageBytes + messageBytes > this.maxBufferedBytes) {
+      const droppedMessage = this.pendingMessages.shift();
+      const droppedBytes = this.pendingMessageByteSizes.shift() ?? 0;
+      if (!droppedMessage)
+        break;
+      this.pendingMessageBytes = Math.max(0, this.pendingMessageBytes - droppedBytes);
       this.droppedMessageCount++;
-      this.log(`Fallback queue full, dropped oldest message (total dropped: ${this.droppedMessageCount})`);
+      dropped++;
+    }
+    if (dropped > 0) {
+      this.log(`Fallback queue overflow: dropped ${dropped} oldest message${dropped > 1 ? "s" : ""} ` + `(${this.pendingMessages.length} pending, ${formatBytes(this.pendingMessageBytes)} buffered, ` + `${this.droppedMessageCount} dropped since last drain)`);
     }
     this.pendingMessages.push(message);
-    this.log(`Queued fallback message (${this.pendingMessages.length} pending, instance=${this.instanceId})`);
+    this.pendingMessageByteSizes.push(messageBytes);
+    this.pendingMessageBytes += messageBytes;
+    this.log(`Queued fallback message (${this.pendingMessages.length} pending, ` + `${formatBytes(this.pendingMessageBytes)} buffered, instance=${this.instanceId})`);
   }
   drainMessages() {
-    this.log(`get_messages called (instance=${this.instanceId}, pending=${this.pendingMessages.length}, dropped=${this.droppedMessageCount})`);
-    if (this.pendingMessages.length === 0 && this.droppedMessageCount === 0) {
+    this.log(`get_messages called (instance=${this.instanceId}, pending=${this.pendingMessages.length}, ` + `bytes=${this.pendingMessageBytes}, dropped=${this.droppedMessageCount}, oversized=${this.oversizedMessageCount})`);
+    if (this.pendingMessages.length === 0 && this.droppedMessageCount === 0 && this.oversizedMessageCount === 0) {
       return {
         content: [{ type: "text", text: "No new messages from Codex." }]
       };
     }
     const messages = this.pendingMessages;
     this.pendingMessages = [];
+    this.pendingMessageByteSizes = [];
+    this.pendingMessageBytes = 0;
     const dropped = this.droppedMessageCount;
     this.droppedMessageCount = 0;
+    const oversizedSourceCounts = this.oversizedMessageSourceCounts;
+    const oversized = this.oversizedMessageCount;
+    const oversizedBytes = this.oversizedMessageBytes;
+    this.oversizedMessageSourceCounts = {};
+    this.oversizedMessageCount = 0;
+    this.oversizedMessageBytes = 0;
     const count = messages.length;
-    let header = `[${count} new message${count > 1 ? "s" : ""} from Codex]`;
+    const notices = [];
     if (dropped > 0) {
-      header += ` (${dropped} older message${dropped > 1 ? "s" : ""} were dropped due to queue overflow)`;
+      notices.push(`${dropped} older message${dropped > 1 ? "s" : ""} ` + `${dropped > 1 ? "were" : "was"} dropped due to fallback queue overflow`);
     }
-    header += `
-chat_id: ${this.sessionId}`;
+    if (oversized > 0) {
+      for (const [source, sourceCount] of Object.entries(oversizedSourceCounts)) {
+        notices.push(`${sourceCount} oversized message${sourceCount === 1 ? "" : "s"} ` + `from ${formatSource(source)} omitted ` + `(>${formatBytes(this.maxBufferedBytes)})`);
+      }
+    }
     const formatted = messages.map((msg, i) => {
       const ts = new Date(msg.timestamp).toISOString();
       return `---
@@ -14090,14 +14128,25 @@ Codex: ${msg.content}`;
     }).join(`
 
 `);
-    this.log(`get_messages returning ${count} message(s) (instance=${this.instanceId}, dropped=${dropped})`);
+    const noticeText = notices.map((notice) => `WARNING: ${notice}`).join(`
+`);
+    const parts = [];
+    if (count > 0) {
+      parts.push(`[${count} new message${count > 1 ? "s" : ""} from Codex]
+chat_id: ${this.sessionId}`);
+    }
+    if (noticeText)
+      parts.push(noticeText);
+    if (formatted)
+      parts.push(formatted);
+    this.log(`get_messages returning ${count} message(s) ` + `(instance=${this.instanceId}, dropped=${dropped}, oversized=${oversized}, oversizedBytes=${oversizedBytes})`);
     return {
       content: [
         {
           type: "text",
-          text: `${header}
+          text: parts.join(`
 
-${formatted}`
+`)
         }
       ]
     };
@@ -14253,6 +14302,27 @@ ${formatted}`
     this.logger.log(msg);
   }
 }
+function parsePositiveIntegerEnv(name, fallback) {
+  return positiveIntegerOr(parseInt(process.env[name] ?? "", 10), fallback);
+}
+function positiveIntegerOr(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+function utf8ByteLength(value) {
+  return Buffer.byteLength(value, "utf8");
+}
+function formatSource(source) {
+  return source === "codex" ? "Codex" : "Claude";
+}
+function formatBytes(bytes) {
+  if (bytes < 1024)
+    return `${bytes}B`;
+  if (bytes % (1024 * 1024) === 0)
+    return `${bytes / (1024 * 1024)}MiB`;
+  if (bytes % 1024 === 0)
+    return `${bytes / 1024}KiB`;
+  return `${bytes}B`;
+}
 
 // src/contract-version.ts
 var CONTRACT_VERSION = 1;
@@ -14271,7 +14341,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("56a5f87", "source"),
+  commit: defineString("ccd2875", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -18,7 +18,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("56a5f87", "source"),
+  commit: defineString("ccd2875", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -33,6 +33,14 @@ export type ReplySender = (
   idempotencyKey?: string,
 ) => Promise<{ success: boolean; error?: string; code?: string; phase?: string; retryAfterMs?: number }>;
 
+export interface ClaudeAdapterOptions {
+  maxBufferedMessages?: number;
+  maxBufferedBytes?: number;
+}
+
+const DEFAULT_MAX_BUFFERED_MESSAGES = 100;
+const DEFAULT_MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
+
 export const CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
   "",
@@ -82,13 +90,19 @@ export class ClaudeAdapter extends EventEmitter {
 
   // Push transport with a per-message fallback queue (drained by get_messages).
   private pendingMessages: BridgeMessage[] = [];
+  private pendingMessageByteSizes: number[] = [];
+  private pendingMessageBytes = 0;
   private readonly maxBufferedMessages: number;
+  private readonly maxBufferedBytes: number;
   private droppedMessageCount = 0;
+  private oversizedMessageCount = 0;
+  private oversizedMessageBytes = 0;
+  private oversizedMessageSourceCounts: Partial<Record<BridgeMessage["source"], number>> = {};
 
   // Latest budget snapshot, fed by bridge from DaemonStatus.budget broadcasts.
   private budgetSnapshot: BudgetSnapshot | null = null;
 
-  constructor(logFile = new StateDirResolver().logFile) {
+  constructor(logFile = new StateDirResolver().logFile, options: ClaudeAdapterOptions = {}) {
     super();
     this.logFile = logFile;
     this.logger = createProcessLogger({ component: "ClaudeAdapter", logFile: this.logFile });
@@ -105,7 +119,14 @@ export class ClaudeAdapter extends EventEmitter {
         "pull mode was removed; push delivery (with per-message fallback queue) is always used.",
       );
     }
-    this.maxBufferedMessages = parseInt(process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES ?? "100", 10);
+    this.maxBufferedMessages = positiveIntegerOr(
+      options.maxBufferedMessages,
+      parsePositiveIntegerEnv("AGENTBRIDGE_MAX_BUFFERED_MESSAGES", DEFAULT_MAX_BUFFERED_MESSAGES),
+    );
+    this.maxBufferedBytes = positiveIntegerOr(
+      options.maxBufferedBytes,
+      parsePositiveIntegerEnv("AGENTBRIDGE_MAX_BUFFERED_BYTES", DEFAULT_MAX_BUFFERED_BYTES),
+    );
 
     this.server = new Server(
       { name: "agentbridge", version: "0.1.0" },
@@ -180,20 +201,57 @@ export class ClaudeAdapter extends EventEmitter {
 
   /** Per-message fallback when a push fails; drained by the get_messages tool. */
   private queueFallbackMessage(message: BridgeMessage) {
-    if (this.pendingMessages.length >= this.maxBufferedMessages) {
-      this.pendingMessages.shift();
-      this.droppedMessageCount++;
-      this.log(`Fallback queue full, dropped oldest message (total dropped: ${this.droppedMessageCount})`);
+    const messageBytes = utf8ByteLength(message.content);
+    if (messageBytes > this.maxBufferedBytes) {
+      this.oversizedMessageCount++;
+      this.oversizedMessageBytes += messageBytes;
+      this.oversizedMessageSourceCounts[message.source] =
+        (this.oversizedMessageSourceCounts[message.source] ?? 0) + 1;
+      this.log(
+        `Fallback queue omitted oversized ${message.source} message ` +
+        `(${formatBytes(messageBytes)} > ${formatBytes(this.maxBufferedBytes)}; ` +
+        `total oversized: ${this.oversizedMessageCount})`,
+      );
+      return;
     }
+
+    let dropped = 0;
+    while (
+      this.pendingMessages.length >= this.maxBufferedMessages ||
+      this.pendingMessageBytes + messageBytes > this.maxBufferedBytes
+    ) {
+      const droppedMessage = this.pendingMessages.shift();
+      const droppedBytes = this.pendingMessageByteSizes.shift() ?? 0;
+      if (!droppedMessage) break;
+      this.pendingMessageBytes = Math.max(0, this.pendingMessageBytes - droppedBytes);
+      this.droppedMessageCount++;
+      dropped++;
+    }
+    if (dropped > 0) {
+      this.log(
+        `Fallback queue overflow: dropped ${dropped} oldest message${dropped > 1 ? "s" : ""} ` +
+        `(${this.pendingMessages.length} pending, ${formatBytes(this.pendingMessageBytes)} buffered, ` +
+        `${this.droppedMessageCount} dropped since last drain)`,
+      );
+    }
+
     this.pendingMessages.push(message);
-    this.log(`Queued fallback message (${this.pendingMessages.length} pending, instance=${this.instanceId})`);
+    this.pendingMessageByteSizes.push(messageBytes);
+    this.pendingMessageBytes += messageBytes;
+    this.log(
+      `Queued fallback message (${this.pendingMessages.length} pending, ` +
+      `${formatBytes(this.pendingMessageBytes)} buffered, instance=${this.instanceId})`,
+    );
   }
 
   // ── get_messages ───────────────────────────────────────────
 
   private drainMessages(): { content: Array<{ type: "text"; text: string }> } {
-    this.log(`get_messages called (instance=${this.instanceId}, pending=${this.pendingMessages.length}, dropped=${this.droppedMessageCount})`);
-    if (this.pendingMessages.length === 0 && this.droppedMessageCount === 0) {
+    this.log(
+      `get_messages called (instance=${this.instanceId}, pending=${this.pendingMessages.length}, ` +
+      `bytes=${this.pendingMessageBytes}, dropped=${this.droppedMessageCount}, oversized=${this.oversizedMessageCount})`,
+    );
+    if (this.pendingMessages.length === 0 && this.droppedMessageCount === 0 && this.oversizedMessageCount === 0) {
       return {
         content: [{ type: "text" as const, text: "No new messages from Codex." }],
       };
@@ -202,15 +260,34 @@ export class ClaudeAdapter extends EventEmitter {
     // Snapshot and clear atomically to avoid issues with concurrent writes
     const messages = this.pendingMessages;
     this.pendingMessages = [];
+    this.pendingMessageByteSizes = [];
+    this.pendingMessageBytes = 0;
     const dropped = this.droppedMessageCount;
     this.droppedMessageCount = 0;
+    const oversizedSourceCounts = this.oversizedMessageSourceCounts;
+    const oversized = this.oversizedMessageCount;
+    const oversizedBytes = this.oversizedMessageBytes;
+    this.oversizedMessageSourceCounts = {};
+    this.oversizedMessageCount = 0;
+    this.oversizedMessageBytes = 0;
 
     const count = messages.length;
-    let header = `[${count} new message${count > 1 ? "s" : ""} from Codex]`;
+    const notices: string[] = [];
     if (dropped > 0) {
-      header += ` (${dropped} older message${dropped > 1 ? "s" : ""} were dropped due to queue overflow)`;
+      notices.push(
+        `${dropped} older message${dropped > 1 ? "s" : ""} ` +
+        `${dropped > 1 ? "were" : "was"} dropped due to fallback queue overflow`,
+      );
     }
-    header += `\nchat_id: ${this.sessionId}`;
+    if (oversized > 0) {
+      for (const [source, sourceCount] of Object.entries(oversizedSourceCounts)) {
+        notices.push(
+          `${sourceCount} oversized message${sourceCount === 1 ? "" : "s"} ` +
+          `from ${formatSource(source as BridgeMessage["source"])} omitted ` +
+          `(>${formatBytes(this.maxBufferedBytes)})`,
+        );
+      }
+    }
 
     const formatted = messages
       .map((msg, i) => {
@@ -219,12 +296,23 @@ export class ClaudeAdapter extends EventEmitter {
       })
       .join("\n\n");
 
-    this.log(`get_messages returning ${count} message(s) (instance=${this.instanceId}, dropped=${dropped})`);
+    const noticeText = notices.map((notice) => `WARNING: ${notice}`).join("\n");
+    const parts: string[] = [];
+    if (count > 0) {
+      parts.push(`[${count} new message${count > 1 ? "s" : ""} from Codex]\nchat_id: ${this.sessionId}`);
+    }
+    if (noticeText) parts.push(noticeText);
+    if (formatted) parts.push(formatted);
+
+    this.log(
+      `get_messages returning ${count} message(s) ` +
+      `(instance=${this.instanceId}, dropped=${dropped}, oversized=${oversized}, oversizedBytes=${oversizedBytes})`,
+    );
     return {
       content: [
         {
           type: "text" as const,
-          text: `${header}\n\n${formatted}`,
+          text: parts.join("\n\n"),
         },
       ],
     };
@@ -415,4 +503,29 @@ export class ClaudeAdapter extends EventEmitter {
   private log(msg: string) {
     this.logger.log(msg);
   }
+}
+
+function parsePositiveIntegerEnv(name: string, fallback: number): number {
+  return positiveIntegerOr(parseInt(process.env[name] ?? "", 10), fallback);
+}
+
+function positiveIntegerOr(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function formatSource(source: BridgeMessage["source"]): string {
+  return source === "codex" ? "Codex" : "Claude";
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes % (1024 * 1024) === 0) return `${bytes / (1024 * 1024)}MiB`;
+  if (bytes % 1024 === 0) return `${bytes / 1024}KiB`;
+  return `${bytes}B`;
 }

--- a/src/unit-test/message-delivery.test.ts
+++ b/src/unit-test/message-delivery.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { ClaudeAdapter } from "../claude-adapter";
 
 // Access internals for testing
-function createAdapter(envMode?: string): any {
+function createAdapter(
+  envMode?: string,
+  options?: { maxBufferedMessages?: number; maxBufferedBytes?: number },
+): any {
   const origMode = process.env.AGENTBRIDGE_MODE;
   const origMax = process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES;
 
@@ -12,7 +15,7 @@ function createAdapter(envMode?: string): any {
     delete process.env.AGENTBRIDGE_MODE;
   }
 
-  const adapter = new ClaudeAdapter() as any;
+  const adapter = new ClaudeAdapter(undefined, options) as any;
 
   // Restore env immediately after construction reads it
   if (origMode !== undefined) {
@@ -38,19 +41,20 @@ function makeBridgeMessage(content: string, ts?: number) {
   };
 }
 
+function withMockedChannel(adapter: any, mode: "success" | "fail" = "success") {
+  const notifications: any[] = [];
+  adapter.server = {
+    notification: async (payload: any) => {
+      if (mode === "fail") throw new Error("channel unavailable");
+      notifications.push(payload);
+    },
+  };
+  return notifications;
+}
+
 describe("Push-only delivery: AGENTBRIDGE_MODE is ignored", () => {
   // Pull mode was removed (it could not wake an idle session and silently
   // broke the budget RESUME chain). Any legacy env value must be ignored.
-  function withMockedChannel(adapter: any) {
-    const notifications: any[] = [];
-    adapter.server = {
-      notification: async (payload: any) => {
-        notifications.push(payload);
-      },
-    };
-    return notifications;
-  }
-
   test("delivers via channel when AGENTBRIDGE_MODE is unset", async () => {
     const adapter = createAdapter();
     const notifications = withMockedChannel(adapter);
@@ -101,10 +105,7 @@ describe("Message delivery: fallback queue", () => {
   });
 
   test("queueFallbackMessage drops oldest when queue is full", () => {
-    const orig = process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES;
-    process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES = "3";
-    const adapter = createAdapter();
-    process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES = orig;
+    const adapter = createAdapter(undefined, { maxBufferedMessages: 3 });
 
     adapter.queueFallbackMessage(makeBridgeMessage("msg1"));
     adapter.queueFallbackMessage(makeBridgeMessage("msg2"));
@@ -115,6 +116,43 @@ describe("Message delivery: fallback queue", () => {
     expect(adapter.pendingMessages[0].content).toBe("msg2");
     expect(adapter.pendingMessages[2].content).toBe("msg4");
     expect(adapter.droppedMessageCount).toBe(1);
+  });
+
+  test("queueFallbackMessage drops oldest until the byte cap is respected", () => {
+    const adapter = createAdapter(undefined, { maxBufferedMessages: 10, maxBufferedBytes: 8 });
+
+    adapter.queueFallbackMessage(makeBridgeMessage("aa"));
+    adapter.queueFallbackMessage(makeBridgeMessage("bbb"));
+    adapter.queueFallbackMessage(makeBridgeMessage("cccc"));
+    adapter.queueFallbackMessage(makeBridgeMessage("dd"));
+
+    expect(adapter.pendingMessages.map((m: any) => m.content)).toEqual(["cccc", "dd"]);
+    expect(adapter.pendingMessageBytes).toBe(6);
+    expect(adapter.droppedMessageCount).toBe(2);
+  });
+
+  test("queueFallbackMessage counts UTF-8 bytes, not JavaScript string length", () => {
+    const adapter = createAdapter(undefined, { maxBufferedMessages: 10, maxBufferedBytes: 7 });
+
+    adapter.queueFallbackMessage(makeBridgeMessage("éé")); // 4 UTF-8 bytes
+    adapter.queueFallbackMessage(makeBridgeMessage("abc")); // 3 UTF-8 bytes
+    adapter.queueFallbackMessage(makeBridgeMessage("d")); // drops the 4-byte message
+
+    expect(adapter.pendingMessages.map((m: any) => m.content)).toEqual(["abc", "d"]);
+    expect(adapter.pendingMessageBytes).toBe(4);
+    expect(adapter.droppedMessageCount).toBe(1);
+  });
+
+  test("queueFallbackMessage omits a single oversized message without storing its payload", () => {
+    const adapter = createAdapter(undefined, { maxBufferedMessages: 10, maxBufferedBytes: 8 });
+
+    adapter.queueFallbackMessage(makeBridgeMessage("small"));
+    adapter.queueFallbackMessage(makeBridgeMessage("x".repeat(9)));
+
+    expect(adapter.pendingMessages.map((m: any) => m.content)).toEqual(["small"]);
+    expect(adapter.pendingMessageBytes).toBe(5);
+    expect(adapter.oversizedMessageCount).toBe(1);
+    expect(adapter.oversizedMessageBytes).toBe(9);
   });
 
   test("push message ids include a session-unique prefix", async () => {
@@ -143,17 +181,25 @@ describe("Message delivery: fallback queue", () => {
 
   test("pushNotification falls back to the queue when push delivery throws", async () => {
     const adapter = createAdapter();
-
-    adapter.server = {
-      notification: async () => {
-        throw new Error("channel unavailable");
-      },
-    };
+    withMockedChannel(adapter, "fail");
 
     await adapter.pushNotification(makeBridgeMessage("fallback msg"));
 
     expect(adapter.pendingMessages).toHaveLength(1);
     expect(adapter.pendingMessages[0].content).toBe("fallback msg");
+  });
+
+  test("push recovery does not auto-replay fallback backlog or duplicate messages", async () => {
+    const adapter = createAdapter();
+    withMockedChannel(adapter, "fail");
+    await adapter.pushNotification(makeBridgeMessage("queued while push failed"));
+
+    const notifications = withMockedChannel(adapter, "success");
+    await adapter.pushNotification(makeBridgeMessage("live after recovery"));
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].params.content).toBe("live after recovery");
+    expect(adapter.pendingMessages.map((m: any) => m.content)).toEqual(["queued while push failed"]);
   });
 });
 
@@ -188,10 +234,7 @@ describe("Message delivery: drainMessages (get_messages)", () => {
   });
 
   test("includes dropped count when messages were lost", () => {
-    const orig = process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES;
-    process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES = "2";
-    const adapter = createAdapter();
-    process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES = orig;
+    const adapter = createAdapter(undefined, { maxBufferedMessages: 2 });
 
     adapter.queueFallbackMessage(makeBridgeMessage("a"));
     adapter.queueFallbackMessage(makeBridgeMessage("b"));
@@ -200,8 +243,56 @@ describe("Message delivery: drainMessages (get_messages)", () => {
     const result = adapter.drainMessages();
     const text = result.content[0].text;
     expect(text).toContain("1 older message");
-    expect(text).toContain("dropped due to queue overflow");
+    expect(text).toContain("dropped due to fallback queue overflow");
     expect(adapter.droppedMessageCount).toBe(0); // reset after drain
+  });
+
+  test("includes byte overflow and oversized notices without enqueuing sentinel messages", () => {
+    const adapter = createAdapter(undefined, { maxBufferedMessages: 10, maxBufferedBytes: 10 });
+
+    adapter.queueFallbackMessage(makeBridgeMessage("12345"));
+    adapter.queueFallbackMessage(makeBridgeMessage("abcdef"));
+    adapter.queueFallbackMessage(makeBridgeMessage("x".repeat(11)));
+
+    const result = adapter.drainMessages();
+    const text = result.content[0].text;
+
+    expect(text).toContain("[1 new message from Codex]");
+    expect(text).toContain("1 older message");
+    expect(text).toContain("dropped due to fallback queue overflow");
+    expect(text).toContain("1 oversized message from Codex omitted (>10B)");
+    expect(text).not.toContain("12345");
+    expect(text).not.toContain("xxxxxxxxxxx");
+    expect(adapter.pendingMessages).toHaveLength(0);
+    expect(adapter.pendingMessageBytes).toBe(0);
+    expect(adapter.droppedMessageCount).toBe(0);
+    expect(adapter.oversizedMessageCount).toBe(0);
+  });
+
+  test("omits empty count header when drain only has oversized notices", () => {
+    const adapter = createAdapter(undefined, { maxBufferedMessages: 10, maxBufferedBytes: 8 });
+
+    adapter.queueFallbackMessage(makeBridgeMessage("x".repeat(9)));
+
+    const result = adapter.drainMessages();
+    const text = result.content[0].text;
+
+    expect(text).not.toContain("0 new");
+    expect(text).not.toContain("[0 new message from Codex]");
+    expect(text).toContain("1 oversized message from Codex omitted (>8B)");
+  });
+
+  test("drainMessages reports no messages after clearing since-drain drop counters", () => {
+    const adapter = createAdapter(undefined, { maxBufferedMessages: 1 });
+
+    adapter.queueFallbackMessage(makeBridgeMessage("first"));
+    adapter.queueFallbackMessage(makeBridgeMessage("second"));
+
+    const firstDrain = adapter.drainMessages();
+    expect(firstDrain.content[0].text).toContain("dropped due to fallback queue overflow");
+
+    const secondDrain = adapter.drainMessages();
+    expect(secondDrain.content[0].text).toBe("No new messages from Codex.");
   });
 
   test("singular message uses correct grammar", () => {
@@ -237,6 +328,17 @@ describe("Message delivery: reply pending hint", () => {
 
     const result = await adapter.handleReply({ chat_id: "test", text: "hello codex" });
     expect(result.content[0].text).toBe("Reply sent to Codex.");
+  });
+
+  test("handleReply failures do not enqueue fallback messages", async () => {
+    const adapter = createAdapter();
+    adapter.replySender = async () => ({ success: false, error: "busy", code: "busy_reject" });
+
+    const result = await adapter.handleReply({ text: "hello codex" });
+
+    expect(result.isError).toBe(true);
+    expect(adapter.pendingMessages).toHaveLength(0);
+    expect(adapter.getPendingMessageCount()).toBe(0);
   });
 
   test("handleReply returns error when text is missing", async () => {


### PR DESCRIPTION
## 摘要 / Summary
把 claude-adapter 的 MCP fallback 队列（push 失败回退、`get_messages` 抽干）从「仅条数上界」升级为「条数 + 字节双上界」，防单条/少量超大消息吃内存。
- 既有 `AGENTBRIDGE_MAX_BUFFERED_MESSAGES`(默认100) + 新增 `AGENTBRIDGE_MAX_BUFFERED_BYTES`(默认 4 MiB, UTF-8)。
- 容量可注入 `new ClaudeAdapter(logFile, opts?)`（兼容旧单参），测试不依赖真实 env。
- FIFO drop-oldest；`drainMessages` 渲染 overflow notice（count==0 直接以 WARNING 领起，无误导性 "[0 new]" 头部），notice 不入队（守 source-loop）。
- 单条超 byte cap：不存 payload，记 oversized 计数，notice 带来源+阈值。push 恢复不 auto-replay；reply 失败不进队列。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1041 pass / 0 fail** / `verify:plugin-sync` ✅
- `message-delivery.test.ts`：count cap / byte cap / UTF-8 计数 / drop-oldest / oversized 省略 / overflow notice / oversized-only 无 "0 new" / drain reset / push 恢复无重复 / source-loop 不串。
- Cross-review：R1 发现 1 render issue（oversized-only "[0 new]" 头部）→ 已修；R2（logic+integration）**0 REAL**，运行时探针验证字节计数/淘汰/drain。

## 备注
攒批发布：release-on-merge 暂禁。