### PR TITLE
fix(security): interrupt 路径 attach 守卫 TOCTOU——await 后重检注入授权 / re-check attach guard after the interrupt await

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14379,7 +14379,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("3f988c0", "source"),
+  commit: defineString("392fac9", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -21,7 +21,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("3f988c0", "source"),
+  commit: defineString("392fac9", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -5318,6 +5318,17 @@ async function handleClaudeToCodex(ws, message) {
       return;
     }
     log("Interrupt reached terminal boundary \u2014 injecting the message as a new turn");
+    const postWaitAttachGuard = evaluateInjectionAttachGuard(attachedClaude, ws);
+    if (!postWaitAttachGuard.allowed) {
+      releaseInterruptKey();
+      log(`Rejecting interrupt-path injection from socket #${ws.data.clientId} that lost the attach ` + `slot during the terminal-boundary wait (request ${message.requestId}, ` + `attached=${attachedClaude ? "#" + attachedClaude.data.clientId : "none"})`);
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: "not_attached",
+        error: "The original Claude session disconnected (or was replaced by a newer session) while " + "the interrupt was waiting to take effect. Your message was NOT injected \u2014 this avoids " + "delivering it into a different session's thread. Reconnect and resend if still needed."
+      });
+      return;
+    }
     if (interruptThreadId && codex.activeThreadId !== interruptThreadId) {
       releaseInterruptKey();
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1051,6 +1051,41 @@ async function handleClaudeToCodex(
       return;
     }
     log("Interrupt reached terminal boundary — injecting the message as a new turn");
+    // Attach-convergence re-check (TOCTOU fix). The attach guard at the top of
+    // this handler (#283 defense layer 1) only proves `ws` held the slot at
+    // DISPATCH time. The interrupt path then `await`s waitForInterruptOutcome
+    // for up to the terminal-boundary timeout, during which `ws` may
+    // `claude_disconnect` (clearing attachedClaude) and another socket may
+    // attach and become the new attachedClaude. Falling through to the shared
+    // injection block with the stale `ws` would inject this turn on behalf of a
+    // detached session and emit turn_started to the NEW session (which never
+    // asked for it). Re-evaluate the same pure guard against the CURRENT
+    // attachedClaude before injecting; reject (no injection, no turn/start, no
+    // turn_started) if `ws` lost the slot during the wait. steer has no such
+    // await and the normal reply/inject paths satisfy attachedClaude===ws by
+    // construction, so neither is affected.
+    const postWaitAttachGuard = evaluateInjectionAttachGuard(attachedClaude, ws);
+    if (!postWaitAttachGuard.allowed) {
+      // The upfront accept() (under interruptThreadId) must not strand. Release
+      // it — releaseInterruptKey is scoped to interruptThreadId and is a no-op
+      // if the thread-change branch (below, now skipped) would have released,
+      // so this neither leaks nor double-frees the key.
+      releaseInterruptKey();
+      log(
+        `Rejecting interrupt-path injection from socket #${ws.data.clientId} that lost the attach ` +
+        `slot during the terminal-boundary wait (request ${message.requestId}, ` +
+        `attached=${attachedClaude ? "#" + attachedClaude.data.clientId : "none"})`,
+      );
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: "not_attached",
+        error:
+          "The original Claude session disconnected (or was replaced by a newer session) while " +
+          "the interrupt was waiting to take effect. Your message was NOT injected — this avoids " +
+          "delivering it into a different session's thread. Reconnect and resend if still needed.",
+      });
+      return;
+    }
     // Defensive: if the active thread changed during the wait, the upfront
     // accept() would strand under the old thread — release it; the shared
     // injection block re-registers under the thread it actually injects into.

--- a/src/unit-test/daemon-wiring.test.ts
+++ b/src/unit-test/daemon-wiring.test.ts
@@ -813,6 +813,134 @@ describe("daemon wiring", () => {
     }
   }, 60000);
 
+  // --- Security: interrupt-path attach-convergence TOCTOU (HIGH fix) ---
+  //
+  // The top-of-handler attach guard (#283) only proves the socket held the slot
+  // at DISPATCH time. The interrupt path then awaits the terminal boundary; if
+  // the originating socket detaches and another attaches DURING that await, the
+  // post-wait re-check must reject — otherwise the detached socket's message is
+  // injected and turn_started is emitted to the NEW (innocent) session.
+  test("interrupt TOCTOU: if the originating socket loses the attach slot during the terminal-boundary wait, the message is NOT injected and reports not_attached", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-int-toctou-"));
+    const interruptLog = join(fixtureRoot, "turninterrupt.jsonl");
+    const turnStartLog = join(fixtureRoot, "turn-starts.jsonl");
+    const readJsonl = (path: string): Array<Record<string, any>> =>
+      existsSync(path)
+        ? readFileSync(path, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+        : [];
+
+    const harness = await startHarness({
+      pairId: "main-toctouabc",
+      pairName: "main",
+      extraEnv: {
+        FAKE_APP_TURNINTERRUPT_LOG: interruptLog,
+        FAKE_APP_TURNSTART_LOG: turnStartLog,
+        // Defer the interrupt terminal boundary so the daemon's await stays
+        // open while we detach socket A and attach socket B.
+        FAKE_APP_INTERRUPT_DELAY_MS: "500",
+      },
+    });
+
+    // Socket A: the legit attached frontend. Its onmessage (set by attachClaude)
+    // records into harness.statusMessages — we read A's result from there. A is
+    // only DETACHED (claude_disconnect), not closed, so it can still receive the
+    // daemon's rejection result.
+    const resultForA = (requestId: string) =>
+      harness.statusMessages.find(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === requestId,
+      ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }> | undefined;
+
+    // Socket B: a SEPARATE control socket that will steal the attach slot mid-wait.
+    const bMessages: ControlServerMessage[] = [];
+    let socketB: WebSocket | null = null;
+
+    try {
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      // Drive into a running turn so the interrupt path is active.
+      harness.sendAppCommand("start-turn");
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_turn_started"),
+        "system_turn_started",
+      );
+
+      // A issues interrupt+inject. The fake records turn/interrupt immediately
+      // but defers the terminal boundary by FAKE_APP_INTERRUPT_DELAY_MS, so the
+      // daemon is now parked inside waitForInterruptOutcome.
+      harness.sendClaudeToCodex("req-toctou-1", "message from the OLD session", {
+        onBusy: "interrupt",
+        idempotencyKey: "key-toctou-1",
+      });
+
+      // Confirm the daemon entered the await: the fake logged turn/interrupt.
+      await waitFor(() => readJsonl(interruptLog).length >= 1, "recorded turn/interrupt (await entered)", 100, 100);
+
+      // While the daemon is awaiting: A detaches (slot freed) ...
+      harness.controlWs!.send(JSON.stringify({ type: "claude_disconnect" }));
+
+      // ... and B connects + wins the attach slot, becoming attachedClaude.
+      socketB = await connectControlSocket(harness.controlPort);
+      socketB.onmessage = (event) => {
+        const raw = typeof event.data === "string" ? event.data : event.data.toString();
+        bMessages.push(JSON.parse(raw) as ControlServerMessage);
+      };
+      const controlToken = readControlToken(resolveControlTokenPath(harness.stateDir));
+      socketB.send(JSON.stringify({
+        type: "claude_connect",
+        identity: {
+          pairId: "main-toctouabc",
+          pairName: "main",
+          cwd: harness.cwd,
+          stateDir: harness.stateDir,
+          clientPid: process.pid,
+          contractVersion: 1,
+          ...(controlToken ? { controlToken } : {}),
+        },
+      }));
+      // Wait until B's attachClaude completed: attachClaude unconditionally
+      // sends a `status` message to the freshly-attached socket, so receiving
+      // one on B proves attachedClaude === B (the slot was stolen mid-wait).
+      await waitFor(
+        () => bMessages.some((m) => m.type === "status"),
+        "socket B became the attached frontend (received status)",
+        100,
+        50,
+      );
+
+      // Now let the deferred terminal boundary fire (delay is 500ms).
+      const result = await waitFor(
+        () => resultForA("req-toctou-1") !== undefined,
+        "claude_to_codex_result for req-toctou-1 (delivered to detached socket A)",
+        120,
+        50,
+      ).then(() => resultForA("req-toctou-1")!);
+
+      // GREEN: the detached origin socket is rejected, NOT injected.
+      expect(result.success).toBe(false);
+      expect(result.code).toBe("not_attached");
+      expect(result.error).toContain("disconnected");
+
+      // No turn/start ever reached the app-server for this interrupt+inject.
+      await sleep(300);
+      expect(readJsonl(turnStartLog)).toHaveLength(0);
+
+      // The new session (B) never received a turn_started for req-toctou-1 — the
+      // old session's message was never injected on its behalf.
+      expect(
+        bMessages.some((m) => m.type === "turn_started" && m.requestId === "req-toctou-1"),
+      ).toBe(false);
+      // ... and A (the origin) likewise never saw a turn_started.
+      expect(
+        harness.statusMessages.some((m) => m.type === "turn_started" && m.requestId === "req-toctou-1"),
+      ).toBe(false);
+    } finally {
+      try { socketB?.close(); } catch {}
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 60000);
+
   test("a rejected keyed steer RELEASES its idempotency key — a same-key retry is allowed (PR B REAL #2)", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-steerfail-fixture-"));
     const steerLog = join(fixtureRoot, "turnsteer.jsonl");
@@ -1485,9 +1613,23 @@ const server = Bun.serve({
           if (process.env.FAKE_APP_TURNINTERRUPT_LOG) {
             appendFileSync(process.env.FAKE_APP_TURNINTERRUPT_LOG, JSON.stringify(msg.params) + "\\n");
           }
-          ws.send(JSON.stringify({ id: msg.id, result: {} }));
-          ws.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: msg.params.turnId, status: "interrupted" } } }));
-          if (lastStartedTurnId === msg.params.turnId) lastStartedTurnId = null;
+          // Harness-only switch (TOCTOU test): defer the terminal boundary so
+          // the daemon's waitForInterruptOutcome await stays open long enough
+          // for the originating control socket to detach and another to attach
+          // mid-wait. Real app-server defers the success response until
+          // TurnAborted, so deferring BOTH the {} response and the terminal
+          // turn/completed faithfully models a slow interrupt.
+          const interruptDelayMs = Number(process.env.FAKE_APP_INTERRUPT_DELAY_MS || 0);
+          const emitInterruptTerminal = () => {
+            ws.send(JSON.stringify({ id: msg.id, result: {} }));
+            ws.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: msg.params.turnId, status: "interrupted" } } }));
+            if (lastStartedTurnId === msg.params.turnId) lastStartedTurnId = null;
+          };
+          if (interruptDelayMs > 0) {
+            setTimeout(emitInterruptTerminal, interruptDelayMs);
+          } else {
+            emitInterruptTerminal();
+          }
         }
         // turn/steer: record params, then ack — or reject when the text carries
         // the [force-steer-error] marker (drives the steerFailed wiring test).


### PR DESCRIPTION
## 摘要 / Summary
深度扫描（合并后 master）发现的 **HIGH** 集成缺口（#283 attach 守卫 ⊕ PR B interrupt）：`handleClaudeToCodex` 顶部跑一次 attach 守卫，但 interrupt 分支在 `await waitForInterruptOutcome`（最长 ~13s）后**直接 fall-through 注入**——await 期间发起 socket 可 detach、新 socket attach，导致**已 detach 的旧 socket 仍能注入 turn**、`turn_started` 误发新 socket，绕过 #283 守卫。
- **修复**：terminal boundary 成功后、注入前**重跑 `evaluateInjectionAttachGuard(attachedClaude, ws)`**；失败则 release interrupt/idempotency key + 回 `not_attached` + return（不注入、不发 turn_started、不污染 pendingTurnStarts）。
- steer 分支无此 await 不受影响；正常 attached 注入路径逐位不变。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1118 pass / 0 fail**（含 #303 合并后全量）/ `verify:plugin-sync` ✅
- `daemon-wiring.test.ts`：harness-only `FAKE_APP_INTERRUPT_DELAY_MS` 撑开 await 窗口 + **RED→GREEN TOCTOU 回归**（旧实现下 detach 的 socket 仍注入=漏洞；修复后 not_attached）。
- Cross-review：R1+R2 security+regression **连续 2 轮 0 REAL**（R1 删 fix block 证 RED→GREEN；R2 独立复核 key 释放 exactly-once、唯一 await、状态一致）。

## 备注
攒批发布：release-on-merge 暂禁。daemon.ts 仅 interrupt 分支重检，与 #303（claude_connect）不同区已自动三方合并（full gate 1118 pass 复验）。