### PR TITLE
refactor: BudgetCoordinator 抽出显式状态机 classifyPoll 纯 reducer / extract BudgetCoordinator into a pure classifyPoll state-machine reducer

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14341,7 +14341,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("2f27278", "source"),
+  commit: defineString("2981e06", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -21,7 +21,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("2f27278", "source"),
+  commit: defineString("2981e06", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -3338,6 +3338,27 @@ class ConfigService {
   }
 }
 
+// src/budget/budget-gate.ts
+function matchingGateReset(usage) {
+  if (!usage)
+    return 0;
+  const windows = [usage.fiveHour, usage.weekly].filter((window) => !!window && window.resetEpoch > 0);
+  const matching = windows.filter((window) => Math.abs(window.util - usage.gateUtil) < 0.0001);
+  const candidates = matching.length > 0 ? matching : windows;
+  if (candidates.length === 0)
+    return 0;
+  return Math.min(...candidates.map((window) => window.resetEpoch));
+}
+function resumeBlockingEpoch(usage, cfg, now) {
+  if (!usage)
+    return 0;
+  if (usage.rateLimitedUntil > now)
+    return usage.rateLimitedUntil;
+  if (usage.gateUtil >= cfg.resumeBelow)
+    return matchingGateReset(usage);
+  return 0;
+}
+
 // src/budget/types.ts
 var STALE_MAX_AGE_SEC = 600;
 
@@ -3361,25 +3382,6 @@ function usageSummary(name, usage) {
   if (!usage)
     return `${AGENT_LABEL[name]} \u672A\u77E5`;
   return `${AGENT_LABEL[name]} gate=${pct(usage.gateUtil)} warn=${pct(usage.warnUtil)} 5h\u91CD\u7F6E=${formatEpoch(usage.fiveHour?.resetEpoch ?? 0)}`;
-}
-function matchingGateReset(usage) {
-  if (!usage)
-    return 0;
-  const windows = [usage.fiveHour, usage.weekly].filter((window) => !!window && window.resetEpoch > 0);
-  const matching = windows.filter((window) => Math.abs(window.util - usage.gateUtil) < 0.0001);
-  const candidates = matching.length > 0 ? matching : windows;
-  if (candidates.length === 0)
-    return 0;
-  return Math.min(...candidates.map((window) => window.resetEpoch));
-}
-function resumeBlockingEpoch(usage, cfg, now) {
-  if (!usage)
-    return 0;
-  if (usage.rateLimitedUntil > now)
-    return usage.rateLimitedUntil;
-  if (usage.gateUtil >= cfg.resumeBelow)
-    return matchingGateReset(usage);
-  return 0;
 }
 function resumeAfterEpoch(claude, codex, cfg, now) {
   const epochs = [
@@ -3563,8 +3565,162 @@ function computeBudgetState(claude, codex, cfg, now) {
   };
 }
 
-// src/budget/budget-coordinator.ts
+// src/budget/budget-fingerprint.ts
 var RESET_FINGERPRINT_BUCKET_SEC = 600;
+var AGENT_LABEL2 = {
+  claude: "Claude",
+  codex: "Codex"
+};
+function pct2(value) {
+  return `${Math.round(value * 10) / 10}%`;
+}
+function formatEpoch2(epoch) {
+  return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+}
+var INITIAL_FINGERPRINT_STATE = {
+  side: null,
+  fingerprint: null,
+  resumeEpoch: null,
+  reason: null
+};
+function sideToAgents(side) {
+  if (side === "both")
+    return ["claude", "codex"];
+  if (side === "claude")
+    return ["claude"];
+  if (side === "codex")
+    return ["codex"];
+  return [];
+}
+function agentsToSide(agents) {
+  const claude = agents.has("claude");
+  const codex = agents.has("codex");
+  if (claude && codex)
+    return "both";
+  if (claude)
+    return "claude";
+  if (codex)
+    return "codex";
+  return null;
+}
+function shouldEnter(usage, cfg, now) {
+  if (!isDecisionGrade(usage, now))
+    return false;
+  return usage.gateUtil >= cfg.pauseAt;
+}
+function canAgentResume(usage, cfg, now) {
+  if (!isDecisionGrade(usage, now))
+    return false;
+  if (usage.rateLimitedUntil > now)
+    return false;
+  return usage.gateUtil < cfg.resumeBelow;
+}
+function nextActiveSide(prevSide, state, cfg) {
+  const active = new Set(sideToAgents(prevSide));
+  for (const agent of ["claude", "codex"]) {
+    const usage = state.perAgent[agent];
+    if (shouldEnter(usage, cfg, state.now)) {
+      active.add(agent);
+    } else if (active.has(agent) && canAgentResume(usage, cfg, state.now)) {
+      active.delete(agent);
+    }
+  }
+  return agentsToSide(active);
+}
+function activeSideReason(agent, usage, cfg, now) {
+  if (!usage)
+    return `${AGENT_LABEL2[agent]} \u63A2\u6D4B\u6682\u65F6\u4E0D\u53EF\u7528\uFF0C\u4FDD\u6301\u4E0A\u4E00\u8F6E\u9884\u7B97\u5E72\u9884`;
+  if (usage.rateLimitedUntil > now) {
+    return `${AGENT_LABEL2[agent]} \u63A2\u9488\u88AB\u9650\u6D41\u81F3 ${formatEpoch2(usage.rateLimitedUntil)}`;
+  }
+  if (usage.gateUtil >= cfg.pauseAt) {
+    return `${AGENT_LABEL2[agent]} gateUtil ${pct2(usage.gateUtil)} \u2265 pauseAt ${pct2(cfg.pauseAt)}`;
+  }
+  return `${AGENT_LABEL2[agent]} gateUtil ${pct2(usage.gateUtil)} \u5C1A\u672A\u4F4E\u4E8E resumeBelow ${pct2(cfg.resumeBelow)}`;
+}
+function interventionReason(side, state, cfg) {
+  return sideToAgents(side).map((agent) => activeSideReason(agent, state.perAgent[agent], cfg, state.now)).join("\uFF1B");
+}
+function resumeAfterEpoch2(side, state, cfg) {
+  const epochs = sideToAgents(side).map((agent) => resumeBlockingEpoch(state.perAgent[agent], cfg, state.now)).filter((epoch) => epoch > 0);
+  if (epochs.length === 0)
+    return null;
+  return Math.max(...epochs);
+}
+function activeSideProbeUncertain(side, state) {
+  return sideToAgents(side).some((agent) => {
+    const usage = state.perAgent[agent];
+    return usage === null || usage.rateLimitedUntil > state.now || !isDecisionGrade(usage, state.now);
+  });
+}
+function directiveFingerprint(state, activeSide) {
+  const side = activeSide ?? (state.phase === "balance" ? state.drift.lighter ?? "none" : state.pause.side ?? "none");
+  let reset = 0;
+  if (activeSide === "claude") {
+    reset = state.pause.resetEpochs.claude;
+  } else if (activeSide === "codex") {
+    reset = state.pause.resetEpochs.codex;
+  } else if (activeSide === "both") {
+    reset = Math.max(state.pause.resetEpochs.claude, state.pause.resetEpochs.codex);
+  } else if (state.phase === "balance" && state.drift.lighter) {
+    reset = state.perAgent[state.drift.lighter]?.fiveHour?.resetEpoch ?? 0;
+  }
+  return [
+    activeSide ? "paused" : state.phase,
+    state.drift.heavier ?? "none",
+    side,
+    Math.round(reset / RESET_FINGERPRINT_BUCKET_SEC)
+  ].join("|");
+}
+function classifyPoll(prev, state, cfg) {
+  const previousSide = prev.side;
+  const currentSide = nextActiveSide(previousSide, state, cfg);
+  if (currentSide) {
+    const reason = interventionReason(currentSide, state, cfg);
+    const nextResumeRaw = resumeAfterEpoch2(currentSide, state, cfg);
+    const resumeEpoch = previousSide === currentSide ? nextResumeRaw ?? prev.resumeEpoch : nextResumeRaw;
+    const uncertain = previousSide === currentSide && activeSideProbeUncertain(currentSide, state) && prev.fingerprint;
+    const fingerprint2 = uncertain ? prev.fingerprint : directiveFingerprint(state, currentSide);
+    const pauseChanged = !previousSide;
+    const emit = !previousSide || previousSide !== currentSide || fingerprint2 !== prev.fingerprint;
+    return {
+      next: { side: currentSide, fingerprint: fingerprint2, resumeEpoch, reason },
+      effect: {
+        kind: uncertain ? "hold-uncertain" : "enter",
+        side: currentSide,
+        reason,
+        resumeEpoch,
+        emit,
+        pauseChanged
+      }
+    };
+  }
+  if (previousSide) {
+    return {
+      next: { side: null, fingerprint: null, resumeEpoch: null, reason: null },
+      effect: { kind: "exit", previousSide }
+    };
+  }
+  if (!isDecisionGrade(state.perAgent.claude, state.now) || !isDecisionGrade(state.perAgent.codex, state.now)) {
+    return { next: prev, effect: { kind: "none" } };
+  }
+  if (!state.directiveToClaude) {
+    return {
+      next: { side: null, fingerprint: null, resumeEpoch: null, reason: null },
+      effect: { kind: "none" }
+    };
+  }
+  const fingerprint = directiveFingerprint(state);
+  if (fingerprint !== prev.fingerprint) {
+    return {
+      next: { side: null, fingerprint, resumeEpoch: null, reason: null },
+      effect: { kind: "advise", phase: state.phase }
+    };
+  }
+  return { next: prev, effect: { kind: "none" } };
+}
+
+// src/budget/budget-coordinator.ts
 var LOW_UTIL_PCT = 50;
 var NEAR_PAUSE_MARGIN_PCT = 10;
 var NEAR_WARN_UTIL_PCT = 75;
@@ -3582,27 +3738,17 @@ var REAL_BUDGET_POLL_SCHEDULER = {
     clearTimeout(timer);
   }
 };
-var AGENT_LABEL2 = {
+var AGENT_LABEL3 = {
   claude: "Claude",
   codex: "Codex"
 };
-function pct2(value) {
+function pct3(value) {
   return `${Math.round(value * 10) / 10}%`;
 }
 function usageLine(agent, usage) {
   if (!usage)
-    return `${AGENT_LABEL2[agent]} \u672A\u77E5`;
-  return `${AGENT_LABEL2[agent]} gate=${pct2(usage.gateUtil)} warn=${pct2(usage.warnUtil)}`;
-}
-function matchingGateReset2(usage) {
-  if (!usage)
-    return 0;
-  const windows = [usage.fiveHour, usage.weekly].filter((window) => !!window && window.resetEpoch > 0);
-  const matching = windows.filter((window) => Math.abs(window.util - usage.gateUtil) < 0.0001);
-  const candidates = matching.length > 0 ? matching : windows;
-  if (candidates.length === 0)
-    return 0;
-  return Math.min(...candidates.map((window) => window.resetEpoch));
+    return `${AGENT_LABEL3[agent]} \u672A\u77E5`;
+  return `${AGENT_LABEL3[agent]} gate=${pct3(usage.gateUtil)} warn=${pct3(usage.warnUtil)}`;
 }
 function maxPollDelayMs(config) {
   return Math.max(0, config.pollSeconds * 1000);
@@ -3665,11 +3811,8 @@ class BudgetCoordinator {
   log;
   timer = null;
   running = false;
-  activeSides = new Set;
-  lastDirectiveFingerprint = null;
+  fpState = INITIAL_FINGERPRINT_STATE;
   latestSnapshot = null;
-  pauseReason = null;
-  pauseResumeAfterEpoch = null;
   pendingOverrideTier = null;
   pendingOverrides = null;
   lastAppliedTier = "full";
@@ -3701,10 +3844,10 @@ class BudgetCoordinator {
     }
   }
   isPaused() {
-    return this.activeSides.size > 0;
+    return this.fpState.side !== null;
   }
   isGateClosed() {
-    return this.activeSides.has("codex");
+    return this.fpState.side === "codex" || this.fpState.side === "both";
   }
   getSnapshot() {
     return this.latestSnapshot;
@@ -3774,81 +3917,31 @@ class BudgetCoordinator {
     this.onSnapshot(snapshot);
   }
   applyState(state) {
-    const previousSide = this.pauseSide();
-    this.updateActiveSides(state);
-    const currentSide = this.pauseSide();
-    if (currentSide) {
-      this.pauseReason = this.interventionReason(state);
-      const nextResumeAfterEpoch = this.resumeAfterEpoch(state);
-      this.pauseResumeAfterEpoch = previousSide === currentSide ? nextResumeAfterEpoch ?? this.pauseResumeAfterEpoch : nextResumeAfterEpoch;
-      const fingerprint2 = previousSide === currentSide && this.activeSideProbeUncertain(state) && this.lastDirectiveFingerprint ? this.lastDirectiveFingerprint : this.directiveFingerprint(state, currentSide);
-      if (!previousSide) {
-        this.onPauseChange(true);
+    const { next, effect } = classifyPoll(this.fpState, state, this.config);
+    this.fpState = next;
+    switch (effect.kind) {
+      case "enter":
+      case "hold-uncertain": {
+        if (effect.pauseChanged)
+          this.onPauseChange(true);
+        if (effect.emit) {
+          this.emitDirective(this.interventionPrefix(effect.side), this.interventionDirective(state, effect.side, effect.reason, effect.resumeEpoch));
+        }
+        return;
       }
-      if (!previousSide || previousSide !== currentSide || fingerprint2 !== this.lastDirectiveFingerprint) {
-        this.emitDirective(this.interventionPrefix(currentSide), this.interventionDirective(state, currentSide));
+      case "exit": {
+        this.onPauseChange(false);
+        this.emitDirective(this.recoveryPrefix(effect.previousSide), this.recoveryDirective(state, effect.previousSide));
+        return;
       }
-      this.lastDirectiveFingerprint = fingerprint2;
-      return;
-    }
-    if (previousSide) {
-      this.pauseReason = null;
-      this.pauseResumeAfterEpoch = null;
-      this.lastDirectiveFingerprint = null;
-      this.onPauseChange(false);
-      this.emitDirective(this.recoveryPrefix(previousSide), this.recoveryDirective(state, previousSide));
-      return;
-    }
-    if (!isDecisionGrade(state.perAgent.claude, state.now) || !isDecisionGrade(state.perAgent.codex, state.now)) {
-      return;
-    }
-    if (!state.directiveToClaude) {
-      this.lastDirectiveFingerprint = null;
-      return;
-    }
-    const fingerprint = this.directiveFingerprint(state);
-    if (fingerprint !== this.lastDirectiveFingerprint) {
-      const prefix = state.phase === "balance" ? "system_budget_balance" : "system_budget_parallel";
-      this.emitDirective(prefix, state.directiveToClaude);
-      this.lastDirectiveFingerprint = fingerprint;
-    }
-  }
-  updateActiveSides(state) {
-    for (const agent of ["claude", "codex"]) {
-      const usage = state.perAgent[agent];
-      if (this.shouldEnter(usage, state.now)) {
-        this.activeSides.add(agent);
-      } else if (this.activeSides.has(agent) && this.canAgentResume(usage, state.now)) {
-        this.activeSides.delete(agent);
+      case "advise": {
+        const prefix = effect.phase === "balance" ? "system_budget_balance" : "system_budget_parallel";
+        this.emitDirective(prefix, state.directiveToClaude);
+        return;
       }
+      case "none":
+        return;
     }
-  }
-  shouldEnter(usage, now) {
-    if (!isDecisionGrade(usage, now))
-      return false;
-    return usage.gateUtil >= this.config.pauseAt;
-  }
-  canAgentResume(usage, now) {
-    if (!isDecisionGrade(usage, now))
-      return false;
-    if (usage.rateLimitedUntil > now)
-      return false;
-    return usage.gateUtil < this.config.resumeBelow;
-  }
-  resumeAfterEpoch(state) {
-    const epochs = ["claude", "codex"].filter((agent) => this.activeSides.has(agent)).map((agent) => this.resumeBlockingEpoch(state.perAgent[agent], state.now)).filter((epoch) => epoch > 0);
-    if (epochs.length === 0)
-      return null;
-    return Math.max(...epochs);
-  }
-  resumeBlockingEpoch(usage, now) {
-    if (!usage)
-      return 0;
-    if (usage.rateLimitedUntil > now)
-      return usage.rateLimitedUntil;
-    if (usage.gateUtil >= this.config.resumeBelow)
-      return matchingGateReset2(usage);
-    return 0;
   }
   tierControlEnabled() {
     if (!this.config.codexTierControl)
@@ -3883,44 +3976,8 @@ class BudgetCoordinator {
     this.pendingOverrideTier = tier;
     this.pendingOverrides = { ...overrides };
   }
-  directiveFingerprint(state, activeSide) {
-    const side = activeSide ?? (state.phase === "balance" ? state.drift.lighter ?? "none" : state.pause.side ?? "none");
-    let reset = 0;
-    if (activeSide === "claude") {
-      reset = state.pause.resetEpochs.claude;
-    } else if (activeSide === "codex") {
-      reset = state.pause.resetEpochs.codex;
-    } else if (activeSide === "both") {
-      reset = Math.max(state.pause.resetEpochs.claude, state.pause.resetEpochs.codex);
-    } else if (state.phase === "balance" && state.drift.lighter) {
-      reset = state.perAgent[state.drift.lighter]?.fiveHour?.resetEpoch ?? 0;
-    } else if (side === "claude") {
-      reset = state.pause.resetEpochs.claude;
-    } else if (side === "codex") {
-      reset = state.pause.resetEpochs.codex;
-    } else if (side === "both") {
-      reset = Math.max(state.pause.resetEpochs.claude, state.pause.resetEpochs.codex);
-    }
-    return [
-      activeSide ? "paused" : state.phase,
-      state.drift.heavier ?? "none",
-      side,
-      Math.round(reset / RESET_FINGERPRINT_BUCKET_SEC)
-    ].join("|");
-  }
   emitDirective(prefix, content) {
     this.emit(`${prefix}_${this.sequence++}`, content);
-  }
-  pauseSide() {
-    const claude = this.activeSides.has("claude");
-    const codex = this.activeSides.has("codex");
-    if (claude && codex)
-      return "both";
-    if (claude)
-      return "claude";
-    if (codex)
-      return "codex";
-    return null;
   }
   interventionPrefix(side) {
     return side === "claude" ? "system_budget_handoff" : "system_budget_pause";
@@ -3928,37 +3985,15 @@ class BudgetCoordinator {
   recoveryPrefix(previousSide) {
     return previousSide === "claude" ? "system_budget_claude_recovered" : "system_budget_resume";
   }
-  interventionDirective(state, side) {
-    return renderBudgetInterventionDirective(state.perAgent.claude, state.perAgent.codex, side, this.pauseReason ?? "\u9884\u7B97\u63A5\u8FD1\u8017\u5C3D", this.pauseResumeAfterEpoch, this.config);
-  }
-  interventionReason(state) {
-    return ["claude", "codex"].filter((agent) => this.activeSides.has(agent)).map((agent) => this.activeSideReason(agent, state.perAgent[agent], state.now)).join("\uFF1B");
-  }
-  activeSideProbeUncertain(state) {
-    return ["claude", "codex"].some((agent) => {
-      if (!this.activeSides.has(agent))
-        return false;
-      const usage = state.perAgent[agent];
-      return usage === null || usage.rateLimitedUntil > state.now || !isDecisionGrade(usage, state.now);
-    });
-  }
-  activeSideReason(agent, usage, now) {
-    if (!usage)
-      return `${AGENT_LABEL2[agent]} \u63A2\u6D4B\u6682\u65F6\u4E0D\u53EF\u7528\uFF0C\u4FDD\u6301\u4E0A\u4E00\u8F6E\u9884\u7B97\u5E72\u9884`;
-    if (usage.rateLimitedUntil > now) {
-      return `${AGENT_LABEL2[agent]} \u63A2\u9488\u88AB\u9650\u6D41\u81F3 ${this.formatEpoch(usage.rateLimitedUntil)}`;
-    }
-    if (usage.gateUtil >= this.config.pauseAt) {
-      return `${AGENT_LABEL2[agent]} gateUtil ${pct2(usage.gateUtil)} \u2265 pauseAt ${pct2(this.config.pauseAt)}`;
-    }
-    return `${AGENT_LABEL2[agent]} gateUtil ${pct2(usage.gateUtil)} \u5C1A\u672A\u4F4E\u4E8E resumeBelow ${pct2(this.config.resumeBelow)}`;
+  interventionDirective(state, side, reason, resumeEpoch) {
+    return renderBudgetInterventionDirective(state.perAgent.claude, state.perAgent.codex, side, reason || "\u9884\u7B97\u63A5\u8FD1\u8017\u5C3D", resumeEpoch, this.config);
   }
   recoveryDirective(state, previousSide) {
     if (previousSide === "claude") {
       return [
         "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Claude \u4FA7\u9884\u7B97\u5DF2\u6062\u590D\u3002",
         `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
-        `Claude gateUtil \u5DF2\u4F4E\u4E8E ${pct2(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
+        `Claude gateUtil \u5DF2\u4F4E\u4E8E ${pct3(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
         "Claude \u53EF\u6062\u590D orchestrator \u89D2\u8272\uFF1B\u540E\u7EED\u5206\u914D\u524D\u8BF7\u91CD\u65B0\u67E5\u8BE2\u5B9E\u65F6\u989D\u5EA6\uFF0C\u4E0D\u8981\u4F9D\u8D56\u65E7\u6570\u5B57\u3002"
       ].join(`
 `);
@@ -3967,7 +4002,7 @@ class BudgetCoordinator {
       return [
         "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Codex \u4FA7\u9884\u7B97\u95F8\u95E8\u89E3\u9664\u3002",
         `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
-        `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1ACodex gateUtil \u4F4E\u4E8E ${pct2(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
+        `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1ACodex gateUtil \u4F4E\u4E8E ${pct3(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
         "\u5EFA\u8BAE Claude \u7528 reply \u5E26\u4E0A\u5F53\u524D\u76EE\u6807\u3001checkpoint \u548C\u4E0B\u4E00\u6B65\uFF0C\u5524\u9192 Codex \u63A5\u7EED\u6267\u884C\u3002"
       ].join(`
 `);
@@ -3975,13 +4010,10 @@ class BudgetCoordinator {
     return [
       "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011\u8054\u5408\u6682\u505C\u89E3\u9664\u3002",
       `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
-      `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1A\u53CC\u65B9 gateUtil \u5747\u4F4E\u4E8E ${pct2(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
+      `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1A\u53CC\u65B9 gateUtil \u5747\u4F4E\u4E8E ${pct3(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
       "\u5EFA\u8BAE Claude \u7528 reply \u5E26\u4E0A\u5F53\u524D\u76EE\u6807\u3001checkpoint \u548C\u4E0B\u4E00\u6B65\uFF0C\u5524\u9192 Codex \u63A5\u7EED\u6267\u884C\u3002"
     ].join(`
 `);
-  }
-  formatEpoch(epoch) {
-    return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
   }
   toSnapshot(state) {
     const paused = this.isPaused();
@@ -3993,9 +4025,9 @@ class BudgetCoordinator {
       driftPct: state.drift.pct,
       paused,
       gateClosed: this.isGateClosed(),
-      pauseSide: this.pauseSide(),
-      pauseReason: paused ? this.pauseReason ?? state.pause.reason : null,
-      resumeAfterEpoch: paused ? this.pauseResumeAfterEpoch ?? state.pause.resumeAfterEpoch : null,
+      pauseSide: this.fpState.side,
+      pauseReason: paused ? this.fpState.reason ?? state.pause.reason : null,
+      resumeAfterEpoch: paused ? this.fpState.resumeEpoch ?? state.pause.resumeAfterEpoch : null,
       parallelRecommended: paused ? false : state.parallel.recommended,
       codexTier: state.effort.codexTier,
       claudeAdvice: state.effort.claudeAdvice
@@ -5165,8 +5197,8 @@ async function handleClaudeToCodex(ws, message) {
   if (budgetCoordinator?.isGateClosed()) {
     const reason = budgetPauseGateError();
     log(`Injection rejected by budget pause gate`);
-    const resumeAfterEpoch2 = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
-    const retryAfterMs = resumeAfterEpoch2 !== null ? Math.max(0, resumeAfterEpoch2 * 1000 - Date.now()) : undefined;
+    const resumeAfterEpoch3 = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
+    const retryAfterMs = resumeAfterEpoch3 !== null ? Math.max(0, resumeAfterEpoch3 * 1000 - Date.now()) : undefined;
     sendClaudeToCodexResult(ws, message.requestId, {
       success: false,
       code: "budget_paused",

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -1,4 +1,9 @@
-import { computeBudgetState, isDecisionGrade, renderBudgetInterventionDirective } from "./budget-state";
+import { computeBudgetState, renderBudgetInterventionDirective } from "./budget-state";
+import {
+  classifyPoll,
+  INITIAL_FINGERPRINT_STATE,
+  type FingerprintState,
+} from "./budget-fingerprint";
 import type {
   AgentName,
   AgentUsage,
@@ -27,9 +32,6 @@ export interface BudgetPollDelayInput {
   paused: boolean;
 }
 
-// Directive-fingerprint quantum for reset epochs. Must absorb probe jitter
-// (seconds) while still distinguishing a genuine window reset (hours).
-const RESET_FINGERPRINT_BUCKET_SEC = 600;
 const LOW_UTIL_PCT = 50;
 const NEAR_PAUSE_MARGIN_PCT = 10;
 const NEAR_WARN_UTIL_PCT = 75;
@@ -72,18 +74,6 @@ function pct(value: number): string {
 function usageLine(agent: AgentName, usage: AgentUsage | null): string {
   if (!usage) return `${AGENT_LABEL[agent]} 未知`;
   return `${AGENT_LABEL[agent]} gate=${pct(usage.gateUtil)} warn=${pct(usage.warnUtil)}`;
-}
-
-function matchingGateReset(usage: AgentUsage | null): number {
-  if (!usage) return 0;
-
-  const windows = [usage.fiveHour, usage.weekly].filter((window): window is NonNullable<typeof window> =>
-    !!window && window.resetEpoch > 0
-  );
-  const matching = windows.filter((window) => Math.abs(window.util - usage.gateUtil) < 0.0001);
-  const candidates = matching.length > 0 ? matching : windows;
-  if (candidates.length === 0) return 0;
-  return Math.min(...candidates.map((window) => window.resetEpoch));
 }
 
 function maxPollDelayMs(config: Pick<BudgetConfig, "pollSeconds">): number {
@@ -158,11 +148,11 @@ export class BudgetCoordinator {
 
   private timer: BudgetPollTimer | null = null;
   private running = false;
-  private readonly activeSides = new Set<AgentName>();
-  private lastDirectiveFingerprint: string | null = null;
+  // Single source of truth for the directive state machine (side / fingerprint
+  // / resume bookkeeping). Replaces the former 4 mutable fields
+  // (activeSides, lastDirectiveFingerprint, pauseReason, pauseResumeAfterEpoch).
+  private fpState: FingerprintState = INITIAL_FINGERPRINT_STATE;
   private latestSnapshot: BudgetSnapshot | null = null;
-  private pauseReason: string | null = null;
-  private pauseResumeAfterEpoch: number | null = null;
   private pendingOverrideTier: CodexTier | null = null;
   private pendingOverrides: CodexTurnOverrides | null = null;
   private lastAppliedTier: CodexTier = "full";
@@ -196,11 +186,11 @@ export class BudgetCoordinator {
   }
 
   isPaused(): boolean {
-    return this.activeSides.size > 0;
+    return this.fpState.side !== null;
   }
 
   isGateClosed(): boolean {
-    return this.activeSides.has("codex");
+    return this.fpState.side === "codex" || this.fpState.side === "both";
   }
 
   getSnapshot(): BudgetSnapshot | null {
@@ -286,121 +276,43 @@ export class BudgetCoordinator {
     this.onSnapshot(snapshot);
   }
 
+  /**
+   * IO shell over the pure {@link classifyPoll} reducer. The reducer decides
+   * the next directive state and what to do; this method only carries out the
+   * effect (emit / onPauseChange) and commits the new state. All transition
+   * semantics — including the branch order that keeps a phantom blip from
+   * resetting the fingerprint — live in budget-fingerprint.ts.
+   */
   private applyState(state: BudgetState): void {
-    const previousSide = this.pauseSide();
-    this.updateActiveSides(state);
-    const currentSide = this.pauseSide();
+    const { next, effect } = classifyPoll(this.fpState, state, this.config);
+    this.fpState = next;
 
-    if (currentSide) {
-      this.pauseReason = this.interventionReason(state);
-      const nextResumeAfterEpoch = this.resumeAfterEpoch(state);
-      this.pauseResumeAfterEpoch = previousSide === currentSide
-        ? nextResumeAfterEpoch ?? this.pauseResumeAfterEpoch
-        : nextResumeAfterEpoch;
-      const fingerprint = previousSide === currentSide && this.activeSideProbeUncertain(state) && this.lastDirectiveFingerprint
-        ? this.lastDirectiveFingerprint
-        : this.directiveFingerprint(state, currentSide);
-      if (!previousSide) {
-        this.onPauseChange(true);
+    switch (effect.kind) {
+      case "enter":
+      case "hold-uncertain": {
+        if (effect.pauseChanged) this.onPauseChange(true);
+        if (effect.emit) {
+          this.emitDirective(
+            this.interventionPrefix(effect.side),
+            this.interventionDirective(state, effect.side, effect.reason, effect.resumeEpoch),
+          );
+        }
+        return;
       }
-      if (!previousSide || previousSide !== currentSide || fingerprint !== this.lastDirectiveFingerprint) {
-        this.emitDirective(
-          this.interventionPrefix(currentSide),
-          this.interventionDirective(state, currentSide),
-        );
+      case "exit": {
+        this.onPauseChange(false);
+        this.emitDirective(this.recoveryPrefix(effect.previousSide), this.recoveryDirective(state, effect.previousSide));
+        return;
       }
-      this.lastDirectiveFingerprint = fingerprint;
-      return;
-    }
-
-    if (previousSide) {
-      this.pauseReason = null;
-      this.pauseResumeAfterEpoch = null;
-      this.lastDirectiveFingerprint = null;
-      this.onPauseChange(false);
-      this.emitDirective(this.recoveryPrefix(previousSide), this.recoveryDirective(state, previousSide));
-      return;
-    }
-
-    // Drift/parallel advice compares the two sides — against a non-decision-
-    // grade record the comparison is a phantom. Observed live: a transient
-    // empty Claude probe record (gate=0%, no windows) inflated drift 54%→58%
-    // and emitted a directive on each side of the blip. Hold the previous
-    // directive state and KEEP the fingerprint — whether the phantom inflated
-    // drift (directive present) or deflated it away (directive null), the
-    // recovery to the same real state must re-emit nothing. This sits BEFORE
-    // the null-directive branch so a blip cannot reset the fingerprint.
-    // (Pause entry/exit above has its own decision-grade guards in
-    // shouldEnter/canAgentResume.)
-    if (
-      !isDecisionGrade(state.perAgent.claude, state.now) ||
-      !isDecisionGrade(state.perAgent.codex, state.now)
-    ) {
-      return;
-    }
-
-    if (!state.directiveToClaude) {
-      this.lastDirectiveFingerprint = null;
-      return;
-    }
-
-    const fingerprint = this.directiveFingerprint(state);
-    if (fingerprint !== this.lastDirectiveFingerprint) {
-      const prefix = state.phase === "balance" ? "system_budget_balance" : "system_budget_parallel";
-      this.emitDirective(prefix, state.directiveToClaude);
-      this.lastDirectiveFingerprint = fingerprint;
-    }
-  }
-
-  private updateActiveSides(state: BudgetState): void {
-    for (const agent of ["claude", "codex"] as const) {
-      const usage = state.perAgent[agent];
-      if (this.shouldEnter(usage, state.now)) {
-        this.activeSides.add(agent);
-      } else if (this.activeSides.has(agent) && this.canAgentResume(usage, state.now)) {
-        this.activeSides.delete(agent);
+      case "advise": {
+        const prefix = effect.phase === "balance" ? "system_budget_balance" : "system_budget_parallel";
+        // state.directiveToClaude is non-null whenever the reducer emits advise.
+        this.emitDirective(prefix, state.directiveToClaude!);
+        return;
       }
+      case "none":
+        return;
     }
-  }
-
-  // Only decision-grade records may CHANGE intervention state (enter or exit).
-  // Two real-machine failure shapes feed untrustworthy records into the
-  // decision loop:
-  //  - the probe serves a stale cache during an outage: hours-old utils with
-  //    resetEpochs already in the past would enter (and then freeze) a pause
-  //    whose "estimated resume" predates now;
-  //  - a windowless rate-limit-only record reads gateUtil=0, which must not
-  //    AUTHORIZE a resume the moment the throttle expires (the entry-side
-  //    information floor in quota-source has no resume-side counterpart).
-  // Untrustworthy data holds the current state — same semantics as a probe
-  // miss. The check itself is shared with the entry-side guard: see
-  // isDecisionGrade in budget-state.ts.
-
-  private shouldEnter(usage: AgentUsage | null, now: number): boolean {
-    if (!isDecisionGrade(usage, now)) return false;
-    return usage!.gateUtil >= this.config.pauseAt;
-  }
-
-  private canAgentResume(usage: AgentUsage | null, now: number): boolean {
-    if (!isDecisionGrade(usage, now)) return false;
-    if (usage!.rateLimitedUntil > now) return false;
-    return usage!.gateUtil < this.config.resumeBelow;
-  }
-
-  private resumeAfterEpoch(state: BudgetState): number | null {
-    const epochs = (["claude", "codex"] as const)
-      .filter((agent) => this.activeSides.has(agent))
-      .map((agent) => this.resumeBlockingEpoch(state.perAgent[agent], state.now))
-      .filter((epoch) => epoch > 0);
-    if (epochs.length === 0) return null;
-    return Math.max(...epochs);
-  }
-
-  private resumeBlockingEpoch(usage: AgentUsage | null, now: number): number {
-    if (!usage) return 0;
-    if (usage.rateLimitedUntil > now) return usage.rateLimitedUntil;
-    if (usage.gateUtil >= this.config.resumeBelow) return matchingGateReset(usage);
-    return 0;
   }
 
   private tierControlEnabled(): boolean {
@@ -439,55 +351,8 @@ export class BudgetCoordinator {
     this.pendingOverrides = { ...overrides };
   }
 
-  private directiveFingerprint(state: BudgetState, activeSide?: Exclude<PauseSide, null>): string {
-    const side = activeSide ?? (state.phase === "balance"
-      ? state.drift.lighter ?? "none"
-      : state.pause.side ?? "none");
-    let reset = 0;
-    if (activeSide === "claude") {
-      reset = state.pause.resetEpochs.claude;
-    } else if (activeSide === "codex") {
-      reset = state.pause.resetEpochs.codex;
-    } else if (activeSide === "both") {
-      reset = Math.max(state.pause.resetEpochs.claude, state.pause.resetEpochs.codex);
-    } else if (state.phase === "balance" && state.drift.lighter) {
-      reset = state.perAgent[state.drift.lighter]?.fiveHour?.resetEpoch ?? 0;
-    } else if (side === "claude") {
-      reset = state.pause.resetEpochs.claude;
-    } else if (side === "codex") {
-      reset = state.pause.resetEpochs.codex;
-    } else if (side === "both") {
-      reset = Math.max(state.pause.resetEpochs.claude, state.pause.resetEpochs.codex);
-    }
-
-    return [
-      activeSide ? "paused" : state.phase,
-      state.drift.heavier ?? "none",
-      side,
-      // Round-to-nearest bucket, not the raw epoch: the probe's reset_epoch
-      // jitters by ±1s between polls (observed live: 09:49:59 ⇄ 09:50:00),
-      // and a raw value re-emits the same directive every poll. Rounding —
-      // not floor — because real reset times sit ON round boundaries, so a
-      // floor bucket edge would keep flapping. A genuine window reset jumps
-      // hours and still lands in a different bucket.
-      // Domain assumption: jitter tolerance holds because reset epochs sit
-      // near bucket-aligned times. An ARBITRARY epoch at a half-bucket point
-      // (k*600+300) would still flap under ±1s — not a shape the probe emits.
-      Math.round(reset / RESET_FINGERPRINT_BUCKET_SEC),
-    ].join("|");
-  }
-
   private emitDirective(prefix: string, content: string): void {
     this.emit(`${prefix}_${this.sequence++}`, content);
-  }
-
-  private pauseSide(): PauseSide {
-    const claude = this.activeSides.has("claude");
-    const codex = this.activeSides.has("codex");
-    if (claude && codex) return "both";
-    if (claude) return "claude";
-    if (codex) return "codex";
-    return null;
   }
 
   private interventionPrefix(side: Exclude<PauseSide, null>): string {
@@ -498,46 +363,25 @@ export class BudgetCoordinator {
     return previousSide === "claude" ? "system_budget_claude_recovered" : "system_budget_resume";
   }
 
-  private interventionDirective(state: BudgetState, side: Exclude<PauseSide, null>): string {
+  private interventionDirective(
+    state: BudgetState,
+    side: Exclude<PauseSide, null>,
+    reason: string,
+    resumeEpoch: number | null,
+  ): string {
     return renderBudgetInterventionDirective(
       state.perAgent.claude,
       state.perAgent.codex,
       side,
-      this.pauseReason ?? "预算接近耗尽",
-      this.pauseResumeAfterEpoch,
+      // `reason` is always a non-empty string here: it comes from
+      // interventionReason(curSide) which joins ≥1 active agent, so the `||`
+      // fallback is defensive-only and never fires — observationally identical
+      // to the old `this.pauseReason ?? "..."` (whose null default was also
+      // never reached on this paused path).
+      reason || "预算接近耗尽",
+      resumeEpoch,
       this.config,
     );
-  }
-
-  private interventionReason(state: BudgetState): string {
-    return (["claude", "codex"] as const)
-      .filter((agent) => this.activeSides.has(agent))
-      .map((agent) => this.activeSideReason(agent, state.perAgent[agent], state.now))
-      .join("；");
-  }
-
-  private activeSideProbeUncertain(state: BudgetState): boolean {
-    return (["claude", "codex"] as const).some((agent) => {
-      if (!this.activeSides.has(agent)) return false;
-      const usage = state.perAgent[agent];
-      // Non-decision-grade covers every degraded shape (#103 lets stale /
-      // unknown-reset records through as display data): mid-pause they must
-      // hold the directive fingerprint, not recompute it against a phantom
-      // reset bucket — recomputing re-emitted the pause directive on each
-      // data-quality flap, the exact regression e7a66fc guarded against.
-      return usage === null || usage.rateLimitedUntil > state.now || !isDecisionGrade(usage, state.now);
-    });
-  }
-
-  private activeSideReason(agent: AgentName, usage: AgentUsage | null, now: number): string {
-    if (!usage) return `${AGENT_LABEL[agent]} 探测暂时不可用，保持上一轮预算干预`;
-    if (usage.rateLimitedUntil > now) {
-      return `${AGENT_LABEL[agent]} 探针被限流至 ${this.formatEpoch(usage.rateLimitedUntil)}`;
-    }
-    if (usage.gateUtil >= this.config.pauseAt) {
-      return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} ≥ pauseAt ${pct(this.config.pauseAt)}`;
-    }
-    return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} 尚未低于 resumeBelow ${pct(this.config.resumeBelow)}`;
   }
 
   private recoveryDirective(state: BudgetState, previousSide: Exclude<PauseSide, null>): string {
@@ -567,10 +411,6 @@ export class BudgetCoordinator {
     ].join("\n");
   }
 
-  private formatEpoch(epoch: number): string {
-    return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
-  }
-
   private toSnapshot(state: BudgetState): BudgetSnapshot {
     const paused = this.isPaused();
     return {
@@ -581,9 +421,9 @@ export class BudgetCoordinator {
       driftPct: state.drift.pct,
       paused,
       gateClosed: this.isGateClosed(),
-      pauseSide: this.pauseSide(),
-      pauseReason: paused ? this.pauseReason ?? state.pause.reason : null,
-      resumeAfterEpoch: paused ? this.pauseResumeAfterEpoch ?? state.pause.resumeAfterEpoch : null,
+      pauseSide: this.fpState.side,
+      pauseReason: paused ? this.fpState.reason ?? state.pause.reason : null,
+      resumeAfterEpoch: paused ? this.fpState.resumeEpoch ?? state.pause.resumeAfterEpoch : null,
       parallelRecommended: paused ? false : state.parallel.recommended,
       codexTier: state.effort.codexTier,
       claudeAdvice: state.effort.claudeAdvice,

--- a/src/budget/budget-fingerprint.ts
+++ b/src/budget/budget-fingerprint.ts
@@ -1,0 +1,313 @@
+/**
+ * Explicit state machine for the budget coordinator's directive bookkeeping.
+ *
+ * This module isolates the pure transition logic that decides, on every poll,
+ * which directive (if any) to emit and what fingerprint/resume bookkeeping to
+ * carry forward. `BudgetCoordinator` keeps only the IO shell (timer, emit,
+ * onPauseChange, snapshot) and delegates every decision to `classifyPoll`.
+ *
+ * The machine has three states:
+ *   - idle                       — no intervention, no pending advisory
+ *   - advising(fingerprint)      — drift/parallel advisory active (gate open)
+ *   - paused(side, fingerprint, resumeEpoch) — handoff/pause active
+ *
+ * `side` is the activeSides set rendered as a value: null⇄idle/advising,
+ * "claude"/"codex"/"both" map bijectively to the {claude}/{codex}/{claude,codex}
+ * active sets. The hysteresis (enter on shouldEnter, exit on canAgentResume) is
+ * recomputed inside the reducer from the prior side, so the coordinator no
+ * longer mutates a Set.
+ *
+ * Behavior is a verbatim port of the previous BudgetCoordinator.applyState —
+ * every branch order (notably: the non-decision-grade hold sits BEFORE the
+ * null-directive reset so a phantom blip cannot clear the fingerprint) is
+ * preserved. See budget-coordinator.test.ts for the regression baseline.
+ *
+ * Keep this file dependency-free beyond ./types, ./budget-gate and
+ * ./budget-state; it is bundled into the plugin daemon.
+ */
+import { resumeBlockingEpoch } from "./budget-gate";
+import { isDecisionGrade } from "./budget-state";
+import type { AgentName, AgentUsage, BudgetConfig, BudgetState } from "./types";
+
+/** Active side, identical to the old pauseSide() bijection over activeSides. */
+export type PauseSide = AgentName | "both" | null;
+type ActivePauseSide = Exclude<PauseSide, null>;
+
+/** Directive-fingerprint quantum for reset epochs. Must absorb probe jitter
+ * (seconds) while still distinguishing a genuine window reset (hours). */
+const RESET_FINGERPRINT_BUCKET_SEC = 600;
+
+const AGENT_LABEL: Record<AgentName, string> = {
+  claude: "Claude",
+  codex: "Codex",
+};
+
+function pct(value: number): string {
+  return `${Math.round(value * 10) / 10}%`;
+}
+
+function formatEpoch(epoch: number): string {
+  return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+}
+
+/**
+ * Explicit coordinator state carried between polls. `side === null` means no
+ * intervention; the optional `resumeEpoch`/`fingerprint` describe whichever of
+ * the advising/paused states is active.
+ */
+export interface FingerprintState {
+  /** Active pause side (activeSides rendered as a value); null when not paused. */
+  side: PauseSide;
+  /** Last emitted directive fingerprint; null when there is none to dedup against. */
+  fingerprint: string | null;
+  /** Sticky resume-after epoch while paused; null otherwise. */
+  resumeEpoch: number | null;
+  /** Sticky pause reason while paused; null otherwise. */
+  reason: string | null;
+}
+
+export const INITIAL_FINGERPRINT_STATE: FingerprintState = {
+  side: null,
+  fingerprint: null,
+  resumeEpoch: null,
+  reason: null,
+};
+
+/** What the coordinator must DO after a poll. The reducer is pure; the shell
+ * applies these effects (emit, onPauseChange) in order. */
+export type CoordinatorEffect =
+  | {
+      /** Entering or holding/refreshing an intervention. */
+      kind: "enter" | "hold-uncertain";
+      side: ActivePauseSide;
+      reason: string;
+      resumeEpoch: number | null;
+      /** True when a directive should be emitted this poll. */
+      emit: boolean;
+      /** True only on the first poll that enters a pause (drives onPauseChange(true)). */
+      pauseChanged: boolean;
+    }
+  | {
+      /** Leaving an intervention back to idle. */
+      kind: "exit";
+      previousSide: ActivePauseSide;
+    }
+  | {
+      /** Drift/parallel advisory emitted (gate stays open). */
+      kind: "advise";
+      phase: BudgetState["phase"];
+    }
+  | {
+      /** No directive to emit; covers phantom holds, dedup no-ops, and the
+       * null-directive fingerprint reset. */
+      kind: "none";
+    };
+
+export interface ClassifyResult {
+  next: FingerprintState;
+  effect: CoordinatorEffect;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (verbatim ports of the old coordinator private methods, now
+// parametrized by an explicit activeSides set instead of reading `this`).
+// ---------------------------------------------------------------------------
+
+function sideToAgents(side: PauseSide): AgentName[] {
+  if (side === "both") return ["claude", "codex"];
+  if (side === "claude") return ["claude"];
+  if (side === "codex") return ["codex"];
+  return [];
+}
+
+function agentsToSide(agents: ReadonlySet<AgentName>): PauseSide {
+  const claude = agents.has("claude");
+  const codex = agents.has("codex");
+  if (claude && codex) return "both";
+  if (claude) return "claude";
+  if (codex) return "codex";
+  return null;
+}
+
+function shouldEnter(usage: AgentUsage | null, cfg: BudgetConfig, now: number): boolean {
+  if (!isDecisionGrade(usage, now)) return false;
+  return usage!.gateUtil >= cfg.pauseAt;
+}
+
+function canAgentResume(usage: AgentUsage | null, cfg: BudgetConfig, now: number): boolean {
+  if (!isDecisionGrade(usage, now)) return false;
+  if (usage!.rateLimitedUntil > now) return false;
+  return usage!.gateUtil < cfg.resumeBelow;
+}
+
+/**
+ * Hysteresis transition over the activeSides set: shouldEnter adds, an already
+ * active side that canAgentResume is removed. Verbatim port of the old
+ * updateActiveSides, made pure over the prior side.
+ */
+function nextActiveSide(prevSide: PauseSide, state: BudgetState, cfg: BudgetConfig): PauseSide {
+  const active = new Set<AgentName>(sideToAgents(prevSide));
+  for (const agent of ["claude", "codex"] as const) {
+    const usage = state.perAgent[agent];
+    if (shouldEnter(usage, cfg, state.now)) {
+      active.add(agent);
+    } else if (active.has(agent) && canAgentResume(usage, cfg, state.now)) {
+      active.delete(agent);
+    }
+  }
+  return agentsToSide(active);
+}
+
+function activeSideReason(agent: AgentName, usage: AgentUsage | null, cfg: BudgetConfig, now: number): string {
+  if (!usage) return `${AGENT_LABEL[agent]} 探测暂时不可用，保持上一轮预算干预`;
+  if (usage.rateLimitedUntil > now) {
+    return `${AGENT_LABEL[agent]} 探针被限流至 ${formatEpoch(usage.rateLimitedUntil)}`;
+  }
+  if (usage.gateUtil >= cfg.pauseAt) {
+    return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} ≥ pauseAt ${pct(cfg.pauseAt)}`;
+  }
+  return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} 尚未低于 resumeBelow ${pct(cfg.resumeBelow)}`;
+}
+
+function interventionReason(side: PauseSide, state: BudgetState, cfg: BudgetConfig): string {
+  return sideToAgents(side)
+    .map((agent) => activeSideReason(agent, state.perAgent[agent], cfg, state.now))
+    .join("；");
+}
+
+function resumeAfterEpoch(side: PauseSide, state: BudgetState, cfg: BudgetConfig): number | null {
+  const epochs = sideToAgents(side)
+    .map((agent) => resumeBlockingEpoch(state.perAgent[agent], cfg, state.now))
+    .filter((epoch) => epoch > 0);
+  if (epochs.length === 0) return null;
+  return Math.max(...epochs);
+}
+
+function activeSideProbeUncertain(side: PauseSide, state: BudgetState): boolean {
+  return sideToAgents(side).some((agent) => {
+    const usage = state.perAgent[agent];
+    // Non-decision-grade covers every degraded shape (#103 lets stale /
+    // unknown-reset records through as display data): mid-pause they must
+    // hold the directive fingerprint, not recompute it against a phantom
+    // reset bucket — recomputing re-emitted the pause directive on each
+    // data-quality flap, the exact regression e7a66fc guarded against.
+    return usage === null || usage.rateLimitedUntil > state.now || !isDecisionGrade(usage, state.now);
+  });
+}
+
+/**
+ * Stable dedup fingerprint for a directive. When `activeSide` is set we are
+ * paused; otherwise the phase (balance/parallel) drives the side selection.
+ */
+export function directiveFingerprint(state: BudgetState, activeSide?: ActivePauseSide): string {
+  const side = activeSide ?? (state.phase === "balance"
+    ? state.drift.lighter ?? "none"
+    : state.pause.side ?? "none");
+  let reset = 0;
+  if (activeSide === "claude") {
+    reset = state.pause.resetEpochs.claude;
+  } else if (activeSide === "codex") {
+    reset = state.pause.resetEpochs.codex;
+  } else if (activeSide === "both") {
+    reset = Math.max(state.pause.resetEpochs.claude, state.pause.resetEpochs.codex);
+  } else if (state.phase === "balance" && state.drift.lighter) {
+    reset = state.perAgent[state.drift.lighter]?.fiveHour?.resetEpoch ?? 0;
+  }
+  // NB: the old code had `side === "claude"/"codex"/"both"` branches here as
+  // well. They were dead: when activeSide is set the chain already matched
+  // above; when activeSide is undefined the phase is balance (handled above) or
+  // parallel (side is always "none"). Proven unreachable — instrumenting them
+  // with throws kept all 53 budget tests green — so they are removed.
+
+  return [
+    activeSide ? "paused" : state.phase,
+    state.drift.heavier ?? "none",
+    side,
+    // Round-to-nearest bucket, not the raw epoch: the probe's reset_epoch
+    // jitters by ±1s between polls (observed live: 09:49:59 ⇄ 09:50:00),
+    // and a raw value re-emits the same directive every poll. Rounding —
+    // not floor — because real reset times sit ON round boundaries, so a
+    // floor bucket edge would keep flapping. A genuine window reset jumps
+    // hours and still lands in a different bucket.
+    // Domain assumption: jitter tolerance holds because reset epochs sit
+    // near bucket-aligned times. An ARBITRARY epoch at a half-bucket point
+    // (k*600+300) would still flap under ±1s — not a shape the probe emits.
+    Math.round(reset / RESET_FINGERPRINT_BUCKET_SEC),
+  ].join("|");
+}
+
+/**
+ * Pure reducer: given the prior fingerprint state and a freshly computed
+ * BudgetState, decide the next state and the effect the coordinator must apply.
+ *
+ * This is a 1:1 port of the old BudgetCoordinator.applyState. The five
+ * transitions (pause enter / pause hold / pause exit / advise / reset) and
+ * their branch ORDER are preserved exactly; in particular the non-decision-
+ * grade phantom hold runs BEFORE the null-directive reset.
+ */
+export function classifyPoll(prev: FingerprintState, state: BudgetState, cfg: BudgetConfig): ClassifyResult {
+  const previousSide = prev.side;
+  const currentSide = nextActiveSide(previousSide, state, cfg);
+
+  // --- Paused branch (intervention active) ---
+  if (currentSide) {
+    const reason = interventionReason(currentSide, state, cfg);
+    const nextResumeRaw = resumeAfterEpoch(currentSide, state, cfg);
+    const resumeEpoch = previousSide === currentSide
+      ? nextResumeRaw ?? prev.resumeEpoch
+      : nextResumeRaw;
+    const uncertain = previousSide === currentSide && activeSideProbeUncertain(currentSide, state) && prev.fingerprint;
+    const fingerprint = uncertain
+      ? prev.fingerprint!
+      : directiveFingerprint(state, currentSide);
+    const pauseChanged = !previousSide;
+    const emit = !previousSide || previousSide !== currentSide || fingerprint !== prev.fingerprint;
+    return {
+      next: { side: currentSide, fingerprint, resumeEpoch, reason },
+      effect: {
+        kind: uncertain ? "hold-uncertain" : "enter",
+        side: currentSide,
+        reason,
+        resumeEpoch,
+        emit,
+        pauseChanged,
+      },
+    };
+  }
+
+  // --- Recovery branch (was paused, now clear) ---
+  if (previousSide) {
+    return {
+      next: { side: null, fingerprint: null, resumeEpoch: null, reason: null },
+      effect: { kind: "exit", previousSide },
+    };
+  }
+
+  // --- Phantom hold: a non-decision-grade record on either side holds the
+  // previous advisory state AND keeps the fingerprint. This sits BEFORE the
+  // null-directive branch so a blip cannot reset the fingerprint. ---
+  if (
+    !isDecisionGrade(state.perAgent.claude, state.now) ||
+    !isDecisionGrade(state.perAgent.codex, state.now)
+  ) {
+    return { next: prev, effect: { kind: "none" } };
+  }
+
+  // --- Null-directive reset: decision-grade but nothing to advise. ---
+  if (!state.directiveToClaude) {
+    return {
+      next: { side: null, fingerprint: null, resumeEpoch: null, reason: null },
+      effect: { kind: "none" },
+    };
+  }
+
+  // --- Advise branch: emit only when the fingerprint changed. ---
+  const fingerprint = directiveFingerprint(state);
+  if (fingerprint !== prev.fingerprint) {
+    return {
+      next: { side: null, fingerprint, resumeEpoch: null, reason: null },
+      effect: { kind: "advise", phase: state.phase },
+    };
+  }
+  return { next: prev, effect: { kind: "none" } };
+}

--- a/src/budget/budget-gate.ts
+++ b/src/budget/budget-gate.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared resume-gate helpers for the budget coordination layer.
+ *
+ * `matchingGateReset` and `resumeBlockingEpoch` were previously duplicated
+ * verbatim in budget-coordinator.ts and budget-state.ts. types.ts already
+ * warns that a fork between the entry-side guard and the coordinator's resume
+ * gate is an accident waiting to happen (see STALE_MAX_AGE_SEC); these two
+ * helpers are the same shape, so they live here as the single source of truth.
+ *
+ * Keep this file dependency-free beyond ./types; it is bundled into the plugin
+ * daemon.
+ */
+import type { AgentUsage, BudgetConfig } from "./types";
+
+/**
+ * Earliest reset epoch among the windows that explain the current gateUtil.
+ * Prefer windows whose util matches gateUtil (the resettable hard winner); if
+ * none match, fall back to any window with a known reset. Returns 0 when there
+ * is no usable window.
+ */
+export function matchingGateReset(usage: AgentUsage | null): number {
+  if (!usage) return 0;
+
+  const windows = [usage.fiveHour, usage.weekly].filter((window): window is NonNullable<typeof window> =>
+    !!window && window.resetEpoch > 0
+  );
+  const matching = windows.filter((window) => Math.abs(window.util - usage.gateUtil) < 0.0001);
+  const candidates = matching.length > 0 ? matching : windows;
+  if (candidates.length === 0) return 0;
+  return Math.min(...candidates.map((window) => window.resetEpoch));
+}
+
+/**
+ * Epoch at which this side stops blocking resume: the active rate-limit if one
+ * is in effect, else the gate-window reset while gateUtil is still at/above
+ * resumeBelow, else 0 (this side no longer blocks resume).
+ */
+export function resumeBlockingEpoch(usage: AgentUsage | null, cfg: BudgetConfig, now: number): number {
+  if (!usage) return 0;
+  if (usage.rateLimitedUntil > now) return usage.rateLimitedUntil;
+  if (usage.gateUtil >= cfg.resumeBelow) return matchingGateReset(usage);
+  return 0;
+}

--- a/src/budget/budget-state.ts
+++ b/src/budget/budget-state.ts
@@ -1,3 +1,4 @@
+import { matchingGateReset, resumeBlockingEpoch } from "./budget-gate";
 import { STALE_MAX_AGE_SEC } from "./types";
 import type { AgentName, AgentUsage, BudgetConfig, BudgetState, CodexTier } from "./types";
 
@@ -29,25 +30,6 @@ function formatEpoch(epoch: number | null): string {
 function usageSummary(name: AgentName, usage: AgentUsage | null): string {
   if (!usage) return `${AGENT_LABEL[name]} 未知`;
   return `${AGENT_LABEL[name]} gate=${pct(usage.gateUtil)} warn=${pct(usage.warnUtil)} 5h重置=${formatEpoch(usage.fiveHour?.resetEpoch ?? 0)}`;
-}
-
-function matchingGateReset(usage: AgentUsage | null): number {
-  if (!usage) return 0;
-
-  const windows = [usage.fiveHour, usage.weekly].filter((window): window is NonNullable<typeof window> =>
-    !!window && window.resetEpoch > 0
-  );
-  const matching = windows.filter((window) => Math.abs(window.util - usage.gateUtil) < 0.0001);
-  const candidates = matching.length > 0 ? matching : windows;
-  if (candidates.length === 0) return 0;
-  return Math.min(...candidates.map((window) => window.resetEpoch));
-}
-
-function resumeBlockingEpoch(usage: AgentUsage | null, cfg: BudgetConfig, now: number): number {
-  if (!usage) return 0;
-  if (usage.rateLimitedUntil > now) return usage.rateLimitedUntil;
-  if (usage.gateUtil >= cfg.resumeBelow) return matchingGateReset(usage);
-  return 0;
 }
 
 function resumeAfterEpoch(

--- a/src/unit-test/budget-fingerprint.test.ts
+++ b/src/unit-test/budget-fingerprint.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, test } from "bun:test";
+import { computeBudgetState } from "../budget/budget-state";
+import {
+  classifyPoll,
+  directiveFingerprint,
+  INITIAL_FINGERPRINT_STATE,
+  type FingerprintState,
+} from "../budget/budget-fingerprint";
+import type { AgentUsage, BudgetConfig, BudgetState } from "../budget/types";
+
+const NOW = 1_700_000_000;
+
+const CONFIG: BudgetConfig = {
+  enabled: true,
+  pollSeconds: 60,
+  pauseAt: 90,
+  resumeBelow: 30,
+  syncDriftPct: 10,
+  parallel: { minRemainingPct: 60, timeWindowSec: 3600 },
+  codexTierControl: false,
+  codexTiers: {
+    full: { effort: "high" },
+    balanced: { effort: "medium" },
+    eco: { effort: "low" },
+  },
+};
+
+function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {
+  const gateUtil = overrides.gateUtil ?? 20;
+  const warnUtil = overrides.warnUtil ?? gateUtil;
+  return {
+    ok: true,
+    stale: false,
+    gateUtil,
+    warnUtil,
+    fiveHour: { util: gateUtil, resetEpoch: NOW + 3600 },
+    weekly: { util: warnUtil, resetEpoch: NOW + 500_000 },
+    remaining: 100 - gateUtil,
+    rateLimitedUntil: 0,
+    fetchedAt: NOW,
+    parsedVia: "id-match",
+    ...overrides,
+  };
+}
+
+/** Build a real BudgetState from a per-agent probe pair (drives the reducer
+ * through the same shape the coordinator feeds it in production). */
+function state(claude: AgentUsage | null, codex: AgentUsage | null, now = NOW): BudgetState {
+  return computeBudgetState(claude, codex, CONFIG, now);
+}
+
+/** Drive a sequence of polls from an initial state, returning the final state
+ * and the ordered list of effects (kind only, with side where present). */
+function runPolls(
+  states: BudgetState[],
+  start: FingerprintState = INITIAL_FINGERPRINT_STATE,
+): { final: FingerprintState; effects: Array<ReturnType<typeof classifyPoll>["effect"]> } {
+  let current = start;
+  const effects: Array<ReturnType<typeof classifyPoll>["effect"]> = [];
+  for (const s of states) {
+    const { next, effect } = classifyPoll(current, s, CONFIG);
+    effects.push(effect);
+    current = next;
+  }
+  return { final: current, effects };
+}
+
+describe("classifyPoll reducer — event coverage", () => {
+  test("none: both sides healthy, no directive, from idle", () => {
+    const { final, effects } = runPolls([state(usage(), usage({ gateUtil: 21, warnUtil: 21 }))]);
+    expect(effects[0]).toEqual({ kind: "none" });
+    expect(final.side).toBeNull();
+    expect(final.fingerprint).toBeNull();
+  });
+
+  test("enter: codex trips the gate from idle", () => {
+    const { final, effects } = runPolls([
+      state(usage(), usage({ gateUtil: 92, warnUtil: 92, remaining: 8 })),
+    ]);
+    expect(effects[0].kind).toBe("enter");
+    expect(effects[0]).toMatchObject({ kind: "enter", side: "codex", emit: true, pauseChanged: true });
+    expect(final.side).toBe("codex");
+    expect(final.fingerprint).not.toBeNull();
+  });
+
+  test("enter: claude-only trips as handoff (side=claude)", () => {
+    const { effects } = runPolls([
+      state(usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }), usage()),
+    ]);
+    expect(effects[0]).toMatchObject({ kind: "enter", side: "claude", emit: true, pauseChanged: true });
+  });
+
+  test("enter: both sides trip as joint pause (side=both)", () => {
+    const { effects } = runPolls([
+      state(
+        usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }),
+        usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+      ),
+    ]);
+    expect(effects[0]).toMatchObject({ kind: "enter", side: "both", emit: true, pauseChanged: true });
+  });
+
+  test("pause hold (none-emit): same side, decision-grade, fingerprint unchanged → no re-emit", () => {
+    const paused = state(usage(), usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }));
+    // Second poll: still over the gate, same reset bucket → fingerprint stable.
+    const stillPaused = state(usage(), usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }));
+    const { effects, final } = runPolls([paused, stillPaused]);
+    expect(effects[0].kind).toBe("enter");
+    // Second poll is still an "enter" kind (decision-grade), but must NOT emit
+    // and must NOT flip pauseChanged.
+    expect(effects[1]).toMatchObject({ kind: "enter", side: "codex", emit: false, pauseChanged: false });
+    expect(final.side).toBe("codex");
+  });
+
+  test("hold-uncertain: mid-pause degraded record holds fingerprint without re-emit", () => {
+    const paused = state(usage(), usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }));
+    // Degraded windowless stale record on the active (codex) side — not
+    // decision-grade, so canAgentResume is false → side stays codex, and the
+    // probe-uncertain path holds the prior fingerprint.
+    const degraded = state(
+      usage(),
+      usage({ gateUtil: 0, warnUtil: 0, stale: true, fiveHour: { util: 0, resetEpoch: 0 }, weekly: null }),
+    );
+    const { effects, final } = runPolls([paused, degraded]);
+    expect(effects[0].kind).toBe("enter");
+    expect(effects[1]).toMatchObject({ kind: "hold-uncertain", side: "codex", emit: false });
+    // Fingerprint preserved across the blip.
+    expect(final.fingerprint).toBe((classifyPoll(INITIAL_FINGERPRINT_STATE, paused, CONFIG)).next.fingerprint);
+  });
+
+  test("exit: previously paused side recovers below resumeBelow → exit", () => {
+    const paused = state(usage(), usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }));
+    const recovered = state(usage(), usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }));
+    const { effects, final } = runPolls([paused, recovered]);
+    expect(effects[0].kind).toBe("enter");
+    expect(effects[1]).toEqual({ kind: "exit", previousSide: "codex" });
+    expect(final.side).toBeNull();
+    expect(final.fingerprint).toBeNull();
+    expect(final.resumeEpoch).toBeNull();
+    expect(final.reason).toBeNull();
+  });
+
+  test("advise: drift above threshold emits a balance advisory from idle", () => {
+    const drifted = state(usage({ gateUtil: 35, warnUtil: 45 }), usage({ gateUtil: 20, warnUtil: 20 }));
+    expect(drifted.phase).toBe("balance");
+    const { effects, final } = runPolls([drifted]);
+    expect(effects[0]).toEqual({ kind: "advise", phase: "balance" });
+    expect(final.side).toBeNull();
+    expect(final.fingerprint).not.toBeNull();
+  });
+
+  test("advise dedup: identical drift on the next poll → none (no re-emit)", () => {
+    const drifted = state(usage({ gateUtil: 35, warnUtil: 45 }), usage({ gateUtil: 20, warnUtil: 20 }));
+    const { effects } = runPolls([drifted, drifted]);
+    expect(effects[0]).toEqual({ kind: "advise", phase: "balance" });
+    expect(effects[1]).toEqual({ kind: "none" });
+  });
+
+  test("advise: parallel phase emits with phase=parallel", () => {
+    const parallel = state(
+      usage({ gateUtil: 20, warnUtil: 20, remaining: 80, fiveHour: { util: 20, resetEpoch: NOW + 3500 } }),
+      usage({ gateUtil: 25, warnUtil: 25, remaining: 75, fiveHour: { util: 25, resetEpoch: NOW + 5000 } }),
+    );
+    expect(parallel.phase).toBe("parallel");
+    const { effects } = runPolls([parallel]);
+    expect(effects[0]).toEqual({ kind: "advise", phase: "parallel" });
+  });
+
+  test("reset: advising → directive disappears (decision-grade) clears fingerprint", () => {
+    const drifted = state(usage({ gateUtil: 35, warnUtil: 45 }), usage({ gateUtil: 20, warnUtil: 20 }));
+    const calm = state(usage({ gateUtil: 20, warnUtil: 20 }), usage({ gateUtil: 20, warnUtil: 20 }));
+    expect(calm.directiveToClaude).toBeNull();
+    const { effects, final } = runPolls([drifted, calm]);
+    expect(effects[0].kind).toBe("advise");
+    // null-directive on decision-grade data → effect none, but fingerprint reset.
+    expect(effects[1]).toEqual({ kind: "none" });
+    expect(final.fingerprint).toBeNull();
+    expect(final.side).toBeNull();
+  });
+});
+
+describe("classifyPoll reducer — branch-order sensitivity", () => {
+  // The decision-grade phantom HOLD must run BEFORE the null-directive reset.
+  // A phantom (windowless) record that makes a drift directive disappear must
+  // NOT clear the fingerprint, or the directive re-emits when data recovers.
+  test("phantom hold preserves the advising fingerprint (drift deflated to nothing)", () => {
+    const drifted = state(usage({ gateUtil: 15, warnUtil: 15 }), usage({ gateUtil: 2, warnUtil: 2 }));
+    const phantom = state(
+      usage({ gateUtil: 0, warnUtil: 0, fiveHour: null, weekly: null }),
+      usage({ gateUtil: 2, warnUtil: 2 }),
+    );
+    const afterDrift = classifyPoll(INITIAL_FINGERPRINT_STATE, drifted, CONFIG);
+    expect(afterDrift.effect.kind).toBe("advise");
+
+    const afterPhantom = classifyPoll(afterDrift.next, phantom, CONFIG);
+    // Phantom branch runs first → none effect, fingerprint held (NOT reset).
+    expect(afterPhantom.effect).toEqual({ kind: "none" });
+    expect(afterPhantom.next.fingerprint).toBe(afterDrift.next.fingerprint);
+
+    // Recovery to the same real drift must re-emit NOTHING (fingerprint match).
+    const afterRecovery = classifyPoll(afterPhantom.next, drifted, CONFIG);
+    expect(afterRecovery.effect).toEqual({ kind: "none" });
+  });
+
+  test("phantom that inflates the heavier side still holds (no spurious re-emit)", () => {
+    const drifted = state(usage({ gateUtil: 35, warnUtil: 45 }), usage({ gateUtil: 20, warnUtil: 20 }));
+    const phantom = state(
+      usage({ gateUtil: 0, warnUtil: 0, fiveHour: null, weekly: null }),
+      usage({ gateUtil: 20, warnUtil: 20 }),
+    );
+    const { effects } = runPolls([drifted, phantom, drifted]);
+    expect(effects.map((e) => e.kind)).toEqual(["advise", "none", "none"]);
+  });
+
+  test("a NEW five-hour window on the lighter side DOES update the fingerprint", () => {
+    // Contrast with phantom-hold: a decision-grade change in the reset bucket
+    // legitimately re-emits.
+    const a = state(
+      usage({ gateUtil: 35, warnUtil: 45 }),
+      usage({ gateUtil: 20, warnUtil: 20, fiveHour: { util: 20, resetEpoch: NOW + 3600 } }),
+    );
+    const b = state(
+      usage({ gateUtil: 35, warnUtil: 45 }),
+      usage({ gateUtil: 20, warnUtil: 20, fiveHour: { util: 20, resetEpoch: NOW + 7200 } }),
+    );
+    const { effects } = runPolls([a, b]);
+    expect(effects.map((e) => e.kind)).toEqual(["advise", "advise"]);
+  });
+
+  test("reset-epoch jitter (±1s) does NOT re-emit (bucket rounding)", () => {
+    const base = (epoch: number) =>
+      state(
+        usage({ gateUtil: 35, warnUtil: 45 }),
+        usage({ gateUtil: 20, warnUtil: 20, fiveHour: { util: 20, resetEpoch: epoch } }),
+      );
+    const { effects } = runPolls([base(NOW + 3600), base(NOW + 3601), base(NOW + 3599)]);
+    expect(effects.map((e) => e.kind)).toEqual(["advise", "none", "none"]);
+  });
+
+  test("non-decision-grade entry data holds idle (no false enter)", () => {
+    // Expired-window stale cache: gateUtil 95 but every window already reset and
+    // fetchedAt ancient → not decision-grade → must NOT enter.
+    const stale = state(
+      usage(),
+      usage({
+        gateUtil: 95,
+        fiveHour: { util: 95, resetEpoch: NOW - 5400 },
+        weekly: { util: 95, resetEpoch: NOW - 100 },
+        fetchedAt: NOW - 7200,
+      }),
+    );
+    const { effects, final } = runPolls([stale]);
+    expect(effects[0]).toEqual({ kind: "none" });
+    expect(final.side).toBeNull();
+  });
+
+  test("windowless rate-limit record cannot authorize resume mid-pause", () => {
+    const paused = state(usage(), usage({ gateUtil: 95 }));
+    const rateLimitOnly = state(
+      usage(),
+      usage({ ok: false, gateUtil: 0, warnUtil: 0, fiveHour: null, weekly: null, rateLimitedUntil: NOW - 1 }),
+    );
+    const { effects, final } = runPolls([paused, rateLimitOnly]);
+    expect(effects[0].kind).toBe("enter");
+    // gateUtil=0 is absence of information, not recovery → still paused, held.
+    expect(effects[1].kind).toBe("hold-uncertain");
+    expect(final.side).toBe("codex");
+  });
+});
+
+describe("classifyPoll reducer — hysteresis side transitions", () => {
+  test("claude handoff → joint pause → codex pause", () => {
+    const s1 = state(usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }), usage());
+    const s2 = state(
+      usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }),
+      usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+    );
+    const s3 = state(usage(), usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }));
+    const { effects, final } = runPolls([s1, s2, s3]);
+    expect(effects.map((e) => (e.kind === "enter" ? e.side : e.kind))).toEqual(["claude", "both", "codex"]);
+    // Each side change emits.
+    for (const e of effects) {
+      if (e.kind === "enter") expect(e.emit).toBe(true);
+    }
+    expect(final.side).toBe("codex");
+  });
+
+  test("joint pause downgrades to claude handoff when codex recovers", () => {
+    const s1 = state(
+      usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }),
+      usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+    );
+    const s2 = state(usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }), usage());
+    const { effects, final } = runPolls([s1, s2]);
+    expect(effects.map((e) => (e.kind === "enter" ? e.side : e.kind))).toEqual(["both", "claude"]);
+    expect(final.side).toBe("claude");
+  });
+
+  test("resumeEpoch is sticky on same side, reset on side change", () => {
+    // Codex paused with a rate-limit resume epoch.
+    const s1 = state(usage(), usage({ gateUtil: 92, warnUtil: 92, remaining: 8, rateLimitedUntil: NOW + 900 }));
+    const r1 = classifyPoll(INITIAL_FINGERPRINT_STATE, s1, CONFIG);
+    expect(r1.next.resumeEpoch).toBe(NOW + 900);
+
+    // Next poll: still codex over gate but now no blocking epoch readable
+    // (gateUtil high, no rate-limit, reset bucket present) — resumeEpoch comes
+    // from the gate reset; assert it stays defined on the same side.
+    const s2 = state(usage(), usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }));
+    const r2 = classifyPoll(r1.next, s2, CONFIG);
+    expect(r2.next.side).toBe("codex");
+    expect(r2.next.resumeEpoch).toBe(NOW + 3600);
+  });
+});
+
+describe("directiveFingerprint — pure fingerprint", () => {
+  test("paused fingerprint differs by side", () => {
+    const s = state(
+      usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+      usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+    );
+    expect(directiveFingerprint(s, "claude")).not.toBe(directiveFingerprint(s, "codex"));
+    expect(directiveFingerprint(s, "both")).not.toBe(directiveFingerprint(s, "claude"));
+  });
+
+  test("balance fingerprint uses lighter side, ignores ±1s jitter via bucket", () => {
+    const a = state(
+      usage({ gateUtil: 35, warnUtil: 45 }),
+      usage({ gateUtil: 20, warnUtil: 20, fiveHour: { util: 20, resetEpoch: NOW + 3600 } }),
+    );
+    const b = state(
+      usage({ gateUtil: 35, warnUtil: 45 }),
+      usage({ gateUtil: 20, warnUtil: 20, fiveHour: { util: 20, resetEpoch: NOW + 3601 } }),
+    );
+    expect(directiveFingerprint(a)).toBe(directiveFingerprint(b));
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary
arch-review P2 #506：把 BudgetCoordinator 里五类交织的 pause/advise/resume 转移（靠分支顺序保证语义、#100/#101 各叠过有序守卫）抽成一个**纯 reducer**，**行为逐位保持**。
- **新增 `src/budget/budget-fingerprint.ts`**：`classifyPoll(prevState, budgetState) → CoordinatorEffect(enter/hold-uncertain/exit/advise/none)`，可表驱动测试的纯函数；`BudgetCoordinator` 只保留 IO 壳。8 个可变字段中的 4 个合并为单个 `fpState`。
- **新增 `src/budget/budget-gate.ts`**：合并两文件逐字重复的 `matchingGateReset` + `resumeBlockingEpoch`。
- 清理 `directiveFingerprint` 不可达死分支 + 孤儿 `formatEpoch`。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1046 pass / 0 fail** / `verify:plugin-sync` ✅
- **53 个既有 budget 测试断言零改、全绿**（端到端经 `pollOnce→applyState` 路径驱动新 reducer——最强等价证据）；新增 **22 个 reducer 表驱动单测**锁分支顺序敏感 case（phantom-hold 先于 null-reset / decision-grade hold vs blip / windowless rate-limit 不授权 resume / hysteresis 侧迁移）。
- Cross-review：dead-code/merge 镜头 **0 REAL**（死分支 throw-injection 实证不可达、合并函数逐字相等）；equivalence 镜头 re-review **0 REAL**（6 点等价逐一核验）。`?? → ||` 经实证不可达并加注释。

## 备注
攒批发布：release-on-merge 暂禁。reducer 已 inline 进 daemon bundle。