### PR TITLE
refactor: Codex→Claude 投递路由矩阵显式化为 routeCodexMessage 纯函数 / extract the routing matrix into pure routeCodexMessage

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14341,7 +14341,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("c8dba20", "source"),
+  commit: defineString("2f27278", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -21,7 +21,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("c8dba20", "source"),
+  commit: defineString("2f27278", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2399,6 +2399,37 @@ function classifyMessage(content, mode) {
     case "untagged":
       return { action: "forward", marker };
   }
+}
+function routeCodexMessage(content, ctx) {
+  const result = classifyMessage(content, ctx.mode);
+  if (ctx.replyArmed) {
+    return {
+      action: "forward",
+      marker: result.marker,
+      reason: "force-forward-reply-required",
+      flushStatusBuffer: true,
+      noteReplyForwarded: true
+    };
+  }
+  if (ctx.inAttentionWindow && result.marker === "status") {
+    return {
+      action: "buffer",
+      marker: result.marker,
+      reason: "buffer-attention"
+    };
+  }
+  if (result.action === "forward" && result.marker === "important") {
+    return {
+      ...result,
+      reason: "forward",
+      flushStatusBuffer: true,
+      startAttentionWindow: true
+    };
+  }
+  return {
+    ...result,
+    reason: result.action
+  };
 }
 var REPLY_REQUIRED_INSTRUCTION = `
 
@@ -4839,29 +4870,22 @@ codex.on("turnStarted", () => {
 codex.on("agentMessage", (msg) => {
   if (msg.source !== "codex")
     return;
-  const result = classifyMessage(msg.content, FILTER_MODE);
-  if (replyTracker.isArmed) {
-    log(`Codex \u2192 Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
+  const route = routeCodexMessage(msg.content, {
+    mode: FILTER_MODE,
+    replyArmed: replyTracker.isArmed,
+    inAttentionWindow
+  });
+  log(`Codex \u2192 Claude [${route.marker}/${route.reason}] (${msg.content.length} chars)`);
+  if (route.noteReplyForwarded) {
     replyTracker.noteForwarded();
-    if (statusBuffer.size > 0) {
-      statusBuffer.flush("reply-required message arrived");
-    }
-    emitToClaude(msg);
-    return;
   }
-  if (inAttentionWindow && result.marker === "status") {
-    log(`Codex \u2192 Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
-    statusBuffer.add(msg);
-    return;
+  if (route.flushStatusBuffer) {
+    statusBuffer.flush(route.noteReplyForwarded ? "reply-required message arrived" : "important message arrived");
   }
-  log(`Codex \u2192 Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
-  switch (result.action) {
+  switch (route.action) {
     case "forward":
-      if (result.marker === "important" && statusBuffer.size > 0) {
-        statusBuffer.flush("important message arrived");
-      }
       emitToClaude(msg);
-      if (result.marker === "important") {
+      if (route.startAttentionWindow) {
         startAttentionWindow();
       }
       break;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -8,7 +8,7 @@ import { validateClaudeClientIdentity, evaluateInjectionAttachGuard } from "./da
 import {
   REPLY_REQUIRED_INSTRUCTION,
   StatusBuffer,
-  classifyMessage,
+  routeCodexMessage,
   type FilterMode,
 } from "./message-filter";
 import { TuiConnectionState } from "./tui-connection-state";
@@ -440,35 +440,26 @@ codex.on("turnStarted", () => {
 
 codex.on("agentMessage", (msg: BridgeMessage) => {
   if (msg.source !== "codex") return;
-  const result = classifyMessage(msg.content, FILTER_MODE);
+  const route = routeCodexMessage(msg.content, {
+    mode: FILTER_MODE,
+    replyArmed: replyTracker.isArmed,
+    inAttentionWindow,
+  });
 
-  // When require_reply is armed, force-forward ALL messages regardless of marker
-  if (replyTracker.isArmed) {
-    log(`Codex → Claude [${result.marker}/force-forward-reply-required] (${msg.content.length} chars)`);
+  log(`Codex → Claude [${route.marker}/${route.reason}] (${msg.content.length} chars)`);
+
+  if (route.noteReplyForwarded) {
     replyTracker.noteForwarded();
-    if (statusBuffer.size > 0) {
-      statusBuffer.flush("reply-required message arrived");
-    }
-    emitToClaude(msg);
-    return;
   }
 
-  // During attention window, suppress STATUS to give Claude space to respond
-  if (inAttentionWindow && result.marker === "status") {
-    log(`Codex → Claude [${result.marker}/buffer-attention] (${msg.content.length} chars)`);
-    statusBuffer.add(msg);
-    return;
+  if (route.flushStatusBuffer) {
+    statusBuffer.flush(route.noteReplyForwarded ? "reply-required message arrived" : "important message arrived");
   }
 
-  log(`Codex → Claude [${result.marker}/${result.action}] (${msg.content.length} chars)`);
-  switch (result.action) {
+  switch (route.action) {
     case "forward":
-      if (result.marker === "important" && statusBuffer.size > 0) {
-        statusBuffer.flush("important message arrived");
-      }
       emitToClaude(msg);
-      // IMPORTANT message — give Claude an attention window to respond
-      if (result.marker === "important") {
+      if (route.startAttentionWindow) {
         startAttentionWindow();
       }
       break;

--- a/src/message-filter.ts
+++ b/src/message-filter.ts
@@ -8,6 +8,19 @@ export interface FilterResult {
   marker: MarkerLevel;
 }
 
+export interface RouteCodexMessageContext {
+  mode: FilterMode;
+  replyArmed: boolean;
+  inAttentionWindow: boolean;
+}
+
+export interface RouteCodexMessageResult extends FilterResult {
+  reason: "forward" | "buffer" | "drop" | "buffer-attention" | "force-forward-reply-required";
+  flushStatusBuffer?: boolean;
+  startAttentionWindow?: boolean;
+  noteReplyForwarded?: boolean;
+}
+
 const MARKER_REGEX = /^\s*\[(IMPORTANT|STATUS|FYI)\]\s*/i;
 
 export function parseMarker(content: string): { marker: MarkerLevel; body: string } {
@@ -32,6 +45,45 @@ export function classifyMessage(content: string, mode: FilterMode): FilterResult
     case "untagged":
       return { action: "forward", marker };
   }
+}
+
+export function routeCodexMessage(
+  content: string,
+  ctx: RouteCodexMessageContext,
+): RouteCodexMessageResult {
+  const result = classifyMessage(content, ctx.mode);
+
+  if (ctx.replyArmed) {
+    return {
+      action: "forward",
+      marker: result.marker,
+      reason: "force-forward-reply-required",
+      flushStatusBuffer: true,
+      noteReplyForwarded: true,
+    };
+  }
+
+  if (ctx.inAttentionWindow && result.marker === "status") {
+    return {
+      action: "buffer",
+      marker: result.marker,
+      reason: "buffer-attention",
+    };
+  }
+
+  if (result.action === "forward" && result.marker === "important") {
+    return {
+      ...result,
+      reason: "forward",
+      flushStatusBuffer: true,
+      startAttentionWindow: true,
+    };
+  }
+
+  return {
+    ...result,
+    reason: result.action,
+  };
 }
 
 // NOTE: the static "bridge contract" (message markers, git-write prohibition,

--- a/src/unit-test/daemon-wiring.test.ts
+++ b/src/unit-test/daemon-wiring.test.ts
@@ -131,6 +131,66 @@ describe("daemon wiring", () => {
     expect(aborted.content).toContain("retry");
   }, 20000);
 
+  test("filtered routing buffers STATUS, flushes it on IMPORTANT, then buffers STATUS during attention", async () => {
+    const harness = await startHarness({
+      pairId: "main-routeabcd",
+      pairName: "main",
+      extraEnv: { AGENTBRIDGE_ATTENTION_WINDOW_MS: "1000" },
+    });
+
+    await harness.attachClaude();
+    await harness.connectTui();
+
+    harness.sendAppCommand("agent-message:[STATUS] buffered before important");
+    await sleep(200);
+    expect(harness.messages.some((m) => m.content.includes("buffered before important"))).toBe(false);
+
+    harness.sendAppCommand("agent-message:[IMPORTANT] important flush trigger");
+    const summary = await waitForMessage(
+      harness.messages,
+      (message) => message.content.includes("buffered before important"),
+      "status summary flushed by IMPORTANT",
+    );
+    const important = await waitForMessage(
+      harness.messages,
+      (message) => message.content.includes("important flush trigger"),
+      "forwarded IMPORTANT message",
+    );
+
+    expect(summary.content).toContain("[STATUS summary");
+    expect(important.content).toContain("[IMPORTANT] important flush trigger");
+
+    harness.sendAppCommand("agent-message:[STATUS] buffered during attention");
+    await sleep(200);
+    expect(harness.messages.some((m) => m.content.includes("buffered during attention"))).toBe(false);
+  }, 20000);
+
+  test("full mode forwards IMPORTANT without opening an attention window", async () => {
+    const harness = await startHarness({
+      pairId: "main-fullroute",
+      pairName: "main",
+      extraEnv: {
+        AGENTBRIDGE_FILTER_MODE: "full",
+        AGENTBRIDGE_ATTENTION_WINDOW_MS: "1000",
+      },
+    });
+
+    await harness.attachClaude();
+    await harness.connectTui();
+
+    harness.sendAppCommand("agent-message:[IMPORTANT] full mode important");
+    await waitForMessage(
+      harness.messages,
+      (message) => message.content.includes("full mode important"),
+      "full-mode IMPORTANT",
+    );
+
+    const res = await fetch(`http://127.0.0.1:${harness.controlPort}/healthz`);
+    expect(res.ok).toBe(true);
+    const status = (await res.json()) as DaemonStatus;
+    expect(status.attentionWindowActive).toBe(false);
+  }, 20000);
+
   test("budget pause gate: STOP directive, reply rejected, RESUME reopens", async () => {
     // Fixture probe driven by per-agent JSON files the test rewrites at runtime
     // (explicit AGENTBRIDGE_QUOTA_PROBE is exclusive — no fallback to real probes).
@@ -1271,6 +1331,7 @@ const commandFile = process.env.FAKE_APP_COMMAND_FILE;
 let appWs = null;
 let lastStartedTurnId = null;
 let turnStartCounter = 0;
+let agentMessageCounter = 0;
 
 const server = Bun.serve({
   hostname: "127.0.0.1",
@@ -1367,6 +1428,13 @@ setInterval(() => {
   if (command === "complete-turn" && lastStartedTurnId) {
     appWs.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: lastStartedTurnId } } }));
     lastStartedTurnId = null;
+  }
+  if (command.startsWith("agent-message:")) {
+    const content = command.slice("agent-message:".length);
+    const id = "agent-message-" + (++agentMessageCounter);
+    appWs.send(JSON.stringify({ method: "item/started", params: { item: { id, type: "agentMessage" } } }));
+    appWs.send(JSON.stringify({ method: "item/agentMessage/delta", params: { itemId: id, delta: content } }));
+    appWs.send(JSON.stringify({ method: "item/completed", params: { item: { id, type: "agentMessage" } } }));
   }
   if (command === "close-app-server") {
     appWs.close(1011, "test app-server close");

--- a/src/unit-test/message-filter.test.ts
+++ b/src/unit-test/message-filter.test.ts
@@ -3,6 +3,7 @@ import {
   StatusBuffer,
   classifyMessage,
   parseMarker,
+  routeCodexMessage,
 } from "../message-filter";
 import type { BridgeMessage } from "../types";
 
@@ -70,6 +71,101 @@ describe("classifyMessage", () => {
   test("forwards everything in full mode", () => {
     expect(classifyMessage("[FYI] x", "full")).toEqual({ action: "forward", marker: "untagged" });
     expect(classifyMessage("[STATUS] x", "full")).toEqual({ action: "forward", marker: "untagged" });
+  });
+});
+
+describe("routeCodexMessage", () => {
+  const markerCases = [
+    { marker: "important", content: "[IMPORTANT] important update" },
+    { marker: "status", content: "[STATUS] progress update" },
+    { marker: "fyi", content: "[FYI] background update" },
+    { marker: "untagged", content: "plain update" },
+  ] as const;
+
+  test("covers the full mode x reply armed x attention window x marker matrix", () => {
+    for (const mode of ["filtered", "full"] as const) {
+      for (const replyArmed of [false, true]) {
+        for (const inAttentionWindow of [false, true]) {
+          for (const markerCase of markerCases) {
+            const route = routeCodexMessage(markerCase.content, { mode, replyArmed, inAttentionWindow });
+
+            if (replyArmed) {
+              expect(route).toEqual({
+                action: "forward",
+                marker: mode === "full" ? "untagged" : markerCase.marker,
+                reason: "force-forward-reply-required",
+                flushStatusBuffer: true,
+                noteReplyForwarded: true,
+              });
+              continue;
+            }
+
+            if (mode === "full") {
+              expect(route).toEqual({
+                action: "forward",
+                marker: "untagged",
+                reason: "forward",
+              });
+              continue;
+            }
+
+            if (inAttentionWindow && markerCase.marker === "status") {
+              expect(route).toEqual({
+                action: "buffer",
+                marker: "status",
+                reason: "buffer-attention",
+              });
+              continue;
+            }
+
+            switch (markerCase.marker) {
+              case "important":
+                expect(route).toEqual({
+                  action: "forward",
+                  marker: "important",
+                  reason: "forward",
+                  flushStatusBuffer: true,
+                  startAttentionWindow: true,
+                });
+                break;
+              case "status":
+                expect(route).toEqual({
+                  action: "buffer",
+                  marker: "status",
+                  reason: "buffer",
+                });
+                break;
+              case "fyi":
+                expect(route).toEqual({
+                  action: "drop",
+                  marker: "fyi",
+                  reason: "drop",
+                });
+                break;
+              case "untagged":
+                expect(route).toEqual({
+                  action: "forward",
+                  marker: "untagged",
+                  reason: "forward",
+                });
+                break;
+            }
+          }
+        }
+      }
+    }
+  });
+
+  test("does not start an attention window for IMPORTANT in full mode", () => {
+    expect(routeCodexMessage("[IMPORTANT] x", {
+      mode: "full",
+      replyArmed: false,
+      inAttentionWindow: false,
+    })).toEqual({
+      action: "forward",
+      marker: "untagged",
+      reason: "forward",
+    });
   });
 });
 


### PR DESCRIPTION
## 摘要 / Summary
arch-review P1 #333：把散在 daemon.ts agentMessage 回调里的 Codex→Claude 投递决策矩阵抽成 message-filter.ts 的纯函数 `routeCodexMessage`，**行为逐位保持**。
- `routeCodexMessage(content, ctx:{mode, replyArmed, inAttentionWindow}) → {action: forward|buffer|drop, marker, reason, flushStatusBuffer?, startAttentionWindow?, noteReplyForwarded?}`。
- daemon.ts 回调改为消费 route 结果按 flags 执行原副作用（noteForwarded / statusBuffer flush / emitToClaude / startAttentionWindow），**顺序与条件逐位保持**。
- 决策表保持：full mode IMPORTANT 不启 attention window；replyArmed 强制 forward+flush+noteForwarded；filtered STATUS 缓冲（attention 感知）；FYI drop；untagged forward。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1065 pass / 0 fail**（rebase 到含 #283 的 master 后全量）/ `verify:plugin-sync` ✅
- message-filter.test.ts 完整 32 格矩阵；daemon-wiring.test.ts 加 filtered/full routing 集成哨兵 + fake `agent-message:` 命令驱动真实 codex-adapter 装配路径。
- Cross-review：2 独立 reviewer（32-cell 矩阵等价 + daemon 副作用顺序对齐 HEAD）round-1 **0 REAL**。

## 备注
攒批发布：release-on-merge 暂禁。daemon.ts 与 #283 不同区已自动三方合并（full gate 复验 1065 pass）。