### PR TITLE
fix: budget paused 指纹剔除 drift.heavier 防重复暂停横幅 / drop drift.heavier from paused fingerprint

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14382,7 +14382,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("ab65a14", "source"),
+  commit: defineString("b00d7b8", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -22,7 +22,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("ab65a14", "source"),
+  commit: defineString("b00d7b8", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -3886,9 +3886,10 @@ function directiveFingerprint(state, activeSide) {
   } else if (state.phase === "balance" && state.drift.lighter) {
     reset = state.perAgent[state.drift.lighter]?.fiveHour?.resetEpoch ?? 0;
   }
+  const heavier = activeSide ? "" : state.drift.heavier ?? "none";
   return [
     activeSide ? "paused" : state.phase,
-    state.drift.heavier ?? "none",
+    heavier,
     side,
     Math.round(reset / RESET_FINGERPRINT_BUCKET_SEC)
   ].join("|");

--- a/src/budget/budget-fingerprint.ts
+++ b/src/budget/budget-fingerprint.ts
@@ -219,9 +219,18 @@ export function directiveFingerprint(state: BudgetState, activeSide?: ActivePaus
   // parallel (side is always "none"). Proven unreachable — instrumenting them
   // with throws kept all 53 budget tests green — so they are removed.
 
+  // `drift.heavier` is which side carries more usage by drift — relevant only
+  // to a balance/parallel advisory. A pause is keyed on the paused side
+  // (activeSide), so folding `heavier` into a PAUSED fingerprint lets the
+  // NON-paused side's warnUtil re-emit a duplicate pause banner whenever its
+  // drift flips `heavier`, even though the pause itself never changed. Drop
+  // `heavier` from the fingerprint while paused; keep it when not paused so the
+  // balance/parallel dedup behavior is unchanged.
+  const heavier = activeSide ? "" : (state.drift.heavier ?? "none");
+
   return [
     activeSide ? "paused" : state.phase,
-    state.drift.heavier ?? "none",
+    heavier,
     side,
     // Round-to-nearest bucket, not the raw epoch: the probe's reset_epoch
     // jitters by ±1s between polls (observed live: 09:49:59 ⇄ 09:50:00),

--- a/src/unit-test/budget-fingerprint.test.ts
+++ b/src/unit-test/budget-fingerprint.test.ts
@@ -333,4 +333,59 @@ describe("directiveFingerprint — pure fingerprint", () => {
     );
     expect(directiveFingerprint(a)).toBe(directiveFingerprint(b));
   });
+
+  // Regression (MEDIUM-4): the PAUSED fingerprint must NOT depend on
+  // `drift.heavier`. A pause is keyed on the paused side; `heavier` reflects the
+  // NON-paused side's relative drift, which is irrelevant to a pause decision.
+  // Folding it in let the non-paused side's warnUtil re-emit a DUPLICATE pause
+  // banner whenever its drift flipped `heavier`, even though the pause never
+  // changed.
+  test("paused fingerprint ignores drift.heavier flipped by the non-paused side", () => {
+    // Codex is the paused side (gateUtil 92). Only claude (the NON-paused side)
+    // changes its warnUtil, flipping drift.heavier claude⇄codex while codex's
+    // pause-relevant state stays identical.
+    const heavierClaude = state(
+      usage({ gateUtil: 20, warnUtil: 70 }),
+      usage({ gateUtil: 92, warnUtil: 50, remaining: 8 }),
+    );
+    const heavierCodex = state(
+      usage({ gateUtil: 20, warnUtil: 30 }),
+      usage({ gateUtil: 92, warnUtil: 50, remaining: 8 }),
+    );
+    // Sanity: drift.heavier genuinely flipped between the two states.
+    expect(heavierClaude.drift.heavier).toBe("claude");
+    expect(heavierCodex.drift.heavier).toBe("codex");
+    // The PAUSED fingerprint (activeSide = "codex") must be EQUAL → no dup banner.
+    expect(directiveFingerprint(heavierClaude, "codex")).toBe(
+      directiveFingerprint(heavierCodex, "codex"),
+    );
+  });
+
+  test("not-paused fingerprint still folds in drift.heavier (behavior preserved)", () => {
+    // Two balance states identical except for drift.heavier (lighter held the
+    // same) — the NON-paused path must still distinguish them, or a real
+    // balance-direction change would be silently deduped.
+    const base: BudgetState = {
+      phase: "balance",
+      now: NOW,
+      perAgent: { claude: usage({ gateUtil: 35, warnUtil: 45 }), codex: usage({ gateUtil: 20, warnUtil: 20 }) },
+      drift: { pct: 25, heavier: "claude", lighter: "codex" },
+      pause: {
+        active: false,
+        side: null,
+        reason: null,
+        resumeBelow: CONFIG.resumeBelow,
+        resumeAfterEpoch: null,
+        resetEpochs: { claude: 0, codex: 0 },
+      },
+      parallel: { recommended: false, reason: null },
+      effort: { claudeAdvice: null, codexTier: "full" },
+      directiveToClaude: "balance",
+    };
+    const heavierClaude: BudgetState = { ...base, drift: { ...base.drift, heavier: "claude" } };
+    const heavierCodex: BudgetState = { ...base, drift: { ...base.drift, heavier: "codex" } };
+    // lighter is identical → balance `side` is identical → the ONLY difference is
+    // heavier. The fingerprints must still differ.
+    expect(directiveFingerprint(heavierClaude)).not.toBe(directiveFingerprint(heavierCodex));
+  });
 });


### PR DESCRIPTION
## 深扫 round-2 · MEDIUM-4

`directiveFingerprint` 在 **paused** 路径仍把 `state.drift.heavier` 折进指纹，而 heavier 由 `claude.warnUtil - codex.warnUtil` 推导，与哪侧暂停无关。非暂停侧 warnUtil 翻转 drift 符号 → paused 指纹变化 → `classifyPoll` 的 `emit = ... || fingerprint !== prev.fingerprint` 误判新指令 → **重复弹暂停横幅**。

### 修复 / Fix
`const heavier = activeSide ? "" : (state.drift.heavier ?? "none")` — paused 时不折 heavier；非暂停路径字节级不变（pure no-op）。

The paused-state dedup fingerprint no longer folds in `drift.heavier`; a non-paused-side warnUtil flip no longer re-fires a duplicate pause banner. Advise/balance path unchanged.

### 测试 / Tests
- 2 new: paused 指纹在 heavier 翻转下相等（无重复横幅）；非暂停仍区分（行为保持）。TDD RED→GREEN。
- 全量 `bun test src`：1168 pass / 0 fail。bundle 重建，`verify:plugin-sync` clean。

### Cross-review
2 fresh reviewers（逻辑/正确性 + 集成/回归）均报 **0 REAL**（Reviewer B 五轴全 clean：无持久化指纹、paused 横幅文案不含 heavier、bundle 仅 daemon.js、null 安全不变）。