### PR TITLE
feat: 控制协议契约版本协商——attach 校验 contractVersion（CLOSE 4006）/ contract-version negotiation on attach (protocol trio finale)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14379,7 +14379,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("a2d8062", "source"),
+  commit: defineString("3f988c0", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14408,6 +14408,7 @@ var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 var CLOSE_CODE_PAIR_MISMATCH = 4004;
 var CLOSE_CODE_TOKEN_MISMATCH = 4005;
+var CLOSE_CODE_CONTRACT_MISMATCH = 4006;
 
 // src/interrupt-timing.ts
 var CLIENT_REPLY_TIMEOUT_MS = 15000;
@@ -14633,7 +14634,7 @@ class DaemonClient extends EventEmitter2 {
       if (isCurrent) {
         this.ws = null;
         this.rejectPendingReplies("AgentBridge daemon disconnected.");
-        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE || event.code === CLOSE_CODE_PROBE_IN_PROGRESS || event.code === CLOSE_CODE_PAIR_MISMATCH || event.code === CLOSE_CODE_TOKEN_MISMATCH) {
+        if (event.code === CLOSE_CODE_REPLACED || event.code === CLOSE_CODE_EVICTED_STALE || event.code === CLOSE_CODE_PROBE_IN_PROGRESS || event.code === CLOSE_CODE_PAIR_MISMATCH || event.code === CLOSE_CODE_TOKEN_MISMATCH || event.code === CLOSE_CODE_CONTRACT_MISMATCH) {
           this.emit("rejected", event.code);
         } else {
           this.emit("disconnect");
@@ -15926,6 +15927,11 @@ daemonClient.on("rejected", async (code) => {
       reason = "rejected";
       notificationId = "system_bridge_token_mismatch";
       notificationContent = `\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 control token mismatch (the daemon likely restarted and rotated its token). Start a fresh session with \`${pairScopedCommand("claude")}\` to pick up the current token. AgentBridge \u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u63A7\u5236\u4EE4\u724C\u4E0D\u5339\u914D\uFF08daemon \u53EF\u80FD\u5DF2\u91CD\u542F\u5E76\u8F6E\u6362\u4EE4\u724C\uFF09\u3002\u8BF7\u7528 \`${pairScopedCommand("claude")}\` \u91CD\u65B0\u542F\u52A8\u4EE5\u83B7\u53D6\u6700\u65B0\u4EE4\u724C\u3002`;
+      break;
+    case CLOSE_CODE_CONTRACT_MISMATCH:
+      reason = "rejected";
+      notificationId = "system_bridge_contract_mismatch";
+      notificationContent = `\u26A0\uFE0F AgentBridge daemon rejected this session \u2014 protocol contract mismatch. The installed plugin and the running daemon are built from out-of-sync protocol versions. Run \`bun run install:global\` to rebuild + reinstall, then close and reopen Claude Code. Do NOT kill other pairs \u2014 this is local build skew, not a session conflict. AgentBridge \u62D2\u7EDD\u4E86\u6B64\u4F1A\u8BDD\u2014\u2014\u534F\u8BAE\u5951\u7EA6\u7248\u672C\u4E0D\u5339\u914D\u3002\u5DF2\u5B89\u88C5\u7684\u63D2\u4EF6\u4E0E\u8FD0\u884C\u4E2D\u7684 daemon \u534F\u8BAE\u7248\u672C\u4E0D\u4E00\u81F4\u3002\u8BF7\u8FD0\u884C \`bun run install:global\` \u91CD\u65B0\u7F16\u8BD1\u5E76\u5B89\u88C5\uFF0C\u7136\u540E\u5173\u95ED\u5E76\u91CD\u65B0\u6253\u5F00 Claude Code\u3002\u8BF7\u52FF kill \u5176\u5B83 pair\u2014\u2014\u8FD9\u662F\u672C\u5730\u6784\u5EFA\u7248\u672C\u6F02\u79FB\uFF0C\u4E0D\u662F\u4F1A\u8BDD\u51B2\u7A81\u3002`;
       break;
     default:
       reason = "rejected";

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -21,7 +21,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("a2d8062", "source"),
+  commit: defineString("3f988c0", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -2253,6 +2253,7 @@ var CLOSE_CODE_EVICTED_STALE = 4002;
 var CLOSE_CODE_PROBE_IN_PROGRESS = 4003;
 var CLOSE_CODE_PAIR_MISMATCH = 4004;
 var CLOSE_CODE_TOKEN_MISMATCH = 4005;
+var CLOSE_CODE_CONTRACT_MISMATCH = 4006;
 
 // src/control-token.ts
 import { chmodSync as chmodSync2, readFileSync } from "fs";
@@ -2344,8 +2345,9 @@ function validateClaudeClientIdentity(input) {
       };
     }
   }
-  if (!input.expectedPairId)
-    return { ok: true };
+  if (!input.expectedPairId) {
+    return input.identity ? validateContractVersion(input) : { ok: true };
+  }
   if (!input.identity) {
     return input.allowIdentityless ? { ok: true } : { ok: false, closeCode: CLOSE_CODE_PAIR_MISMATCH, reason: "missing client identity" };
   }
@@ -2361,6 +2363,26 @@ function validateClaudeClientIdentity(input) {
       ok: false,
       closeCode: CLOSE_CODE_PAIR_MISMATCH,
       reason: `cwd mismatch: expected ${input.daemonCwd}, got ${input.identity.cwd ?? "<none>"}`
+    };
+  }
+  return validateContractVersion(input);
+}
+function validateContractVersion(input) {
+  if (input.expectedContractVersion === undefined)
+    return { ok: true };
+  const provided = input.identity?.contractVersion;
+  if (provided === undefined || provided === null) {
+    return {
+      ok: false,
+      closeCode: CLOSE_CODE_CONTRACT_MISMATCH,
+      reason: `missing contract version: daemon speaks contract v${input.expectedContractVersion}`
+    };
+  }
+  if (provided !== input.expectedContractVersion) {
+    return {
+      ok: false,
+      closeCode: CLOSE_CODE_CONTRACT_MISMATCH,
+      reason: `contract version mismatch: daemon v${input.expectedContractVersion}, client v${provided}`
     };
   }
   return { ok: true };
@@ -5091,7 +5113,8 @@ function handleControlMessage(ws, raw) {
         daemonCwd: process.cwd(),
         identity: message.identity,
         allowIdentityless: ALLOW_IDENTITYLESS_CLIENT,
-        expectedControlToken: controlToken
+        expectedControlToken: controlToken,
+        expectedContractVersion: BUILD_INFO.contractVersion
       });
       if (!admission.ok) {
         log(`Rejecting Claude frontend #${ws.data.clientId}: ${admission.reason}`);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -18,6 +18,7 @@ import {
   CLOSE_CODE_PAIR_MISMATCH,
   CLOSE_CODE_PROBE_IN_PROGRESS,
   CLOSE_CODE_TOKEN_MISMATCH,
+  CLOSE_CODE_CONTRACT_MISMATCH,
 } from "./control-protocol";
 import type { ControlClientIdentity } from "./control-protocol";
 import type { BridgeMessage } from "./types";
@@ -214,6 +215,17 @@ daemonClient.on("rejected", async (code: number) => {
       reason = "rejected";
       notificationId = "system_bridge_token_mismatch";
       notificationContent = `⚠️ AgentBridge daemon rejected this session — control token mismatch (the daemon likely restarted and rotated its token). Start a fresh session with \`${pairScopedCommand("claude")}\` to pick up the current token. AgentBridge 拒绝了此会话——控制令牌不匹配（daemon 可能已重启并轮换令牌）。请用 \`${pairScopedCommand("claude")}\` 重新启动以获取最新令牌。`;
+      break;
+    case CLOSE_CODE_CONTRACT_MISMATCH:
+      // The frontend and daemon were built from incompatible protocol snapshots
+      // (one upgraded, the other did not) — messages would parse but silently
+      // drift. The fix is to rebuild/reinstall so BOTH sides share the same
+      // contract, NOT to kill another pair (its daemon is fine; the mismatch is
+      // local build skew). Distinct message so the user reinstalls instead of
+      // chasing a phantom "another session" / "wrong directory" conflict.
+      reason = "rejected";
+      notificationId = "system_bridge_contract_mismatch";
+      notificationContent = `⚠️ AgentBridge daemon rejected this session — protocol contract mismatch. The installed plugin and the running daemon are built from out-of-sync protocol versions. Run \`bun run install:global\` to rebuild + reinstall, then close and reopen Claude Code. Do NOT kill other pairs — this is local build skew, not a session conflict. AgentBridge 拒绝了此会话——协议契约版本不匹配。已安装的插件与运行中的 daemon 协议版本不一致。请运行 \`bun run install:global\` 重新编译并安装，然后关闭并重新打开 Claude Code。请勿 kill 其它 pair——这是本地构建版本漂移，不是会话冲突。`;
       break;
     default:
       reason = "rejected";

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -176,3 +176,21 @@ export const CLOSE_CODE_PAIR_MISMATCH = 4004;
  * rotated its token, and a fresh `claude` launch (re-reading the token) recovers.
  */
 export const CLOSE_CODE_TOKEN_MISMATCH = 4005;
+
+/**
+ * WebSocket close code sent when a Claude frontend's `claude_connect` carries a
+ * missing or mismatched control-protocol contract version (arch-review P1 #303).
+ * Distinct from CLOSE_CODE_PAIR_MISMATCH (4004, wrong directory) and
+ * CLOSE_CODE_TOKEN_MISMATCH (4005, stale token): a contract mismatch means the
+ * installed plugin/daemon are built from incompatible protocol snapshots (one
+ * side upgraded, the other did not), so the messages on this socket would parse
+ * but silently misbehave. Recovery is a rebuild/reinstall (`bun run
+ * install:global`) + a fresh Claude Code session, NOT killing another pair.
+ *
+ * Checked LAST in admission (after pair/cwd → 4004 and token → 4005) so a token
+ * error is never masked as a contract error. A frontend that carries NO identity
+ * (legacy / AGENTBRIDGE_COMPAT_IDENTITYLESS) is exempt: with no identity it can
+ * carry no contractVersion to negotiate, so the same compat policy as the token
+ * gate applies — only identity-carrying sockets are held to the contract.
+ */
+export const CLOSE_CODE_CONTRACT_MISMATCH = 4006;

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -6,6 +6,7 @@ import {
   CLOSE_CODE_PROBE_IN_PROGRESS,
   CLOSE_CODE_PAIR_MISMATCH,
   CLOSE_CODE_TOKEN_MISMATCH,
+  CLOSE_CODE_CONTRACT_MISMATCH,
 } from "./control-protocol";
 import type { ControlClientIdentity, ControlClientMessage, ControlServerMessage, DaemonStatus, TurnPhase } from "./control-protocol";
 import { CLIENT_REPLY_TIMEOUT_MS } from "./interrupt-timing";
@@ -328,7 +329,8 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
           event.code === CLOSE_CODE_EVICTED_STALE ||
           event.code === CLOSE_CODE_PROBE_IN_PROGRESS ||
           event.code === CLOSE_CODE_PAIR_MISMATCH ||
-          event.code === CLOSE_CODE_TOKEN_MISMATCH
+          event.code === CLOSE_CODE_TOKEN_MISMATCH ||
+          event.code === CLOSE_CODE_CONTRACT_MISMATCH
         ) {
           this.emit("rejected", event.code);
         } else {

--- a/src/daemon-identity.ts
+++ b/src/daemon-identity.ts
@@ -1,4 +1,5 @@
 import {
+  CLOSE_CODE_CONTRACT_MISMATCH,
   CLOSE_CODE_PAIR_MISMATCH,
   CLOSE_CODE_TOKEN_MISMATCH,
   type ControlClientIdentity,
@@ -17,6 +18,21 @@ export interface ClaudeIdentityValidationInput {
    * pre-token pair/cwd checks plus the attach-convergence guard at injection.
    */
   expectedControlToken?: string | null;
+  /**
+   * The daemon's control-protocol contract version (arch-review P1 #303, from
+   * BUILD_INFO.contractVersion). When set, an identity-carrying client MUST echo
+   * the SAME contractVersion or it is rejected with CLOSE_CODE_CONTRACT_MISMATCH
+   * (4006) — a missing or mismatched version means the frontend/daemon were
+   * built from incompatible protocol snapshots and would silently drift.
+   *
+   * Compat (mirrors the token gate): undefined disables the contract gate (an
+   * older daemon that never negotiated a contract); and an identity-LESS client
+   * (legacy / AGENTBRIDGE_COMPAT_IDENTITYLESS) is exempt because it carries no
+   * version to negotiate — the identityless admit paths below stay intact. The
+   * check runs LAST (after pair/cwd → 4004 and token → 4005) so a token error is
+   * never masked as a contract error.
+   */
+  expectedContractVersion?: number;
 }
 
 export type ClaudeIdentityValidationResult =
@@ -59,7 +75,13 @@ export function validateClaudeClientIdentity(
     }
   }
 
-  if (!input.expectedPairId) return { ok: true };
+  // Legacy mode (no pairId enforcement): pair/cwd are not checked, but an
+  // identity-carrying client still negotiates the contract (and already cleared
+  // the token gate above). An identityless legacy client carries no version to
+  // negotiate, so it is admitted unchanged.
+  if (!input.expectedPairId) {
+    return input.identity ? validateContractVersion(input) : { ok: true };
+  }
   if (!input.identity) {
     return input.allowIdentityless
       ? { ok: true }
@@ -77,6 +99,38 @@ export function validateClaudeClientIdentity(
       ok: false,
       closeCode: CLOSE_CODE_PAIR_MISMATCH,
       reason: `cwd mismatch: expected ${input.daemonCwd}, got ${input.identity.cwd ?? "<none>"}`,
+    };
+  }
+  // Contract-version gate (P1 #303) runs LAST — after pair/cwd (4004) and the
+  // token gate (4005) above — so a token/pair error is never mislabeled 4006.
+  return validateContractVersion(input);
+}
+
+/**
+ * Contract-version gate (arch-review P1 #303). Only reached for identity-
+ * carrying clients that have already cleared the token + pair/cwd gates. When
+ * the daemon advertises a contract (expectedContractVersion set), the client's
+ * identity MUST echo the exact same version; a missing or mismatched version is
+ * rejected with CLOSE_CODE_CONTRACT_MISMATCH (4006). expectedContractVersion
+ * undefined disables the gate (older daemon that never negotiated a contract).
+ */
+function validateContractVersion(
+  input: ClaudeIdentityValidationInput,
+): ClaudeIdentityValidationResult {
+  if (input.expectedContractVersion === undefined) return { ok: true };
+  const provided = input.identity?.contractVersion;
+  if (provided === undefined || provided === null) {
+    return {
+      ok: false,
+      closeCode: CLOSE_CODE_CONTRACT_MISMATCH,
+      reason: `missing contract version: daemon speaks contract v${input.expectedContractVersion}`,
+    };
+  }
+  if (provided !== input.expectedContractVersion) {
+    return {
+      ok: false,
+      closeCode: CLOSE_CODE_CONTRACT_MISMATCH,
+      reason: `contract version mismatch: daemon v${input.expectedContractVersion}, client v${provided}`,
     };
   }
   return { ok: true };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,7 +2,7 @@
 
 import type { ServerWebSocket } from "bun";
 import { rmSync } from "node:fs";
-import { daemonStatusBuildInfo } from "./build-info";
+import { BUILD_INFO, daemonStatusBuildInfo } from "./build-info";
 import { CodexAdapter } from "./codex-adapter";
 import { validateClaudeClientIdentity, evaluateInjectionAttachGuard } from "./daemon-identity";
 import {
@@ -696,12 +696,18 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
 
   switch (message.type) {
     case "claude_connect":
+      // Contract-version negotiation (arch-review P1 #303) applies ONLY here, at
+      // claude_connect attach admission. control-only paths (probe_incumbent /
+      // status / generic WS) deliberately never reach this validator, so a
+      // contract mismatch can never reject a doctor/budget/probe socket — it is
+      // purely an attach-precondition.
       const admission = validateClaudeClientIdentity({
         expectedPairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
         daemonCwd: process.cwd(),
         identity: message.identity,
         allowIdentityless: ALLOW_IDENTITYLESS_CLIENT,
         expectedControlToken: controlToken,
+        expectedContractVersion: BUILD_INFO.contractVersion,
       });
       if (!admission.ok) {
         log(`Rejecting Claude frontend #${ws.data.clientId}: ${admission.reason}`);

--- a/src/unit-test/daemon-client.test.ts
+++ b/src/unit-test/daemon-client.test.ts
@@ -153,6 +153,28 @@ describe("DaemonClient", () => {
     expect(disconnectEmitted).toBe(false);
   });
 
+  test("emits rejected (not disconnect) when server closes with code 4006 (contract mismatch)", async () => {
+    await client.connect();
+
+    let disconnectEmitted = false;
+    client.on("disconnect", () => { disconnectEmitted = true; });
+
+    const rejected = new Promise<number>((resolve) => {
+      client.on("rejected", (code) => resolve(code));
+    });
+
+    for (const ws of serverSockets) {
+      ws.close(4006, "contract version mismatch: daemon v1, client v2");
+    }
+
+    const code = await rejected;
+    expect(code).toBe(4006);
+    await new Promise((r) => setTimeout(r, 50));
+    // A contract mismatch is terminal-until-reinstall, like pair/token mismatch:
+    // it must NOT fall into the disconnect (auto-reconnect) path.
+    expect(disconnectEmitted).toBe(false);
+  });
+
   test("attachClaudeAndWaitForStatus resolves daemon status when the daemon confirms attachment", async () => {
     onServerMessage = (ws, raw) => {
       const message = JSON.parse(raw.toString());

--- a/src/unit-test/daemon-identity.test.ts
+++ b/src/unit-test/daemon-identity.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { CLOSE_CODE_PAIR_MISMATCH, CLOSE_CODE_TOKEN_MISMATCH } from "../control-protocol";
+import {
+  CLOSE_CODE_CONTRACT_MISMATCH,
+  CLOSE_CODE_PAIR_MISMATCH,
+  CLOSE_CODE_TOKEN_MISMATCH,
+} from "../control-protocol";
 import {
   evaluateInjectionAttachGuard,
   validateClaudeClientIdentity,
@@ -173,6 +177,162 @@ describe("control-token admission gate (arch-review P1 #283)", () => {
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.closeCode).toBe(CLOSE_CODE_TOKEN_MISMATCH);
+  });
+});
+
+describe("contract-version admission gate (arch-review P1 #303)", () => {
+  // A fully-correct token+pair+cwd identity so the ONLY variable under test is
+  // the contract version (everything before the contract gate already passes).
+  const identity = (contractVersion?: number) => ({
+    pairId: "main-12345678",
+    cwd: "/tmp/project",
+    controlToken: "the-secret-token",
+    ...(contractVersion !== undefined ? { contractVersion } : {}),
+  });
+
+  const baseInput = {
+    expectedPairId: "main-12345678",
+    daemonCwd: "/tmp/project",
+    allowIdentityless: false,
+    expectedControlToken: "the-secret-token",
+    expectedContractVersion: 1,
+  };
+
+  test("matching contract version → admitted", () => {
+    const result = validateClaudeClientIdentity({ ...baseInput, identity: identity(1) });
+    expect(result.ok).toBe(true);
+  });
+
+  test("missing contractVersion (daemon expects one) → rejected with CONTRACT_MISMATCH (4006)", () => {
+    const result = validateClaudeClientIdentity({ ...baseInput, identity: identity(undefined) });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.closeCode).toBe(CLOSE_CODE_CONTRACT_MISMATCH);
+      expect(result.reason).toContain("missing contract version");
+    }
+  });
+
+  test("null contractVersion is treated as missing → 4006", () => {
+    // A JSON wire payload can deliver `contractVersion: null`; the validator must
+    // treat null exactly like an absent version. The field type is `number?`, so
+    // the null is constructed via a typed-loophole to mirror real wire data.
+    const result = validateClaudeClientIdentity({
+      ...baseInput,
+      identity: {
+        pairId: "main-12345678",
+        cwd: "/tmp/project",
+        controlToken: "the-secret-token",
+        contractVersion: null as unknown as number,
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.closeCode).toBe(CLOSE_CODE_CONTRACT_MISMATCH);
+  });
+
+  test("mismatched contractVersion → rejected with 4006", () => {
+    const result = validateClaudeClientIdentity({ ...baseInput, identity: identity(2) });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.closeCode).toBe(CLOSE_CODE_CONTRACT_MISMATCH);
+      expect(result.reason).toContain("contract version mismatch");
+    }
+  });
+
+  test("expectedContractVersion undefined disables the gate (older daemon) — compat", () => {
+    const result = validateClaudeClientIdentity({
+      ...baseInput,
+      expectedContractVersion: undefined,
+      identity: identity(undefined), // no version at all, but gate is off
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  // --- Priority: 4004 (pair/cwd) > 4005 (token) > 4006 (contract), contract LAST ---
+
+  test("PRIORITY: pair mismatch wins over a (correct) contract version → 4004, not 4006", () => {
+    const result = validateClaudeClientIdentity({
+      ...baseInput,
+      identity: {
+        pairId: "other-aaaaaaaa", // wrong pair
+        cwd: "/tmp/elsewhere",
+        controlToken: "the-secret-token",
+        contractVersion: 1, // correct contract — but pair fails first
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.closeCode).toBe(CLOSE_CODE_PAIR_MISMATCH);
+  });
+
+  test("PRIORITY: token mismatch wins over a missing/wrong contract version → 4005, not 4006", () => {
+    // BOTH the token AND the contract are wrong; the token gate runs first, so a
+    // contract error must NOT mask the (more fundamental) token failure.
+    const result = validateClaudeClientIdentity({
+      ...baseInput,
+      identity: {
+        pairId: "main-12345678",
+        cwd: "/tmp/project",
+        controlToken: "attacker-guess", // wrong token
+        contractVersion: 999, // also wrong contract
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.closeCode).toBe(CLOSE_CODE_TOKEN_MISMATCH);
+  });
+
+  test("PRIORITY: contract is checked LAST — a wrong contract with everything else correct → 4006", () => {
+    // Pair/cwd/token all pass; only the contract is wrong. The contract gate is
+    // the final word, proving it runs after (not before) the other gates.
+    const result = validateClaudeClientIdentity({ ...baseInput, identity: identity(7) });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.closeCode).toBe(CLOSE_CODE_CONTRACT_MISMATCH);
+  });
+
+  // --- Backward-compat: identityless clients are exempt (mirror the token gate) ---
+
+  test("identityless client is EXEMPT from the contract gate (legacy / COMPAT_IDENTITYLESS)", () => {
+    const result = validateClaudeClientIdentity({
+      ...baseInput,
+      allowIdentityless: true,
+      identity: undefined, // no identity → no version to negotiate
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("legacy mode (no expectedPairId) still enforces the contract for identity-carrying clients", () => {
+    // Token cleared, no pair enforcement, but the contract is wrong → 4006. This
+    // mirrors the token gate which also fires in legacy mode for identity clients.
+    const result = validateClaudeClientIdentity({
+      expectedPairId: null,
+      daemonCwd: "/tmp/project",
+      allowIdentityless: false,
+      expectedControlToken: "legacy-secret",
+      expectedContractVersion: 1,
+      identity: { controlToken: "legacy-secret", contractVersion: 2 },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.closeCode).toBe(CLOSE_CODE_CONTRACT_MISMATCH);
+
+    // The legitimate legacy client with the right token AND contract is admitted.
+    expect(validateClaudeClientIdentity({
+      expectedPairId: null,
+      daemonCwd: "/tmp/project",
+      allowIdentityless: false,
+      expectedControlToken: "legacy-secret",
+      expectedContractVersion: 1,
+      identity: { controlToken: "legacy-secret", contractVersion: 1 },
+    }).ok).toBe(true);
+  });
+
+  test("legacy identityless client carries no version → admitted unchanged", () => {
+    const result = validateClaudeClientIdentity({
+      expectedPairId: null,
+      daemonCwd: "/tmp/project",
+      allowIdentityless: false,
+      expectedControlToken: null, // token gate off
+      expectedContractVersion: 1,
+      identity: undefined,
+    });
+    expect(result.ok).toBe(true);
   });
 });
 

--- a/src/unit-test/daemon-wiring.test.ts
+++ b/src/unit-test/daemon-wiring.test.ts
@@ -17,6 +17,7 @@ import type { BridgeMessage } from "../types";
 import type { ControlServerMessage, DaemonStatus } from "../control-protocol";
 import { portsForSlot, type PairPorts } from "../pair-registry";
 import { readControlToken, resolveControlTokenPath } from "../control-token";
+import { CONTRACT_VERSION } from "../contract-version";
 
 const DAEMON_PATH = join(process.cwd(), "src", "daemon.ts");
 const DEFAULT_TEST_SLOT_START = 2500 + (process.pid % 500);
@@ -1032,7 +1033,7 @@ describe("daemon wiring", () => {
         cwd: harness.cwd,
         stateDir: harness.stateDir,
         clientPid: process.pid,
-        contractVersion: 1,
+        contractVersion: CONTRACT_VERSION,
         controlToken: "totally-wrong-token",
       },
     }));
@@ -1070,7 +1071,7 @@ describe("daemon wiring", () => {
         cwd: harness.cwd,
         stateDir: harness.stateDir,
         clientPid: process.pid,
-        contractVersion: 1,
+        contractVersion: CONTRACT_VERSION,
       },
     }));
 
@@ -1099,6 +1100,109 @@ describe("daemon wiring", () => {
       (m) => m.type === "claude_to_codex_result" && m.requestId === "req-ok-1",
     ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }>;
     expect(accepted.success).toBe(true);
+  }, 30000);
+
+  // --- Contract-version negotiation (arch-review P1 #303) ---
+
+  test("contract gate: claude_connect with a MISMATCHED contractVersion is rejected and closed (4006)", async () => {
+    const harness = await startHarness({ pairId: "main-contmism", pairName: "main" });
+
+    const ws = await connectControlSocket(harness.controlPort);
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      ws.onclose = (event) => resolve({ code: event.code, reason: event.reason });
+    });
+
+    // Correct pair/cwd AND the correct capability token, so the ONLY thing the
+    // daemon can reject is the contract version (proves 4006 is checked last and
+    // is the deciding gate here, not 4004/4005).
+    const controlToken = readControlToken(resolveControlTokenPath(harness.stateDir));
+    ws.send(JSON.stringify({
+      type: "claude_connect",
+      identity: {
+        pairId: "main-contmism",
+        pairName: "main",
+        cwd: harness.cwd,
+        stateDir: harness.stateDir,
+        clientPid: process.pid,
+        contractVersion: CONTRACT_VERSION + 999, // deliberately incompatible
+        ...(controlToken ? { controlToken } : {}),
+      },
+    }));
+
+    const result = await Promise.race([closed, sleep(4000).then(() => null)]);
+    expect(result).not.toBeNull();
+    expect(result!.code).toBe(4006); // CLOSE_CODE_CONTRACT_MISMATCH
+    expect(result!.reason).toContain("contract version mismatch");
+
+    // The mismatched socket was NOT attached: the daemon still serves /healthz.
+    const healthz = await fetch(`http://127.0.0.1:${harness.controlPort}/healthz`);
+    expect(healthz.ok).toBe(true);
+  }, 30000);
+
+  test("contract gate: claude_connect MISSING contractVersion is rejected (4006)", async () => {
+    const harness = await startHarness({ pairId: "main-contmiss", pairName: "main" });
+
+    const ws = await connectControlSocket(harness.controlPort);
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      ws.onclose = (event) => resolve({ code: event.code, reason: event.reason });
+    });
+
+    // Correct pair/cwd + token, but NO contractVersion at all — an old frontend
+    // that predates contract negotiation. Default policy = reject (can't negotiate).
+    const controlToken = readControlToken(resolveControlTokenPath(harness.stateDir));
+    ws.send(JSON.stringify({
+      type: "claude_connect",
+      identity: {
+        pairId: "main-contmiss",
+        pairName: "main",
+        cwd: harness.cwd,
+        stateDir: harness.stateDir,
+        clientPid: process.pid,
+        // contractVersion intentionally omitted
+        ...(controlToken ? { controlToken } : {}),
+      },
+    }));
+
+    const result = await Promise.race([closed, sleep(4000).then(() => null)]);
+    expect(result).not.toBeNull();
+    expect(result!.code).toBe(4006);
+    expect(result!.reason).toContain("missing contract version");
+  }, 30000);
+
+  test("control-only path: probe_incumbent is NEVER rejected by the contract gate (no claude_connect)", async () => {
+    // A control-only socket (the `abg claude` conflict guard) connects and sends
+    // ONLY probe_incumbent — it carries no identity / contractVersion. The contract
+    // gate lives in claude_connect admission, so this socket must get a normal
+    // incumbent_status reply and must NOT be closed with 4006.
+    const harness = await startHarness({ pairId: "main-probecon", pairName: "main" });
+
+    const ws = await connectControlSocket(harness.controlPort);
+    const replies: ControlServerMessage[] = [];
+    ws.onmessage = (event) => {
+      const raw = typeof event.data === "string" ? event.data : event.data.toString();
+      replies.push(JSON.parse(raw) as ControlServerMessage);
+    };
+    let closeCode: number | null = null;
+    ws.onclose = (event) => { closeCode = event.code; };
+
+    ws.send(JSON.stringify({ type: "probe_incumbent" }));
+
+    await waitFor(
+      () => replies.some((m) => m.type === "incumbent_status"),
+      "incumbent_status reply for the control-only probe socket",
+    );
+    const reply = replies.find((m) => m.type === "incumbent_status") as Extract<
+      ControlServerMessage,
+      { type: "incumbent_status" }
+    >;
+    // No live frontend attached yet → connected:false. The point: a normal reply,
+    // not a 4006 close.
+    expect(reply.connected).toBe(false);
+    // Give any (erroneous) close a chance to arrive, then assert it never did.
+    await sleep(200);
+    expect(closeCode).toBeNull();
+
+    try { ws.close(); } catch {}
   }, 30000);
 });
 
@@ -1211,7 +1315,9 @@ async function startHarness(opts: {
           cwd,
           stateDir,
           clientPid: process.pid,
-          contractVersion: 1,
+          // Mirror bridge.ts: echo the daemon's contract version (#303). Read from
+          // the single source so a future bump keeps the happy path green.
+          contractVersion: CONTRACT_VERSION,
           ...(controlToken ? { controlToken } : {}),
         },
       }));


### PR DESCRIPTION
## 摘要 / Summary
arch-review P1 #303（协议三件 #333/#313/#303 最后一件）：attach 准入校验前后端协议契约版本，杜绝"契约不一致仍 attach → 静默跑偏"。
- `control-protocol.ts`：`CLOSE_CODE_CONTRACT_MISMATCH = 4006`（4005 已被 #283 token 占）。
- `daemon-identity.ts`：`validateClaudeClientIdentity` 在 token(4005)/pair-cwd(4004) 通过后校 `identity.contractVersion === BUILD_INFO.contractVersion`，缺失/不等 → **4006（契约门最后，token 错不被掩盖）**。
- `daemon.ts`：**只在 `case claude_connect`** 传 expectedContractVersion；**control-only（probe_incumbent/status/doctor/budget/kill）绝不进契约门**。
- `bridge.ts`：rejected `case 4006` 双语 UX（install:global 重装 + 重开 Claude，不建议 kill 其它 pair）。
- `daemon-client.ts`：4006 → 终态 rejected（不 auto-reconnect，无重连风暴）。
- 兼容：identityless/`COMPAT_IDENTITYLESS` 跳过契约门（镜像 token 门）；与 #283 attach 守卫纵深防御。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1107 pass / 0 fail** / `verify:plugin-sync` ✅
- daemon-identity（优先级 4004>4005>4006、缺失/不等/identityless 豁免/legacy）、daemon-client（4006→rejected）、daemon-wiring（真 daemon spawn：4006 拒 attach + control-only/probe_incumbent 不被拒）。
- Cross-review：R1 security 0 + compat 1 LOW（测试单源一致性）→ 已修；R2 security+compat **0 REAL**（2 连 clean）。

## 备注
攒批发布：release-on-merge 暂禁。daemon.ts 仅 import + claude_connect 两处，与并行的 interrupt-TOCTOU 修复不同区。