### PR TITLE
feat: 投递去重键——稳定 message_id + 消费端 LRU/TTL deduper / delivery dedup key + consumer-side deduper

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13662,6 +13662,7 @@ class StdioServerTransport {
 // src/claude-adapter.ts
 import { EventEmitter } from "events";
 import { randomUUID } from "crypto";
+import { performance } from "perf_hooks";
 
 // src/rotating-log.ts
 import { appendFileSync, existsSync, renameSync, statSync, unlinkSync } from "fs";
@@ -13942,6 +13943,8 @@ var BUDGET_UNAVAILABLE_TEXT = "\u9884\u7B97\u611F\u77E5\u4E0D\u53EF\u7528\uFF1A\
 // src/claude-adapter.ts
 var DEFAULT_MAX_BUFFERED_MESSAGES = 100;
 var DEFAULT_MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
+var DEFAULT_DEDUPE_CAPACITY = 2048;
+var DEFAULT_DEDUPE_TTL_MS = 20 * 60 * 1000;
 var CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
   "",
@@ -13998,6 +14001,10 @@ class ClaudeAdapter extends EventEmitter {
   oversizedMessageCount = 0;
   oversizedMessageBytes = 0;
   oversizedMessageSourceCounts = {};
+  dedupeCapacity;
+  dedupeTtlMs;
+  monotonicNow;
+  deliveredMessageIds = new Map;
   budgetSnapshot = null;
   constructor(logFile = new StateDirResolver().logFile, options = {}) {
     super();
@@ -14012,6 +14019,9 @@ class ClaudeAdapter extends EventEmitter {
     }
     this.maxBufferedMessages = positiveIntegerOr(options.maxBufferedMessages, parsePositiveIntegerEnv("AGENTBRIDGE_MAX_BUFFERED_MESSAGES", DEFAULT_MAX_BUFFERED_MESSAGES));
     this.maxBufferedBytes = positiveIntegerOr(options.maxBufferedBytes, parsePositiveIntegerEnv("AGENTBRIDGE_MAX_BUFFERED_BYTES", DEFAULT_MAX_BUFFERED_BYTES));
+    this.dedupeCapacity = positiveIntegerOr(options.dedupeCapacity, DEFAULT_DEDUPE_CAPACITY);
+    this.dedupeTtlMs = positiveIntegerOr(options.dedupeTtlMs, DEFAULT_DEDUPE_TTL_MS);
+    this.monotonicNow = options.now ?? (() => performance.now());
     this.server = new Server({ name: "agentbridge", version: "0.1.0" }, {
       capabilities: {
         experimental: { "claude/channel": {} },
@@ -14038,10 +14048,12 @@ class ClaudeAdapter extends EventEmitter {
   }
   async pushNotification(message) {
     this.log(`pushNotification (instance=${this.instanceId}, msgId=${message.id}, len=${message.content.length})`);
+    if (!this.rememberDelivery(message))
+      return;
     await this.pushViaChannel(message);
   }
   async pushViaChannel(message) {
-    const msgId = `codex_msg_${this.notificationIdPrefix}_${++this.notificationSeq}`;
+    const deliveryAttemptId = `codex_msg_${this.notificationIdPrefix}_${++this.notificationSeq}`;
     const ts = new Date(message.timestamp).toISOString();
     try {
       await this.server.notification({
@@ -14050,7 +14062,8 @@ class ClaudeAdapter extends EventEmitter {
           content: message.content,
           meta: {
             chat_id: this.sessionId,
-            message_id: msgId,
+            message_id: message.id,
+            delivery_attempt_id: deliveryAttemptId,
             user: "Codex",
             user_id: "codex",
             ts,
@@ -14058,10 +14071,35 @@ class ClaudeAdapter extends EventEmitter {
           }
         }
       });
-      this.log(`Pushed notification: ${msgId}`);
+      this.log(`Pushed notification: ${message.id} (attempt=${deliveryAttemptId})`);
     } catch (e) {
       this.log(`Push notification failed: ${e.message}`);
       this.queueFallbackMessage(message);
+    }
+  }
+  rememberDelivery(message) {
+    const now = this.monotonicNow();
+    this.pruneDeliveredMessageIds(now);
+    if (this.deliveredMessageIds.has(message.id)) {
+      this.deliveredMessageIds.delete(message.id);
+      this.deliveredMessageIds.set(message.id, now);
+      this.log(`Duplicate Codex message suppressed (msgId=${message.id}, source=${message.source}, ` + `instance=${this.instanceId})`);
+      return false;
+    }
+    this.deliveredMessageIds.set(message.id, now);
+    while (this.deliveredMessageIds.size > this.dedupeCapacity) {
+      const oldest = this.deliveredMessageIds.keys().next().value;
+      if (oldest === undefined)
+        break;
+      this.deliveredMessageIds.delete(oldest);
+    }
+    return true;
+  }
+  pruneDeliveredMessageIds(now) {
+    for (const [id, seenAt] of this.deliveredMessageIds) {
+      if (now - seenAt <= this.dedupeTtlMs)
+        break;
+      this.deliveredMessageIds.delete(id);
     }
   }
   queueFallbackMessage(message) {
@@ -14341,7 +14379,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("2981e06", "source"),
+  commit: defineString("75e139d", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -15789,6 +15827,7 @@ var lastReconnectNotifyTs = 0;
 var disabledRecoveryTimer = null;
 var disabledRecoveryInFlight = false;
 var disabledRecoveryAttempts = 0;
+var nextSystemMessageId = 0;
 var DISABLED_RECOVERY_MAX_ATTEMPTS = 6;
 var DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS = 1000;
 if (process.env.AGENTBRIDGE_TRACE === "1") {
@@ -16124,7 +16163,7 @@ async function pollDisabledRecovery() {
 }
 function systemMessage(idPrefix, content) {
   return {
-    id: `${idPrefix}_${Date.now()}`,
+    id: `${idPrefix}_${++nextSystemMessageId}`,
     source: "codex",
     content,
     timestamp: Date.now()

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -21,7 +21,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("2981e06", "source"),
+  commit: defineString("75e139d", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -66,6 +66,7 @@ let lastReconnectNotifyTs = 0;
 let disabledRecoveryTimer: ReturnType<typeof setInterval> | null = null;
 let disabledRecoveryInFlight = false;
 let disabledRecoveryAttempts = 0;
+let nextSystemMessageId = 0;
 
 const DISABLED_RECOVERY_MAX_ATTEMPTS = 6;
 const DISABLED_RECOVERY_CONFIRM_TIMEOUT_MS = 1000;
@@ -555,7 +556,7 @@ async function pollDisabledRecovery() {
 
 function systemMessage(idPrefix: string, content: string): BridgeMessage {
   return {
-    id: `${idPrefix}_${Date.now()}`,
+    id: `${idPrefix}_${++nextSystemMessageId}`,
     source: "codex",
     content,
     timestamp: Date.now(),

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -20,6 +20,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { EventEmitter } from "node:events";
 import { randomUUID } from "node:crypto";
+import { performance } from "node:perf_hooks";
 import { createProcessLogger, type ProcessLogger } from "./process-log";
 import { StateDirResolver } from "./state-dir";
 import type { BridgeMessage } from "./types";
@@ -36,10 +37,16 @@ export type ReplySender = (
 export interface ClaudeAdapterOptions {
   maxBufferedMessages?: number;
   maxBufferedBytes?: number;
+  dedupeCapacity?: number;
+  dedupeTtlMs?: number;
+  /** Monotonic milliseconds for internal dedupe TTL; defaults to performance.now(). */
+  now?: () => number;
 }
 
 const DEFAULT_MAX_BUFFERED_MESSAGES = 100;
 const DEFAULT_MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
+const DEFAULT_DEDUPE_CAPACITY = 2048;
+const DEFAULT_DEDUPE_TTL_MS = 20 * 60 * 1000;
 
 export const CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
@@ -98,6 +105,10 @@ export class ClaudeAdapter extends EventEmitter {
   private oversizedMessageCount = 0;
   private oversizedMessageBytes = 0;
   private oversizedMessageSourceCounts: Partial<Record<BridgeMessage["source"], number>> = {};
+  private readonly dedupeCapacity: number;
+  private readonly dedupeTtlMs: number;
+  private readonly monotonicNow: () => number;
+  private deliveredMessageIds = new Map<string, number>();
 
   // Latest budget snapshot, fed by bridge from DaemonStatus.budget broadcasts.
   private budgetSnapshot: BudgetSnapshot | null = null;
@@ -127,6 +138,9 @@ export class ClaudeAdapter extends EventEmitter {
       options.maxBufferedBytes,
       parsePositiveIntegerEnv("AGENTBRIDGE_MAX_BUFFERED_BYTES", DEFAULT_MAX_BUFFERED_BYTES),
     );
+    this.dedupeCapacity = positiveIntegerOr(options.dedupeCapacity, DEFAULT_DEDUPE_CAPACITY);
+    this.dedupeTtlMs = positiveIntegerOr(options.dedupeTtlMs, DEFAULT_DEDUPE_TTL_MS);
+    this.monotonicNow = options.now ?? (() => performance.now());
 
     this.server = new Server(
       { name: "agentbridge", version: "0.1.0" },
@@ -170,11 +184,12 @@ export class ClaudeAdapter extends EventEmitter {
 
   async pushNotification(message: BridgeMessage) {
     this.log(`pushNotification (instance=${this.instanceId}, msgId=${message.id}, len=${message.content.length})`);
+    if (!this.rememberDelivery(message)) return;
     await this.pushViaChannel(message);
   }
 
   private async pushViaChannel(message: BridgeMessage) {
-    const msgId = `codex_msg_${this.notificationIdPrefix}_${++this.notificationSeq}`;
+    const deliveryAttemptId = `codex_msg_${this.notificationIdPrefix}_${++this.notificationSeq}`;
     const ts = new Date(message.timestamp).toISOString();
 
     try {
@@ -184,7 +199,8 @@ export class ClaudeAdapter extends EventEmitter {
           content: message.content,
           meta: {
             chat_id: this.sessionId,
-            message_id: msgId,
+            message_id: message.id,
+            delivery_attempt_id: deliveryAttemptId,
             user: "Codex",
             user_id: "codex",
             ts,
@@ -192,10 +208,40 @@ export class ClaudeAdapter extends EventEmitter {
           },
         },
       });
-      this.log(`Pushed notification: ${msgId}`);
+      this.log(`Pushed notification: ${message.id} (attempt=${deliveryAttemptId})`);
     } catch (e: any) {
       this.log(`Push notification failed: ${e.message}`);
       this.queueFallbackMessage(message);
+    }
+  }
+
+  private rememberDelivery(message: BridgeMessage): boolean {
+    const now = this.monotonicNow();
+    this.pruneDeliveredMessageIds(now);
+    if (this.deliveredMessageIds.has(message.id)) {
+      // Refresh recency so duplicate bursts do not evict a still-active key.
+      this.deliveredMessageIds.delete(message.id);
+      this.deliveredMessageIds.set(message.id, now);
+      this.log(
+        `Duplicate Codex message suppressed (msgId=${message.id}, source=${message.source}, ` +
+        `instance=${this.instanceId})`,
+      );
+      return false;
+    }
+
+    this.deliveredMessageIds.set(message.id, now);
+    while (this.deliveredMessageIds.size > this.dedupeCapacity) {
+      const oldest = this.deliveredMessageIds.keys().next().value;
+      if (oldest === undefined) break;
+      this.deliveredMessageIds.delete(oldest);
+    }
+    return true;
+  }
+
+  private pruneDeliveredMessageIds(now: number): void {
+    for (const [id, seenAt] of this.deliveredMessageIds) {
+      if (now - seenAt <= this.dedupeTtlMs) break;
+      this.deliveredMessageIds.delete(id);
     }
   }
 

--- a/src/unit-test/message-delivery.test.ts
+++ b/src/unit-test/message-delivery.test.ts
@@ -4,7 +4,13 @@ import { ClaudeAdapter } from "../claude-adapter";
 // Access internals for testing
 function createAdapter(
   envMode?: string,
-  options?: { maxBufferedMessages?: number; maxBufferedBytes?: number },
+  options?: {
+    maxBufferedMessages?: number;
+    maxBufferedBytes?: number;
+    dedupeCapacity?: number;
+    dedupeTtlMs?: number;
+    now?: () => number;
+  },
 ): any {
   const origMode = process.env.AGENTBRIDGE_MODE;
   const origMax = process.env.AGENTBRIDGE_MAX_BUFFERED_MESSAGES;
@@ -32,9 +38,11 @@ function createAdapter(
   return adapter;
 }
 
-function makeBridgeMessage(content: string, ts?: number) {
+let nextTestMessageId = 0;
+
+function makeBridgeMessage(content: string, ts?: number, id?: string) {
   return {
-    id: `test_${Date.now()}`,
+    id: id ?? `test_${++nextTestMessageId}`,
     source: "codex" as const,
     content,
     timestamp: ts ?? Date.now(),
@@ -155,7 +163,7 @@ describe("Message delivery: fallback queue", () => {
     expect(adapter.oversizedMessageBytes).toBe(9);
   });
 
-  test("push message ids include a session-unique prefix", async () => {
+  test("push meta uses BridgeMessage.id as message_id and a separate delivery_attempt_id", async () => {
     const adapter = createAdapter();
 
     const notifications: any[] = [];
@@ -165,18 +173,100 @@ describe("Message delivery: fallback queue", () => {
       },
     };
 
-    await adapter.pushNotification(makeBridgeMessage("first push", 1705312200000));
-    await adapter.pushNotification(makeBridgeMessage("second push", 1705312205000));
+    await adapter.pushNotification(makeBridgeMessage("first push", 1705312200000, "codex-item-1"));
+    await adapter.pushNotification(makeBridgeMessage("second push", 1705312205000, "codex-item-2"));
 
     expect(notifications).toHaveLength(2);
 
-    const firstId = notifications[0].params.meta.message_id as string;
-    const secondId = notifications[1].params.meta.message_id as string;
+    const firstMeta = notifications[0].params.meta;
+    const secondMeta = notifications[1].params.meta;
 
-    expect(firstId).toMatch(/^codex_msg_[a-f0-9]{12}_1$/);
-    expect(secondId).toMatch(/^codex_msg_[a-f0-9]{12}_2$/);
-    expect(firstId.replace(/_1$/, "")).toBe(secondId.replace(/_2$/, ""));
-    expect(firstId).not.toBe("codex_msg_1");
+    expect(firstMeta.message_id).toBe("codex-item-1");
+    expect(secondMeta.message_id).toBe("codex-item-2");
+    expect(firstMeta.delivery_attempt_id).toMatch(/^codex_msg_[a-f0-9]{12}_1$/);
+    expect(secondMeta.delivery_attempt_id).toMatch(/^codex_msg_[a-f0-9]{12}_2$/);
+    expect(firstMeta.delivery_attempt_id.replace(/_1$/, "")).toBe(secondMeta.delivery_attempt_id.replace(/_2$/, ""));
+    expect(firstMeta.delivery_attempt_id).not.toBe(firstMeta.message_id);
+  });
+
+  test("pushNotification absorbs a backpressure rebuffer replay with the same BridgeMessage.id", async () => {
+    const adapter = createAdapter();
+    const notifications = withMockedChannel(adapter);
+    const logs: string[] = [];
+    adapter.logger = { log: (msg: string) => logs.push(msg) };
+
+    await adapter.pushNotification(makeBridgeMessage("first delivery", 1705312200000, "same-id"));
+    await adapter.pushNotification(makeBridgeMessage("duplicate delivery", 1705312201000, "same-id"));
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].params.content).toBe("first delivery");
+    expect(adapter.pendingMessages).toHaveLength(0);
+    expect(logs.some((line) => line.includes("Duplicate Codex message suppressed") && line.includes("same-id"))).toBe(true);
+  });
+
+  test("pushNotification does not enqueue fallback twice for the same BridgeMessage.id", async () => {
+    const adapter = createAdapter();
+    withMockedChannel(adapter, "fail");
+
+    await adapter.pushNotification(makeBridgeMessage("queued once", 1705312200000, "fallback-id"));
+    await adapter.pushNotification(makeBridgeMessage("queued duplicate", 1705312201000, "fallback-id"));
+
+    expect(adapter.pendingMessages.map((m: any) => m.content)).toEqual(["queued once"]);
+    expect(adapter.pendingMessageBytes).toBe(Buffer.byteLength("queued once", "utf8"));
+  });
+
+  test("pushNotification accepts an id again after LRU eviction", async () => {
+    const adapter = createAdapter(undefined, { dedupeCapacity: 2 });
+    const notifications = withMockedChannel(adapter);
+
+    await adapter.pushNotification(makeBridgeMessage("first a", 1705312200000, "id-a"));
+    await adapter.pushNotification(makeBridgeMessage("first b", 1705312201000, "id-b"));
+    await adapter.pushNotification(makeBridgeMessage("first c", 1705312202000, "id-c"));
+    await adapter.pushNotification(makeBridgeMessage("second a", 1705312203000, "id-a"));
+
+    expect(notifications.map((n) => n.params.content)).toEqual([
+      "first a",
+      "first b",
+      "first c",
+      "second a",
+    ]);
+  });
+
+  test("pushNotification accepts an id again after dedupe TTL expires", async () => {
+    let now = 1_000;
+    const adapter = createAdapter(undefined, {
+      dedupeCapacity: 10,
+      dedupeTtlMs: 100,
+      now: () => now,
+    });
+    const notifications = withMockedChannel(adapter);
+
+    await adapter.pushNotification(makeBridgeMessage("first", 1705312200000, "ttl-id"));
+    now += 50;
+    await adapter.pushNotification(makeBridgeMessage("duplicate within ttl", 1705312201000, "ttl-id"));
+    now += 101;
+    await adapter.pushNotification(makeBridgeMessage("after ttl", 1705312202000, "ttl-id"));
+
+    expect(notifications.map((n) => n.params.content)).toEqual(["first", "after ttl"]);
+  });
+
+  test("pushNotification dedupe TTL ignores wall-clock jumps", async () => {
+    const originalDateNow = Date.now;
+    let wallNow = 1_000;
+    Date.now = () => wallNow;
+
+    try {
+      const adapter = createAdapter(undefined, { dedupeTtlMs: 60_000 });
+      const notifications = withMockedChannel(adapter);
+
+      await adapter.pushNotification(makeBridgeMessage("first", 1705312200000, "wall-clock-id"));
+      wallNow += 120_000;
+      await adapter.pushNotification(makeBridgeMessage("duplicate after wall jump", 1705312201000, "wall-clock-id"));
+
+      expect(notifications.map((n) => n.params.content)).toEqual(["first"]);
+    } finally {
+      Date.now = originalDateNow;
+    }
   });
 
   test("pushNotification falls back to the queue when push delivery throws", async () => {


### PR DESCRIPTION
## 摘要 / Summary
arch-review P1 #313：给 Codex→Claude channel 通知一个**稳定 message_id**，让消费端去重 at-least-once 投递（pendingBackpressure 在 close 前后可 replay 同一条）。
- channel `meta.message_id` 改用稳定 **`BridgeMessage.id`**（旧 `codex_msg_<prefix>_<seq>` 保留为 `delivery_attempt_id` 仅日志）。
- ClaudeAdapter 加有界 **LRU+TTL deduper**（默认 2048/20min，可注入），key=message.id：重复 id 不 push、不入 fallback queue。TTL 用**单调时钟 `performance.now`**（避免墙钟回拨影响 prune 的插入序假设）。
- `bridge.ts` 本地 `systemMessage()` 从墙钟改为 prefix+counter 单调 id（避免同毫秒 dedup key 碰撞）。
- **source-loop**：dedupe 只作用 Codex→Claude / system→Claude 入口；Claude→Codex `reply` 仍只受 idempotency_key。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1070 pass / 0 fail** / `verify:plugin-sync` ✅
- message_id==BridgeMessage.id / delivery_attempt_id 递增 / 重复只投一次 / fallback 不重复 / LRU 淘汰+TTL 过期可重收 / backpressure rebuffer replay 吸收 / 墙钟跳变不影响 TTL。
- Cross-review：R1 dedup 正确性 0 bug + source-loop 干净；compat 镜头 1 LOW（prune 墙钟假设）→ 已修（单调时钟）；R2 **0 REAL**。

## 已知后续（folded into #303）
daemon 的 system message id 计数器在 daemon 重启时归零，而 bridge deduper 跨重连存活——重启后同 id 在 20min TTL 内可能被误抑制（LOW，自愈）。修法=daemon system id 带 per-process nonce，随 #303 一并处理。

## 备注
攒批发布：release-on-merge 暂禁。