### PR TITLE
refactor: 收编 attach/probe 事件式等待器进 PendingRequestRegistry（#546 完成）/ adopt attach/probe waiters (#546 complete)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14379,7 +14379,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("797ae05", "source"),
+  commit: defineString("ee9d6ec", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14495,6 +14495,7 @@ class DaemonClient extends EventEmitter2 {
   wsId = 0;
   nextRequestId = 1;
   pendingReplies = new PendingRequestRegistry;
+  pendingEventWaiters = new PendingRequestRegistry;
   constructor(url, options = {}) {
     super();
     this.url = url;
@@ -14554,72 +14555,58 @@ class DaemonClient extends EventEmitter2 {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return null;
     }
-    return await new Promise((resolve) => {
-      let settled = false;
-      let timer = null;
-      const cleanup = () => {
-        if (settled)
-          return;
-        settled = true;
-        if (timer) {
-          clearTimeout(timer);
-          timer = null;
-        }
-        this.off("status", onStatus);
-        this.off("rejected", onRejected);
-        this.off("disconnect", onDisconnect);
-      };
-      const finish = (value) => {
-        cleanup();
-        resolve(value);
-      };
-      const onStatus = (status) => finish(status);
-      const onRejected = () => finish(null);
-      const onDisconnect = () => finish(null);
-      this.on("status", onStatus);
-      this.on("rejected", onRejected);
-      this.on("disconnect", onDisconnect);
-      timer = setTimeout(() => {
-        finish(null);
-      }, timeoutMs);
-      try {
-        this.attachClaude();
-      } catch {
-        finish(null);
-      }
+    return this.awaitTypedResponse({
+      key: "status",
+      successEvent: "status",
+      successValue: (status) => status,
+      failValue: null,
+      timeoutMs,
+      send: () => this.attachClaude()
     });
   }
   async probeIncumbent(timeoutMs = 3000) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return { connected: false, alive: false };
     }
-    return await new Promise((resolve) => {
-      let settled = false;
-      let timer = null;
-      const finish = (value) => {
-        if (settled)
-          return;
-        settled = true;
-        if (timer)
-          clearTimeout(timer);
-        this.off("incumbentStatus", onStatus);
-        this.off("disconnect", onDisconnect);
-        this.off("rejected", onRejected);
-        resolve(value);
-      };
-      const onStatus = (s) => finish(s);
-      const onDisconnect = () => finish({ connected: false, alive: false });
-      const onRejected = () => finish({ connected: false, alive: false });
-      this.on("incumbentStatus", onStatus);
-      this.on("disconnect", onDisconnect);
-      this.on("rejected", onRejected);
-      timer = setTimeout(() => finish({ connected: false, alive: false }), timeoutMs);
-      try {
-        this.send({ type: "probe_incumbent" });
-      } catch {
-        finish({ connected: false, alive: false });
-      }
+    return this.awaitTypedResponse({
+      key: "incumbent_status",
+      successEvent: "incumbentStatus",
+      successValue: (s) => s,
+      failValue: { connected: false, alive: false },
+      timeoutMs,
+      send: () => this.send({ type: "probe_incumbent" })
     });
+  }
+  awaitTypedResponse(opts) {
+    const { key, successEvent, successValue, failValue, timeoutMs, send } = opts;
+    const onSuccess = (payload) => {
+      this.pendingEventWaiters.settle(key, successValue(payload));
+    };
+    const onRejected = () => {
+      this.pendingEventWaiters.settle(key, failValue);
+    };
+    const onDisconnect = () => {
+      this.pendingEventWaiters.settle(key, failValue);
+    };
+    const pending = this.pendingEventWaiters.register(key, {
+      timeoutMs,
+      onTimeout: ({ resolve }) => resolve(failValue)
+    });
+    const cleanup = () => {
+      this.off(successEvent, onSuccess);
+      this.off("rejected", onRejected);
+      this.off("disconnect", onDisconnect);
+    };
+    pending.finally(cleanup);
+    this.on(successEvent, onSuccess);
+    this.on("rejected", onRejected);
+    this.on("disconnect", onDisconnect);
+    try {
+      send();
+    } catch {
+      this.pendingEventWaiters.settle(key, failValue);
+    }
+    return pending;
   }
   async disconnect() {
     if (!this.ws)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -21,7 +21,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("797ae05", "source"),
+  commit: defineString("ee9d6ec", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -59,6 +59,17 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   // CLIENT_REPLY_TIMEOUT_MS timer is intentionally ref'd (registry default),
   // matching the prior raw setTimeout.
   private pendingReplies = new PendingRequestRegistry<SendReplyResult>();
+  // Event-style waiters (attach-status / probe-incumbent). Keyed by the control
+  // message TYPE we are awaiting ("status" / "incumbent_status") — safe because
+  // these requests never race the same type on one connection (attach reconnect
+  // is serialized by bridge.ts's reconnectTask + disabledRecoveryInFlight guards;
+  // probeIncumbent runs once per short-lived DaemonClient). Distinct types use
+  // distinct keys, so a concurrent attach+probe would still be independent.
+  // RESOLVE-ONLY: every exit path (typed response, disconnect, rejected,
+  // timeout, send throw) RESOLVES with a per-site fail-open / success value;
+  // none reject. Timers are ref'd (registry default), matching the prior raw
+  // setTimeout in both waiters.
+  private pendingEventWaiters = new PendingRequestRegistry<unknown>();
 
   constructor(private readonly url: string, private readonly options: DaemonClientOptions = {}) {
     super();
@@ -131,44 +142,17 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       return null;
     }
 
-    return await new Promise<DaemonStatus | null>((resolve) => {
-      let settled = false;
-      let timer: ReturnType<typeof setTimeout> | null = null;
-
-      const cleanup = () => {
-        if (settled) return;
-        settled = true;
-        if (timer) {
-          clearTimeout(timer);
-          timer = null;
-        }
-        this.off("status", onStatus);
-        this.off("rejected", onRejected);
-        this.off("disconnect", onDisconnect);
-      };
-
-      const finish = (value: DaemonStatus | null) => {
-        cleanup();
-        resolve(value);
-      };
-
-      const onStatus = (status: DaemonStatus) => finish(status);
-      const onRejected = () => finish(null);
-      const onDisconnect = () => finish(null);
-
-      this.on("status", onStatus);
-      this.on("rejected", onRejected);
-      this.on("disconnect", onDisconnect);
-
-      timer = setTimeout(() => {
-        finish(null);
-      }, timeoutMs);
-
-      try {
-        this.attachClaude();
-      } catch {
-        finish(null);
-      }
+    // Fail-OPEN to null on timeout / disconnect / rejected close / send throw,
+    // so a hung or contesting daemon lets the caller proceed (the daemon's own
+    // admission probe at attach time is the backstop). Resolves the actual
+    // DaemonStatus when the daemon confirms the attach via a `status` event.
+    return this.awaitTypedResponse<DaemonStatus | null>({
+      key: "status",
+      successEvent: "status",
+      successValue: (status: DaemonStatus) => status,
+      failValue: null,
+      timeoutMs,
+      send: () => this.attachClaude(),
     });
   }
 
@@ -186,36 +170,87 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       return { connected: false, alive: false };
     }
 
-    return await new Promise((resolve) => {
-      let settled = false;
-      let timer: ReturnType<typeof setTimeout> | null = null;
-
-      const finish = (value: { connected: boolean; alive: boolean }) => {
-        if (settled) return;
-        settled = true;
-        if (timer) clearTimeout(timer);
-        this.off("incumbentStatus", onStatus);
-        this.off("disconnect", onDisconnect);
-        this.off("rejected", onRejected);
-        resolve(value);
-      };
-
-      const onStatus = (s: { connected: boolean; alive: boolean }) => finish(s);
-      const onDisconnect = () => finish({ connected: false, alive: false });
-      const onRejected = () => finish({ connected: false, alive: false });
-
-      this.on("incumbentStatus", onStatus);
-      this.on("disconnect", onDisconnect);
-      this.on("rejected", onRejected);
-
-      timer = setTimeout(() => finish({ connected: false, alive: false }), timeoutMs);
-
-      try {
-        this.send({ type: "probe_incumbent" });
-      } catch {
-        finish({ connected: false, alive: false });
-      }
+    // Fail-OPEN to {connected:false, alive:false} on timeout, a closed socket,
+    // a rejected close, a send throw, or an older daemon that stays silent —
+    // so the conflict guard never blocks a legitimate launch on a probe
+    // failure (admission #68 is the backstop). Resolves the daemon's reported
+    // incumbent state when it answers via an `incumbentStatus` event.
+    return this.awaitTypedResponse<{ connected: boolean; alive: boolean }>({
+      key: "incumbent_status",
+      successEvent: "incumbentStatus",
+      successValue: (s: { connected: boolean; alive: boolean }) => s,
+      failValue: { connected: false, alive: false },
+      timeoutMs,
+      send: () => this.send({ type: "probe_incumbent" }),
     });
+  }
+
+  /**
+   * Shared skeleton for the two event-style request/response waiters
+   * (attach-status, probe-incumbent). Each waiter sends a control message and
+   * awaits a single typed response, with RESOLVE-ONLY fail-open semantics on
+   * timeout / disconnect / rejected close / send throw.
+   *
+   * The `PendingRequestRegistry` owns the timer + idempotent settle bookkeeping
+   * (keyed by the awaited message `key`). This helper additionally wires the
+   * EventEmitter listeners the registry does not manage: the success event maps
+   * to `settle(key, successValue)`, while `disconnect` / `rejected` settle the
+   * fail value. Listeners are removed on EVERY settle path via the promise's
+   * `finally`, so no path leaks a listener — equivalent to the prior per-waiter
+   * `cleanup()` that ran on its single `settled` transition.
+   *
+   * NOTE on key collision: `key` is the awaited message TYPE. attach uses
+   * "status" and probe uses "incumbent_status" (distinct), and same-type calls
+   * never run concurrently on one connection (see `pendingEventWaiters` doc), so
+   * the registry's id→entry map never overwrites a live waiter here.
+   */
+  private awaitTypedResponse<T>(opts: {
+    key: string;
+    successEvent: "status" | "incumbentStatus";
+    successValue: (payload: any) => T;
+    failValue: T;
+    timeoutMs: number;
+    send: () => void;
+  }): Promise<T> {
+    const { key, successEvent, successValue, failValue, timeoutMs, send } = opts;
+
+    const onSuccess = (payload: any) => {
+      this.pendingEventWaiters.settle(key, successValue(payload));
+    };
+    const onRejected = () => {
+      this.pendingEventWaiters.settle(key, failValue);
+    };
+    const onDisconnect = () => {
+      this.pendingEventWaiters.settle(key, failValue);
+    };
+
+    const pending = this.pendingEventWaiters.register(key, {
+      timeoutMs,
+      onTimeout: ({ resolve }) => resolve(failValue),
+    }) as Promise<T>;
+
+    // Remove listeners on every settle path (success / disconnect / rejected /
+    // timeout / send-throw). registry.settle and the timeout both resolve the
+    // promise, so `finally` is the single cleanup site — matching the prior
+    // idempotent `cleanup()`.
+    const cleanup = () => {
+      this.off(successEvent, onSuccess);
+      this.off("rejected", onRejected);
+      this.off("disconnect", onDisconnect);
+    };
+    pending.finally(cleanup);
+
+    this.on(successEvent, onSuccess);
+    this.on("rejected", onRejected);
+    this.on("disconnect", onDisconnect);
+
+    try {
+      send();
+    } catch {
+      this.pendingEventWaiters.settle(key, failValue);
+    }
+
+    return pending;
   }
 
   async disconnect() {


### PR DESCRIPTION
## 摘要 / Summary
arch-review P2 #546 part2（收尾）：把 daemon-client 里 2 个 **type-matched 事件式**等待器 `attachClaudeAndWaitForStatus` + `probeIncumbent`（arch-review 点名的「nearly line-for-line dup」）也收编进 part1 的 `PendingRequestRegistry`。**4 个等待器全部收编，#546 完成。**
- 抽共享 `awaitTypedResponse` helper，以 message type 作 registry key（利用「同型不并发」约束：已实证 bridge reconnectTask + disabledRecoveryInFlight 守卫互斥 + probe 用独立短命 client）。
- **净减 ~60 行重复**；每站点 timeout（1000/3000ms）+ fail-open（null / {connected:false,alive:false}）逐位保留。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1132 pass / 0 fail** / `verify:plugin-sync` ✅
- daemon-client / daemon-client-probe 断言**零改全绿**（attach 超时 null、probe silent/close fail-open）。
- Cross-review：equivalence + concurrency 双镜头 **0 REAL**；3 SUSPECT（microtask cleanup / type-key 并发 / `<unknown>` cast）经独立核验均安全。

## 备注
攒批发布：release-on-merge 暂禁。仅 daemon-client.ts。type-key 脆弱点（未来若新增并发同型调用点）已记 backlog。