### PR TITLE
test: 统一内联 fake-codex app-server 为参数化 fixture / unify inline fake-codex into one parameterized fixture

### DIFF
--- a/src/integration-test/daemon-wiring.test.ts
+++ b/src/integration-test/daemon-wiring.test.ts
@@ -18,6 +18,7 @@ import type { ControlServerMessage, DaemonStatus } from "../control-protocol";
 import { portsForSlot, type PairPorts } from "../pair-registry";
 import { readControlToken, resolveControlTokenPath } from "../control-token";
 import { CONTRACT_VERSION } from "../contract-version";
+import { installFakeCodex } from "./fixtures/fake-codex-install";
 
 const DAEMON_PATH = join(process.cwd(), "src", "daemon.ts");
 const DEFAULT_TEST_SLOT_START = 2500 + (process.pid % 500);
@@ -1359,9 +1360,7 @@ async function startHarness(opts: {
   const { slot, ports } = await reserveFreePairSlot();
   const { appPort, proxyPort, controlPort } = ports;
 
-  const codexPath = join(binDir, "codex");
-  writeFileSync(codexPath, fakeCodexScript(), "utf-8");
-  chmodSync(codexPath, 0o755);
+  installFakeCodex({ binDir, capability: "command-driven" });
 
   const env = {
     ...scrubAgentBridgeEnv(process.env),
@@ -1542,159 +1541,6 @@ function rawUpgradeStatus(port: number, path: string, origin: string): Promise<s
       reject(e);
     });
   });
-}
-
-function fakeCodexScript(): string {
-  return `#!/usr/bin/env bun
-import { appendFileSync, existsSync, readFileSync, unlinkSync } from "node:fs";
-
-if (process.argv.includes("--version")) {
-  console.log("codex fake");
-  process.exit(0);
-}
-
-if (process.argv[2] !== "app-server") {
-  await Bun.sleep(60_000);
-  process.exit(0);
-}
-
-const listenIndex = process.argv.indexOf("--listen");
-const listen = process.argv[listenIndex + 1];
-const port = Number(new URL(listen).port);
-const commandFile = process.env.FAKE_APP_COMMAND_FILE;
-let appWs = null;
-let lastStartedTurnId = null;
-let turnStartCounter = 0;
-let agentMessageCounter = 0;
-
-const server = Bun.serve({
-  hostname: "127.0.0.1",
-  port,
-  fetch(req, serverInstance) {
-    const url = new URL(req.url);
-    if (url.pathname === "/healthz" || url.pathname === "/readyz") {
-      return Response.json({ ok: true });
-    }
-    if (serverInstance.upgrade(req)) return undefined;
-    return new Response("fake codex app-server");
-  },
-  websocket: {
-    open(ws) {
-      appWs = ws;
-    },
-    message(ws, raw) {
-      // Minimal handshake support: auto-respond to thread/start so the adapter
-      // can detect an active thread and emit "ready" (used by budget gate tests).
-      try {
-        const msg = JSON.parse(typeof raw === "string" ? raw : raw.toString());
-        if (msg.method === "thread/start") {
-          ws.send(JSON.stringify({ id: msg.id, result: { thread: { id: "thread-fake-1" } } }));
-        }
-        // Record received turn/start params (tier-override assertions), then
-        // respond success with the created turn id like the real app-server
-        // (TurnStartResponse.turn.id) so the bridge's turn_started ACK
-        // correlation can be asserted end-to-end. NOTE: deliberately NO
-        // turn/started notification here — emitting one would mark the
-        // adapter busy and break the multi-injection budget tests; the
-        // "start-turn" command drives the busy state explicitly.
-        if (msg.method === "turn/start") {
-          if (process.env.FAKE_APP_TURNSTART_LOG) {
-            appendFileSync(process.env.FAKE_APP_TURNSTART_LOG, JSON.stringify(msg.params) + "\\n");
-          }
-          turnStartCounter += 1;
-          ws.send(JSON.stringify({ id: msg.id, result: { turn: { id: "turn-injected-" + turnStartCounter } } }));
-        }
-        // turn/interrupt: record params, respond success ({}), then emit the
-        // terminal turn/completed for that turnId — mirroring the REAL
-        // app-server (verified in codex-rs): the success response is deferred
-        // until TurnAborted and the interrupted turn's terminal notification
-        // is a normal turn/completed with status "interrupted".
-        if (msg.method === "turn/interrupt") {
-          if (process.env.FAKE_APP_TURNINTERRUPT_LOG) {
-            appendFileSync(process.env.FAKE_APP_TURNINTERRUPT_LOG, JSON.stringify(msg.params) + "\\n");
-          }
-          // Harness-only switch (TOCTOU test): defer the terminal boundary so
-          // the daemon's waitForInterruptOutcome await stays open long enough
-          // for the originating control socket to detach and another to attach
-          // mid-wait. Real app-server defers the success response until
-          // TurnAborted, so deferring BOTH the {} response and the terminal
-          // turn/completed faithfully models a slow interrupt.
-          const interruptDelayMs = Number(process.env.FAKE_APP_INTERRUPT_DELAY_MS || 0);
-          const emitInterruptTerminal = () => {
-            ws.send(JSON.stringify({ id: msg.id, result: {} }));
-            ws.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: msg.params.turnId, status: "interrupted" } } }));
-            if (lastStartedTurnId === msg.params.turnId) lastStartedTurnId = null;
-          };
-          if (interruptDelayMs > 0) {
-            setTimeout(emitInterruptTerminal, interruptDelayMs);
-          } else {
-            emitInterruptTerminal();
-          }
-        }
-        // turn/steer: record params, then ack — or reject when the text carries
-        // the [force-steer-error] marker (drives the steerFailed wiring test).
-        // Strict emulation of the real app-server (expectedTurnId has been
-        // REQUIRED since turn/steer was introduced — live-E2E regression: B0
-        // shipped without the field and every steer bounced): missing field →
-        // serde-style error; wrong value → ExpectedTurnMismatch-style error.
-        if (msg.method === "turn/steer") {
-          if (process.env.FAKE_APP_TURNSTEER_LOG) {
-            appendFileSync(process.env.FAKE_APP_TURNSTEER_LOG, JSON.stringify(msg.params) + "\\n");
-          }
-          const steerText = msg.params?.input?.[0]?.text ?? "";
-          if (typeof msg.params?.expectedTurnId !== "string" || msg.params.expectedTurnId.length === 0) {
-            ws.send(JSON.stringify({ id: msg.id, error: { message: "Invalid request: missing field \`expectedTurnId\`" } }));
-          } else if (lastStartedTurnId && msg.params.expectedTurnId !== lastStartedTurnId) {
-            ws.send(JSON.stringify({ id: msg.id, error: { message: "expected active turn id \`" + msg.params.expectedTurnId + "\` but found \`" + lastStartedTurnId + "\`" } }));
-          } else if (steerText.includes("[hang-steer]")) {
-            // Deliberately send NO verdict — simulate a steer whose app-server
-            // response is lost while the WS stays open (drives the PR B #3
-            // lost-response orphan test: turnTrackingReset must clean it up).
-          } else if (steerText.includes("[force-steer-error]")) {
-            ws.send(JSON.stringify({ id: msg.id, error: { message: "ActiveTurnNotSteerable" } }));
-          } else {
-            ws.send(JSON.stringify({ id: msg.id, result: { turnId: msg.params.expectedTurnId } }));
-          }
-        }
-      } catch {}
-    },
-    close(ws) {
-      if (appWs === ws) appWs = null;
-    },
-  },
-});
-
-setInterval(() => {
-  if (!commandFile || !existsSync(commandFile)) return;
-  const command = readFileSync(commandFile, "utf-8").trim();
-  try { unlinkSync(commandFile); } catch {}
-  if (!appWs) return;
-  if (command === "start-turn") {
-    lastStartedTurnId = "turn-1";
-    appWs.send(JSON.stringify({ method: "turn/started", params: { turn: { id: "turn-1" } } }));
-  }
-  if (command === "complete-turn" && lastStartedTurnId) {
-    appWs.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: lastStartedTurnId } } }));
-    lastStartedTurnId = null;
-  }
-  if (command.startsWith("agent-message:")) {
-    const content = command.slice("agent-message:".length);
-    const id = "agent-message-" + (++agentMessageCounter);
-    appWs.send(JSON.stringify({ method: "item/started", params: { item: { id, type: "agentMessage" } } }));
-    appWs.send(JSON.stringify({ method: "item/agentMessage/delta", params: { itemId: id, delta: content } }));
-    appWs.send(JSON.stringify({ method: "item/completed", params: { item: { id, type: "agentMessage" } } }));
-  }
-  if (command === "close-app-server") {
-    appWs.close(1011, "test app-server close");
-    setTimeout(() => server.stop(true), 20);
-  }
-}, 25).unref();
-
-process.on("SIGTERM", () => process.exit(0));
-process.on("SIGINT", () => process.exit(0));
-
-await new Promise(() => {});
-`;
 }
 
 function scrubAgentBridgeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/src/integration-test/e2e-reconnect.test.ts
+++ b/src/integration-test/e2e-reconnect.test.ts
@@ -1,11 +1,12 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { spawn, type ChildProcess } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DaemonClient } from "../daemon-client";
+import { installFakeCodex } from "./fixtures/fake-codex-install";
 
 /**
  * E2E tests: daemon lifecycle + client reconnect
@@ -47,39 +48,6 @@ function freePort(): Promise<number> {
       srv.close(() => resolve(port));
     });
   });
-}
-
-/** Minimal fake codex app-server: healthz/readyz + WS accept + clean SIGTERM. */
-function fakeCodexScript(): string {
-  return `#!/usr/bin/env bun
-if (process.argv.includes("--version")) {
-  console.log("codex fake");
-  process.exit(0);
-}
-if (process.argv[2] !== "app-server") {
-  await Bun.sleep(60_000);
-  process.exit(0);
-}
-const listenIndex = process.argv.indexOf("--listen");
-const listen = process.argv[listenIndex + 1];
-const port = Number(new URL(listen).port);
-Bun.serve({
-  hostname: "127.0.0.1",
-  port,
-  fetch(req, server) {
-    const url = new URL(req.url);
-    if (url.pathname === "/healthz" || url.pathname === "/readyz") {
-      return Response.json({ ok: true });
-    }
-    if (server.upgrade(req)) return undefined;
-    return new Response("fake codex app-server");
-  },
-  websocket: { open() {}, message() {}, close() {} },
-});
-process.on("SIGTERM", () => process.exit(0));
-process.on("SIGINT", () => process.exit(0));
-await new Promise(() => {});
-`;
 }
 
 function launchDaemon(): ChildProcess {
@@ -147,9 +115,8 @@ describe("E2E: daemon lifecycle + reconnect", () => {
     stateDir = join(testRoot, "state");
     binDir = join(testRoot, "bin");
     mkdirSync(binDir, { recursive: true });
-    const codexPath = join(binDir, "codex");
-    writeFileSync(codexPath, fakeCodexScript(), "utf-8");
-    chmodSync(codexPath, 0o755);
+    // Minimal fake codex app-server: healthz/readyz + WS accept + clean SIGTERM.
+    installFakeCodex({ binDir, capability: "minimal" });
 
     [controlPort, appPort, proxyPort] = await Promise.all([freePort(), freePort(), freePort()]);
     healthUrl = `http://127.0.0.1:${controlPort}/healthz`;

--- a/src/integration-test/fixtures/fake-codex-install.ts
+++ b/src/integration-test/fixtures/fake-codex-install.ts
@@ -1,0 +1,45 @@
+/**
+ * Helper for integration tests to drop the parameterized fake `codex` binary
+ * (see ./fake-codex.ts) onto a per-test PATH directory.
+ *
+ * The daemon resolves `codex` on PATH and spawns `codex app-server --listen …`.
+ * Tests therefore write an executable `bin/codex` that re-execs the fixture
+ * program under Bun, forwarding argv. The capability tier is baked into the
+ * generated shim via `FAKE_CODEX_CAPABILITY` so the spawned process selects the
+ * right protocol surface; tests still pass per-run wiring (command file, logs,
+ * interrupt delay) through the daemon's spawn env, which the fixture reads.
+ */
+
+import { chmodSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { FakeCodexCapability } from "./fake-codex";
+
+/** Absolute path to the fake-codex fixture program. */
+const FAKE_CODEX_PATH = fileURLToPath(new URL("./fake-codex.ts", import.meta.url));
+
+export type { FakeCodexCapability };
+
+/**
+ * Write an executable `codex` shim into `binDir` that runs the shared fake-codex
+ * fixture at the given capability tier. Returns the absolute path to the shim.
+ *
+ * The shim forwards all CLI args to the fixture and sets FAKE_CODEX_CAPABILITY
+ * only when not already present in the environment, so a caller can still
+ * override the tier via the daemon spawn env if needed.
+ */
+export function installFakeCodex(opts: { binDir: string; capability: FakeCodexCapability }): string {
+  const { binDir, capability } = opts;
+  const codexPath = join(binDir, "codex");
+  // exec the fixture with the same Bun runtime, forwarding argv. `exec` replaces
+  // the shell so the daemon's SIGTERM/SIGKILL reach the fixture process directly
+  // (no intermediate shell holding the pid).
+  const shim =
+    "#!/usr/bin/env bash\n" +
+    `export FAKE_CODEX_CAPABILITY="\${FAKE_CODEX_CAPABILITY:-${capability}}"\n` +
+    `exec bun run ${JSON.stringify(FAKE_CODEX_PATH)} "$@"\n`;
+  writeFileSync(codexPath, shim, "utf-8");
+  chmodSync(codexPath, 0o755);
+  return codexPath;
+}

--- a/src/integration-test/fixtures/fake-codex.ts
+++ b/src/integration-test/fixtures/fake-codex.ts
@@ -1,0 +1,266 @@
+#!/usr/bin/env bun
+/**
+ * Single parameterized fake `codex app-server` for integration tests.
+ *
+ * Before this fixture, every integration test that needed a stand-in for the
+ * real `codex app-server` carried its own inline template-string program. Those
+ * copies drifted: one answered `thread/start`, another did not; the interrupt
+ * delay switch lived in only one. This file collapses all of them into ONE real
+ * TypeScript program (type-checked by `tsc --noEmit`, no `eval`'d strings),
+ * gated by capability tier so each call site asks for exactly the protocol
+ * surface it exercises.
+ *
+ * The daemon launches the codex binary as `codex app-server --listen ws://…`
+ * by resolving `codex` on PATH. Tests therefore drop an executable `bin/codex`
+ * that re-execs this file (see `installFakeCodex` in ./fake-codex-install.ts).
+ *
+ * ── Capability tiers ───────────────────────────────────────────────────────
+ *  - "minimal":        healthz/readyz + WS accept + clean SIGTERM. Nothing
+ *                      more — the daemon only needs the app-server to be
+ *                      reachable and to die cleanly (e2e-reconnect lifecycle).
+ *  - "handshake":      minimal + auto-respond to `thread/start` so the adapter
+ *                      can set an active thread and reach "ready".
+ *  - "command-driven": handshake + the full turn protocol the daemon-wiring
+ *                      tests drive: turn/start (+ optional log), turn/interrupt
+ *                      (+ optional log, + FAKE_APP_INTERRUPT_DELAY_MS deferral),
+ *                      turn/steer (+ optional log, error markers), plus a
+ *                      command-file injection loop (start-turn / complete-turn /
+ *                      agent-message:<text> / close-app-server).
+ *
+ * Each higher tier is a strict superset of the lower one, so a call site can
+ * always pick the LEAST capable tier that still passes — keeping the contract
+ * each test depends on explicit.
+ *
+ * Tier + injection wiring are read from the environment so the single program
+ * stays parameterized at runtime:
+ *  - FAKE_CODEX_CAPABILITY      "minimal" | "handshake" | "command-driven"
+ *                               (default "minimal")
+ *  - FAKE_APP_COMMAND_FILE      path polled for injection commands (command-driven)
+ *  - FAKE_APP_TURNSTART_LOG     append turn/start params (command-driven)
+ *  - FAKE_APP_TURNINTERRUPT_LOG append turn/interrupt params (command-driven)
+ *  - FAKE_APP_TURNSTEER_LOG     append turn/steer params (command-driven)
+ *  - FAKE_APP_INTERRUPT_DELAY_MS defer the interrupt terminal boundary (command-driven)
+ */
+
+import { appendFileSync, existsSync, readFileSync, unlinkSync } from "node:fs";
+
+export type FakeCodexCapability = "minimal" | "handshake" | "command-driven";
+
+const CAPABILITIES: readonly FakeCodexCapability[] = ["minimal", "handshake", "command-driven"] as const;
+
+function parseCapability(raw: string | undefined): FakeCodexCapability {
+  if (raw && (CAPABILITIES as readonly string[]).includes(raw)) {
+    return raw as FakeCodexCapability;
+  }
+  return "minimal";
+}
+
+/** Tier ordering for superset checks: command-driven ⊇ handshake ⊇ minimal. */
+function capabilityRank(capability: FakeCodexCapability): number {
+  return CAPABILITIES.indexOf(capability);
+}
+
+function hasAtLeast(active: FakeCodexCapability, required: FakeCodexCapability): boolean {
+  return capabilityRank(active) >= capabilityRank(required);
+}
+
+function main(): void {
+  if (process.argv.includes("--version")) {
+    console.log("codex fake");
+    process.exit(0);
+  }
+
+  // Any non-`app-server` invocation (e.g. a stray `codex --enable …`) just idles
+  // then exits — the real binary would block on its own subcommand. Matches the
+  // legacy inline behavior so PATH lookups that aren't app-server don't crash.
+  if (process.argv[2] !== "app-server") {
+    void Bun.sleep(60_000).then(() => process.exit(0));
+    return;
+  }
+
+  const capability = parseCapability(process.env.FAKE_CODEX_CAPABILITY);
+
+  const listenIndex = process.argv.indexOf("--listen");
+  const listen = process.argv[listenIndex + 1];
+  if (!listen) {
+    console.error("fake codex app-server: missing --listen <url>");
+    process.exit(1);
+  }
+  const port = Number(new URL(listen).port);
+
+  const commandFile = process.env.FAKE_APP_COMMAND_FILE;
+  const turnStartLog = process.env.FAKE_APP_TURNSTART_LOG;
+  const turnInterruptLog = process.env.FAKE_APP_TURNINTERRUPT_LOG;
+  const turnSteerLog = process.env.FAKE_APP_TURNSTEER_LOG;
+  const interruptDelayMs = Number(process.env.FAKE_APP_INTERRUPT_DELAY_MS || 0);
+
+  // Single live app-server WS — the daemon keeps ONE persistent connection.
+  let appWs: import("bun").ServerWebSocket<unknown> | null = null;
+  let lastStartedTurnId: string | null = null;
+  let turnStartCounter = 0;
+  let agentMessageCounter = 0;
+
+  const handshakeEnabled = hasAtLeast(capability, "handshake");
+  const turnProtocolEnabled = hasAtLeast(capability, "command-driven");
+
+  function handleMessage(ws: import("bun").ServerWebSocket<unknown>, raw: string | Buffer): void {
+    let msg: {
+      id?: unknown;
+      method?: unknown;
+      params?: { turnId?: string; expectedTurnId?: unknown; input?: Array<{ text?: string }> };
+    };
+    try {
+      msg = JSON.parse(typeof raw === "string" ? raw : raw.toString());
+    } catch {
+      return;
+    }
+
+    // handshake: auto-respond to thread/start so the adapter can detect an
+    // active thread and emit "ready" (used by budget/ready-gate tests).
+    if (handshakeEnabled && msg.method === "thread/start") {
+      ws.send(JSON.stringify({ id: msg.id, result: { thread: { id: "thread-fake-1" } } }));
+      return;
+    }
+
+    if (!turnProtocolEnabled) return;
+
+    // Record received turn/start params (tier-override assertions), then respond
+    // success with the created turn id like the real app-server
+    // (TurnStartResponse.turn.id) so the bridge's turn_started ACK correlation
+    // can be asserted end-to-end. NOTE: deliberately NO turn/started notification
+    // here — emitting one would mark the adapter busy and break the multi-injection
+    // budget tests; the "start-turn" command drives the busy state explicitly.
+    if (msg.method === "turn/start") {
+      if (turnStartLog) {
+        appendFileSync(turnStartLog, JSON.stringify(msg.params) + "\n");
+      }
+      turnStartCounter += 1;
+      ws.send(JSON.stringify({ id: msg.id, result: { turn: { id: "turn-injected-" + turnStartCounter } } }));
+      return;
+    }
+
+    // turn/interrupt: record params, respond success ({}), then emit the terminal
+    // turn/completed for that turnId — mirroring the REAL app-server (verified in
+    // codex-rs): the success response is deferred until TurnAborted and the
+    // interrupted turn's terminal notification is a normal turn/completed with
+    // status "interrupted".
+    if (msg.method === "turn/interrupt") {
+      if (turnInterruptLog) {
+        appendFileSync(turnInterruptLog, JSON.stringify(msg.params) + "\n");
+      }
+      const turnId = msg.params?.turnId;
+      // Harness-only switch (TOCTOU test): defer the terminal boundary so the
+      // daemon's waitForInterruptOutcome await stays open long enough for the
+      // originating control socket to detach and another to attach mid-wait. Real
+      // app-server defers the success response until TurnAborted, so deferring
+      // BOTH the {} response and the terminal turn/completed faithfully models a
+      // slow interrupt.
+      const emitInterruptTerminal = () => {
+        ws.send(JSON.stringify({ id: msg.id, result: {} }));
+        ws.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: turnId, status: "interrupted" } } }));
+        if (lastStartedTurnId === turnId) lastStartedTurnId = null;
+      };
+      if (interruptDelayMs > 0) {
+        setTimeout(emitInterruptTerminal, interruptDelayMs);
+      } else {
+        emitInterruptTerminal();
+      }
+      return;
+    }
+
+    // turn/steer: record params, then ack — or reject when the text carries the
+    // [force-steer-error] marker (drives the steerFailed wiring test). Strict
+    // emulation of the real app-server (expectedTurnId has been REQUIRED since
+    // turn/steer was introduced — live-E2E regression: B0 shipped without the
+    // field and every steer bounced): missing field → serde-style error; wrong
+    // value → ExpectedTurnMismatch-style error.
+    if (msg.method === "turn/steer") {
+      if (turnSteerLog) {
+        appendFileSync(turnSteerLog, JSON.stringify(msg.params) + "\n");
+      }
+      const steerText = msg.params?.input?.[0]?.text ?? "";
+      const expectedTurnId = msg.params?.expectedTurnId;
+      if (typeof expectedTurnId !== "string" || expectedTurnId.length === 0) {
+        ws.send(JSON.stringify({ id: msg.id, error: { message: "Invalid request: missing field `expectedTurnId`" } }));
+      } else if (lastStartedTurnId && expectedTurnId !== lastStartedTurnId) {
+        ws.send(JSON.stringify({ id: msg.id, error: { message: "expected active turn id `" + expectedTurnId + "` but found `" + lastStartedTurnId + "`" } }));
+      } else if (steerText.includes("[hang-steer]")) {
+        // Deliberately send NO verdict — simulate a steer whose app-server
+        // response is lost while the WS stays open (drives the PR B #3
+        // lost-response orphan test: turnTrackingReset must clean it up).
+      } else if (steerText.includes("[force-steer-error]")) {
+        ws.send(JSON.stringify({ id: msg.id, error: { message: "ActiveTurnNotSteerable" } }));
+      } else {
+        ws.send(JSON.stringify({ id: msg.id, result: { turnId: expectedTurnId } }));
+      }
+    }
+  }
+
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port,
+    fetch(req, serverInstance) {
+      const url = new URL(req.url);
+      if (url.pathname === "/healthz" || url.pathname === "/readyz") {
+        return Response.json({ ok: true });
+      }
+      if (serverInstance.upgrade(req)) return undefined;
+      return new Response("fake codex app-server");
+    },
+    websocket: {
+      open(ws) {
+        appWs = ws;
+      },
+      message(ws, raw) {
+        handleMessage(ws, raw);
+      },
+      close(ws) {
+        if (appWs === ws) appWs = null;
+      },
+    },
+  });
+
+  // command-driven injection loop: poll a file the test writes injection commands
+  // into, and drive the corresponding app-server notifications.
+  if (turnProtocolEnabled && commandFile) {
+    setInterval(() => {
+      if (!existsSync(commandFile)) return;
+      const command = readFileSync(commandFile, "utf-8").trim();
+      try {
+        unlinkSync(commandFile);
+      } catch {}
+      const ws = appWs;
+      if (!ws) return;
+      if (command === "start-turn") {
+        lastStartedTurnId = "turn-1";
+        ws.send(JSON.stringify({ method: "turn/started", params: { turn: { id: "turn-1" } } }));
+      }
+      if (command === "complete-turn" && lastStartedTurnId) {
+        ws.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: lastStartedTurnId } } }));
+        lastStartedTurnId = null;
+      }
+      if (command.startsWith("agent-message:")) {
+        const content = command.slice("agent-message:".length);
+        const id = "agent-message-" + (++agentMessageCounter);
+        ws.send(JSON.stringify({ method: "item/started", params: { item: { id, type: "agentMessage" } } }));
+        ws.send(JSON.stringify({ method: "item/agentMessage/delta", params: { itemId: id, delta: content } }));
+        ws.send(JSON.stringify({ method: "item/completed", params: { item: { id, type: "agentMessage" } } }));
+      }
+      if (command === "close-app-server") {
+        ws.close(1011, "test app-server close");
+        setTimeout(() => server.stop(true), 20);
+      }
+    }, 25).unref();
+  }
+
+  process.on("SIGTERM", () => process.exit(0));
+  process.on("SIGINT", () => process.exit(0));
+}
+
+main();
+
+// Keep the process alive for the `app-server` path; --version / non-app-server
+// paths have already exited (or scheduled their own exit) inside main().
+if (process.argv[2] === "app-server") {
+  await new Promise(() => {});
+}


### PR DESCRIPTION
## 摘要 / Summary
arch-review P2 #526（step 1）：把 2 份漂移的内联 fake-codex app-server（字符串内嵌、无类型检查、已漂移）统一为一个受 `tsc` 检查的参数化 fixture。
- 新增 `src/integration-test/fixtures/fake-codex.ts`（按 `FAKE_CODEX_CAPABILITY` 分 minimal/handshake/command-driven 严格 superset）+ `fake-codex-install.ts`。
- daemon-wiring（command-driven，**保留** `FAKE_APP_INTERRUPT_DELAY_MS` + thread/start + turn/* + steer markers + command-file 注入）+ e2e-reconnect（minimal）改用共用 fixture，**删 ~193 行漂移内联模板**。
- **范围判定**：e2e-cli 的 argv-logger shim + control-protocol fake-daemon 是**异构协议**，正确不并入（reviewer 确认）。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1132 pass / 0 fail** / `test:integration` 79 pass。断言零改。
- Cross-review：capability + judgment 双镜头 **0 REAL**；fixture 能力 path-by-path 对照无遗漏；exec/SIGTERM 独立 smoke 验证。

## 后续 / Follow-up
step 2（录真实 codex 报文 JSON fixture）+ step 3（nightly e2e:transport CI job）需真实 codex 会话登录，留 backlog。

## 备注
攒批发布：release-on-merge 暂禁。仅测试基础设施，无生产/bundle 改动。