### PR TITLE
fix: 投递层深度扫描 3 LOW——status_summary id 唯一化 + StatusBuffer 上界 + agentMessageBuffers 泄漏 / delivery-layer hardening

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14379,7 +14379,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("75e139d", "source"),
+  commit: defineString("a2d8062", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -21,7 +21,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("75e139d", "source"),
+  commit: defineString("a2d8062", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2044,6 +2044,7 @@ class CodexAdapter extends EventEmitter {
       this.clearAllTurnWatchdogs();
       this.stalledTurnIds.clear();
       this.currentlyStalledTurnIds.clear();
+      this.agentMessageBuffers.clear();
     }
     this.lastTurnEndedAbnormally = false;
     this.turnInProgress = this.activeTurnIds.size > 0;
@@ -2106,6 +2107,7 @@ class CodexAdapter extends EventEmitter {
     this.clearAllTurnWatchdogs();
     this.stalledTurnIds.clear();
     this.currentlyStalledTurnIds.clear();
+    this.agentMessageBuffers.clear();
     this.turnInProgress = false;
     if (wasInProgress) {
       this.lastTurnEndedAbnormally = !emitCompleted;
@@ -2375,6 +2377,9 @@ function evaluateInjectionAttachGuard(attachedSocket, requestingSocket) {
 }
 
 // src/message-filter.ts
+import { randomUUID as randomUUID3 } from "crypto";
+var STATUS_SUMMARY_SALT = randomUUID3().slice(0, 8);
+var statusSummaryCounter = 0;
 var MARKER_REGEX = /^\s*\[(IMPORTANT|STATUS|FYI)\]\s*/i;
 function parseMarker(content) {
   const match = content.match(MARKER_REGEX);
@@ -2440,11 +2445,14 @@ class StatusBuffer {
   flushTimer = null;
   flushThreshold;
   flushTimeoutMs;
+  maxBuffered;
   paused = false;
+  droppedCount = 0;
   constructor(onFlush, options) {
     this.onFlush = onFlush;
     this.flushThreshold = options?.flushThreshold ?? 3;
     this.flushTimeoutMs = options?.flushTimeoutMs ?? 15000;
+    this.maxBuffered = options?.maxBuffered ?? 200;
   }
   get size() {
     return this.buffer.length;
@@ -2464,6 +2472,10 @@ class StatusBuffer {
   }
   add(message) {
     this.buffer.push(message);
+    while (this.buffer.length > this.maxBuffered) {
+      this.buffer.shift();
+      this.droppedCount++;
+    }
     if (this.paused)
       return;
     this.resetTimer();
@@ -2478,19 +2490,22 @@ class StatusBuffer {
     const combined = this.buffer.map((m) => parseMarker(m.content).body).join(`
 ---
 `);
+    const droppedNote = this.droppedCount > 0 ? `, ${this.droppedCount} older dropped` : "";
     const summary = {
-      id: `status_summary_${Date.now()}`,
+      id: `status_summary_${STATUS_SUMMARY_SALT}_${++statusSummaryCounter}`,
       source: "codex",
-      content: `[STATUS summary \u2014 ${this.buffer.length} update(s), flushed: ${reason}]
+      content: `[STATUS summary \u2014 ${this.buffer.length} update(s)${droppedNote}, flushed: ${reason}]
 ${combined}`,
       timestamp: Date.now()
     };
     this.onFlush(summary);
     this.buffer = [];
+    this.droppedCount = 0;
   }
   dispose() {
     this.clearTimer();
     this.buffer = [];
+    this.droppedCount = 0;
   }
   clearTimer() {
     if (this.flushTimer) {

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -2223,6 +2223,10 @@ export class CodexAdapter extends EventEmitter {
       this.clearAllTurnWatchdogs();
       this.stalledTurnIds.clear();
       this.currentlyStalledTurnIds.clear();
+      // A completion with no turn id clears ALL active turns, so any
+      // agentMessage still mid-stream will never see its item/completed —
+      // drop the dangling buffers instead of leaking them.
+      this.agentMessageBuffers.clear();
     }
 
     this.lastTurnEndedAbnormally = false;
@@ -2318,6 +2322,11 @@ export class CodexAdapter extends EventEmitter {
     this.clearAllTurnWatchdogs();
     this.stalledTurnIds.clear();
     this.currentlyStalledTurnIds.clear();
+    // app-server close / reconnect / stop interrupts any in-flight agentMessage
+    // stream: the item/completed that would normally delete its buffer never
+    // arrives, so clear here (single reset boundary) to prevent unbounded growth
+    // across the daemon's long lifetime. Matches the per-turn map discipline.
+    this.agentMessageBuffers.clear();
     this.turnInProgress = false;
     if (wasInProgress) {
       this.lastTurnEndedAbnormally = !emitCompleted;

--- a/src/message-filter.ts
+++ b/src/message-filter.ts
@@ -1,4 +1,19 @@
+import { randomUUID } from "node:crypto";
+
 import type { BridgeMessage } from "./types";
+
+// Per-process salt + monotonic counter for status_summary ids.
+//
+// The summary id is used as the dedup key by ClaudeAdapter.rememberDelivery
+// (claude-adapter.ts). Using `Date.now()` alone collides when two summaries
+// flush within the same millisecond — the second is silently suppressed as a
+// "duplicate". The salt makes ids unique ACROSS processes/restarts (so a fresh
+// process never re-emits an id a previous process used inside the dedup TTL),
+// and the monotonic counter makes ids unique WITHIN a process (no same-ms
+// collision). This mirrors the monotonic id discipline #313 applied to the
+// system message ids in bridge.ts / daemon.ts.
+const STATUS_SUMMARY_SALT = randomUUID().slice(0, 8);
+let statusSummaryCounter = 0;
 
 export type MarkerLevel = "important" | "status" | "fyi" | "untagged";
 export type FilterMode = "filtered" | "full";
@@ -102,14 +117,23 @@ export class StatusBuffer {
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly flushThreshold: number;
   private readonly flushTimeoutMs: number;
+  private readonly maxBuffered: number;
   private paused = false;
+  // Number of oldest STATUS updates dropped because the buffer hit maxBuffered
+  // (e.g. a long attention window with auto-flush paused). Surfaced in the next
+  // summary so the drop is observable rather than silent, then reset on flush.
+  private droppedCount = 0;
 
   constructor(
     private readonly onFlush: (summary: BridgeMessage) => void,
-    options?: { flushThreshold?: number; flushTimeoutMs?: number },
+    options?: { flushThreshold?: number; flushTimeoutMs?: number; maxBuffered?: number },
   ) {
     this.flushThreshold = options?.flushThreshold ?? 3;
     this.flushTimeoutMs = options?.flushTimeoutMs ?? 15000;
+    // Upper bound on retained STATUS updates. Mirrors the bounded buffers on
+    // the daemon side (bufferedMessages / pendingBackpressure) so a paused
+    // buffer cannot grow without limit during a long attention window.
+    this.maxBuffered = options?.maxBuffered ?? 200;
   }
 
   get size(): number {
@@ -135,6 +159,13 @@ export class StatusBuffer {
 
   add(message: BridgeMessage): void {
     this.buffer.push(message);
+    // Enforce the upper bound regardless of pause state: drop the OLDEST so the
+    // most recent STATUS context is preserved. Track how many we shed so the
+    // next summary can report it instead of dropping silently.
+    while (this.buffer.length > this.maxBuffered) {
+      this.buffer.shift();
+      this.droppedCount++;
+    }
     if (this.paused) return; // Don't auto-flush while paused
     this.resetTimer();
     if (this.buffer.length >= this.flushThreshold) {
@@ -148,10 +179,15 @@ export class StatusBuffer {
     const combined = this.buffer
       .map((m) => parseMarker(m.content).body)
       .join("\n---\n");
+    const droppedNote =
+      this.droppedCount > 0 ? `, ${this.droppedCount} older dropped` : "";
     const summary: BridgeMessage = {
-      id: `status_summary_${Date.now()}`,
+      // Process-unique id (salt + monotonic counter): no same-ms collision
+      // and no cross-process reuse, so the ClaudeAdapter deduper never
+      // suppresses a distinct summary. timestamp below stays wall-clock.
+      id: `status_summary_${STATUS_SUMMARY_SALT}_${++statusSummaryCounter}`,
       source: "codex",
-      content: `[STATUS summary — ${this.buffer.length} update(s), flushed: ${reason}]\n${combined}`,
+      content: `[STATUS summary — ${this.buffer.length} update(s)${droppedNote}, flushed: ${reason}]\n${combined}`,
       timestamp: Date.now(),
     };
     // Clear AFTER calling onFlush — if the send fails, emitToClaude's
@@ -159,11 +195,13 @@ export class StatusBuffer {
     // first would lose messages when ws.send() throws on a closing socket.
     this.onFlush(summary);
     this.buffer = [];
+    this.droppedCount = 0;
   }
 
   dispose(): void {
     this.clearTimer();
     this.buffer = [];
+    this.droppedCount = 0;
   }
 
   private clearTimer(): void {

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -3014,3 +3014,83 @@ describe("CodexAdapter turn/interrupt (protocol v2 PR B)", () => {
     expect(completedIds).toEqual(["t1", null]);
   });
 });
+
+describe("CodexAdapter agentMessageBuffers lifecycle (LOW-3)", () => {
+  // agentMessageBuffers is filled on item/started(agentMessage) and normally
+  // deleted on item/completed. When a turn is interrupted / aborted / the
+  // app-server socket drops mid-stream, the item/completed never arrives and
+  // the entry leaks forever. It must be cleared at the reset boundaries.
+  test("handleAppServerClose clears a dangling agentMessage buffer (no item/completed)", () => {
+    const adapter = createAdapter();
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    // Stream STARTS an agent message but never COMPLETES it.
+    adapter.handleServerNotification({
+      method: "item/started",
+      params: { item: { type: "agentMessage", id: "item-1" } },
+    });
+    adapter.handleServerNotification({
+      method: "item/agentMessage/delta",
+      params: { itemId: "item-1", delta: "partial..." },
+    });
+    expect(adapter.agentMessageBuffers.size).toBe(1);
+
+    // App-server socket drops mid-stream (routes through resetTurnState).
+    adapter.intentionalDisconnect = true;
+    adapter.handleAppServerClose();
+
+    expect(adapter.agentMessageBuffers.size).toBe(0);
+    adapter.clearResponseTrackingState();
+  });
+
+  test("resetTurnState clears dangling agentMessage buffers", () => {
+    const adapter = createAdapter();
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    adapter.handleServerNotification({
+      method: "item/started",
+      params: { item: { type: "agentMessage", id: "item-a" } },
+    });
+    adapter.handleServerNotification({
+      method: "item/started",
+      params: { item: { type: "agentMessage", id: "item-b" } },
+    });
+    expect(adapter.agentMessageBuffers.size).toBe(2);
+
+    adapter.resetTurnState("interrupted", false);
+    expect(adapter.agentMessageBuffers.size).toBe(0);
+  });
+
+  test("markTurnCompleted with missing turnId clears all agentMessage buffers", () => {
+    const adapter = createAdapter();
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    adapter.handleServerNotification({
+      method: "item/started",
+      params: { item: { type: "agentMessage", id: "item-x" } },
+    });
+    expect(adapter.agentMessageBuffers.size).toBe(1);
+
+    // turn/completed with NO id (the "all active turns cleared" branch).
+    adapter.handleServerNotification({ method: "turn/completed", params: {} });
+    expect(adapter.agentMessageBuffers.size).toBe(0);
+  });
+
+  test("normal item/completed still drains its own buffer (no regression)", () => {
+    const adapter = createAdapter();
+    const emitted: string[] = [];
+    adapter.on("agentMessage", (m: { content: string }) => emitted.push(m.content));
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    adapter.handleServerNotification({
+      method: "item/started",
+      params: { item: { type: "agentMessage", id: "item-1" } },
+    });
+    adapter.handleServerNotification({
+      method: "item/agentMessage/delta",
+      params: { itemId: "item-1", delta: "hello" },
+    });
+    adapter.handleServerNotification({
+      method: "item/completed",
+      params: { item: { type: "agentMessage", id: "item-1" } },
+    });
+    expect(adapter.agentMessageBuffers.size).toBe(0);
+    expect(emitted).toEqual(["hello"]);
+  });
+});

--- a/src/unit-test/message-filter.test.ts
+++ b/src/unit-test/message-filter.test.ts
@@ -281,4 +281,110 @@ describe("StatusBuffer pause/resume", () => {
     buf.dispose();
   });
 });
+
+describe("StatusBuffer summary id uniqueness (LOW-1)", () => {
+  // The summary id is used as the dedup key by ClaudeAdapter.rememberDelivery.
+  // Two flushes within the same millisecond MUST NOT collide, otherwise the
+  // second summary is silently suppressed as a "duplicate".
+  test("two flushes in the same millisecond produce distinct ids", () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), { flushThreshold: 1, flushTimeoutMs: 60000 });
+    buf.add(makeMsg("[STATUS] a"));
+    buf.add(makeMsg("[STATUS] b"));
+    expect(flushed).toHaveLength(2);
+    expect(flushed[0].id).not.toBe(flushed[1].id);
+    buf.dispose();
+  });
+
+  test("ids are monotonic within a process and prefixed with a stable salt", () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), { flushThreshold: 1, flushTimeoutMs: 60000 });
+    for (let i = 0; i < 5; i++) buf.add(makeMsg(`[STATUS] ${i}`));
+    expect(flushed).toHaveLength(5);
+    const ids = flushed.map((m) => m.id);
+    // All distinct.
+    expect(new Set(ids).size).toBe(ids.length);
+    // Shape: status_summary_<salt>_<counter>. Salt is shared, counter strictly increases.
+    const parsed = ids.map((id) => {
+      const m = id.match(/^status_summary_([^_]+)_(\d+)$/);
+      expect(m).not.toBeNull();
+      return { salt: m![1], counter: Number(m![2]) };
+    });
+    const salt = parsed[0].salt;
+    for (const p of parsed) expect(p.salt).toBe(salt);
+    for (let i = 1; i < parsed.length; i++) {
+      expect(parsed[i].counter).toBeGreaterThan(parsed[i - 1].counter);
+    }
+    buf.dispose();
+  });
+
+  test("timestamp field still reflects wall-clock time", () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), { flushThreshold: 1, flushTimeoutMs: 60000 });
+    const before = Date.now();
+    buf.add(makeMsg("[STATUS] a"));
+    const after = Date.now();
+    expect(flushed[0].timestamp).toBeGreaterThanOrEqual(before);
+    expect(flushed[0].timestamp).toBeLessThanOrEqual(after);
+    buf.dispose();
+  });
+});
+
+describe("StatusBuffer bounded buffer (LOW-2)", () => {
+  // Without an upper bound, a long attention window (auto-flush paused) lets
+  // STATUS messages accumulate without limit. Cap the buffer and drop oldest.
+  test("drops oldest beyond maxBuffered while paused", () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), {
+      flushThreshold: 100,
+      flushTimeoutMs: 60000,
+      maxBuffered: 3,
+    });
+    buf.pause();
+    for (let i = 0; i < 6; i++) buf.add(makeMsg(`[STATUS] msg${i}`));
+    // Buffer never exceeds the cap.
+    expect(buf.size).toBe(3);
+    buf.flush("manual");
+    expect(flushed).toHaveLength(1);
+    const content = flushed[0].content;
+    // Oldest (msg0..msg2) dropped, newest (msg3..msg5) retained.
+    expect(content).toContain("msg5");
+    expect(content).toContain("msg3");
+    expect(content).not.toContain("msg0");
+    expect(content).not.toContain("msg2");
+    // Sentinel reflects the dropped count.
+    expect(content).toContain("3");
+    buf.dispose();
+  });
+
+  test("dropped count resets after a flush", () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), {
+      flushThreshold: 100,
+      flushTimeoutMs: 60000,
+      maxBuffered: 2,
+    });
+    buf.pause();
+    for (let i = 0; i < 5; i++) buf.add(makeMsg(`[STATUS] a${i}`)); // drops 3
+    buf.flush("first");
+    // After flush, a fresh fill that stays under the cap must NOT report drops.
+    buf.add(makeMsg("[STATUS] b0"));
+    buf.add(makeMsg("[STATUS] b1"));
+    buf.flush("second");
+    expect(flushed).toHaveLength(2);
+    expect(flushed[1].content).not.toContain("dropped");
+    buf.dispose();
+  });
+
+  test("default maxBuffered allows normal small bursts without drops", () => {
+    const flushed: BridgeMessage[] = [];
+    const buf = new StatusBuffer((m) => flushed.push(m), { flushThreshold: 100, flushTimeoutMs: 60000 });
+    buf.pause();
+    for (let i = 0; i < 50; i++) buf.add(makeMsg(`[STATUS] x${i}`));
+    expect(buf.size).toBe(50);
+    buf.flush("manual");
+    expect(flushed[0].content).not.toContain("dropped");
+    buf.dispose();
+  });
+});
 // (The bridge-contract marker spec moved to AGENTS_MD_SECTION; see role-patterns.test.ts.)


### PR DESCRIPTION
## 摘要 / Summary
深度扫描（合并后 master）发现的 3 个投递层 LOW，全部修复（均非 daemon.ts handleClaudeToCodex 区）：
- **message-filter.ts status_summary id**：墙钟 → `status_summary_${salt}_${++counter}`。修 #313 deduper 漏扫的 dedup-key 碰撞（同毫秒两条 summary 第二条被误丢）。salt=每进程随机，跨进程/重启也不碰撞。
- **message-filter.ts StatusBuffer 上界**：加 `maxBuffered`（默认 200，可注入），drop-oldest + flush 时 "N older dropped" 哨兵。修长 paused attention window 内无界增长（daemon 其它缓冲都有界，唯此无界）。
- **codex-adapter.ts agentMessageBuffers 泄漏**：在 `resetTurnState`（app-server close/reconnect/stop）+ `markTurnCompleted` missing-turnId 分支清空。修 interrupt/turnAborted/socket-drop 中断的 agentMessage 残留无界增长（interrupt 现已常规化）。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1102 pass / 0 fail** / `verify:plugin-sync` ✅
- id 唯一性（同毫秒 + 跨进程）、有界 buffer drop-oldest + 哨兵、泄漏 cleared-on-close + 正常完成回归。
- Cross-review：correctness + regression 双镜头 **0 REAL**。

## 备注
攒批发布：release-on-merge 暂禁。StatusBuffer maxBuffered 用默认值，daemon 构造点零改动。