### PR TITLE
fix: codex turn key 对称清除 + unix-ws upgrade 定时器清理 / symmetric turn-key eviction + probe-timer cleanup

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14382,7 +14382,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("b00d7b8", "source"),
+  commit: defineString("2ea9d06", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -22,7 +22,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("b00d7b8", "source"),
+  commit: defineString("2ea9d06", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -741,10 +741,13 @@ async function waitForUnixWsReady(socketPath, maxRetries = 40, delayMs = 250) {
 function attemptUnixWsUpgrade(socketPath) {
   return new Promise((resolve) => {
     let settled = false;
+    let timeout;
     const done = (ok) => {
       if (settled)
         return;
       settled = true;
+      if (timeout !== undefined)
+        clearTimeout(timeout);
       try {
         socket.destroy();
       } catch {}
@@ -769,7 +772,8 @@ Sec-WebSocket-Version: 13\r
     });
     socket.on("error", () => done(false));
     socket.on("close", () => done(false));
-    setTimeout(() => done(false), 1500);
+    timeout = setTimeout(() => done(false), 1500);
+    timeout.unref?.();
   });
 }
 
@@ -2238,10 +2242,21 @@ class CodexAdapter extends EventEmitter {
   markTurnCompleted(turnId) {
     const completedId = typeof turnId === "string" && turnId.length > 0 ? turnId : null;
     if (completedId !== null) {
+      const idWasTracked = this.activeTurnIds.has(completedId);
       this.activeTurnIds.delete(completedId);
       this.clearTurnWatchdog(completedId);
       this.stalledTurnIds.delete(completedId);
       this.currentlyStalledTurnIds.delete(completedId);
+      if (!idWasTracked) {
+        const placeholders = [...this.activeTurnIds].filter((id) => id.startsWith("unknown:"));
+        if (placeholders.length === 1) {
+          const placeholder = placeholders[0];
+          this.activeTurnIds.delete(placeholder);
+          this.clearTurnWatchdog(placeholder);
+          this.stalledTurnIds.delete(placeholder);
+          this.currentlyStalledTurnIds.delete(placeholder);
+        }
+      }
     } else {
       this.activeTurnIds.clear();
       this.clearAllTurnWatchdogs();

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -2226,10 +2226,38 @@ export class CodexAdapter extends EventEmitter {
   private markTurnCompleted(turnId?: string) {
     const completedId = typeof turnId === "string" && turnId.length > 0 ? turnId : null;
     if (completedId !== null) {
+      // LOW-7: symmetric eviction. A turn STARTED without an id is keyed
+      // `unknown:<ts>`; its COMPLETED event may carry a real id. Evicting only
+      // the real id strands the placeholder, pinning turnInProgress=true forever
+      // (every later reply gets busy-rejected). Conservatively reclaim a SINGLE
+      // dangling `unknown:` placeholder here — only when exactly one exists, so a
+      // legitimate concurrent real turn is never collateral. We reclaim whether
+      // or not the real id matched: if the id-keyed turn existed it was a normal
+      // completion, and any lone placeholder still belongs to the
+      // started-without-id pair this completion closes out.
+      const idWasTracked = this.activeTurnIds.has(completedId);
       this.activeTurnIds.delete(completedId);
       this.clearTurnWatchdog(completedId);
       this.stalledTurnIds.delete(completedId);
       this.currentlyStalledTurnIds.delete(completedId);
+
+      // Reclaim the placeholder ONLY when the completed real id was NOT already
+      // tracked: that means the matching turn/started carried no id and was
+      // keyed `unknown:` — this completion closes it out. If the id WAS tracked
+      // it was a normal id-keyed turn, so any lingering placeholder belongs to a
+      // different, possibly still-live, started-without-id turn — leave it for
+      // the watchdog / reset path. Require exactly one placeholder so a real turn
+      // is never collateral when correlation is ambiguous.
+      if (!idWasTracked) {
+        const placeholders = [...this.activeTurnIds].filter((id) => id.startsWith("unknown:"));
+        if (placeholders.length === 1) {
+          const placeholder = placeholders[0]!;
+          this.activeTurnIds.delete(placeholder);
+          this.clearTurnWatchdog(placeholder);
+          this.stalledTurnIds.delete(placeholder);
+          this.currentlyStalledTurnIds.delete(placeholder);
+        }
+      }
     } else {
       this.activeTurnIds.clear();
       this.clearAllTurnWatchdogs();

--- a/src/codex-transport.ts
+++ b/src/codex-transport.ts
@@ -308,9 +308,14 @@ export async function waitForUnixWsReady(
 function attemptUnixWsUpgrade(socketPath: string): Promise<boolean> {
   return new Promise((resolve) => {
     let settled = false;
+    // LOW-8: hold the timer handle so we can clear it on every settle path. An
+    // unstored, uncleared timer keeps the event loop alive (pins the process /
+    // test runner) and can fire AFTER the upgrade already resolved.
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     const done = (ok: boolean) => {
-      if (settled) return;
+      if (settled) return; // settle exactly once (timer vs upgrade race)
       settled = true;
+      if (timeout !== undefined) clearTimeout(timeout);
       try { socket.destroy(); } catch { /* ignore */ }
       resolve(ok);
     };
@@ -329,6 +334,8 @@ function attemptUnixWsUpgrade(socketPath: string): Promise<boolean> {
     });
     socket.on("error", () => done(false));
     socket.on("close", () => done(false));
-    setTimeout(() => done(false), 1500);
+    timeout = setTimeout(() => done(false), 1500);
+    // Never keep the process / test runner alive on account of this probe timer.
+    timeout.unref?.();
   });
 }

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -276,6 +276,68 @@ describe("CodexAdapter turn state machine", () => {
     expect(adapter.turnInProgress).toBe(false);
   });
 
+  test("LOW-7: started-without-id then completed-with-id leaves the map empty (no strand)", () => {
+    // Regression: turn/started arriving WITHOUT a turn id is keyed `unknown:<ts>`.
+    // The matching turn/completed arrives WITH a real id. markTurnCompleted evicts
+    // by the real id only — leaving the `unknown:` placeholder stranded, so
+    // turnInProgress stayed true forever and every later reply was busy-rejected.
+    const adapter = createAdapter();
+    const completedEvents: string[] = [];
+    adapter.on("turnCompleted", () => completedEvents.push("completed"));
+
+    // turn/started with no id → keyed `unknown:<timestamp>`
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: {} } });
+    expect(adapter.turnInProgress).toBe(true);
+    expect(adapter.activeTurnIds.size).toBe(1);
+    expect([...adapter.activeTurnIds][0].startsWith("unknown:")).toBe(true);
+
+    // turn/completed WITH a real id — the placeholder must also be evicted
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "real-1" } } });
+
+    expect(adapter.activeTurnIds.size).toBe(0);
+    expect(adapter.turnInProgress).toBe(false);
+    expect(completedEvents).toEqual(["completed"]);
+
+    // A following reply must NOT be busy-rejected: injectMessage works again.
+    adapter.threadId = "thread-1";
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+    expect(adapter.injectMessage("hello after strand-free completion")).toBeLessThan(0);
+  });
+
+  test("LOW-7: a completed-with-id does NOT over-evict a legit concurrent real turn", () => {
+    // The placeholder eviction must be conservative: when a real-id turn is also
+    // in flight alongside the `unknown:` placeholder, completing a DIFFERENT real
+    // id must not clear the unrelated real turn (only the placeholder + matched id).
+    const adapter = createAdapter();
+
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "real-A" } } });
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: {} } }); // unknown placeholder
+    expect(adapter.activeTurnIds.size).toBe(2);
+
+    // Complete a real id NOT present (its start was the placeholder). The
+    // placeholder is reclaimed, but the legit real-A turn must survive.
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "real-B" } } });
+
+    expect(adapter.activeTurnIds.has("real-A")).toBe(true);
+    expect([...adapter.activeTurnIds].some((id: string) => id.startsWith("unknown:"))).toBe(false);
+    expect(adapter.turnInProgress).toBe(true);
+  });
+
+  test("LOW-7: completed-with-id evicts only the matching id when no placeholder exists", () => {
+    // No `unknown:` placeholder present → behaviour is unchanged: only the
+    // matching real id is evicted, concurrent real turns are untouched.
+    const adapter = createAdapter();
+
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t2" } } });
+
+    adapter.handleServerNotification({ method: "turn/completed", params: { turn: { id: "t1" } } });
+
+    expect(adapter.activeTurnIds.has("t1")).toBe(false);
+    expect(adapter.activeTurnIds.has("t2")).toBe(true);
+    expect(adapter.turnInProgress).toBe(true);
+  });
+
   test("resetTurnState emits turnAborted (not turnCompleted) when a turn is interrupted", () => {
     // RB-1 regression: an app-server close / reconnect / stop resets turn state
     // with emitCompleted=false. The daemon's require_reply tracker only resets on

--- a/src/unit-test/codex-transport.test.ts
+++ b/src/unit-test/codex-transport.test.ts
@@ -242,4 +242,48 @@ describe("waitForUnixWsReady", () => {
     const sock = tmpSocket(); // nothing listening here
     await expect(waitForUnixWsReady(sock, 3, 30)).rejects.toThrow(/did not become ready/);
   });
+
+  test("LOW-8: a successful upgrade clears & unrefs its 1.5s probe timer (no dangling handle)", async () => {
+    // Regression: attemptUnixWsUpgrade created a setTimeout(1500) whose handle was
+    // never stored, cleared, or unref'd — so it pinned the event loop and could
+    // fire after the upgrade already resolved. Spy on setTimeout/clearTimeout/unref
+    // to prove the probe timer is unref'd on creation and cleared on settle.
+    const sock = tmpSocket();
+    const { server } = await startFakeCodexUnix(sock);
+    cleanups.push(() => { server.close(); removeSocketFile(sock); });
+
+    const realSetTimeout = globalThis.setTimeout;
+    const realClearTimeout = globalThis.clearTimeout;
+    const probeTimers = new Set<ReturnType<typeof setTimeout>>();
+    const unreffed = new Set<ReturnType<typeof setTimeout>>();
+    const cleared = new Set<ReturnType<typeof setTimeout>>();
+
+    globalThis.setTimeout = ((fn: (...a: any[]) => void, ms?: number, ...rest: any[]) => {
+      const handle = realSetTimeout(fn, ms as number, ...rest);
+      if (ms === 1500) {
+        probeTimers.add(handle);
+        const origUnref = handle.unref?.bind(handle);
+        // Track that .unref() is actually invoked on the probe timer.
+        (handle as any).unref = () => { unreffed.add(handle); return origUnref?.(); };
+      }
+      return handle;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = ((handle: ReturnType<typeof setTimeout>) => {
+      if (probeTimers.has(handle)) cleared.add(handle);
+      return realClearTimeout(handle);
+    }) as typeof clearTimeout;
+
+    try {
+      await waitForUnixWsReady(sock, 10, 50); // resolves on the first attempt
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+      globalThis.clearTimeout = realClearTimeout;
+    }
+
+    // Exactly one probe timer was created, it was unref'd, and it was cleared on
+    // the success settle path (so nothing dangles past resolution).
+    expect(probeTimers.size).toBe(1);
+    expect(unreffed.size).toBe(1);
+    expect(cleared.size).toBe(1);
+  });
 });


### PR DESCRIPTION
## 深扫 round-2 · LOW-7 + LOW-8

### LOW-7 — `markTurnCompleted` 漏清 `unknown:` 占位键（codex-adapter.ts）
无 id 启动的 turn 记为 `unknown:<ts>`，带 id 完成时旧代码只删真实 id → 占位残留 → `turnInProgress` 永真 → 后续 reply 被 **busy_reject**。修复：对称清除——完成 id 原未被跟踪(`idWasTracked===false`)且恰有 1 个 `unknown:` 占位时一并回收（activeTurnIds + watchdog + stalledTurnIds + currentlyStalledTurnIds）。双重守卫防误清并发真实 turn。

### LOW-8 — `attemptUnixWsUpgrade` 1.5s 探测定时器泄漏（codex-transport.ts）
句柄未存/未清/未 unref → 钉住事件循环、可在 settle 后迟发。修复：存句柄 + `.unref?.()` + `done()` 中 `clearTimeout`（覆盖 success/error/close/timeout 全 settle 路径）。

### 测试 / Tests
4 new（3 LOW-7 strand/over-evict/no-placeholder；1 LOW-8 unref+clear on success path）。TDD RED→GREEN。全量 `bun test src` 1170 pass / 0 fail。bundle 重建，`verify:plugin-sync` clean。

### Cross-review
2 fresh reviewers（逻辑/并发 + 集成/回归）均报 **0 REAL**。Reviewer B 实证：占位键从不绑定幂等键（steer/interrupt 均过滤 `unknown:`），LOW-7 静默回收不 strand 任何幂等键；`.unref()` 仅作用于探测计时器、不影响 startup await。

### Known limitation（pre-existing，非本 PR 引入）
≥2 个不同毫秒 `unknown:` 占位同时在飞且完成到达时，`length===1` 守卫保守地不回收，`turnInProgress` 维持到 `resetTurnState`（连接重置）——本 PR 严格改善主导的单占位场景，不恶化此边界。