### PR TITLE
refactor: 抽出共享 PendingRequestRegistry（收编 sendReply + replayPending）/ extract a shared PendingRequestRegistry

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14379,7 +14379,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("392fac9", "source"),
+  commit: defineString("797ae05", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14415,6 +14415,76 @@ var CLIENT_REPLY_TIMEOUT_MS = 15000;
 var INTERRUPT_CLIENT_MARGIN_MS = 2000;
 var MAX_INTERRUPT_TIMEOUT_MS = CLIENT_REPLY_TIMEOUT_MS - INTERRUPT_CLIENT_MARGIN_MS;
 
+// src/pending-request-registry.ts
+class PendingRequestRegistry {
+  entries = new Map;
+  setTimer;
+  clearTimer;
+  constructor(deps = {}) {
+    this.setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = deps.clearTimer ?? ((handle) => clearTimeout(handle));
+  }
+  get size() {
+    return this.entries.size;
+  }
+  has(id) {
+    return this.entries.has(id);
+  }
+  register(id, options) {
+    const existing = this.entries.get(id);
+    if (existing) {
+      this.clearTimer(existing.timer);
+      this.entries.delete(id);
+    }
+    return new Promise((resolve, reject) => {
+      const timer = this.setTimer(() => {
+        if (!this.entries.has(id))
+          return;
+        this.entries.delete(id);
+        options.onTimeout({ resolve, reject });
+      }, options.timeoutMs);
+      if (options.unref) {
+        timer.unref?.();
+      }
+      this.entries.set(id, { resolve, reject, timer });
+    });
+  }
+  settle(id, value) {
+    const entry = this.entries.get(id);
+    if (!entry)
+      return false;
+    this.clearTimer(entry.timer);
+    this.entries.delete(id);
+    entry.resolve(value);
+    return true;
+  }
+  reject(id, error2) {
+    const entry = this.entries.get(id);
+    if (!entry)
+      return false;
+    this.clearTimer(entry.timer);
+    this.entries.delete(id);
+    entry.reject(error2);
+    return true;
+  }
+  settleAll(value) {
+    const make = typeof value === "function" ? value : () => value;
+    for (const [id, entry] of this.entries) {
+      this.clearTimer(entry.timer);
+      this.entries.delete(id);
+      entry.resolve(make(id));
+    }
+  }
+  rejectAll(error2) {
+    const make = typeof error2 === "function" ? error2 : () => error2;
+    for (const [id, entry] of this.entries) {
+      this.clearTimer(entry.timer);
+      this.entries.delete(id);
+      entry.reject(make(id));
+    }
+  }
+}
+
 // src/daemon-client.ts
 var nextSocketId = 0;
 
@@ -14424,7 +14494,7 @@ class DaemonClient extends EventEmitter2 {
   ws = null;
   wsId = 0;
   nextRequestId = 1;
-  pendingReplies = new Map;
+  pendingReplies = new PendingRequestRegistry;
   constructor(url, options = {}) {
     super();
     this.url = url;
@@ -14568,21 +14638,19 @@ class DaemonClient extends EventEmitter2 {
       return { success: false, error: "AgentBridge daemon is not connected." };
     }
     const requestId = `reply_${Date.now()}_${this.nextRequestId++}`;
-    return new Promise((resolve) => {
-      const timer = setTimeout(() => {
-        this.pendingReplies.delete(requestId);
-        resolve({ success: false, error: "Timed out waiting for AgentBridge daemon reply." });
-      }, CLIENT_REPLY_TIMEOUT_MS);
-      this.pendingReplies.set(requestId, { resolve, timer });
-      this.send({
-        type: "claude_to_codex",
-        requestId,
-        message,
-        ...requireReply ? { requireReply: true } : {},
-        ...onBusy && onBusy !== "reject" ? { onBusy } : {},
-        ...idempotencyKey ? { idempotencyKey } : {}
-      });
+    const pending = this.pendingReplies.register(requestId, {
+      timeoutMs: CLIENT_REPLY_TIMEOUT_MS,
+      onTimeout: ({ resolve }) => resolve({ success: false, error: "Timed out waiting for AgentBridge daemon reply." })
     });
+    this.send({
+      type: "claude_to_codex",
+      requestId,
+      message,
+      ...requireReply ? { requireReply: true } : {},
+      ...onBusy && onBusy !== "reject" ? { onBusy } : {},
+      ...idempotencyKey ? { idempotencyKey } : {}
+    });
+    return pending;
   }
   attachSocketHandlers(ws, socketId) {
     ws.onmessage = (event) => {
@@ -14598,12 +14666,7 @@ class DaemonClient extends EventEmitter2 {
           this.emit("codexMessage", message.message);
           return;
         case "claude_to_codex_result": {
-          const pending = this.pendingReplies.get(message.requestId);
-          if (!pending)
-            return;
-          clearTimeout(pending.timer);
-          this.pendingReplies.delete(message.requestId);
-          pending.resolve({
+          this.pendingReplies.settle(message.requestId, {
             success: message.success,
             error: message.error,
             ...message.code !== undefined ? { code: message.code } : {},
@@ -14644,11 +14707,7 @@ class DaemonClient extends EventEmitter2 {
     ws.onerror = () => {};
   }
   rejectPendingReplies(error2) {
-    for (const [requestId, pending] of this.pendingReplies.entries()) {
-      clearTimeout(pending.timer);
-      pending.resolve({ success: false, error: error2 });
-      this.pendingReplies.delete(requestId);
-    }
+    this.pendingReplies.settleAll(() => ({ success: false, error: error2 }));
   }
   send(message) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -21,7 +21,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("392fac9", "source"),
+  commit: defineString("797ae05", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -676,6 +676,76 @@ function wsOriginRejectedResponse() {
   return new Response("Forbidden: WebSocket Origin not allowed", { status: 403 });
 }
 
+// src/pending-request-registry.ts
+class PendingRequestRegistry {
+  entries = new Map;
+  setTimer;
+  clearTimer;
+  constructor(deps = {}) {
+    this.setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = deps.clearTimer ?? ((handle) => clearTimeout(handle));
+  }
+  get size() {
+    return this.entries.size;
+  }
+  has(id) {
+    return this.entries.has(id);
+  }
+  register(id, options) {
+    const existing = this.entries.get(id);
+    if (existing) {
+      this.clearTimer(existing.timer);
+      this.entries.delete(id);
+    }
+    return new Promise((resolve, reject) => {
+      const timer = this.setTimer(() => {
+        if (!this.entries.has(id))
+          return;
+        this.entries.delete(id);
+        options.onTimeout({ resolve, reject });
+      }, options.timeoutMs);
+      if (options.unref) {
+        timer.unref?.();
+      }
+      this.entries.set(id, { resolve, reject, timer });
+    });
+  }
+  settle(id, value) {
+    const entry = this.entries.get(id);
+    if (!entry)
+      return false;
+    this.clearTimer(entry.timer);
+    this.entries.delete(id);
+    entry.resolve(value);
+    return true;
+  }
+  reject(id, error) {
+    const entry = this.entries.get(id);
+    if (!entry)
+      return false;
+    this.clearTimer(entry.timer);
+    this.entries.delete(id);
+    entry.reject(error);
+    return true;
+  }
+  settleAll(value) {
+    const make = typeof value === "function" ? value : () => value;
+    for (const [id, entry] of this.entries) {
+      this.clearTimer(entry.timer);
+      this.entries.delete(id);
+      entry.resolve(make(id));
+    }
+  }
+  rejectAll(error) {
+    const make = typeof error === "function" ? error : () => error;
+    for (const [id, entry] of this.entries) {
+      this.clearTimer(entry.timer);
+      this.entries.delete(id);
+      entry.reject(make(id));
+    }
+  }
+}
+
 // src/codex-adapter.ts
 class CodexAdapter extends EventEmitter {
   static RESPONSE_TRACKING_TTL_MS = 30000;
@@ -730,7 +800,8 @@ class CodexAdapter extends EventEmitter {
   warnedAppServerVersions = new Set;
   warnedFragileRateLimitMessages = new Set;
   sessionRestoreInProgress = false;
-  replayPending = new Map;
+  replayPending = new PendingRequestRegistry;
+  replayMethods = new Map;
   static SESSION_REPLAY_TIMEOUT_MS = 5000;
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
     super();
@@ -1242,36 +1313,38 @@ class CodexAdapter extends EventEmitter {
       const m = e instanceof Error ? e.message : String(e);
       return Promise.reject(new Error(`replay parse failed for ${method}: ${m}`));
     }
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.replayPending.delete(id);
-        reject(new Error(`replay timeout (${CodexAdapter.SESSION_REPLAY_TIMEOUT_MS}ms) for ${method} id=${JSON.stringify(id)}`));
-      }, CodexAdapter.SESSION_REPLAY_TIMEOUT_MS);
-      this.replayPending.set(id, { method, resolve, reject, timer });
-      try {
-        this.appServerWs.send(raw);
-      } catch (e) {
-        clearTimeout(timer);
-        this.replayPending.delete(id);
-        const m = e instanceof Error ? e.message : String(e);
-        reject(new Error(`replay send failed for ${method}: ${m}`));
+    const timeoutMs = CodexAdapter.SESSION_REPLAY_TIMEOUT_MS;
+    this.replayMethods.set(id, method);
+    const pending = this.replayPending.register(id, {
+      timeoutMs,
+      onTimeout: ({ reject }) => {
+        this.replayMethods.delete(id);
+        reject(new Error(`replay timeout (${timeoutMs}ms) for ${method} id=${JSON.stringify(id)}`));
       }
     });
+    try {
+      this.appServerWs.send(raw);
+    } catch (e) {
+      this.replayMethods.delete(id);
+      const m = e instanceof Error ? e.message : String(e);
+      this.replayPending.reject(id, new Error(`replay send failed for ${method}: ${m}`));
+    }
+    return pending;
   }
   tryConsumeReplayResponse(payload) {
     const id = payload.id;
     if (id === undefined)
       return false;
-    const pending = this.replayPending.get(id);
-    if (!pending)
+    const key = id;
+    if (!this.replayPending.has(key))
       return false;
-    clearTimeout(pending.timer);
-    this.replayPending.delete(id);
+    const method = this.replayMethods.get(key) ?? "replay";
+    this.replayMethods.delete(key);
     if (payload.error !== undefined) {
       const errMsg = typeof payload.error === "object" && payload.error !== null && "message" in payload.error ? String(payload.error.message ?? "unknown") : JSON.stringify(payload.error);
-      pending.reject(new Error(`${pending.method} rejected: ${errMsg}`));
+      this.replayPending.reject(key, new Error(`${method} rejected: ${errMsg}`));
     } else {
-      pending.resolve(payload);
+      this.replayPending.settle(key, payload);
     }
     return true;
   }

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -55,6 +55,7 @@ import {
   APP_SERVER_RECONNECT_NEW_TUI_REASON,
 } from "./turn-notices";
 import { isAllowedWsUpgrade, wsOriginRejectedResponse } from "./ws-origin-guard";
+import { PendingRequestRegistry } from "./pending-request-registry";
 
 interface TuiSocketData {
   connId: number;
@@ -260,12 +261,15 @@ export class CodexAdapter extends EventEmitter {
   // error message, so a repeated legacy rate-limit error does not spam the log.
   private warnedFragileRateLimitMessages = new Set<string>();
   private sessionRestoreInProgress = false;
-  private replayPending = new Map<number | string, {
-    method: string;
-    resolve: (response: unknown) => void;
-    reject: (err: Error) => void;
-    timer: ReturnType<typeof setTimeout>;
-  }>();
+  // Session-replay waiter: id-keyed pending-request registry. REJECT semantics —
+  // a timeout, a send failure, and an app-server error response all REJECT;
+  // only a clean app-server response resolves. The timer is intentionally ref'd
+  // (registry default), matching the prior raw setTimeout (no unref).
+  private replayPending = new PendingRequestRegistry<unknown>();
+  // Companion lookup so tryConsumeReplayResponse can name the method in its
+  // reject message (`${method} rejected: ...`). Keyed by the same replay id and
+  // cleared in lockstep with the registry entry on every exit path.
+  private replayMethods = new Map<number | string, string>();
   private static readonly SESSION_REPLAY_TIMEOUT_MS = 5000;
 
   constructor(appPort = 4500, proxyPort = 4501, logFile = new StateDirResolver().logFile) {
@@ -1044,22 +1048,28 @@ export class CodexAdapter extends EventEmitter {
       return Promise.reject(new Error(`replay parse failed for ${method}: ${m}`));
     }
 
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.replayPending.delete(id);
-        reject(new Error(`replay timeout (${CodexAdapter.SESSION_REPLAY_TIMEOUT_MS}ms) for ${method} id=${JSON.stringify(id)}`));
-      }, CodexAdapter.SESSION_REPLAY_TIMEOUT_MS);
-
-      this.replayPending.set(id, { method, resolve, reject, timer });
-      try {
-        this.appServerWs!.send(raw);
-      } catch (e: unknown) {
-        clearTimeout(timer);
-        this.replayPending.delete(id);
-        const m = e instanceof Error ? e.message : String(e);
-        reject(new Error(`replay send failed for ${method}: ${m}`));
-      }
+    // Read the (test-mutable) static ONCE for both the arm value and the
+    // timeout message, matching the prior raw setTimeout which interpolated
+    // the same field at fire time.
+    const timeoutMs = CodexAdapter.SESSION_REPLAY_TIMEOUT_MS;
+    this.replayMethods.set(id, method);
+    const pending = this.replayPending.register(id, {
+      timeoutMs,
+      onTimeout: ({ reject }) => {
+        this.replayMethods.delete(id);
+        reject(new Error(`replay timeout (${timeoutMs}ms) for ${method} id=${JSON.stringify(id)}`));
+      },
     });
+    try {
+      this.appServerWs!.send(raw);
+    } catch (e: unknown) {
+      // reject() clears the timer + drops the registry entry; keep the
+      // companion method map in lockstep.
+      this.replayMethods.delete(id);
+      const m = e instanceof Error ? e.message : String(e);
+      this.replayPending.reject(id, new Error(`replay send failed for ${method}: ${m}`));
+    }
+    return pending;
   }
 
   /**
@@ -1071,19 +1081,21 @@ export class CodexAdapter extends EventEmitter {
   private tryConsumeReplayResponse(payload: Record<string, unknown>): boolean {
     const id = payload.id;
     if (id === undefined) return false;
-    const pending = this.replayPending.get(id as number | string);
-    if (!pending) return false;
+    const key = id as number | string;
+    if (!this.replayPending.has(key)) return false;
 
-    clearTimeout(pending.timer);
-    this.replayPending.delete(id as number | string);
+    const method = this.replayMethods.get(key) ?? "replay";
+    this.replayMethods.delete(key);
 
     if (payload.error !== undefined) {
       const errMsg = typeof payload.error === "object" && payload.error !== null && "message" in payload.error
         ? String((payload.error as { message?: unknown }).message ?? "unknown")
         : JSON.stringify(payload.error);
-      pending.reject(new Error(`${pending.method} rejected: ${errMsg}`));
+      // reject() clears the timer + drops the registry entry.
+      this.replayPending.reject(key, new Error(`${method} rejected: ${errMsg}`));
     } else {
-      pending.resolve(payload);
+      // settle() clears the timer + drops the registry entry.
+      this.replayPending.settle(key, payload);
     }
     return true;
   }

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -10,6 +10,7 @@ import {
 } from "./control-protocol";
 import type { ControlClientIdentity, ControlClientMessage, ControlServerMessage, DaemonStatus, TurnPhase } from "./control-protocol";
 import { CLIENT_REPLY_TIMEOUT_MS } from "./interrupt-timing";
+import { PendingRequestRegistry } from "./pending-request-registry";
 
 /**
  * Result of a claude_to_codex round trip. `code` / `phase` / `retryAfterMs`
@@ -52,13 +53,12 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   private ws: WebSocket | null = null;
   private wsId: number = 0; // Track socket identity for debugging
   private nextRequestId = 1;
-  private pendingReplies = new Map<
-    string,
-    {
-      resolve: (value: SendReplyResult) => void;
-      timer: ReturnType<typeof setTimeout>;
-    }
-  >();
+  // Reply waiter: id-keyed pending-request registry. RESOLVE-ONLY semantics —
+  // a timeout, a daemon result, and a connection drop all RESOLVE the promise
+  // with a SendReplyResult (success or failure); none of them reject. The
+  // CLIENT_REPLY_TIMEOUT_MS timer is intentionally ref'd (registry default),
+  // matching the prior raw setTimeout.
+  private pendingReplies = new PendingRequestRegistry<SendReplyResult>();
 
   constructor(private readonly url: string, private readonly options: DaemonClientOptions = {}) {
     super();
@@ -244,30 +244,28 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     }
 
     const requestId = `reply_${Date.now()}_${this.nextRequestId++}`;
-    return new Promise((resolve) => {
-      // CLIENT_REPLY_TIMEOUT_MS applies to the daemon's IMMEDIATE result. The
-      // interrupt path can legitimately defer the result until the daemon-side
-      // terminal-wait budget elapses — that budget is CLAMPED below this value
-      // (see interrupt-timing.ts: clampInterruptTimeoutMs), so the daemon always
-      // answers before this timer fires. INVARIANT: do not shrink this timeout
-      // without also lowering MAX_INTERRUPT_TIMEOUT_MS, or an over-large
-      // AGENTBRIDGE_INTERRUPT_TIMEOUT_MS could outlast it and a false timeout +
-      // Claude retry would double-turn.
-      const timer = setTimeout(() => {
-        this.pendingReplies.delete(requestId);
-        resolve({ success: false, error: "Timed out waiting for AgentBridge daemon reply." });
-      }, CLIENT_REPLY_TIMEOUT_MS);
-
-      this.pendingReplies.set(requestId, { resolve, timer });
-      this.send({
-        type: "claude_to_codex",
-        requestId,
-        message,
-        ...(requireReply ? { requireReply: true } : {}),
-        ...(onBusy && onBusy !== "reject" ? { onBusy } : {}),
-        ...(idempotencyKey ? { idempotencyKey } : {}),
-      });
+    // CLIENT_REPLY_TIMEOUT_MS applies to the daemon's IMMEDIATE result. The
+    // interrupt path can legitimately defer the result until the daemon-side
+    // terminal-wait budget elapses — that budget is CLAMPED below this value
+    // (see interrupt-timing.ts: clampInterruptTimeoutMs), so the daemon always
+    // answers before this timer fires. INVARIANT: do not shrink this timeout
+    // without also lowering MAX_INTERRUPT_TIMEOUT_MS, or an over-large
+    // AGENTBRIDGE_INTERRUPT_TIMEOUT_MS could outlast it and a false timeout +
+    // Claude retry would double-turn.
+    const pending = this.pendingReplies.register(requestId, {
+      timeoutMs: CLIENT_REPLY_TIMEOUT_MS,
+      onTimeout: ({ resolve }) =>
+        resolve({ success: false, error: "Timed out waiting for AgentBridge daemon reply." }),
     });
+    this.send({
+      type: "claude_to_codex",
+      requestId,
+      message,
+      ...(requireReply ? { requireReply: true } : {}),
+      ...(onBusy && onBusy !== "reject" ? { onBusy } : {}),
+      ...(idempotencyKey ? { idempotencyKey } : {}),
+    });
+    return pending;
   }
 
   private attachSocketHandlers(ws: WebSocket, socketId: number) {
@@ -286,13 +284,11 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
           this.emit("codexMessage", message.message);
           return;
         case "claude_to_codex_result": {
-          const pending = this.pendingReplies.get(message.requestId);
-          if (!pending) return;
-          clearTimeout(pending.timer);
-          this.pendingReplies.delete(message.requestId);
           // Pass the PR B structured fields through when the daemon sent them
-          // (older daemons only populate success/error).
-          pending.resolve({
+          // (older daemons only populate success/error). settle() is a no-op for
+          // an unknown / already-settled requestId — same guard as the prior
+          // `if (!pending) return`.
+          this.pendingReplies.settle(message.requestId, {
             success: message.success,
             error: message.error,
             ...(message.code !== undefined ? { code: message.code } : {}),
@@ -347,11 +343,11 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   }
 
   private rejectPendingReplies(error: string) {
-    for (const [requestId, pending] of this.pendingReplies.entries()) {
-      clearTimeout(pending.timer);
-      pending.resolve({ success: false, error });
-      this.pendingReplies.delete(requestId);
-    }
+    // RESOLVE-ONLY teardown: every in-flight reply resolves with a failure
+    // value (never rejects), matching the prior per-entry resolve(). Use the
+    // factory form so each settled promise gets its OWN result object, exactly
+    // as the old per-entry literal did (no shared reference across callers).
+    this.pendingReplies.settleAll(() => ({ success: false, error }));
   }
 
   private send(message: ControlClientMessage) {

--- a/src/pending-request-registry.ts
+++ b/src/pending-request-registry.ts
@@ -1,0 +1,180 @@
+/**
+ * PendingRequestRegistry — a shared skeleton for the
+ * "send request → register pending → arm a timeout → settle on event → clean up"
+ * pattern that AgentBridge implements in several reliability-sensitive places
+ * (daemon-client reply waiter, codex-adapter session-replay waiter).
+ *
+ * DESIGN INTENT (arch-review P2 #546)
+ * ----------------------------------
+ * This class deliberately does NOT unify the call sites' timeout values,
+ * fail-open behavior, or resolve-vs-reject semantics — arch-review noted those
+ * are "各自为政" (each site's own policy) and must stay that way. The registry
+ * only owns the mechanical bookkeeping:
+ *   - keeping an id → { promise settlers, timer } map
+ *   - arming / disarming a per-call timeout
+ *   - guaranteeing the timer is cleared and the entry deleted on every exit path
+ *   - idempotency: a second settle/reject/timeout for the same id is a no-op
+ *
+ * Each call site keeps full control of:
+ *   - its own `timeoutMs` (passed per `register`)
+ *   - whether a timeout RESOLVES (fail-open / failure-value) or REJECTS
+ *     (via the `onTimeout` callback, which receives the resolve/reject pair)
+ *   - what value it settles with (`settle`) or what error it rejects with
+ *     (`reject`)
+ *
+ * Timer injection (`setTimer` / `clearTimer`) keeps the class testable without
+ * real wall-clock waits. `unref` is opt-in per call (the existing map+timer
+ * sites do NOT unref their timers, so the default is to leave them ref'd).
+ */
+
+export interface PendingTimeoutControls<T> {
+  /** Resolve the pending promise with a value (fail-open / failure-value path). */
+  resolve: (value: T) => void;
+  /** Reject the pending promise with an error. */
+  reject: (error: Error) => void;
+}
+
+export interface RegisterOptions<T> {
+  /** Per-call timeout in milliseconds. Each site owns its own value. */
+  timeoutMs: number;
+  /**
+   * Invoked when the timeout fires (and only if the entry is still pending).
+   * The registry has already disarmed the timer and removed the entry BEFORE
+   * calling this, so the callback just decides resolve-vs-reject. This preserves
+   * each site's own fail-open / reject-on-timeout policy.
+   */
+  onTimeout: (controls: PendingTimeoutControls<T>) => void;
+  /**
+   * If true, the timeout timer is unref'd so it cannot keep the event loop
+   * alive. Defaults to false to match the existing map+timer call sites, whose
+   * reply/replay timers are intentionally ref'd.
+   */
+  unref?: boolean;
+}
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+interface PendingEntry<T> {
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+  timer: TimerHandle;
+}
+
+export interface PendingRegistryDeps {
+  setTimer?: (fn: () => void, ms: number) => TimerHandle;
+  clearTimer?: (handle: TimerHandle) => void;
+}
+
+export class PendingRequestRegistry<T> {
+  private readonly entries = new Map<string | number, PendingEntry<T>>();
+  private readonly setTimer: (fn: () => void, ms: number) => TimerHandle;
+  private readonly clearTimer: (handle: TimerHandle) => void;
+
+  constructor(deps: PendingRegistryDeps = {}) {
+    this.setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = deps.clearTimer ?? ((handle) => clearTimeout(handle));
+  }
+
+  /** Number of currently-pending entries (for tests / introspection). */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Whether an id is currently pending. */
+  has(id: string | number): boolean {
+    return this.entries.has(id);
+  }
+
+  /**
+   * Register a pending request and return a promise that resolves/rejects when
+   * the request is settled, rejected, or times out. The id MUST be sent on the
+   * wire by the caller AFTER (or as part of) this call so the response can be
+   * matched back via `settle` / `reject`.
+   *
+   * If an id is registered twice, the previous entry is settled defensively by
+   * timing it out is NOT done — instead the new registration overwrites the map
+   * slot, mirroring `Map.set`. Call sites use unique ids, so this is not hit in
+   * practice; the overwrite keeps the timer of the OLD entry cleared to avoid a
+   * leak.
+   */
+  register(id: string | number, options: RegisterOptions<T>): Promise<T> {
+    // Defensive: if the same id is somehow re-registered, clear the stale timer
+    // so it can't fire against the new promise. (Call sites use unique ids.)
+    const existing = this.entries.get(id);
+    if (existing) {
+      this.clearTimer(existing.timer);
+      this.entries.delete(id);
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = this.setTimer(() => {
+        // Only act if still pending — settle/reject may have raced in.
+        if (!this.entries.has(id)) return;
+        this.entries.delete(id);
+        options.onTimeout({ resolve, reject });
+      }, options.timeoutMs);
+
+      if (options.unref) {
+        (timer as { unref?: () => void }).unref?.();
+      }
+
+      this.entries.set(id, { resolve, reject, timer });
+    });
+  }
+
+  /**
+   * Settle a pending request with a value. Clears its timer and removes the
+   * entry. Returns true if an entry existed (and was settled), false otherwise
+   * (unknown / already-settled id → no-op).
+   */
+  settle(id: string | number, value: T): boolean {
+    const entry = this.entries.get(id);
+    if (!entry) return false;
+    this.clearTimer(entry.timer);
+    this.entries.delete(id);
+    entry.resolve(value);
+    return true;
+  }
+
+  /**
+   * Reject a pending request with an error. Clears its timer and removes the
+   * entry. Returns true if an entry existed (and was rejected), false otherwise
+   * (unknown / already-settled id → no-op).
+   */
+  reject(id: string | number, error: Error): boolean {
+    const entry = this.entries.get(id);
+    if (!entry) return false;
+    this.clearTimer(entry.timer);
+    this.entries.delete(id);
+    entry.reject(error);
+    return true;
+  }
+
+  /**
+   * Settle EVERY pending request with a value produced per-entry. Used by call
+   * sites whose "connection dropped" teardown resolves all in-flight waits with
+   * a failure value (resolve-only semantics, e.g. daemon-client reply waiter).
+   * The map is fully drained.
+   */
+  settleAll(value: T | ((id: string | number) => T)): void {
+    const make = typeof value === "function" ? (value as (id: string | number) => T) : () => value;
+    for (const [id, entry] of this.entries) {
+      this.clearTimer(entry.timer);
+      this.entries.delete(id);
+      entry.resolve(make(id));
+    }
+  }
+
+  /**
+   * Reject EVERY pending request with an error. Provided for symmetry / future
+   * teardown paths. The map is fully drained.
+   */
+  rejectAll(error: Error | ((id: string | number) => Error)): void {
+    const make = typeof error === "function" ? (error as (id: string | number) => Error) : () => error;
+    for (const [id, entry] of this.entries) {
+      this.clearTimer(entry.timer);
+      this.entries.delete(id);
+      entry.reject(make(id));
+    }
+  }
+}

--- a/src/unit-test/pending-request-registry.test.ts
+++ b/src/unit-test/pending-request-registry.test.ts
@@ -1,0 +1,317 @@
+import { describe, test, expect } from "bun:test";
+import { PendingRequestRegistry } from "../pending-request-registry";
+
+/**
+ * Direct unit tests for PendingRequestRegistry — the shared skeleton extracted
+ * for arch-review P2 #546. A fake timer (setTimer/clearTimer injection) lets us
+ * fire timeouts deterministically without wall-clock waits.
+ */
+
+/** Controllable fake timer: register callbacks, fire them on demand. */
+function makeFakeTimers() {
+  let nextHandle = 1;
+  const pending = new Map<number, () => void>();
+  const cleared: number[] = [];
+  const unrefed: number[] = [];
+
+  const setTimer = (fn: () => void, _ms: number) => {
+    const handle = nextHandle++;
+    pending.set(handle, fn);
+    // Return an object that mimics a NodeJS.Timeout enough for unref tracking,
+    // but is still usable as the opaque handle the registry stores.
+    const obj = {
+      _handle: handle,
+      unref: () => {
+        unrefed.push(handle);
+        return obj;
+      },
+    };
+    handleToObj.set(handle, obj);
+    objToHandle.set(obj, handle);
+    return obj as unknown as ReturnType<typeof setTimeout>;
+  };
+
+  const handleToObj = new Map<number, unknown>();
+  const objToHandle = new Map<unknown, number>();
+
+  const clearTimer = (handle: ReturnType<typeof setTimeout>) => {
+    const h = objToHandle.get(handle);
+    if (h === undefined) return;
+    cleared.push(h);
+    pending.delete(h);
+  };
+
+  const fire = (handle: number) => {
+    const fn = pending.get(handle);
+    if (!fn) throw new Error(`no pending timer with handle ${handle}`);
+    pending.delete(handle);
+    fn();
+  };
+
+  const fireAll = () => {
+    for (const [h, fn] of [...pending.entries()]) {
+      pending.delete(h);
+      fn();
+    }
+  };
+
+  return { setTimer, clearTimer, fire, fireAll, cleared, unrefed, pending };
+}
+
+describe("PendingRequestRegistry", () => {
+  test("register + settle resolves the promise with the settled value", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<{ ok: boolean }>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p = reg.register("req-1", {
+      timeoutMs: 1000,
+      onTimeout: ({ resolve }) => resolve({ ok: false }),
+    });
+
+    expect(reg.size).toBe(1);
+    expect(reg.has("req-1")).toBe(true);
+
+    const settled = reg.settle("req-1", { ok: true });
+    expect(settled).toBe(true);
+
+    await expect(p).resolves.toEqual({ ok: true });
+    // Entry removed and timer cleared.
+    expect(reg.size).toBe(0);
+    expect(reg.has("req-1")).toBe(false);
+    expect(timers.cleared.length).toBe(1);
+  });
+
+  test("register + reject rejects the promise with the given error", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<string>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p = reg.register(42, {
+      timeoutMs: 500,
+      onTimeout: ({ reject }) => reject(new Error("timed out")),
+    });
+
+    const rejected = reg.reject(42, new Error("boom"));
+    expect(rejected).toBe(true);
+
+    await expect(p).rejects.toThrow("boom");
+    expect(reg.size).toBe(0);
+    expect(timers.cleared.length).toBe(1);
+  });
+
+  test("timeout that resolves (fail-open) settles with the failure value", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<{ success: boolean; error?: string }>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p = reg.register("reply-1", {
+      timeoutMs: 1000,
+      onTimeout: ({ resolve }) => resolve({ success: false, error: "Timed out" }),
+    });
+
+    // Fire the timer (handle 1).
+    timers.fire(1);
+
+    await expect(p).resolves.toEqual({ success: false, error: "Timed out" });
+    // Entry removed by the timeout path.
+    expect(reg.size).toBe(0);
+    expect(reg.has("reply-1")).toBe(false);
+  });
+
+  test("timeout that rejects produces a rejected promise", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<unknown>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p = reg.register("replay-1", {
+      timeoutMs: 5000,
+      onTimeout: ({ reject }) => reject(new Error("replay timeout for initialize")),
+    });
+
+    timers.fire(1);
+
+    await expect(p).rejects.toThrow(/replay timeout for initialize/);
+    expect(reg.size).toBe(0);
+  });
+
+  test("settle after timeout is a no-op (timeout already won)", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<{ v: number }>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p = reg.register("race-1", {
+      timeoutMs: 100,
+      onTimeout: ({ resolve }) => resolve({ v: -1 }),
+    });
+
+    timers.fire(1); // timeout wins, entry deleted
+
+    // Late settle must be a no-op and must NOT change the resolved value.
+    const settled = reg.settle("race-1", { v: 99 });
+    expect(settled).toBe(false);
+
+    await expect(p).resolves.toEqual({ v: -1 });
+  });
+
+  test("timeout after settle is a no-op (settle already won)", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<{ v: number }>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p = reg.register("race-2", {
+      timeoutMs: 100,
+      onTimeout: ({ resolve }) => resolve({ v: -1 }),
+    });
+
+    reg.settle("race-2", { v: 7 }); // settle wins, timer cleared + entry deleted
+
+    // The timer should have been cleared, so firing it would find no entry.
+    // Defensive: even if it were fired, the registry guards on entries.has(id).
+    // (The handle is no longer in `pending` because clearTimer removed it.)
+    expect(timers.pending.size).toBe(0);
+
+    await expect(p).resolves.toEqual({ v: 7 });
+  });
+
+  test("duplicate settle is idempotent (second settle is a no-op)", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<number>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p = reg.register("dup", {
+      timeoutMs: 100,
+      onTimeout: ({ resolve }) => resolve(-1),
+    });
+
+    expect(reg.settle("dup", 1)).toBe(true);
+    expect(reg.settle("dup", 2)).toBe(false); // no-op
+    expect(reg.reject("dup", new Error("late"))).toBe(false); // no-op
+
+    await expect(p).resolves.toBe(1);
+  });
+
+  test("settle on an unknown id is a no-op (returns false)", () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<number>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    expect(reg.settle("never-registered", 1)).toBe(false);
+    expect(reg.reject("never-registered", new Error("x"))).toBe(false);
+    expect(reg.size).toBe(0);
+  });
+
+  test("settleAll drains every pending entry with a constant value", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<{ success: boolean; error?: string }>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p1 = reg.register("a", { timeoutMs: 1000, onTimeout: ({ resolve }) => resolve({ success: false }) });
+    const p2 = reg.register("b", { timeoutMs: 1000, onTimeout: ({ resolve }) => resolve({ success: false }) });
+    expect(reg.size).toBe(2);
+
+    reg.settleAll({ success: false, error: "Daemon connection closed" });
+
+    await expect(p1).resolves.toEqual({ success: false, error: "Daemon connection closed" });
+    await expect(p2).resolves.toEqual({ success: false, error: "Daemon connection closed" });
+    expect(reg.size).toBe(0);
+    // Both timers cleared.
+    expect(timers.cleared.length).toBe(2);
+  });
+
+  test("settleAll accepts a per-id factory", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<string>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p1 = reg.register("x", { timeoutMs: 1000, onTimeout: ({ resolve }) => resolve("") });
+    const p2 = reg.register("y", { timeoutMs: 1000, onTimeout: ({ resolve }) => resolve("") });
+
+    reg.settleAll((id) => `closed:${String(id)}`);
+
+    await expect(p1).resolves.toBe("closed:x");
+    await expect(p2).resolves.toBe("closed:y");
+  });
+
+  test("rejectAll drains every pending entry with an error", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<unknown>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p1 = reg.register("a", { timeoutMs: 1000, onTimeout: ({ reject }) => reject(new Error("t")) });
+    const p2 = reg.register("b", { timeoutMs: 1000, onTimeout: ({ reject }) => reject(new Error("t")) });
+
+    reg.rejectAll(new Error("connection lost"));
+
+    await expect(p1).rejects.toThrow("connection lost");
+    await expect(p2).rejects.toThrow("connection lost");
+    expect(reg.size).toBe(0);
+  });
+
+  test("settleAll on an empty registry is a harmless no-op", () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<number>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+    expect(() => reg.settleAll(0)).not.toThrow();
+    expect(reg.size).toBe(0);
+  });
+
+  test("unref:true unrefs the timer; default leaves it ref'd", () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<number>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    reg.register("ref-default", { timeoutMs: 100, onTimeout: ({ resolve }) => resolve(0) });
+    expect(timers.unrefed).toEqual([]); // default: NOT unref'd
+
+    reg.register("unref-on", { timeoutMs: 100, unref: true, onTimeout: ({ resolve }) => resolve(0) });
+    expect(timers.unrefed).toEqual([2]); // second timer handle, unref'd
+  });
+
+  test("re-registering the same id clears the old timer (no leak)", async () => {
+    const timers = makeFakeTimers();
+    const reg = new PendingRequestRegistry<number>({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+
+    const p1 = reg.register("same", { timeoutMs: 100, onTimeout: ({ resolve }) => resolve(-1) });
+    // Re-register: old timer (handle 1) must be cleared.
+    const p2 = reg.register("same", { timeoutMs: 100, onTimeout: ({ resolve }) => resolve(-2) });
+
+    expect(timers.cleared).toContain(1);
+    expect(reg.size).toBe(1);
+
+    // Settling resolves the SECOND promise; the first is orphaned (never settles)
+    // — acceptable because real call sites use unique ids and never hit this.
+    reg.settle("same", 5);
+    await expect(p2).resolves.toBe(5);
+    void p1; // intentionally not awaited
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary
arch-review P2 #546（part 1）：把「发请求→挂 pending→定时器超时→事件回填→cleanup」的重复模式收敛到一个泛型 `PendingRequestRegistry`，本 PR 先收编 2 个 **id-keyed** 等待器（其余 2 个 type-matched 的 attach/probe 留 part 2）。
- **新增 `src/pending-request-registry.ts`**：`register/settle/reject/settleAll/rejectAll/has/size`，注入 setTimer/clearTimer 便于测试。
- 收编：daemon-client `sendReply`（**resolve-only fail-open** 超时）+ codex-adapter `replayPending`（**reject** 超时 + `replayMethods` 伴随表）。**各站点保留各自的 timeout/fail-open 语义**。
- `staleProxyIds`/`bridgeRequestIds`（TTL 去重 set，语义不同）**不收编**。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1132 pass / 0 fail** / `verify:plugin-sync` ✅
- 现有 daemon-client/daemon-client-probe/codex-adapter 测试断言**零改全绿**；新增 14 个 registry 单测（含 fail-open-resolve vs reject 两种 onTimeout、超时/settle 竞态 no-op、同 id 重注册清旧 timer）。
- Cross-review：equivalence + reliability 双镜头 **0 REAL**；3 个 author SUSPECT 经核验均不成立；`settleAll` 改用 factory 形式保证每条 resolve 独立对象（与旧逐条 literal 逐位一致）。

## 后续 / Follow-up
part 2：把 type-matched 的 `attachClaudeAndWaitForStatus` + `probeIncumbent`（近乎逐行重复）也收编进 registry（type-as-key，利用隐含的同型不并发约束）。

## 备注
攒批发布：release-on-merge 暂禁。