### PR TITLE
refactor: 合并 daemon pid + status.json 为单一原子 daemon.json / unify daemon identity into a single atomic daemon.json (#536)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13840,6 +13840,9 @@ class StateDirResolver {
   get statusFile() {
     return join(this.stateDir, "status.json");
   }
+  get daemonRecordFile() {
+    return join(this.stateDir, "daemon.json");
+  }
   get currentThreadFile() {
     return join(this.stateDir, "current-thread.json");
   }
@@ -14379,7 +14382,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("ee9d6ec", "source"),
+  commit: defineString("ab65a14", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14710,7 +14713,7 @@ class DaemonClient extends EventEmitter2 {
 
 // src/daemon-lifecycle.ts
 import { spawn } from "child_process";
-import { existsSync as existsSync3, readFileSync, statSync as statSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync2, openSync as openSync2, closeSync as closeSync2, constants } from "fs";
+import { existsSync as existsSync3, readFileSync as readFileSync2, statSync as statSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync2, openSync as openSync2, closeSync as closeSync2, constants } from "fs";
 import { fileURLToPath } from "url";
 
 // src/atomic-json.ts
@@ -14794,6 +14797,95 @@ function isAgentBridgeProcess(pid, lookup = commandForPid) {
   if (cmd === null)
     return false;
   return cmd.includes("agentbridge") || cmd.includes("agent_bridge");
+}
+
+// src/daemon-record.ts
+import { readFileSync } from "fs";
+var defaultRead = (path) => readFileSync(path, "utf-8");
+function writeDaemonRecord(path, record3) {
+  atomicWriteJson(path, record3);
+}
+function readDaemonRecord(path, read = defaultRead) {
+  let parsed;
+  try {
+    parsed = JSON.parse(read(path));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null)
+    return null;
+  const obj = parsed;
+  if (typeof obj.pid !== "number" || !Number.isFinite(obj.pid))
+    return null;
+  const phase = obj.phase === "ready" ? "ready" : "booting";
+  return { ...obj, pid: obj.pid, phase };
+}
+function synthesizeLegacyRecord(pidFilePath, statusFilePath, read = defaultRead) {
+  let pidFromPidFile = null;
+  try {
+    const raw = read(pidFilePath).trim();
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n))
+      pidFromPidFile = n;
+  } catch {}
+  let status = null;
+  try {
+    const parsed = JSON.parse(read(statusFilePath));
+    if (typeof parsed === "object" && parsed !== null)
+      status = parsed;
+  } catch {}
+  const pidFromStatus = status && typeof status.pid === "number" && Number.isFinite(status.pid) ? status.pid : null;
+  const pid = pidFromPidFile ?? pidFromStatus;
+  if (pid === null)
+    return null;
+  const record3 = {
+    pid,
+    phase: status ? "ready" : "booting"
+  };
+  if (status) {
+    if (typeof status.proxyUrl === "string")
+      record3.proxyUrl = status.proxyUrl;
+    if (typeof status.appServerUrl === "string")
+      record3.appServerUrl = status.appServerUrl;
+    const controlPort = typeof status.controlPort === "number" ? status.controlPort : undefined;
+    const proxyPort = portFromUrl(status.proxyUrl);
+    const appPort = portFromUrl(status.appServerUrl);
+    if (controlPort !== undefined || proxyPort !== undefined || appPort !== undefined) {
+      record3.ports = {};
+      if (appPort !== undefined)
+        record3.ports.appPort = appPort;
+      if (proxyPort !== undefined)
+        record3.ports.proxyPort = proxyPort;
+      if (controlPort !== undefined)
+        record3.ports.controlPort = controlPort;
+    }
+    if (status.pairId === null || typeof status.pairId === "string")
+      record3.pairId = status.pairId;
+    if (status.cwd === null || typeof status.cwd === "string")
+      record3.cwd = status.cwd;
+    if (status.stateDir === null || typeof status.stateDir === "string")
+      record3.stateDir = status.stateDir;
+    if (typeof status.build === "object" && status.build !== null) {
+      record3.build = status.build;
+    }
+    if (typeof status.turnPhase === "string")
+      record3.turnPhase = status.turnPhase;
+    if (typeof status.turnInProgress === "boolean")
+      record3.turnInProgress = status.turnInProgress;
+    if (typeof status.attentionWindowActive === "boolean") {
+      record3.attentionWindowActive = status.attentionWindowActive;
+    }
+  }
+  return record3;
+}
+function readUnifiedDaemonRecord(paths, read = defaultRead) {
+  return readDaemonRecord(paths.daemonRecordFile, read) ?? synthesizeLegacyRecord(paths.pidFile, paths.statusFile, read);
+}
+function portFromUrl(url) {
+  if (typeof url !== "string")
+    return;
+  const match = url.match(/:(\d+)(?:[/?]|$)/);
+  return match ? Number.parseInt(match[1], 10) : undefined;
 }
 
 // src/daemon-lifecycle.ts
@@ -15024,9 +15116,24 @@ class DaemonLifecycle {
     }
     throw new Error(`Timed out waiting for AgentBridge daemon readiness+identity on ${this.readyUrl} (control port ${this.controlPort})`);
   }
+  readDaemonRecord() {
+    return readUnifiedDaemonRecord({
+      daemonRecordFile: this.stateDir.daemonRecordFile,
+      pidFile: this.stateDir.pidFile,
+      statusFile: this.stateDir.statusFile
+    });
+  }
+  writeDaemonRecord(record3) {
+    writeDaemonRecord(this.stateDir.daemonRecordFile, record3);
+  }
+  removeDaemonRecord() {
+    try {
+      unlinkSync3(this.stateDir.daemonRecordFile);
+    } catch {}
+  }
   readStatus() {
     try {
-      const raw = readFileSync(this.stateDir.statusFile, "utf-8");
+      const raw = readFileSync2(this.stateDir.statusFile, "utf-8");
       return JSON.parse(raw);
     } catch {
       return null;
@@ -15037,7 +15144,7 @@ class DaemonLifecycle {
   }
   readPid() {
     try {
-      const raw = readFileSync(this.stateDir.pidFile, "utf-8").trim();
+      const raw = readFileSync2(this.stateDir.pidFile, "utf-8").trim();
       if (!raw)
         return null;
       const pid = Number.parseInt(raw, 10);
@@ -15089,8 +15196,10 @@ class DaemonLifecycle {
     daemonProc.unref();
   }
   removeStalePidFile() {
-    this.log("Removing stale pid file");
+    this.log("Removing stale daemon identity files");
     this.removePidFile();
+    this.removeStatusFile();
+    this.removeDaemonRecord();
   }
   async replaceUnhealthyDaemon(statusPid) {
     await this.withStartupLockStrict(async (locked) => {
@@ -15150,7 +15259,7 @@ class DaemonLifecycle {
         if (reclaimed)
           return false;
         try {
-          const holderPid = Number.parseInt(readFileSync(this.stateDir.lockFile, "utf-8").trim(), 10);
+          const holderPid = Number.parseInt(readFileSync2(this.stateDir.lockFile, "utf-8").trim(), 10);
           if (Number.isFinite(holderPid) && !isProcessAlive(holderPid)) {
             this.log(`Stale startup lock from dead process ${holderPid}, reclaiming`);
             this.releaseLock();
@@ -15225,6 +15334,7 @@ class DaemonLifecycle {
   cleanup() {
     this.removePidFile();
     this.removeStatusFile();
+    this.removeDaemonRecord();
   }
 }
 async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
@@ -15238,7 +15348,7 @@ async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync2, mkdirSync as mkdirSync3, existsSync as existsSync4 } from "fs";
+import { readFileSync as readFileSync3, mkdirSync as mkdirSync3, existsSync as existsSync4 } from "fs";
 import { join as join2 } from "path";
 var DEFAULT_BUDGET_CONFIG = {
   enabled: true,
@@ -15419,7 +15529,7 @@ class ConfigService {
   load() {
     let raw;
     try {
-      raw = readFileSync2(this.configPath, "utf-8");
+      raw = readFileSync3(this.configPath, "utf-8");
     } catch (err) {
       if (err?.code === "ENOENT") {
         return { state: "absent" };
@@ -15515,7 +15625,7 @@ import {
   lstatSync,
   mkdirSync as mkdirSync4,
   readdirSync,
-  readFileSync as readFileSync3,
+  readFileSync as readFileSync4,
   realpathSync,
   rmSync,
   statSync as statSync3,
@@ -15563,7 +15673,7 @@ function readRegistry(base) {
     return { version: 1, pairs: [] };
   let parsed;
   try {
-    parsed = JSON.parse(readFileSync3(path, "utf-8"));
+    parsed = JSON.parse(readFileSync4(path, "utf-8"));
   } catch (err) {
     throw new PairError("PAIR_REGISTRY_CORRUPT", `Registry JSON is not parseable at ${path}: ${err.message}`, {
       path
@@ -15712,7 +15822,7 @@ function nonEmpty(value) {
 }
 
 // src/control-token.ts
-import { chmodSync, readFileSync as readFileSync4 } from "fs";
+import { chmodSync, readFileSync as readFileSync5 } from "fs";
 import { join as join4 } from "path";
 var CONTROL_TOKEN_FILENAME = "control-token";
 function resolveControlTokenPath(stateDir) {
@@ -15720,7 +15830,7 @@ function resolveControlTokenPath(stateDir) {
 }
 function readControlToken(path) {
   try {
-    const raw = readFileSync4(path, "utf-8").trim();
+    const raw = readFileSync5(path, "utf-8").trim();
     return raw.length > 0 ? raw : null;
   } catch {
     return null;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3,6 +3,7 @@
 
 // src/daemon.ts
 import { rmSync as rmSync2 } from "fs";
+import { randomUUID as randomUUID4 } from "crypto";
 
 // src/contract-version.ts
 var CONTRACT_VERSION = 1;
@@ -21,7 +22,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("ee9d6ec", "source"),
+  commit: defineString("ab65a14", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -44,13 +45,139 @@ function formatBuildInfo(build) {
   return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}`;
 }
 
+// src/daemon-record.ts
+import { readFileSync } from "fs";
+
+// src/atomic-json.ts
+import * as fs from "fs";
+import { randomUUID } from "crypto";
+import { dirname } from "path";
+function tmpPathFor(targetPath) {
+  return `${targetPath}.tmp.${process.pid}.${randomUUID()}`;
+}
+function atomicWriteText(path, content, options = {}) {
+  fs.mkdirSync(dirname(path), { recursive: true });
+  const tmp = tmpPathFor(path);
+  let renamed = false;
+  const fd = fs.openSync(tmp, "w", options.mode ?? 438);
+  try {
+    try {
+      fs.writeFileSync(fd, content, "utf-8");
+      if (options.fsync)
+        fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmp, path);
+    renamed = true;
+  } finally {
+    if (!renamed) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {}
+    }
+  }
+}
+function atomicWriteJson(path, value, options = {}) {
+  atomicWriteText(path, JSON.stringify(value, null, 2) + `
+`, options);
+}
+
+// src/daemon-record.ts
+var defaultRead = (path) => readFileSync(path, "utf-8");
+function writeDaemonRecord(path, record) {
+  atomicWriteJson(path, record);
+}
+function readDaemonRecord(path, read = defaultRead) {
+  let parsed;
+  try {
+    parsed = JSON.parse(read(path));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null)
+    return null;
+  const obj = parsed;
+  if (typeof obj.pid !== "number" || !Number.isFinite(obj.pid))
+    return null;
+  const phase = obj.phase === "ready" ? "ready" : "booting";
+  return { ...obj, pid: obj.pid, phase };
+}
+function synthesizeLegacyRecord(pidFilePath, statusFilePath, read = defaultRead) {
+  let pidFromPidFile = null;
+  try {
+    const raw = read(pidFilePath).trim();
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n))
+      pidFromPidFile = n;
+  } catch {}
+  let status = null;
+  try {
+    const parsed = JSON.parse(read(statusFilePath));
+    if (typeof parsed === "object" && parsed !== null)
+      status = parsed;
+  } catch {}
+  const pidFromStatus = status && typeof status.pid === "number" && Number.isFinite(status.pid) ? status.pid : null;
+  const pid = pidFromPidFile ?? pidFromStatus;
+  if (pid === null)
+    return null;
+  const record = {
+    pid,
+    phase: status ? "ready" : "booting"
+  };
+  if (status) {
+    if (typeof status.proxyUrl === "string")
+      record.proxyUrl = status.proxyUrl;
+    if (typeof status.appServerUrl === "string")
+      record.appServerUrl = status.appServerUrl;
+    const controlPort = typeof status.controlPort === "number" ? status.controlPort : undefined;
+    const proxyPort = portFromUrl(status.proxyUrl);
+    const appPort = portFromUrl(status.appServerUrl);
+    if (controlPort !== undefined || proxyPort !== undefined || appPort !== undefined) {
+      record.ports = {};
+      if (appPort !== undefined)
+        record.ports.appPort = appPort;
+      if (proxyPort !== undefined)
+        record.ports.proxyPort = proxyPort;
+      if (controlPort !== undefined)
+        record.ports.controlPort = controlPort;
+    }
+    if (status.pairId === null || typeof status.pairId === "string")
+      record.pairId = status.pairId;
+    if (status.cwd === null || typeof status.cwd === "string")
+      record.cwd = status.cwd;
+    if (status.stateDir === null || typeof status.stateDir === "string")
+      record.stateDir = status.stateDir;
+    if (typeof status.build === "object" && status.build !== null) {
+      record.build = status.build;
+    }
+    if (typeof status.turnPhase === "string")
+      record.turnPhase = status.turnPhase;
+    if (typeof status.turnInProgress === "boolean")
+      record.turnInProgress = status.turnInProgress;
+    if (typeof status.attentionWindowActive === "boolean") {
+      record.attentionWindowActive = status.attentionWindowActive;
+    }
+  }
+  return record;
+}
+function readUnifiedDaemonRecord(paths, read = defaultRead) {
+  return readDaemonRecord(paths.daemonRecordFile, read) ?? synthesizeLegacyRecord(paths.pidFile, paths.statusFile, read);
+}
+function portFromUrl(url) {
+  if (typeof url !== "string")
+    return;
+  const match = url.match(/:(\d+)(?:[/?]|$)/);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
 // src/codex-adapter.ts
 import { spawn, execFileSync } from "child_process";
 import { createInterface } from "readline";
 import { EventEmitter } from "events";
 
 // src/state-dir.ts
-import { mkdirSync, existsSync } from "fs";
+import { mkdirSync as mkdirSync2, existsSync } from "fs";
 import { join } from "path";
 import { homedir, platform } from "os";
 
@@ -69,7 +196,7 @@ class StateDirResolver {
   }
   ensure() {
     if (!existsSync(this.stateDir)) {
-      mkdirSync(this.stateDir, { recursive: true });
+      mkdirSync2(this.stateDir, { recursive: true });
     }
   }
   get dir() {
@@ -86,6 +213,9 @@ class StateDirResolver {
   }
   get statusFile() {
     return join(this.stateDir, "status.json");
+  }
+  get daemonRecordFile() {
+    return join(this.stateDir, "daemon.json");
   }
   get currentThreadFile() {
     return join(this.stateDir, "current-thread.json");
@@ -205,15 +335,15 @@ async function cleanupPorts(options) {
 }
 
 // src/rotating-log.ts
-import { appendFileSync, existsSync as existsSync2, renameSync, statSync, unlinkSync } from "fs";
-import { dirname } from "path";
+import { appendFileSync, existsSync as existsSync2, renameSync as renameSync2, statSync, unlinkSync as unlinkSync2 } from "fs";
+import { dirname as dirname2 } from "path";
 var DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
 var DEFAULT_KEEP = 3;
-var REAL_FS_OPS = { statSync, renameSync, unlinkSync, appendFileSync, existsSync: existsSync2 };
+var REAL_FS_OPS = { statSync, renameSync: renameSync2, unlinkSync: unlinkSync2, appendFileSync, existsSync: existsSync2 };
 function appendRotatingLog(path, content, options = {}, fsOps = REAL_FS_OPS) {
   const maxBytes = options.maxBytes ?? positiveIntFromEnv("AGENTBRIDGE_LOG_MAX_BYTES", DEFAULT_MAX_BYTES);
   const keep = options.keep ?? positiveIntFromEnv("AGENTBRIDGE_LOG_ROTATE_KEEP", DEFAULT_KEEP);
-  if (!fsOps.existsSync(dirname(path)))
+  if (!fsOps.existsSync(dirname2(path)))
     return;
   rotateIfNeeded(path, Buffer.byteLength(content), maxBytes, keep, fsOps);
   fsOps.appendFileSync(path, content, "utf-8");
@@ -420,7 +550,7 @@ function clampInterruptTimeoutMs(requested) {
 // src/codex-transport.ts
 import { createServer, connect } from "net";
 import { spawnSync } from "child_process";
-import { mkdirSync as mkdirSync2, rmSync, chmodSync } from "fs";
+import { mkdirSync as mkdirSync3, rmSync, chmodSync } from "fs";
 import { join as join2 } from "path";
 import { tmpdir } from "os";
 var CODEX_TRANSPORT_ENV = "AGENTBRIDGE_CODEX_TRANSPORT";
@@ -481,7 +611,7 @@ function ensureSocketDir(socketPath) {
   const dir = socketPath.slice(0, socketPath.lastIndexOf("/"));
   if (!dir)
     return;
-  mkdirSync2(dir, { recursive: true, mode: 448 });
+  mkdirSync3(dir, { recursive: true, mode: 448 });
   try {
     chmodSync(dir, 448);
   } catch (err) {
@@ -2329,46 +2459,9 @@ var CLOSE_CODE_TOKEN_MISMATCH = 4005;
 var CLOSE_CODE_CONTRACT_MISMATCH = 4006;
 
 // src/control-token.ts
-import { chmodSync as chmodSync2, readFileSync } from "fs";
+import { chmodSync as chmodSync2, readFileSync as readFileSync2 } from "fs";
 import { join as join3 } from "path";
 import { randomUUID as randomUUID2 } from "crypto";
-
-// src/atomic-json.ts
-import * as fs from "fs";
-import { randomUUID } from "crypto";
-import { dirname as dirname2 } from "path";
-function tmpPathFor(targetPath) {
-  return `${targetPath}.tmp.${process.pid}.${randomUUID()}`;
-}
-function atomicWriteText(path, content, options = {}) {
-  fs.mkdirSync(dirname2(path), { recursive: true });
-  const tmp = tmpPathFor(path);
-  let renamed = false;
-  const fd = fs.openSync(tmp, "w", options.mode ?? 438);
-  try {
-    try {
-      fs.writeFileSync(fd, content, "utf-8");
-      if (options.fsync)
-        fs.fsyncSync(fd);
-    } finally {
-      fs.closeSync(fd);
-    }
-    fs.renameSync(tmp, path);
-    renamed = true;
-  } finally {
-    if (!renamed) {
-      try {
-        fs.unlinkSync(tmp);
-      } catch {}
-    }
-  }
-}
-function atomicWriteJson(path, value, options = {}) {
-  atomicWriteText(path, JSON.stringify(value, null, 2) + `
-`, options);
-}
-
-// src/control-token.ts
 var CONTROL_TOKEN_FILENAME = "control-token";
 function resolveControlTokenPath(stateDir) {
   return join3(stateDir, CONTROL_TOKEN_FILENAME);
@@ -2697,7 +2790,7 @@ class TuiConnectionState {
 
 // src/daemon-lifecycle.ts
 import { spawn as spawn2 } from "child_process";
-import { existsSync as existsSync3, readFileSync as readFileSync2, statSync as statSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync2, openSync as openSync2, closeSync as closeSync2, constants } from "fs";
+import { existsSync as existsSync3, readFileSync as readFileSync3, statSync as statSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync2, openSync as openSync2, closeSync as closeSync2, constants } from "fs";
 import { fileURLToPath } from "url";
 
 // src/process-lifecycle.ts
@@ -2963,9 +3056,24 @@ class DaemonLifecycle {
     }
     throw new Error(`Timed out waiting for AgentBridge daemon readiness+identity on ${this.readyUrl} (control port ${this.controlPort})`);
   }
+  readDaemonRecord() {
+    return readUnifiedDaemonRecord({
+      daemonRecordFile: this.stateDir.daemonRecordFile,
+      pidFile: this.stateDir.pidFile,
+      statusFile: this.stateDir.statusFile
+    });
+  }
+  writeDaemonRecord(record) {
+    writeDaemonRecord(this.stateDir.daemonRecordFile, record);
+  }
+  removeDaemonRecord() {
+    try {
+      unlinkSync3(this.stateDir.daemonRecordFile);
+    } catch {}
+  }
   readStatus() {
     try {
-      const raw = readFileSync2(this.stateDir.statusFile, "utf-8");
+      const raw = readFileSync3(this.stateDir.statusFile, "utf-8");
       return JSON.parse(raw);
     } catch {
       return null;
@@ -2976,7 +3084,7 @@ class DaemonLifecycle {
   }
   readPid() {
     try {
-      const raw = readFileSync2(this.stateDir.pidFile, "utf-8").trim();
+      const raw = readFileSync3(this.stateDir.pidFile, "utf-8").trim();
       if (!raw)
         return null;
       const pid = Number.parseInt(raw, 10);
@@ -3028,8 +3136,10 @@ class DaemonLifecycle {
     daemonProc.unref();
   }
   removeStalePidFile() {
-    this.log("Removing stale pid file");
+    this.log("Removing stale daemon identity files");
     this.removePidFile();
+    this.removeStatusFile();
+    this.removeDaemonRecord();
   }
   async replaceUnhealthyDaemon(statusPid) {
     await this.withStartupLockStrict(async (locked) => {
@@ -3089,7 +3199,7 @@ class DaemonLifecycle {
         if (reclaimed)
           return false;
         try {
-          const holderPid = Number.parseInt(readFileSync2(this.stateDir.lockFile, "utf-8").trim(), 10);
+          const holderPid = Number.parseInt(readFileSync3(this.stateDir.lockFile, "utf-8").trim(), 10);
           if (Number.isFinite(holderPid) && !isProcessAlive(holderPid)) {
             this.log(`Stale startup lock from dead process ${holderPid}, reclaiming`);
             this.releaseLock();
@@ -3164,6 +3274,7 @@ class DaemonLifecycle {
   cleanup() {
     this.removePidFile();
     this.removeStatusFile();
+    this.removeDaemonRecord();
   }
 }
 async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
@@ -3177,7 +3288,7 @@ async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
 }
 
 // src/config-service.ts
-import { readFileSync as readFileSync3, mkdirSync as mkdirSync4, existsSync as existsSync4 } from "fs";
+import { readFileSync as readFileSync4, mkdirSync as mkdirSync4, existsSync as existsSync4 } from "fs";
 import { join as join4 } from "path";
 var DEFAULT_BUDGET_CONFIG = {
   enabled: true,
@@ -3374,7 +3485,7 @@ class ConfigService {
   load() {
     let raw;
     try {
-      raw = readFileSync3(this.configPath, "utf-8");
+      raw = readFileSync4(this.configPath, "utf-8");
     } catch (err) {
       if (err?.code === "ENOENT") {
         return { state: "absent" };
@@ -4615,7 +4726,7 @@ class ReplyRequiredTracker {
 import {
   existsSync as existsSync6,
   readdirSync,
-  readFileSync as readFileSync4
+  readFileSync as readFileSync5
 } from "fs";
 import { homedir as homedir3 } from "os";
 import { basename as basename2, join as join6 } from "path";
@@ -4631,7 +4742,7 @@ function codexHome(env = process.env) {
 }
 function readRawCurrentThread(stateDir) {
   try {
-    const parsed = JSON.parse(readFileSync4(stateDir.currentThreadFile, "utf-8"));
+    const parsed = JSON.parse(readFileSync5(stateDir.currentThreadFile, "utf-8"));
     if (parsed?.version === 1 && typeof parsed.threadId === "string" && parsed.threadId.length > 0 && (parsed.status === "pending" || parsed.status === "current") && typeof parsed.cwd === "string") {
       return parsed;
     }
@@ -4850,6 +4961,8 @@ var CODEX_BOOT_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_CODEX_BOOT_RETRIES", 2
 var ALLOW_IDENTITYLESS_CLIENT = process.env.AGENTBRIDGE_COMPAT_IDENTITYLESS === "1";
 var BUDGET_CONFIG = applyBudgetEnvOverrides(config.budget);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
+var DAEMON_NONCE = randomUUID4();
+var DAEMON_STARTED_AT = Date.now();
 var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
 var attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 var controlServer = null;
@@ -5730,9 +5843,33 @@ function systemMessage(idPrefix, content) {
 }
 function writePidFile() {
   daemonLifecycle.writePid();
+  daemonLifecycle.writeDaemonRecord(buildDaemonRecord("booting"));
 }
 function removePidFile() {
   daemonLifecycle.removePidFile();
+  daemonLifecycle.removeDaemonRecord();
+}
+function buildDaemonRecord(phase) {
+  return {
+    pid: process.pid,
+    phase,
+    startedAt: DAEMON_STARTED_AT,
+    nonce: DAEMON_NONCE,
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    cwd: process.cwd(),
+    stateDir: stateDir.dir,
+    proxyUrl: codex.proxyUrl,
+    appServerUrl: codex.appServerUrl,
+    ports: {
+      appPort: portFromUrl(codex.appServerUrl) ?? CODEX_APP_PORT,
+      proxyPort: portFromUrl(codex.proxyUrl) ?? CODEX_PROXY_PORT,
+      controlPort: CONTROL_PORT
+    },
+    build: daemonStatusBuildInfo(),
+    turnInProgress: codex.turnInProgress,
+    turnPhase: codex.turnPhase,
+    attentionWindowActive: inAttentionWindow
+  };
 }
 function writeStatusFile() {
   daemonLifecycle.writeStatus({
@@ -5749,9 +5886,11 @@ function writeStatusFile() {
     attentionWindowActive: inAttentionWindow,
     appServerInfo: codex.capturedAppServerInfo
   });
+  daemonLifecycle.writeDaemonRecord(buildDaemonRecord("ready"));
 }
 function removeStatusFile() {
   daemonLifecycle.removeStatusFile();
+  daemonLifecycle.removeDaemonRecord();
 }
 function armBootDeadline() {
   if (bootDeadlineTimer)

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -15,7 +15,7 @@ import { checkAgentsMdContract } from "../agents-contract";
 import {
   captureTuiLogTail,
   discoverNativeChildPid,
-  readTurnInProgress,
+  readUnifiedTurnInProgress,
   refineCleanExitClassification,
 } from "../wrapper-exit-observability";
 import { ConfigService } from "../config-service";
@@ -341,11 +341,12 @@ export async function runCodex(args: string[]) {
     process.exit(1);
   }
 
-  // Read proxyUrl from daemon status or fall back to config
+  // Read proxyUrl from the unified daemon record (daemon.json, falling back to
+  // the legacy status.json) or, last resort, the config.
   let proxyUrl: string;
-  const status = lifecycle.readStatus();
-  if (status?.proxyUrl) {
-    proxyUrl = status.proxyUrl;
+  const record = lifecycle.readDaemonRecord();
+  if (record?.proxyUrl) {
+    proxyUrl = record.proxyUrl;
   } else {
     // Mirror exactly how the daemon resolves its proxy port (daemon.ts:39):
     // CODEX_PROXY_PORT (set by applyPairEnv in pair mode; user-set in manual mode)
@@ -609,7 +610,13 @@ export async function runCodex(args: string[]) {
       // turn state (status.json, refreshed on every turn transition). A clean
       // exit DURING a turn is the alarming one — the user sees "Codex died"
       // while the agent loop usually finishes app-server-side (issue #102).
-      classification = refineCleanExitClassification(readTurnInProgress(stateDir.statusFile));
+      classification = refineCleanExitClassification(
+        readUnifiedTurnInProgress({
+          daemonRecordFile: stateDir.daemonRecordFile,
+          pidFile: stateDir.pidFile,
+          statusFile: stateDir.statusFile,
+        }),
+      );
     }
 
     // Freeze the native TUI's structured-log tail into the exit block — the

--- a/src/cli/kill.ts
+++ b/src/cli/kill.ts
@@ -2,6 +2,7 @@ import { readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { cliInvocationName } from "../cli-invocation";
 import { DaemonLifecycle } from "../daemon-lifecycle";
+import { portFromUrl, readUnifiedDaemonRecord } from "../daemon-record";
 import { PairError, detectLegacyRootDaemon, listPairDirs, type PairEntry, type PairPorts } from "../pair-registry";
 import {
   computeBaseDir,
@@ -207,26 +208,25 @@ function listPairDirsSafe(base: string): string[] {
 
 /**
  * Best-effort port recovery for an UNREGISTERED state dir (no slot to compute
- * from): read what the daemon advertised in its own status.json. Zeroes are
- * fine — kill() targets the pid file, not the ports.
+ * from): read what the daemon advertised in its unified daemon.json record
+ * (falling back to the legacy status.json). Zeroes are fine — kill() targets the
+ * pid, not the ports.
  */
 function portsFromStateDir(stateDir: StateDirResolver): PairPorts {
-  try {
-    const raw = JSON.parse(readFileSync(stateDir.statusFile, "utf-8"));
-    return {
-      appPort: portFromUrl(raw?.appServerUrl) ?? 0,
-      proxyPort: portFromUrl(raw?.proxyUrl) ?? 0,
-      controlPort: typeof raw?.controlPort === "number" ? raw.controlPort : 0,
-    };
-  } catch {
-    return { appPort: 0, proxyPort: 0, controlPort: 0 };
-  }
-}
-
-function portFromUrl(url: unknown): number | null {
-  if (typeof url !== "string") return null;
-  const match = url.match(/:(\d+)(?:[/?]|$)/);
-  return match ? Number.parseInt(match[1]!, 10) : null;
+  const record = readUnifiedDaemonRecord({
+    daemonRecordFile: stateDir.daemonRecordFile,
+    pidFile: stateDir.pidFile,
+    statusFile: stateDir.statusFile,
+  });
+  if (!record) return { appPort: 0, proxyPort: 0, controlPort: 0 };
+  return {
+    // Prefer the explicit ports triple; fall back to parsing the URLs so a
+    // synthesized legacy record (ports derived from proxyUrl/appServerUrl) and a
+    // native daemon.json agree.
+    appPort: record.ports?.appPort ?? portFromUrl(record.appServerUrl) ?? 0,
+    proxyPort: record.ports?.proxyPort ?? portFromUrl(record.proxyUrl) ?? 0,
+    controlPort: record.ports?.controlPort ?? 0,
+  };
 }
 
 async function stopStateDir(label: string, stateDir: StateDirResolver, ports: PairPorts): Promise<StopResult> {
@@ -245,16 +245,17 @@ async function stopStateDir(label: string, stateDir: StateDirResolver, ports: Pa
     });
 
     lifecycle.markKilled();
-    // Prefer the daemon's own status.json proxyUrl over the slot's computed port:
+    // Prefer the daemon's own advertised proxyUrl over the slot's computed port:
     // the legacy/manual kill path resolves ports heuristically (e.g. the legacy
     // root daemon is reported as 4501) and a custom CODEX_PROXY_PORT would not
     // match the slot default. The TUI connected to whatever proxyUrl the daemon
-    // advertised, so that is the URL the orphan scan must match. Read it BEFORE
-    // killing the daemon (kill() deletes status.json). Fall back to the slot port.
-    const status = lifecycle.readStatus();
+    // advertised, so that is the URL the orphan scan must match. Read it from the
+    // unified daemon.json record (falling back to legacy status.json) BEFORE
+    // killing the daemon (kill() deletes those files). Fall back to the slot port.
+    const record = lifecycle.readDaemonRecord();
     const proxyUrl =
-      typeof status?.proxyUrl === "string" && status.proxyUrl.length > 0
-        ? status.proxyUrl
+      typeof record?.proxyUrl === "string" && record.proxyUrl.length > 0
+        ? record.proxyUrl
         : `ws://127.0.0.1:${ports.proxyPort}`;
     const tuiKilled = await killManagedCodexTui(stateDir, proxyUrl, log);
     const daemonKilled = await lifecycle.kill();

--- a/src/cli/pairs.ts
+++ b/src/cli/pairs.ts
@@ -401,9 +401,9 @@ async function rowForPair(base: string, pair: PairEntry): Promise<PairRow> {
     controlPort: ports.controlPort,
     log: () => {},
   });
-  const [running, status] = await Promise.all([
+  const [running, record] = await Promise.all([
     lifecycle.isHealthy(),
-    Promise.resolve(lifecycle.readStatus()),
+    Promise.resolve(lifecycle.readDaemonRecord()),
   ]);
   const thread = readRawCurrentThread(stateDir);
 
@@ -415,7 +415,7 @@ async function rowForPair(base: string, pair: PairEntry): Promise<PairRow> {
     source: pair.source,
     cwd: pair.cwd,
     running,
-    pid: typeof status?.pid === "number" ? status.pid : null,
+    pid: typeof record?.pid === "number" ? record.pid : null,
     threadId: thread?.threadId ?? null,
     threadStatus: thread?.status ?? null,
     threadUpdatedAt: thread?.updatedAt ?? null,

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -6,6 +6,11 @@ import { BUILD_INFO, compatibleContractVersion, formatBuildInfo, sameRuntimeCont
 import { StateDirResolver } from "./state-dir";
 import { parsePositiveIntEnv } from "./env-utils";
 import { isAgentBridgeDaemon, isAgentBridgeProcess, isProcessAlive } from "./process-lifecycle";
+import {
+  readUnifiedDaemonRecord,
+  writeDaemonRecord,
+  type DaemonRecord,
+} from "./daemon-record";
 import type { DaemonStatus } from "./control-protocol";
 import type { AgentBridgeBuildInfo } from "./build-info";
 
@@ -389,7 +394,37 @@ export class DaemonLifecycle {
     );
   }
 
-  /** Read daemon status from status.json. */
+  /**
+   * Read the UNIFIED daemon identity (arch-review P2 #536): prefer `daemon.json`,
+   * fall back to the legacy `daemon.pid` + `status.json` pair. This is the
+   * single source consumers should use for proxyUrl / ports / pid / phase.
+   */
+  readDaemonRecord(): DaemonRecord | null {
+    return readUnifiedDaemonRecord({
+      daemonRecordFile: this.stateDir.daemonRecordFile,
+      pidFile: this.stateDir.pidFile,
+      statusFile: this.stateDir.statusFile,
+    });
+  }
+
+  /** Atomically write the unified daemon.json (tmp+rename). */
+  writeDaemonRecord(record: DaemonRecord): void {
+    writeDaemonRecord(this.stateDir.daemonRecordFile, record);
+  }
+
+  /** Remove the unified daemon.json. */
+  removeDaemonRecord(): void {
+    try {
+      unlinkSync(this.stateDir.daemonRecordFile);
+    } catch {}
+  }
+
+  /**
+   * Read daemon status from status.json (LEGACY pair). Kept for one version cycle
+   * so an older on-disk daemon (no daemon.json) is still readable. New callers
+   * should prefer {@link readDaemonRecord}, which reads daemon.json first and
+   * falls back to this file.
+   */
   readStatus(): { proxyUrl?: string; controlPort?: number; pid?: number } | null {
     try {
       const raw = readFileSync(this.stateDir.statusFile, "utf-8");
@@ -399,7 +434,7 @@ export class DaemonLifecycle {
     }
   }
 
-  /** Write daemon status to status.json. */
+  /** Write daemon status to status.json (LEGACY pair, kept in sync for compat). */
   writeStatus(status: Record<string, unknown>): void {
     atomicWriteJson(this.stateDir.statusFile, status);
   }
@@ -472,8 +507,15 @@ export class DaemonLifecycle {
   }
 
   private removeStalePidFile(): void {
-    this.log("Removing stale pid file");
+    this.log("Removing stale daemon identity files");
+    // Remove ALL three identity files so a recycled/stale pid does not leave a
+    // half-state behind (symmetric with cleanup()/kill()). Previously this
+    // removed only daemon.pid, leaving status.json (and now daemon.json) with
+    // the stale pid until the next launch overwrote them — a bounded leak we
+    // close here.
     this.removePidFile();
+    this.removeStatusFile();
+    this.removeDaemonRecord();
   }
 
   /**
@@ -689,6 +731,10 @@ export class DaemonLifecycle {
   private cleanup(): void {
     this.removePidFile();
     this.removeStatusFile();
+    // Unified daemon.json (arch-review P2 #536) must be removed in lockstep with
+    // the legacy pair — otherwise a killed daemon would leave a daemon.json with
+    // a (now-dead) pid that readDaemonRecord/pairDirDaemonAlive could still read.
+    this.removeDaemonRecord();
   }
 }
 

--- a/src/daemon-record.ts
+++ b/src/daemon-record.ts
@@ -1,0 +1,204 @@
+/**
+ * Unified daemon disk identity (arch-review P2 #536).
+ *
+ * BEFORE: the daemon's on-disk identity was split across two non-atomic,
+ * lifecycle-desynchronized files:
+ *   - `daemon.pid`   — written at process start (pid only).
+ *   - `status.json`  — written ONLY after codex bootstrap succeeded
+ *     (proxyUrl/ports/build/turnPhase/...), via a bare writeFileSync.
+ * A crash could leave a "pid present, status from a previous generation"
+ * combination state, and consumers had to read BOTH files and take the union.
+ *
+ * AFTER: a single atomically-written `daemon.json` carries the full identity
+ * with an explicit `phase`:
+ *   - `phase: "booting"` is written atomically at process start (pid known,
+ *     codex not yet ready — proxyUrl/ports/build may be absent or partial).
+ *   - `phase: "ready"`   atomically replaces it once codex bootstrap completes
+ *     (full proxyUrl/ports/build present).
+ * The explicit phase turns "pid present but status missing" from a guess
+ * ("just started? crashed last time?") into a declared state.
+ *
+ * BACKWARD COMPATIBILITY (one version cycle): the daemon ALSO keeps writing the
+ * legacy `daemon.pid` + `status.json` (so an older reader still works), and all
+ * readers PREFER `daemon.json`, falling back to synthesizing an equivalent
+ * record from the legacy files when `daemon.json` is absent (so a NEW reader
+ * still understands an OLD daemon that only wrote the legacy pair).
+ *
+ * This module is the single source of truth for the schema, the atomic writer,
+ * and the read-with-fallback. It is pure/IO-injectable so it can be unit-tested
+ * across the three states (legacy-only / daemon.json-only / both present).
+ */
+
+import { readFileSync } from "node:fs";
+import { atomicWriteJson } from "./atomic-json";
+import type { AgentBridgeBuildInfo } from "./build-info";
+import type { TurnPhase } from "./control-protocol";
+
+/** Lifecycle phase of the daemon's disk record. */
+export type DaemonRecordPhase = "booting" | "ready";
+
+/** Port triple the daemon owns, mirrored for kill-side port recovery. */
+export interface DaemonRecordPorts {
+  appPort?: number;
+  proxyPort?: number;
+  controlPort?: number;
+}
+
+/**
+ * The unified daemon.json schema. Fields are deliberately optional where the
+ * legacy fallback (or the booting phase) cannot supply them, so a synthesized
+ * record from `daemon.pid` + `status.json` and a real `daemon.json` are the
+ * same shape and every reader takes one code path.
+ */
+export interface DaemonRecord {
+  /** Always present — the daemon's process pid (the liveness anchor). */
+  pid: number;
+  /** Lifecycle phase. Synthesized legacy records use "ready" iff status.json existed (see below). */
+  phase: DaemonRecordPhase;
+  /** Epoch ms the record was first written (booting). Absent for synthesized legacy records. */
+  startedAt?: number;
+  /**
+   * Per-start random identity nonce. Lets a launcher confirm "this is the exact
+   * process I registered" more strongly than a ps regex (the daemon can echo it
+   * on /healthz). Absent for synthesized legacy records (old daemons had none).
+   */
+  nonce?: string;
+  /** Multi-pair identity; null/undefined in legacy/manual single-pair mode. */
+  pairId?: string | null;
+  cwd?: string | null;
+  stateDir?: string | null;
+  /** Codex proxy WS URL the TUI attaches to (the kill-side orphan scan matches it). */
+  proxyUrl?: string;
+  appServerUrl?: string;
+  ports?: DaemonRecordPorts;
+  build?: AgentBridgeBuildInfo;
+  /** Turn lifecycle phase mirror (kept in step with /healthz). */
+  turnPhase?: TurnPhase;
+  /** COMPAT mapping turnPhase ∈ {running,stalled}; read by the TUI-exit classifier. */
+  turnInProgress?: boolean;
+  attentionWindowActive?: boolean;
+}
+
+export type ReadFile = (path: string) => string;
+
+const defaultRead: ReadFile = (path) => readFileSync(path, "utf-8");
+
+/** Atomically write the unified daemon.json (tmp + rename). */
+export function writeDaemonRecord(path: string, record: DaemonRecord): void {
+  atomicWriteJson(path, record);
+}
+
+/**
+ * Read the unified daemon.json. Returns the parsed record only when it is a
+ * well-formed object with a finite numeric pid; otherwise null (a partially
+ * written / corrupt file must NOT masquerade as a live record).
+ */
+export function readDaemonRecord(path: string, read: ReadFile = defaultRead): DaemonRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(read(path));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.pid !== "number" || !Number.isFinite(obj.pid)) return null;
+  const phase: DaemonRecordPhase = obj.phase === "ready" ? "ready" : "booting";
+  return { ...(obj as unknown as DaemonRecord), pid: obj.pid, phase };
+}
+
+/**
+ * Synthesize a DaemonRecord from the LEGACY `daemon.pid` + `status.json` pair,
+ * for backward-compat reads of an old daemon that never wrote `daemon.json`.
+ *
+ * Liveness anchor (the pid) is taken from `daemon.pid` first, then from
+ * `status.json`'s pid — the SAME union the legacy `pairDirDaemonAlive` took, so
+ * a daemon that wrote either file is still seen as alive. Returns null only when
+ * NEITHER file yields a finite pid.
+ *
+ * `phase` is synthesized as "ready" when status.json was present and parseable
+ * (the old daemon only wrote status.json after bootstrap), else "booting" (pid
+ * file alone = started-but-not-bootstrapped, the same meaning the new booting
+ * phase carries).
+ */
+export function synthesizeLegacyRecord(
+  pidFilePath: string,
+  statusFilePath: string,
+  read: ReadFile = defaultRead,
+): DaemonRecord | null {
+  let pidFromPidFile: number | null = null;
+  try {
+    const raw = read(pidFilePath).trim();
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n)) pidFromPidFile = n;
+  } catch {
+    // no/unreadable daemon.pid
+  }
+
+  let status: Record<string, unknown> | null = null;
+  try {
+    const parsed = JSON.parse(read(statusFilePath));
+    if (typeof parsed === "object" && parsed !== null) status = parsed as Record<string, unknown>;
+  } catch {
+    // no/unparseable status.json
+  }
+
+  const pidFromStatus =
+    status && typeof status.pid === "number" && Number.isFinite(status.pid) ? status.pid : null;
+
+  const pid = pidFromPidFile ?? pidFromStatus;
+  if (pid === null) return null;
+
+  const record: DaemonRecord = {
+    pid,
+    // status.json only ever existed post-bootstrap; its presence means "ready".
+    phase: status ? "ready" : "booting",
+  };
+  if (status) {
+    if (typeof status.proxyUrl === "string") record.proxyUrl = status.proxyUrl;
+    if (typeof status.appServerUrl === "string") record.appServerUrl = status.appServerUrl;
+    const controlPort = typeof status.controlPort === "number" ? status.controlPort : undefined;
+    const proxyPort = portFromUrl(status.proxyUrl);
+    const appPort = portFromUrl(status.appServerUrl);
+    if (controlPort !== undefined || proxyPort !== undefined || appPort !== undefined) {
+      record.ports = {};
+      if (appPort !== undefined) record.ports.appPort = appPort;
+      if (proxyPort !== undefined) record.ports.proxyPort = proxyPort;
+      if (controlPort !== undefined) record.ports.controlPort = controlPort;
+    }
+    if (status.pairId === null || typeof status.pairId === "string") record.pairId = status.pairId;
+    if (status.cwd === null || typeof status.cwd === "string") record.cwd = status.cwd;
+    if (status.stateDir === null || typeof status.stateDir === "string") record.stateDir = status.stateDir;
+    if (typeof status.build === "object" && status.build !== null) {
+      record.build = status.build as AgentBridgeBuildInfo;
+    }
+    if (typeof status.turnPhase === "string") record.turnPhase = status.turnPhase as TurnPhase;
+    if (typeof status.turnInProgress === "boolean") record.turnInProgress = status.turnInProgress;
+    if (typeof status.attentionWindowActive === "boolean") {
+      record.attentionWindowActive = status.attentionWindowActive;
+    }
+  }
+  return record;
+}
+
+/**
+ * Read the daemon's disk identity from the UNIFIED source, preferring
+ * `daemon.json` and falling back to the legacy `daemon.pid` + `status.json`
+ * pair. The single entry point every consumer should use.
+ */
+export function readUnifiedDaemonRecord(
+  paths: { daemonRecordFile: string; pidFile: string; statusFile: string },
+  read: ReadFile = defaultRead,
+): DaemonRecord | null {
+  return (
+    readDaemonRecord(paths.daemonRecordFile, read) ??
+    synthesizeLegacyRecord(paths.pidFile, paths.statusFile, read)
+  );
+}
+
+/** Parse a `:PORT` out of a ws/http URL. Shared so kill-side recovery agrees. */
+export function portFromUrl(url: unknown): number | undefined {
+  if (typeof url !== "string") return undefined;
+  const match = url.match(/:(\d+)(?:[/?]|$)/);
+  return match ? Number.parseInt(match[1]!, 10) : undefined;
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,7 +2,9 @@
 
 import type { ServerWebSocket } from "bun";
 import { rmSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { BUILD_INFO, daemonStatusBuildInfo } from "./build-info";
+import { portFromUrl, type DaemonRecord } from "./daemon-record";
 import { CodexAdapter } from "./codex-adapter";
 import { validateClaudeClientIdentity, evaluateInjectionAttachGuard } from "./daemon-identity";
 import {
@@ -117,6 +119,13 @@ const ALLOW_IDENTITYLESS_CLIENT = process.env.AGENTBRIDGE_COMPAT_IDENTITYLESS ==
 const BUDGET_CONFIG = applyBudgetEnvOverrides(config.budget);
 
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
+
+// Unified daemon.json identity (arch-review P2 #536). A per-START random nonce
+// gives launchers a stronger "this is the exact process I registered" check than
+// a ps regex (it can be echoed on /healthz); startedAt timestamps the booting
+// record. Both are stable for the daemon's lifetime.
+const DAEMON_NONCE = randomUUID();
+const DAEMON_STARTED_AT = Date.now();
 
 const codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
 const attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
@@ -1576,10 +1585,50 @@ function systemMessage(idPrefix: string, content: string): BridgeMessage {
 
 function writePidFile() {
   daemonLifecycle.writePid();
+  // Unified daemon.json (arch-review P2 #536): write the BOOTING phase at process
+  // start, atomically, alongside the legacy daemon.pid. proxyUrl/ports/build are
+  // already known here (codex constructed); turn fields default to the idle/boot
+  // state. bootstrap success replaces this with the READY phase (writeStatusFile).
+  daemonLifecycle.writeDaemonRecord(buildDaemonRecord("booting"));
 }
 
 function removePidFile() {
   daemonLifecycle.removePidFile();
+  daemonLifecycle.removeDaemonRecord();
+}
+
+/**
+ * Build the unified daemon.json record (arch-review P2 #536). The `ready` phase
+ * carries the same fields the legacy status.json + /healthz advertised, so every
+ * consumer reads one source. The `booting` phase is the same shape with the
+ * pre-bootstrap turn defaults — proxyUrl/ports/build are known from process
+ * start, so even a booting record is fully port-recoverable for kill.
+ */
+function buildDaemonRecord(phase: "booting" | "ready"): DaemonRecord {
+  return {
+    pid: process.pid,
+    phase,
+    startedAt: DAEMON_STARTED_AT,
+    nonce: DAEMON_NONCE,
+    // Pair identity for diagnostics (null in legacy/manual single-pair mode).
+    pairId: process.env.AGENTBRIDGE_PAIR_ID ?? null,
+    cwd: process.cwd(),
+    stateDir: stateDir.dir,
+    proxyUrl: codex.proxyUrl,
+    appServerUrl: codex.appServerUrl,
+    ports: {
+      appPort: portFromUrl(codex.appServerUrl) ?? CODEX_APP_PORT,
+      proxyPort: portFromUrl(codex.proxyUrl) ?? CODEX_PROXY_PORT,
+      controlPort: CONTROL_PORT,
+    },
+    build: daemonStatusBuildInfo(),
+    // Refreshed on every turn-phase transition (the unified turnPhaseChanged
+    // handler calls tryWriteStatusFile → writeStatusFile) so the TUI wrapper
+    // reads an up-to-date value at exit time: exit_0_during_turn vs exit_0_idle.
+    turnInProgress: codex.turnInProgress,
+    turnPhase: codex.turnPhase,
+    attentionWindowActive: inAttentionWindow,
+  };
 }
 
 function writeStatusFile() {
@@ -1605,10 +1654,15 @@ function writeStatusFile() {
     // the control status stream cannot drift on this field either.
     appServerInfo: codex.capturedAppServerInfo,
   });
+  // Unified daemon.json (arch-review P2 #536): atomically replace booting → ready
+  // (or refresh the ready record on a turn-phase/attention transition) in lockstep
+  // with the legacy status.json, so the two never drift.
+  daemonLifecycle.writeDaemonRecord(buildDaemonRecord("ready"));
 }
 
 function removeStatusFile() {
   daemonLifecycle.removeStatusFile();
+  daemonLifecycle.removeDaemonRecord();
 }
 
 /**

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -907,11 +907,18 @@ export function listPairDirs(base: string): string[] {
 }
 
 /**
- * Conservative liveness probe for a pair dir: returns true if EITHER `daemon.pid`
- * OR `status.json`'s pid points at a living process. Conservative on purpose —
- * any sign of life keeps the dir, because wrongly deleting a live pair's state is
- * far worse than skipping an orphan we are unsure about. Shared by the prune
- * pre-filter and the in-lock delete gate so both agree on EPERM (= alive).
+ * Conservative liveness probe for a pair dir: returns true if the pid from the
+ * unified `daemon.json` record, OR `daemon.pid`, OR `status.json` points at a
+ * living process. Conservative on purpose — any sign of life keeps the dir,
+ * because wrongly deleting a live pair's state is far worse than skipping an
+ * orphan we are unsure about. Shared by the prune pre-filter and the in-lock
+ * delete gate so both agree on EPERM (= alive).
+ *
+ * The daemon.json pid is taken in ADDITION to (not instead of) the legacy pair
+ * (arch-review P2 #536): a new daemon writes all three in lockstep, while an old
+ * daemon wrote only the legacy pair — checking the union keeps both eras alive
+ * and preserves the original "any sign of life" semantics bit-for-bit for a
+ * legacy-only dir.
  *
  * Note: it does NOT confirm the pid is actually an AgentBridge daemon (no
  * isDaemonProcess/ps check), so a stale pid OS-reused by an unrelated live
@@ -922,6 +929,12 @@ export function listPairDirs(base: string): string[] {
 export function pairDirDaemonAlive(base: string, pairId: string): boolean {
   const dir = join(pairsDir(base), pairId);
   const pids: number[] = [];
+  try {
+    const record = JSON.parse(readFileSync(join(dir, "daemon.json"), "utf-8")) as { pid?: unknown };
+    if (typeof record?.pid === "number" && Number.isFinite(record.pid)) pids.push(record.pid);
+  } catch {
+    // no/unparseable daemon.json — fall through to the legacy pair below
+  }
   try {
     const pid = Number.parseInt(readFileSync(join(dir, "daemon.pid"), "utf-8").trim(), 10);
     if (Number.isFinite(pid)) pids.push(pid);

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -64,6 +64,16 @@ export class StateDirResolver {
     return join(this.stateDir, "status.json");
   }
 
+  /**
+   * Unified daemon disk identity (arch-review P2 #536). Atomically written at
+   * startup (phase=booting) and replaced at bootstrap (phase=ready); merges the
+   * legacy `daemon.pid` + `status.json` into one source. Readers prefer this and
+   * fall back to the legacy pair for one version cycle.
+   */
+  get daemonRecordFile(): string {
+    return join(this.stateDir, "daemon.json");
+  }
+
   get currentThreadFile(): string {
     return join(this.stateDir, "current-thread.json");
   }

--- a/src/unit-test/daemon-lifecycle.test.ts
+++ b/src/unit-test/daemon-lifecycle.test.ts
@@ -249,6 +249,65 @@ describe("DaemonLifecycle", () => {
     expect(lc.readStatus()).toBeNull();
   });
 
+  // --- Unified daemon.json (arch-review P2 #536) ---
+
+  test("writeDaemonRecord + readDaemonRecord round-trip via daemon.json", () => {
+    const lc = createLifecycle();
+    lc.writeDaemonRecord({ pid: 4242, phase: "ready", proxyUrl: "ws://127.0.0.1:4501" });
+    expect(existsSync(stateDir.daemonRecordFile)).toBe(true);
+    const rec = lc.readDaemonRecord();
+    expect(rec?.pid).toBe(4242);
+    expect(rec?.proxyUrl).toBe("ws://127.0.0.1:4501");
+    expect(rec?.phase).toBe("ready");
+  });
+
+  test("readDaemonRecord prefers daemon.json over legacy status.json", () => {
+    const lc = createLifecycle();
+    lc.writePid(700);
+    lc.writeStatus({ pid: 700, proxyUrl: "ws://127.0.0.1:4501" });
+    lc.writeDaemonRecord({ pid: 701, phase: "ready", proxyUrl: "ws://127.0.0.1:4701" });
+    const rec = lc.readDaemonRecord();
+    expect(rec?.pid).toBe(701);
+    expect(rec?.proxyUrl).toBe("ws://127.0.0.1:4701");
+  });
+
+  test("readDaemonRecord falls back to legacy files when daemon.json absent (old daemon)", () => {
+    const lc = createLifecycle();
+    lc.writePid(800);
+    lc.writeStatus({ pid: 800, proxyUrl: "ws://127.0.0.1:4801", controlPort: 4802 });
+    expect(existsSync(stateDir.daemonRecordFile)).toBe(false);
+    const rec = lc.readDaemonRecord();
+    expect(rec?.pid).toBe(800);
+    expect(rec?.proxyUrl).toBe("ws://127.0.0.1:4801");
+    expect(rec?.phase).toBe("ready"); // status.json present → ready
+    expect(rec?.ports?.controlPort).toBe(4802);
+  });
+
+  test("readDaemonRecord returns null when nothing on disk", () => {
+    const lc = createLifecycle();
+    expect(lc.readDaemonRecord()).toBeNull();
+  });
+
+  test("cleanup (via kill on dead pid) removes daemon.json alongside legacy files", async () => {
+    const lc = createLifecycle();
+    lc.writePid(9999999);
+    lc.writeStatus({ pid: 9999999 });
+    lc.writeDaemonRecord({ pid: 9999999, phase: "ready" });
+    expect(existsSync(stateDir.daemonRecordFile)).toBe(true);
+
+    // Dead pid → kill() runs cleanup(), which must remove ALL THREE files so a
+    // killed daemon leaves no live-looking record behind.
+    await lc.kill();
+    expect(existsSync(stateDir.pidFile)).toBe(false);
+    expect(existsSync(stateDir.statusFile)).toBe(false);
+    expect(existsSync(stateDir.daemonRecordFile)).toBe(false);
+  });
+
+  test("removeDaemonRecord does not throw when file missing", () => {
+    const lc = createLifecycle();
+    expect(() => lc.removeDaemonRecord()).not.toThrow();
+  });
+
   test("isHealthy returns false for non-existent port", async () => {
     const lc = createLifecycle(19999);
     expect(await lc.isHealthy()).toBe(false);

--- a/src/unit-test/daemon-record.test.ts
+++ b/src/unit-test/daemon-record.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  readDaemonRecord,
+  writeDaemonRecord,
+  synthesizeLegacyRecord,
+  readUnifiedDaemonRecord,
+  portFromUrl,
+  type DaemonRecord,
+} from "../daemon-record";
+
+describe("daemon-record", () => {
+  let dir: string;
+  let paths: { daemonRecordFile: string; pidFile: string; statusFile: string };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agentbridge-record-"));
+    paths = {
+      daemonRecordFile: join(dir, "daemon.json"),
+      pidFile: join(dir, "daemon.pid"),
+      statusFile: join(dir, "status.json"),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("portFromUrl", () => {
+    test("extracts port from ws/http urls, undefined otherwise", () => {
+      expect(portFromUrl("ws://127.0.0.1:4501")).toBe(4501);
+      expect(portFromUrl("ws://127.0.0.1:4501/ws")).toBe(4501);
+      expect(portFromUrl("http://127.0.0.1:4502/healthz")).toBe(4502);
+      expect(portFromUrl("no-port")).toBeUndefined();
+      expect(portFromUrl(123)).toBeUndefined();
+      expect(portFromUrl(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("write/read round-trip + atomicity", () => {
+    test("writeDaemonRecord then readDaemonRecord returns the record", () => {
+      const record: DaemonRecord = {
+        pid: 4242,
+        phase: "ready",
+        startedAt: 1000,
+        nonce: "abc",
+        pairId: "p-1",
+        proxyUrl: "ws://127.0.0.1:4501",
+        ports: { appPort: 4500, proxyPort: 4501, controlPort: 4502 },
+        turnPhase: "idle",
+        turnInProgress: false,
+      };
+      writeDaemonRecord(paths.daemonRecordFile, record);
+      expect(readDaemonRecord(paths.daemonRecordFile)).toEqual(record);
+    });
+
+    test("write is atomic (tmp+rename) — no stray .tmp left behind", () => {
+      writeDaemonRecord(paths.daemonRecordFile, { pid: 1, phase: "booting" });
+      // Only the final file should exist; no leftover .tmp.* siblings.
+      const { readdirSync } = require("node:fs");
+      const stray = readdirSync(dir).filter((n: string) => n.includes(".tmp."));
+      expect(stray.length).toBe(0);
+      expect(existsSync(paths.daemonRecordFile)).toBe(true);
+    });
+
+    test("readDaemonRecord rejects corrupt / non-object / pidless content", () => {
+      writeFileSync(paths.daemonRecordFile, "not-json");
+      expect(readDaemonRecord(paths.daemonRecordFile)).toBeNull();
+      writeFileSync(paths.daemonRecordFile, JSON.stringify([1, 2]));
+      expect(readDaemonRecord(paths.daemonRecordFile)).toBeNull();
+      writeFileSync(paths.daemonRecordFile, JSON.stringify({ phase: "ready" }));
+      expect(readDaemonRecord(paths.daemonRecordFile)).toBeNull();
+      writeFileSync(paths.daemonRecordFile, JSON.stringify({ pid: "x" }));
+      expect(readDaemonRecord(paths.daemonRecordFile)).toBeNull();
+    });
+
+    test("readDaemonRecord normalizes an unknown phase to booting", () => {
+      writeFileSync(paths.daemonRecordFile, JSON.stringify({ pid: 5, phase: "weird" }));
+      expect(readDaemonRecord(paths.daemonRecordFile)?.phase).toBe("booting");
+    });
+
+    test("readDaemonRecord returns null when file absent", () => {
+      expect(readDaemonRecord(paths.daemonRecordFile)).toBeNull();
+    });
+  });
+
+  describe("synthesizeLegacyRecord (old daemon: daemon.pid + status.json)", () => {
+    test("pid from daemon.pid, status present → phase ready + fields recovered", () => {
+      writeFileSync(paths.pidFile, "777\n");
+      writeFileSync(
+        paths.statusFile,
+        JSON.stringify({
+          pid: 777,
+          proxyUrl: "ws://127.0.0.1:4511",
+          appServerUrl: "ws://127.0.0.1:4510",
+          controlPort: 4512,
+          pairId: "legacy-1",
+          cwd: "/tmp/x",
+          turnInProgress: true,
+          turnPhase: "running",
+        }),
+      );
+      const rec = synthesizeLegacyRecord(paths.pidFile, paths.statusFile);
+      expect(rec).not.toBeNull();
+      expect(rec!.pid).toBe(777);
+      expect(rec!.phase).toBe("ready");
+      expect(rec!.proxyUrl).toBe("ws://127.0.0.1:4511");
+      expect(rec!.ports).toEqual({ appPort: 4510, proxyPort: 4511, controlPort: 4512 });
+      expect(rec!.pairId).toBe("legacy-1");
+      expect(rec!.turnInProgress).toBe(true);
+      expect(rec!.turnPhase).toBe("running");
+    });
+
+    test("only daemon.pid (started, not bootstrapped) → phase booting, pid recovered", () => {
+      writeFileSync(paths.pidFile, "888\n");
+      const rec = synthesizeLegacyRecord(paths.pidFile, paths.statusFile);
+      expect(rec!.pid).toBe(888);
+      expect(rec!.phase).toBe("booting");
+      expect(rec!.proxyUrl).toBeUndefined();
+    });
+
+    test("only status.json (no pid file) → pid taken from status (legacy union)", () => {
+      writeFileSync(paths.statusFile, JSON.stringify({ pid: 999, proxyUrl: "ws://127.0.0.1:4501" }));
+      const rec = synthesizeLegacyRecord(paths.pidFile, paths.statusFile);
+      expect(rec!.pid).toBe(999);
+      expect(rec!.phase).toBe("ready");
+      expect(rec!.proxyUrl).toBe("ws://127.0.0.1:4501");
+    });
+
+    test("daemon.pid wins as pid anchor over a stale status.json pid", () => {
+      writeFileSync(paths.pidFile, "111\n");
+      writeFileSync(paths.statusFile, JSON.stringify({ pid: 222 }));
+      expect(synthesizeLegacyRecord(paths.pidFile, paths.statusFile)!.pid).toBe(111);
+    });
+
+    test("neither file yields a pid → null", () => {
+      expect(synthesizeLegacyRecord(paths.pidFile, paths.statusFile)).toBeNull();
+      writeFileSync(paths.statusFile, JSON.stringify({ noPid: true }));
+      expect(synthesizeLegacyRecord(paths.pidFile, paths.statusFile)).toBeNull();
+    });
+  });
+
+  describe("readUnifiedDaemonRecord — three compat states", () => {
+    test("only LEGACY files present → synthesized record", () => {
+      writeFileSync(paths.pidFile, "501\n");
+      writeFileSync(paths.statusFile, JSON.stringify({ pid: 501, proxyUrl: "ws://127.0.0.1:4501" }));
+      const rec = readUnifiedDaemonRecord(paths);
+      expect(rec!.pid).toBe(501);
+      expect(rec!.phase).toBe("ready");
+      expect(rec!.proxyUrl).toBe("ws://127.0.0.1:4501");
+    });
+
+    test("only daemon.json present → that record", () => {
+      writeDaemonRecord(paths.daemonRecordFile, {
+        pid: 601,
+        phase: "ready",
+        proxyUrl: "ws://127.0.0.1:4601",
+      });
+      const rec = readUnifiedDaemonRecord(paths);
+      expect(rec!.pid).toBe(601);
+      expect(rec!.proxyUrl).toBe("ws://127.0.0.1:4601");
+    });
+
+    test("BOTH present → daemon.json wins (legacy ignored)", () => {
+      writeFileSync(paths.pidFile, "700\n");
+      writeFileSync(paths.statusFile, JSON.stringify({ pid: 700, proxyUrl: "ws://127.0.0.1:4501" }));
+      writeDaemonRecord(paths.daemonRecordFile, {
+        pid: 701,
+        phase: "ready",
+        proxyUrl: "ws://127.0.0.1:4701",
+      });
+      const rec = readUnifiedDaemonRecord(paths);
+      expect(rec!.pid).toBe(701);
+      expect(rec!.proxyUrl).toBe("ws://127.0.0.1:4701");
+    });
+
+    test("daemon.json corrupt but legacy valid → falls back to legacy", () => {
+      writeFileSync(paths.daemonRecordFile, "corrupt{");
+      writeFileSync(paths.pidFile, "800\n");
+      writeFileSync(paths.statusFile, JSON.stringify({ pid: 800 }));
+      expect(readUnifiedDaemonRecord(paths)!.pid).toBe(800);
+    });
+
+    test("nothing present → null", () => {
+      expect(readUnifiedDaemonRecord(paths)).toBeNull();
+    });
+  });
+});

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -23,6 +23,7 @@ import {
   isEntryReclaimable,
   listPairDirs,
   MAX_PAIR_SLOT,
+  pairDirDaemonAlive,
   pairDirPath,
   pairsRootDir,
   PairError,
@@ -1040,5 +1041,68 @@ describe("pruneReclaimableEntries via removePairEntryAndDir — apply deletes en
     expect(res.entry?.pairId).toBe(id);
     expect(existsSync(dir)).toBe(false);
     expect(readRegistry(base).pairs.some((p) => p.pairId === id)).toBe(false);
+  });
+});
+
+describe("pairDirDaemonAlive — unified daemon.json + legacy compat (#536)", () => {
+  let base: string;
+  const DEAD_PID = 2147483646; // far outside any live pid range
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "abg-pair-alive-"));
+  });
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  function dirFor(id: string): string {
+    const dir = join(base, "pairs", id);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  test("LEGACY-only: live pid in daemon.pid → alive (bit-for-bit old behavior)", () => {
+    const dir = dirFor("p-legacy-live");
+    writeFileSync(join(dir, "daemon.pid"), `${process.pid}\n`, "utf-8");
+    expect(pairDirDaemonAlive(base, "p-legacy-live")).toBe(true);
+  });
+
+  test("LEGACY-only: live pid only in status.json → alive (union preserved)", () => {
+    const dir = dirFor("p-legacy-status");
+    writeFileSync(join(dir, "status.json"), JSON.stringify({ pid: process.pid }), "utf-8");
+    expect(pairDirDaemonAlive(base, "p-legacy-status")).toBe(true);
+  });
+
+  test("LEGACY-only: dead pid in both → not alive", () => {
+    const dir = dirFor("p-legacy-dead");
+    writeFileSync(join(dir, "daemon.pid"), `${DEAD_PID}\n`, "utf-8");
+    writeFileSync(join(dir, "status.json"), JSON.stringify({ pid: DEAD_PID }), "utf-8");
+    expect(pairDirDaemonAlive(base, "p-legacy-dead")).toBe(false);
+  });
+
+  test("daemon.json-only: live pid → alive", () => {
+    const dir = dirFor("p-record-live");
+    writeFileSync(join(dir, "daemon.json"), JSON.stringify({ pid: process.pid, phase: "ready" }), "utf-8");
+    expect(pairDirDaemonAlive(base, "p-record-live")).toBe(true);
+  });
+
+  test("daemon.json-only: dead pid → not alive", () => {
+    const dir = dirFor("p-record-dead");
+    writeFileSync(join(dir, "daemon.json"), JSON.stringify({ pid: DEAD_PID, phase: "ready" }), "utf-8");
+    expect(pairDirDaemonAlive(base, "p-record-dead")).toBe(false);
+  });
+
+  test("BOTH present, any live anchor → alive (conservative union)", () => {
+    const dir = dirFor("p-both");
+    // daemon.json carries a DEAD pid but legacy daemon.pid is live: union must
+    // still report alive (any sign of life keeps the dir).
+    writeFileSync(join(dir, "daemon.json"), JSON.stringify({ pid: DEAD_PID, phase: "ready" }), "utf-8");
+    writeFileSync(join(dir, "daemon.pid"), `${process.pid}\n`, "utf-8");
+    expect(pairDirDaemonAlive(base, "p-both")).toBe(true);
+  });
+
+  test("nothing on disk → not alive", () => {
+    dirFor("p-empty");
+    expect(pairDirDaemonAlive(base, "p-empty")).toBe(false);
   });
 });

--- a/src/unit-test/wrapper-exit-observability.test.ts
+++ b/src/unit-test/wrapper-exit-observability.test.ts
@@ -8,8 +8,21 @@ import {
   discoverNativeChildPid,
   findCodexSqliteLog,
   readTurnInProgress,
+  readUnifiedTurnInProgress,
   refineCleanExitClassification,
 } from "../wrapper-exit-observability";
+
+const PATHS = { daemonRecordFile: "/rec", pidFile: "/pid", statusFile: "/status" };
+
+/** Build a path-dispatching read fn for the three on-disk states. */
+function reader(files: { rec?: string; pid?: string; status?: string }) {
+  return (p: string): string => {
+    if (p === PATHS.daemonRecordFile && files.rec !== undefined) return files.rec;
+    if (p === PATHS.pidFile && files.pid !== undefined) return files.pid;
+    if (p === PATHS.statusFile && files.status !== undefined) return files.status;
+    throw new Error("ENOENT");
+  };
+}
 
 describe("discoverNativeChildPid", () => {
   test("parses the first child pid from pgrep output", () => {
@@ -47,6 +60,44 @@ describe("readTurnInProgress", () => {
     expect(readTurnInProgress("/x", () => staleTrue, () => true)).toBe(true);
     // No pid recorded (legacy file) → field taken at face value.
     expect(readTurnInProgress("/x", () => JSON.stringify({ turnInProgress: false }), () => false)).toBe(false);
+  });
+});
+
+describe("readUnifiedTurnInProgress (#536 — daemon.json + legacy fallback)", () => {
+  const alive = () => true;
+  const dead = () => false;
+
+  test("reads turnInProgress from daemon.json (preferred source)", () => {
+    const read = reader({ rec: JSON.stringify({ pid: 1, phase: "ready", turnInProgress: true }) });
+    expect(readUnifiedTurnInProgress(PATHS, read, alive)).toBe(true);
+    const read2 = reader({ rec: JSON.stringify({ pid: 1, phase: "ready", turnInProgress: false }) });
+    expect(readUnifiedTurnInProgress(PATHS, read2, alive)).toBe(false);
+  });
+
+  test("falls back to legacy status.json when daemon.json absent (old daemon)", () => {
+    const read = reader({ status: JSON.stringify({ pid: 1, turnInProgress: true }) });
+    expect(readUnifiedTurnInProgress(PATHS, read, alive)).toBe(true);
+  });
+
+  test("daemon.json wins over a stale legacy status.json", () => {
+    const read = reader({
+      rec: JSON.stringify({ pid: 1, phase: "ready", turnInProgress: false }),
+      status: JSON.stringify({ pid: 1, turnInProgress: true }),
+    });
+    expect(readUnifiedTurnInProgress(PATHS, read, alive)).toBe(false);
+  });
+
+  test("unknown when field missing, nothing on disk, or json invalid", () => {
+    expect(readUnifiedTurnInProgress(PATHS, reader({ rec: JSON.stringify({ pid: 1 }) }), alive)).toBeNull();
+    expect(readUnifiedTurnInProgress(PATHS, reader({}), alive)).toBeNull();
+    expect(readUnifiedTurnInProgress(PATHS, reader({ rec: "not-json" }), alive)).toBeNull();
+  });
+
+  test("stale record from a dead daemon degrades to unknown (same trust gate)", () => {
+    // daemon.json with turnInProgress:true but its writing pid is dead → unknown.
+    const read = reader({ rec: JSON.stringify({ pid: 4242, phase: "ready", turnInProgress: true }) });
+    expect(readUnifiedTurnInProgress(PATHS, read, dead)).toBeNull();
+    expect(readUnifiedTurnInProgress(PATHS, read, alive)).toBe(true);
   });
 });
 

--- a/src/wrapper-exit-observability.ts
+++ b/src/wrapper-exit-observability.ts
@@ -19,6 +19,7 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { pidLooksAlive } from "./process-lifecycle";
+import { readUnifiedDaemonRecord, type ReadFile } from "./daemon-record";
 
 export type RunCommand = (cmd: string, args: string[]) => string;
 
@@ -69,6 +70,29 @@ export function readTurnInProgress(
 // Delegates to the consolidated liveness probe (pid<=0 guard + EPERM = alive),
 // the single source of truth in process-lifecycle.ts.
 const defaultIsPidAlive = pidLooksAlive;
+
+/**
+ * Unified turnInProgress read (arch-review P2 #536): prefer the daemon.json
+ * record, fall back to the legacy status.json path. Applies the SAME trust gate
+ * as {@link readTurnInProgress} — the field is only trusted when the writing
+ * daemon's pid is still alive, so a daemon killed MID-TURN (record left with
+ * turnInProgress:true) degrades to "unknown" rather than misclassifying a later
+ * idle exit as exit_0_during_turn. Returns null when no record/field/live-pid is
+ * available.
+ */
+export function readUnifiedTurnInProgress(
+  paths: { daemonRecordFile: string; pidFile: string; statusFile: string },
+  read: ReadFile = (p) => readFileSync(p, "utf-8"),
+  isPidAlive: (pid: number) => boolean = defaultIsPidAlive,
+): boolean | null {
+  const record = readUnifiedDaemonRecord(paths, read);
+  if (!record) return null;
+  if (typeof record.turnInProgress !== "boolean") return null;
+  // Same stale-mid-turn guard as the legacy reader: an absent/dead writer pid
+  // means the record may outlive its daemon — do not trust the field.
+  if (typeof record.pid === "number" && !isPidAlive(record.pid)) return null;
+  return record.turnInProgress;
+}
 
 /**
  * Refine the clean-exit classification using the daemon-side turn state.


### PR DESCRIPTION
## 摘要 / Summary
arch-review P2 #536：daemon 磁盘身份原本分裂在两个非原子、生命周期不同步的文件（daemon.pid 启动即写、status.json 仅 bootstrap 后写、裸 writeFileSync），消费侧要读两文件取并集、kill 抢读 status.json 等。合并为**单一原子 daemon.json**。
- **新增 `src/daemon-record.ts`**：`{pid, phase:"booting"|"ready", startedAt, nonce, pairId, ports, proxyUrl, build, turnPhase, turnInProgress, ...}` + `atomicWriteJson` + **三态读回落**（仅旧/仅新/并存/损坏）。
- `writePidFile` 写 **phase=booting**（启动即知 proxyUrl/ports），bootstrap 成功写 **phase=ready**；phase 让「pid 在但 status 缺」从猜测变显式。
- **所有读者带 legacy 回落**：pairDirDaemonAlive（三 pid 并集）/ kill（proxyUrl 抢读 + 端口反解）/ codex / pairs / wrapper-exit。doctor（HTTP）/ detectLegacyRootDaemon / 旧 lifecycle API 不动。
- **向后兼容**：旧 daemon（仅 legacy 两文件）经 `synthesizeLegacyRecord` 仍正确识别存活 + 拿 proxyUrl/ports（e2e-cli fake-daemon 只写 legacy，实测回落路径）。`removeStalePidFile` 改删全部三文件（对称 cleanup/kill，顺带治旧 status.json 泄漏）。

## 测试 / Test plan
- `bun run typecheck` ✅ / `bun test src` ✅ **1166 pass / 0 fail**（+18 新测试）/ `verify:plugin-sync` ✅
- 三态兼容（daemon-record 16 测）、pairDirDaemonAlive 三态×7、readUnifiedTurnInProgress 三态 + 信任门、cleanup 删三文件、e2e-cli reuse（旧 daemon 回落）。
- Cross-review：**高危 2 连 clean**——reliability + compat 双镜头；R1 1 LOW（removeStalePidFile 只删 pid）已修；R2 reliability 0 REAL，6 个 author SUSPECT 全部核验为非问题。

## 备注 / Notes
攒批发布：release-on-merge 暂禁。nonce 已落盘但 /healthz 回显核对 + legacy-root 纳入留后续（提案 2/3 身份闭环）。#516 stage-2 进一步拆 daemon.ts 留 backlog。