### PR TITLE
fix: daemon 身份/生命周期健壮性簇（bind 竞争 + id 碰撞 + 记录校验 + 未捕获退出）/ daemon identity & lifecycle robustness cluster

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14382,7 +14382,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("2ea9d06", "source"),
+  commit: defineString("2e5a131", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -14805,6 +14805,19 @@ var defaultRead = (path) => readFileSync(path, "utf-8");
 function writeDaemonRecord(path, record3) {
   atomicWriteJson(path, record3);
 }
+function sanitizePorts(value) {
+  if (typeof value !== "object" || value === null)
+    return;
+  const raw = value;
+  const ports = {};
+  if (typeof raw.appPort === "number")
+    ports.appPort = raw.appPort;
+  if (typeof raw.proxyPort === "number")
+    ports.proxyPort = raw.proxyPort;
+  if (typeof raw.controlPort === "number")
+    ports.controlPort = raw.controlPort;
+  return Object.keys(ports).length > 0 ? ports : undefined;
+}
 function readDaemonRecord(path, read = defaultRead) {
   let parsed;
   try {
@@ -14818,7 +14831,35 @@ function readDaemonRecord(path, read = defaultRead) {
   if (typeof obj.pid !== "number" || !Number.isFinite(obj.pid))
     return null;
   const phase = obj.phase === "ready" ? "ready" : "booting";
-  return { ...obj, pid: obj.pid, phase };
+  const record3 = { pid: obj.pid, phase };
+  if (typeof obj.startedAt === "number")
+    record3.startedAt = obj.startedAt;
+  if (typeof obj.nonce === "string")
+    record3.nonce = obj.nonce;
+  if (obj.pairId === null || typeof obj.pairId === "string")
+    record3.pairId = obj.pairId;
+  if (obj.cwd === null || typeof obj.cwd === "string")
+    record3.cwd = obj.cwd;
+  if (obj.stateDir === null || typeof obj.stateDir === "string")
+    record3.stateDir = obj.stateDir;
+  if (typeof obj.proxyUrl === "string")
+    record3.proxyUrl = obj.proxyUrl;
+  if (typeof obj.appServerUrl === "string")
+    record3.appServerUrl = obj.appServerUrl;
+  const ports = sanitizePorts(obj.ports);
+  if (ports !== undefined)
+    record3.ports = ports;
+  if (typeof obj.build === "object" && obj.build !== null) {
+    record3.build = obj.build;
+  }
+  if (typeof obj.turnPhase === "string")
+    record3.turnPhase = obj.turnPhase;
+  if (typeof obj.turnInProgress === "boolean")
+    record3.turnInProgress = obj.turnInProgress;
+  if (typeof obj.attentionWindowActive === "boolean") {
+    record3.attentionWindowActive = obj.attentionWindowActive;
+  }
+  return record3;
 }
 function synthesizeLegacyRecord(pidFilePath, statusFilePath, read = defaultRead) {
   let pidFromPidFile = null;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -22,7 +22,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("2ea9d06", "source"),
+  commit: defineString("2e5a131", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -88,6 +88,19 @@ var defaultRead = (path) => readFileSync(path, "utf-8");
 function writeDaemonRecord(path, record) {
   atomicWriteJson(path, record);
 }
+function sanitizePorts(value) {
+  if (typeof value !== "object" || value === null)
+    return;
+  const raw = value;
+  const ports = {};
+  if (typeof raw.appPort === "number")
+    ports.appPort = raw.appPort;
+  if (typeof raw.proxyPort === "number")
+    ports.proxyPort = raw.proxyPort;
+  if (typeof raw.controlPort === "number")
+    ports.controlPort = raw.controlPort;
+  return Object.keys(ports).length > 0 ? ports : undefined;
+}
 function readDaemonRecord(path, read = defaultRead) {
   let parsed;
   try {
@@ -101,7 +114,35 @@ function readDaemonRecord(path, read = defaultRead) {
   if (typeof obj.pid !== "number" || !Number.isFinite(obj.pid))
     return null;
   const phase = obj.phase === "ready" ? "ready" : "booting";
-  return { ...obj, pid: obj.pid, phase };
+  const record = { pid: obj.pid, phase };
+  if (typeof obj.startedAt === "number")
+    record.startedAt = obj.startedAt;
+  if (typeof obj.nonce === "string")
+    record.nonce = obj.nonce;
+  if (obj.pairId === null || typeof obj.pairId === "string")
+    record.pairId = obj.pairId;
+  if (obj.cwd === null || typeof obj.cwd === "string")
+    record.cwd = obj.cwd;
+  if (obj.stateDir === null || typeof obj.stateDir === "string")
+    record.stateDir = obj.stateDir;
+  if (typeof obj.proxyUrl === "string")
+    record.proxyUrl = obj.proxyUrl;
+  if (typeof obj.appServerUrl === "string")
+    record.appServerUrl = obj.appServerUrl;
+  const ports = sanitizePorts(obj.ports);
+  if (ports !== undefined)
+    record.ports = ports;
+  if (typeof obj.build === "object" && obj.build !== null) {
+    record.build = obj.build;
+  }
+  if (typeof obj.turnPhase === "string")
+    record.turnPhase = obj.turnPhase;
+  if (typeof obj.turnInProgress === "boolean")
+    record.turnInProgress = obj.turnInProgress;
+  if (typeof obj.attentionWindowActive === "boolean") {
+    record.attentionWindowActive = obj.attentionWindowActive;
+  }
+  return record;
 }
 function synthesizeLegacyRecord(pidFilePath, statusFilePath, read = defaultRead) {
   let pidFromPidFile = null;
@@ -4591,6 +4632,27 @@ function createQuotaSource(options) {
   return new QuotaSource(options);
 }
 
+// src/daemon-identity-ownership.ts
+import { readFileSync as readFileSync5 } from "fs";
+var defaultRead2 = (path) => readFileSync5(path, "utf-8");
+function pidFileOwnedByUs(pidFilePath, ourPid, read = defaultRead2) {
+  let raw;
+  try {
+    raw = read(pidFilePath);
+  } catch {
+    return false;
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0)
+    return false;
+  if (!/^[+-]?\d+$/.test(trimmed))
+    return false;
+  const pid = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(pid))
+    return false;
+  return pid === ourPid;
+}
+
 // src/idempotency-tracker.ts
 var DEFAULT_TOMBSTONE_TTL_MS = 20 * 60 * 1000;
 
@@ -4742,7 +4804,7 @@ class ReplyRequiredTracker {
 import {
   existsSync as existsSync6,
   readdirSync,
-  readFileSync as readFileSync5
+  readFileSync as readFileSync6
 } from "fs";
 import { homedir as homedir3 } from "os";
 import { basename as basename2, join as join6 } from "path";
@@ -4758,7 +4820,7 @@ function codexHome(env = process.env) {
 }
 function readRawCurrentThread(stateDir) {
   try {
-    const parsed = JSON.parse(readFileSync5(stateDir.currentThreadFile, "utf-8"));
+    const parsed = JSON.parse(readFileSync6(stateDir.currentThreadFile, "utf-8"));
     if (parsed?.version === 1 && typeof parsed.threadId === "string" && parsed.threadId.length > 0 && (parsed.status === "pending" || parsed.status === "current") && typeof parsed.cwd === "string") {
       return parsed;
     }
@@ -4953,14 +5015,9 @@ var stateDir = new StateDirResolver;
 stateDir.ensure();
 var processLogger = createProcessLogger({ component: "AgentBridgeDaemon", logFile: stateDir.logFile });
 var controlTokenPath = resolveControlTokenPath(stateDir.dir);
-var controlToken = null;
-try {
-  controlToken = generateControlToken();
-  writeControlToken(controlTokenPath, controlToken);
-} catch (err) {
-  controlToken = null;
-  processLogger.log(`Failed to write control token (${controlTokenPath}): ${err?.message ?? err} \u2014 ` + `token layer DISABLED for this daemon (attach guard + Origin guard still active)`);
-}
+var controlToken = generateControlToken();
+var weWroteToken = false;
+var weWrotePid = false;
 var configService = new ConfigService;
 var config = configService.loadOrDefault(processLogger.log);
 var CODEX_APP_PORT = parseInt(process.env.CODEX_WS_PORT ?? String(config.codex.appPort), 10);
@@ -4982,9 +5039,11 @@ var DAEMON_STARTED_AT = Date.now();
 var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile);
 var attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 var controlServer = null;
+var boundControlPort = false;
 var attachedClaude = null;
 var nextControlClientId = 0;
 var nextSystemMessageId = 0;
+var SYSTEM_MSG_SALT = randomUUID4().slice(0, 8);
 var codexBootstrapped = false;
 var attentionWindowTimer = null;
 var inAttentionWindow = false;
@@ -5244,60 +5303,68 @@ codex.on("exit", (code) => {
   armBootDeadline();
 });
 function startControlServer() {
-  controlServer = Bun.serve({
-    port: CONTROL_PORT,
-    hostname: "127.0.0.1",
-    fetch(req, server) {
-      const url = new URL(req.url);
-      if (url.pathname === "/healthz") {
-        return Response.json(currentStatus());
-      }
-      if (url.pathname === "/readyz") {
-        return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
-      }
-      if (url.pathname === "/ws") {
-        if (!isAllowedWsUpgrade(req)) {
-          log("Rejected WS upgrade on control port: Origin header present (possible CSWSH)");
-          return wsOriginRejectedResponse();
+  let server;
+  try {
+    server = Bun.serve({
+      port: CONTROL_PORT,
+      hostname: "127.0.0.1",
+      fetch(req, server2) {
+        const url = new URL(req.url);
+        if (url.pathname === "/healthz") {
+          return Response.json(currentStatus());
         }
-        if (server.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: createPendingBackpressureBuffer() } })) {
-          return;
+        if (url.pathname === "/readyz") {
+          return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
         }
-      }
-      return new Response("AgentBridge daemon");
-    },
-    websocket: {
-      idleTimeout: 960,
-      sendPings: true,
-      open: (ws) => {
-        ws.data.clientId = ++nextControlClientId;
-        ws.data.lastPongAt = Date.now();
-        ws.data.pendingBackpressure = createPendingBackpressureBuffer();
-        log(`Frontend socket opened (#${ws.data.clientId})`);
+        if (url.pathname === "/ws") {
+          if (!isAllowedWsUpgrade(req)) {
+            log("Rejected WS upgrade on control port: Origin header present (possible CSWSH)");
+            return wsOriginRejectedResponse();
+          }
+          if (server2.upgrade(req, { data: { clientId: 0, attached: false, lastPongAt: Date.now(), pongCount: 0, pendingBackpressure: createPendingBackpressureBuffer() } })) {
+            return;
+          }
+        }
+        return new Response("AgentBridge daemon");
       },
-      close: (ws, code, reason) => {
-        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
-        if (attachedClaude === ws) {
-          detachClaude(ws, "frontend socket closed");
-        }
-      },
-      message: (ws, raw) => {
-        handleControlMessage(ws, raw);
-      },
-      pong: (ws) => {
-        ws.data.lastPongAt = Date.now();
-        ws.data.pongCount++;
-      },
-      drain: (ws) => {
-        if (ws.data.pendingBackpressure.length > 0 && ws.getBufferedAmount() === 0) {
-          ws.data.pendingBackpressure.clear();
-        }
-        if (ws === attachedClaude && bufferedMessages.length > 0) {
-          flushBufferedMessages(ws);
+      websocket: {
+        idleTimeout: 960,
+        sendPings: true,
+        open: (ws) => {
+          ws.data.clientId = ++nextControlClientId;
+          ws.data.lastPongAt = Date.now();
+          ws.data.pendingBackpressure = createPendingBackpressureBuffer();
+          log(`Frontend socket opened (#${ws.data.clientId})`);
+        },
+        close: (ws, code, reason) => {
+          log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
+          if (attachedClaude === ws) {
+            detachClaude(ws, "frontend socket closed");
+          }
+        },
+        message: (ws, raw) => {
+          handleControlMessage(ws, raw);
+        },
+        pong: (ws) => {
+          ws.data.lastPongAt = Date.now();
+          ws.data.pongCount++;
+        },
+        drain: (ws) => {
+          if (ws.data.pendingBackpressure.length > 0 && ws.getBufferedAmount() === 0) {
+            ws.data.pendingBackpressure.clear();
+          }
+          if (ws === attachedClaude && bufferedMessages.length > 0) {
+            flushBufferedMessages(ws);
+          }
         }
       }
-    }
-  });
+    });
+  } catch (err) {
+    log(`Control port ${CONTROL_PORT} bind failed (${err?.code ?? err?.message ?? err}) \u2014 ` + `another daemon owns it; exiting without touching shared identity files`);
+    process.exit(0);
+  }
+  controlServer = server;
+  boundControlPort = true;
 }
 function handleControlMessage(ws, raw) {
   let message;
@@ -5851,7 +5918,7 @@ function currentReadyMessage() {
 }
 function systemMessage(idPrefix, content) {
   return {
-    id: `${idPrefix}_${++nextSystemMessageId}`,
+    id: `${idPrefix}_${SYSTEM_MSG_SALT}_${++nextSystemMessageId}`,
     source: "codex",
     content,
     timestamp: Date.now()
@@ -5860,8 +5927,22 @@ function systemMessage(idPrefix, content) {
 function writePidFile() {
   daemonLifecycle.writePid();
   daemonLifecycle.writeDaemonRecord(buildDaemonRecord("booting"));
+  weWrotePid = true;
+}
+function writeControlTokenPostBind() {
+  if (controlToken === null)
+    return;
+  try {
+    writeControlToken(controlTokenPath, controlToken);
+    weWroteToken = true;
+  } catch (err) {
+    controlToken = null;
+    processLogger.log(`Failed to write control token (${controlTokenPath}): ${err?.message ?? err} \u2014 ` + `token layer DISABLED for this daemon (attach guard + Origin guard still active)`);
+  }
 }
 function removePidFile() {
+  if (!weWrotePid || !pidFileOwnedByUs(stateDir.pidFile, process.pid))
+    return;
   daemonLifecycle.removePidFile();
   daemonLifecycle.removeDaemonRecord();
 }
@@ -5905,6 +5986,8 @@ function writeStatusFile() {
   daemonLifecycle.writeDaemonRecord(buildDaemonRecord("ready"));
 }
 function removeStatusFile() {
+  if (!boundControlPort)
+    return;
   daemonLifecycle.removeStatusFile();
   daemonLifecycle.removeDaemonRecord();
 }
@@ -5983,6 +6066,8 @@ function shutdown(reason, exitCode = 0) {
   process.exit(exitCode);
 }
 function removeControlToken() {
+  if (!weWroteToken)
+    return;
   try {
     rmSync2(controlTokenPath, { force: true });
   } catch {}
@@ -5996,10 +6081,22 @@ process.on("exit", () => {
   removeControlToken();
 });
 process.on("uncaughtException", (err) => {
-  processLogger.fatal("UNCAUGHT EXCEPTION", err);
+  processLogger.fatal("UNCAUGHT EXCEPTION \u2014 auto-shutting down daemon", err);
+  try {
+    shutdown("uncaught exception", 1);
+  } catch (shutdownErr) {
+    processLogger.fatal("shutdown during uncaughtException failed", shutdownErr);
+  }
+  process.exit(1);
 });
 process.on("unhandledRejection", (reason) => {
-  processLogger.fatal("UNHANDLED REJECTION", reason);
+  processLogger.fatal("UNHANDLED REJECTION \u2014 auto-shutting down daemon", reason);
+  try {
+    shutdown("unhandled rejection", 1);
+  } catch (shutdownErr) {
+    processLogger.fatal("shutdown during unhandledRejection failed", shutdownErr);
+  }
+  process.exit(1);
 });
 function log(msg) {
   processLogger.log(msg);
@@ -6008,7 +6105,8 @@ if (daemonLifecycle.wasKilled()) {
   log("Killed sentinel found \u2014 daemon was intentionally stopped. Exiting immediately.");
   process.exit(0);
 }
-writePidFile();
 startControlServer();
+writePidFile();
+writeControlTokenPostBind();
 armBootDeadline();
 bootCodex();

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -345,7 +345,11 @@ export async function runCodex(args: string[]) {
   // the legacy status.json) or, last resort, the config.
   let proxyUrl: string;
   const record = lifecycle.readDaemonRecord();
-  if (record?.proxyUrl) {
+  // Defense-in-depth (#536): readDaemonRecord now drops a wrong-typed proxyUrl, but
+  // also guard here so a number/object from a corrupt or hand-edited daemon.json can
+  // never reach `new URL(proxyUrl)` (which would throw and crash the CLI). Only trust
+  // a non-empty STRING; anything else falls through to the config-derived fallback.
+  if (typeof record?.proxyUrl === "string" && record.proxyUrl.length > 0) {
     proxyUrl = record.proxyUrl;
   } else {
     // Mirror exactly how the daemon resolves its proxy port (daemon.ts:39):
@@ -733,7 +737,15 @@ function isManagedCodexTuiProcess(pid: number, proxyUrl: string): boolean {
 }
 
 function proxyHealthUrl(proxyUrl: string): string {
-  const url = new URL(proxyUrl);
+  let url: URL;
+  try {
+    url = new URL(proxyUrl);
+  } catch {
+    // A malformed proxyUrl (e.g. a string that survived the type guard but is not a
+    // valid URL, from a hand-edited daemon.json) must produce an actionable error,
+    // not a bare "Invalid URL" — the caller catches this and exits with the message.
+    throw new Error(`Malformed Codex proxy URL: ${JSON.stringify(proxyUrl)}`);
+  }
   url.protocol = url.protocol === "wss:" ? "https:" : "http:";
   url.pathname = "/healthz";
   url.search = "";

--- a/src/daemon-identity-ownership.ts
+++ b/src/daemon-identity-ownership.ts
@@ -1,0 +1,51 @@
+/**
+ * Ownership checks for the daemon's SHARED per-pair identity files
+ * (daemon.pid / status.json / daemon.json / control token).
+ *
+ * These files live in the pair's state dir and are owned by whichever daemon is
+ * the LIVE incumbent. A losing daemon (D2) that races a live incumbent (D1) for
+ * the control port — and exits when the bind fails with EADDRINUSE — must NEVER
+ * delete or clobber D1's files. The process-level `process.on("exit")` cleanup is
+ * unconditional, so we make the removers OWNERSHIP-AWARE: a remover only unlinks
+ * a shared file when this process can prove the file is ITS OWN.
+ *
+ * This module is the pure, IO-injectable predicate behind that gate so it can be
+ * unit-tested without importing daemon.ts (which has port-bind side effects).
+ */
+
+import { readFileSync } from "node:fs";
+
+export type ReadFile = (path: string) => string;
+
+const defaultRead: ReadFile = (path) => readFileSync(path, "utf-8");
+
+/**
+ * True iff the pid currently written in `pidFilePath` is EXACTLY `ourPid`.
+ *
+ * Used by the ownership-aware pid-file remover: a losing D2 (pid 2222) reading a
+ * file that still holds the live D1's pid (1111) gets `false` and skips the
+ * unlink, so D1's identity survives the race. An unreadable file, an empty file,
+ * or a non-integer payload also yields `false` (do not assume ownership we can't
+ * prove). The match is strict integer equality — "4242abc" is rejected even
+ * though parseInt would coerce it to 4242.
+ */
+export function pidFileOwnedByUs(
+  pidFilePath: string,
+  ourPid: number,
+  read: ReadFile = defaultRead,
+): boolean {
+  let raw: string;
+  try {
+    raw = read(pidFilePath);
+  } catch {
+    return false;
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return false;
+  // Strict: require the WHOLE trimmed payload to be an integer (no trailing
+  // garbage). parseInt("4242abc") === 4242 would be a false-positive ownership.
+  if (!/^[+-]?\d+$/.test(trimmed)) return false;
+  const pid = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(pid)) return false;
+  return pid === ourPid;
+}

--- a/src/daemon-record.ts
+++ b/src/daemon-record.ts
@@ -88,10 +88,30 @@ export function writeDaemonRecord(path: string, record: DaemonRecord): void {
   atomicWriteJson(path, record);
 }
 
+/** Sanitize the untrusted `ports` object — keep only numeric port entries. */
+function sanitizePorts(value: unknown): DaemonRecordPorts | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const raw = value as Record<string, unknown>;
+  const ports: DaemonRecordPorts = {};
+  if (typeof raw.appPort === "number") ports.appPort = raw.appPort;
+  if (typeof raw.proxyPort === "number") ports.proxyPort = raw.proxyPort;
+  if (typeof raw.controlPort === "number") ports.controlPort = raw.controlPort;
+  return Object.keys(ports).length > 0 ? ports : undefined;
+}
+
 /**
  * Read the unified daemon.json. Returns the parsed record only when it is a
  * well-formed object with a finite numeric pid; otherwise null (a partially
  * written / corrupt file must NOT masquerade as a live record).
+ *
+ * HARDENING (#536 regression): every field is typeof-validated INDIVIDUALLY and
+ * only carried through if it matches its expected type — mirroring how
+ * {@link synthesizeLegacyRecord} builds a record. Previously the whole parsed
+ * object was spread raw, so a corrupt / hand-edited daemon.json could pass a
+ * non-string `proxyUrl` (number/object) straight through to consumers — e.g.
+ * cli/codex.ts does `new URL(proxyUrl)`, which throws on a non-string and crashes
+ * the CLI. Dropping (not coercing) wrong-typed fields keeps the trust boundary at
+ * the parse site.
  */
 export function readDaemonRecord(path: string, read: ReadFile = defaultRead): DaemonRecord | null {
   let parsed: unknown;
@@ -104,7 +124,27 @@ export function readDaemonRecord(path: string, read: ReadFile = defaultRead): Da
   const obj = parsed as Record<string, unknown>;
   if (typeof obj.pid !== "number" || !Number.isFinite(obj.pid)) return null;
   const phase: DaemonRecordPhase = obj.phase === "ready" ? "ready" : "booting";
-  return { ...(obj as unknown as DaemonRecord), pid: obj.pid, phase };
+
+  // Build a fresh record, carrying through ONLY well-typed fields.
+  const record: DaemonRecord = { pid: obj.pid, phase };
+  if (typeof obj.startedAt === "number") record.startedAt = obj.startedAt;
+  if (typeof obj.nonce === "string") record.nonce = obj.nonce;
+  if (obj.pairId === null || typeof obj.pairId === "string") record.pairId = obj.pairId;
+  if (obj.cwd === null || typeof obj.cwd === "string") record.cwd = obj.cwd;
+  if (obj.stateDir === null || typeof obj.stateDir === "string") record.stateDir = obj.stateDir;
+  if (typeof obj.proxyUrl === "string") record.proxyUrl = obj.proxyUrl;
+  if (typeof obj.appServerUrl === "string") record.appServerUrl = obj.appServerUrl;
+  const ports = sanitizePorts(obj.ports);
+  if (ports !== undefined) record.ports = ports;
+  if (typeof obj.build === "object" && obj.build !== null) {
+    record.build = obj.build as AgentBridgeBuildInfo;
+  }
+  if (typeof obj.turnPhase === "string") record.turnPhase = obj.turnPhase as TurnPhase;
+  if (typeof obj.turnInProgress === "boolean") record.turnInProgress = obj.turnInProgress;
+  if (typeof obj.attentionWindowActive === "boolean") {
+    record.attentionWindowActive = obj.attentionWindowActive;
+  }
+  return record;
 }
 
 /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -31,6 +31,7 @@ import {
   resolveControlTokenPath,
   writeControlToken,
 } from "./control-token";
+import { pidFileOwnedByUs } from "./daemon-identity-ownership";
 import { IdempotencyTracker, type IdempotencyDuplicate } from "./idempotency-tracker";
 import { ReplyRequiredTracker } from "./reply-required-tracker";
 import { persistCurrentThreadWithRolloutRetry } from "./thread-state";
@@ -78,17 +79,18 @@ const processLogger = createProcessLogger({ component: "AgentBridgeDaemon", logF
 // bricking the daemon. Per-pair isolation is automatic: each pair has its own
 // state dir, hence its own token.
 const controlTokenPath = resolveControlTokenPath(stateDir.dir);
-let controlToken: string | null = null;
-try {
-  controlToken = generateControlToken();
-  writeControlToken(controlTokenPath, controlToken);
-} catch (err: any) {
-  controlToken = null;
-  processLogger.log(
-    `Failed to write control token (${controlTokenPath}): ${err?.message ?? err} — ` +
-    `token layer DISABLED for this daemon (attach guard + Origin guard still active)`,
-  );
-}
+// Generate the per-start token at module load (cheap, no IO), but DEFER the
+// disk write until AFTER a successful control-port bind. Writing it here — before
+// the wasKilled() early-exit and before the bind — would let a no-op killed spawn
+// or a losing bind-race daemon (D2) clobber the LIVE incumbent's (D1) shared token
+// (HIGH-1c / MEDIUM-3). The write now happens in writeControlTokenPostBind() and
+// flips `weWroteToken` so the ownership-aware remover only ever deletes OUR token.
+let controlToken: string | null = generateControlToken();
+// Ownership flags: set true ONLY after WE successfully wrote OUR own shared file
+// post-bind. The process.on("exit") cleanup is unconditional, so these gates are
+// what stop a losing D2 from wiping D1's identity (HIGH-1b).
+let weWroteToken = false;
+let weWrotePid = false;
 const configService = new ConfigService();
 // Thread the daemon logger so a corrupt config.json fails loud (to log + stderr)
 // instead of silently reverting custom budget/idle thresholds to defaults.
@@ -131,9 +133,20 @@ const codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFil
 const attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 
 let controlServer: ReturnType<typeof Bun.serve> | null = null;
+// Set true ONLY after Bun.serve successfully binds the control port. A losing
+// bind-race daemon (EADDRINUSE) never flips this, so its cleanup is a no-op and
+// the live incumbent's identity files survive (HIGH-1a).
+let boundControlPort = false;
 let attachedClaude: ServerWebSocket<ControlSocketData> | null = null;
 let nextControlClientId = 0;
 let nextSystemMessageId = 0;
+// Per-PROCESS salt for systemMessage ids (HIGH-2). The counter resets to 0 on
+// every daemon start, so a restarted daemon would re-emit `system_ready_1` —
+// which the bridge-side deduper (claude-adapter: 20-min LRU/TTL keyed on id)
+// suppresses as a duplicate of the OLD daemon's `system_ready_1`. The salt makes
+// ids unique ACROSS restarts, the counter keeps them unique WITHIN a process.
+// Same fix class as STATUS_SUMMARY_SALT in message-filter.ts (PR #139).
+const SYSTEM_MSG_SALT = randomUUID().slice(0, 8);
 let codexBootstrapped = false;
 let attentionWindowTimer: ReturnType<typeof setTimeout> | null = null;
 let inAttentionWindow = false;
@@ -618,7 +631,9 @@ codex.on("exit", (code: number | null) => {
 });
 
 function startControlServer() {
-  controlServer = Bun.serve({
+  let server: ReturnType<typeof Bun.serve>;
+  try {
+    server = Bun.serve({
     port: CONTROL_PORT,
     hostname: "127.0.0.1",
     fetch(req, server) {
@@ -690,7 +705,22 @@ function startControlServer() {
         }
       },
     },
-  });
+    });
+  } catch (err: any) {
+    // Lost the control-port bind race (typically EADDRINUSE because a live
+    // incumbent D1 still holds the port). We did NOT bind, so boundControlPort
+    // stays false and the unconditional process.on("exit") cleanup is a no-op
+    // for every shared file (the ownership-aware removers all gate on our
+    // bind/write flags). Exit WITHOUT destructive cleanup so D1's identity files
+    // (pid/status/daemon.json/token) survive intact (HIGH-1a).
+    log(
+      `Control port ${CONTROL_PORT} bind failed (${err?.code ?? err?.message ?? err}) — ` +
+      `another daemon owns it; exiting without touching shared identity files`,
+    );
+    process.exit(0);
+  }
+  controlServer = server;
+  boundControlPort = true;
 }
 
 function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: string | Buffer) {
@@ -1576,7 +1606,7 @@ function currentReadyMessage() {
 
 function systemMessage(idPrefix: string, content: string): BridgeMessage {
   return {
-    id: `${idPrefix}_${++nextSystemMessageId}`,
+    id: `${idPrefix}_${SYSTEM_MSG_SALT}_${++nextSystemMessageId}`,
     source: "codex",
     content,
     timestamp: Date.now(),
@@ -1590,9 +1620,36 @@ function writePidFile() {
   // already known here (codex constructed); turn fields default to the idle/boot
   // state. bootstrap success replaces this with the READY phase (writeStatusFile).
   daemonLifecycle.writeDaemonRecord(buildDaemonRecord("booting"));
+  // We now own these shared files — the ownership-aware removers may delete them.
+  weWrotePid = true;
+}
+
+// Deferred control-token write: runs ONLY after a successful control-port bind
+// (HIGH-1c / MEDIUM-3). A write/chmod failure degrades the token layer to OFF
+// (null) rather than bricking the daemon — the attach-convergence guard + Origin
+// guard still apply. `weWroteToken` flips true only on success so the
+// ownership-aware remover never deletes a token we did not write.
+function writeControlTokenPostBind() {
+  if (controlToken === null) return;
+  try {
+    writeControlToken(controlTokenPath, controlToken);
+    weWroteToken = true;
+  } catch (err: any) {
+    controlToken = null;
+    processLogger.log(
+      `Failed to write control token (${controlTokenPath}): ${err?.message ?? err} — ` +
+      `token layer DISABLED for this daemon (attach guard + Origin guard still active)`,
+    );
+  }
 }
 
 function removePidFile() {
+  // Ownership gate (HIGH-1b): only unlink the SHARED pid/daemon.json files when
+  // the pid currently on disk is ours. A losing bind-race D2 reading D1's pid
+  // skips the unlink, so D1's identity survives. We also require weWrotePid so a
+  // no-op killed spawn (which never wrote anything) is a guaranteed no-op even if
+  // a same-pid coincidence ever arose.
+  if (!weWrotePid || !pidFileOwnedByUs(stateDir.pidFile, process.pid)) return;
   daemonLifecycle.removePidFile();
   daemonLifecycle.removeDaemonRecord();
 }
@@ -1661,6 +1718,12 @@ function writeStatusFile() {
 }
 
 function removeStatusFile() {
+  // Ownership gate (HIGH-1b): status.json + daemon.json are shared per-pair files
+  // owned by whichever daemon won the bind. Only remove them if WE bound the
+  // control port (boundControlPort) — a losing D2 never did, so it never wipes
+  // D1's status. We do not have a per-process marker inside status.json to check,
+  // so the bind flag is the safest ownership proxy here.
+  if (!boundControlPort) return;
   daemonLifecycle.removeStatusFile();
   daemonLifecycle.removeDaemonRecord();
 }
@@ -1784,6 +1847,11 @@ function shutdown(reason: string, exitCode = 0) {
  * fresh one anyway. Never throws — removal failure must not block shutdown.
  */
 function removeControlToken() {
+  // Ownership gate (HIGH-1b): the control token is a per-start secret. Only remove
+  // it if WE actually wrote it post-bind (weWroteToken). A losing D2 — or a no-op
+  // killed spawn — never wrote it, so it must not delete the live incumbent's
+  // token (which would lock the legitimate frontend out on a token mismatch).
+  if (!weWroteToken) return;
   try {
     rmSync(controlTokenPath, { force: true });
   } catch {}
@@ -1803,10 +1871,27 @@ process.on("exit", () => {
   removeControlToken();
 });
 process.on("uncaughtException", (err) => {
-  processLogger.fatal("UNCAUGHT EXCEPTION", err);
+  processLogger.fatal("UNCAUGHT EXCEPTION — auto-shutting down daemon", err);
+  // LOW-6: never leave a half-alive daemon. Attempt the graceful shutdown (stops the
+  // control server + codex child, runs ownership-aware cleanup via process.exit's exit
+  // handler) with a non-zero code, then ALWAYS hard-exit. shutdown() is idempotent
+  // (shuttingDown guard) — if it early-returns because a shutdown is already in flight,
+  // or throws, the unconditional exit below still terminates us so we never linger.
+  try {
+    shutdown("uncaught exception", 1);
+  } catch (shutdownErr) {
+    processLogger.fatal("shutdown during uncaughtException failed", shutdownErr);
+  }
+  process.exit(1);
 });
 process.on("unhandledRejection", (reason: any) => {
-  processLogger.fatal("UNHANDLED REJECTION", reason);
+  processLogger.fatal("UNHANDLED REJECTION — auto-shutting down daemon", reason);
+  try {
+    shutdown("unhandled rejection", 1);
+  } catch (shutdownErr) {
+    processLogger.fatal("shutdown during unhandledRejection failed", shutdownErr);
+  }
+  process.exit(1);
 });
 
 function log(msg: string) {
@@ -1821,8 +1906,13 @@ if (daemonLifecycle.wasKilled()) {
   process.exit(0);
 }
 
-writePidFile();
+// Bind the control port FIRST (HIGH-1c / MEDIUM-3): only after we own the port do
+// we write the SHARED pid/status/daemon.json + control token. startControlServer()
+// process.exit(0)'s on a lost bind race WITHOUT touching shared files, so reaching
+// the lines below means we are the sole owner and may safely claim the identity.
 startControlServer();
+writePidFile();
+writeControlTokenPostBind();
 // Arm the readiness watchdog BEFORE bootCodex: if codex.start() hangs (never
 // resolves/rejects), bootCodex's retry/self-exit never runs, so this deadline is
 // the only thing that releases the control port. bootCodex clears it on success.

--- a/src/unit-test/daemon-identity-ownership.test.ts
+++ b/src/unit-test/daemon-identity-ownership.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { pidFileOwnedByUs } from "../daemon-identity-ownership";
+
+describe("daemon-identity-ownership — pidFileOwnedByUs", () => {
+  test("returns true only when the pid in the file equals our pid", () => {
+    const read = () => "4242\n";
+    expect(pidFileOwnedByUs("/x/daemon.pid", 4242, read)).toBe(true);
+  });
+
+  test("returns false when the file holds a DIFFERENT pid (losing D2 must not wipe D1)", () => {
+    // D1 (the live incumbent) owns the file with pid 1111; D2 (us, pid 2222)
+    // lost the bind race — it must treat the shared file as not-ours.
+    const read = () => "1111\n";
+    expect(pidFileOwnedByUs("/x/daemon.pid", 2222, read)).toBe(false);
+  });
+
+  test("tolerates trailing/leading whitespace around the pid", () => {
+    expect(pidFileOwnedByUs("/x/daemon.pid", 77, () => "  77 \n")).toBe(true);
+  });
+
+  test("returns false when the file is unreadable (no file / IO error)", () => {
+    const read = () => {
+      throw new Error("ENOENT");
+    };
+    expect(pidFileOwnedByUs("/x/daemon.pid", 4242, read)).toBe(false);
+  });
+
+  test("returns false when the file content is not a finite integer", () => {
+    expect(pidFileOwnedByUs("/x/daemon.pid", 4242, () => "not-a-pid")).toBe(false);
+    expect(pidFileOwnedByUs("/x/daemon.pid", 4242, () => "")).toBe(false);
+    expect(pidFileOwnedByUs("/x/daemon.pid", 4242, () => "NaN")).toBe(false);
+  });
+
+  test("matches on exact integer equality, not numeric coercion of garbage", () => {
+    // "4242abc" parses to 4242 via parseInt, but we require a clean integer.
+    expect(pidFileOwnedByUs("/x/daemon.pid", 4242, () => "4242abc")).toBe(false);
+  });
+});

--- a/src/unit-test/daemon-record.test.ts
+++ b/src/unit-test/daemon-record.test.ts
@@ -84,6 +84,89 @@ describe("daemon-record", () => {
     test("readDaemonRecord returns null when file absent", () => {
       expect(readDaemonRecord(paths.daemonRecordFile)).toBeNull();
     });
+
+    test("readDaemonRecord drops fields whose type is wrong (untrusted daemon.json — #536 regression)", () => {
+      // A corrupt / hand-edited daemon.json with a numeric proxyUrl etc. must NOT
+      // pass a number through to callers (cli/codex.ts does new URL(proxyUrl)).
+      writeFileSync(
+        paths.daemonRecordFile,
+        JSON.stringify({
+          pid: 4242,
+          phase: "ready",
+          proxyUrl: 1234, // wrong type
+          appServerUrl: { not: "a string" }, // wrong type
+          startedAt: "nope", // wrong type
+          nonce: 99, // wrong type
+          ports: "ws://x", // wrong type (should be object)
+          turnPhase: 7, // wrong type
+          turnInProgress: "yes", // wrong type
+          attentionWindowActive: 1, // wrong type
+          pairId: 5, // wrong type (string | null expected)
+          cwd: false, // wrong type
+        }),
+      );
+      const rec = readDaemonRecord(paths.daemonRecordFile);
+      expect(rec).not.toBeNull();
+      expect(rec!.pid).toBe(4242);
+      expect(rec!.phase).toBe("ready");
+      // Every wrongly-typed field is dropped, not carried through raw.
+      expect(rec!.proxyUrl).toBeUndefined();
+      expect(rec!.appServerUrl).toBeUndefined();
+      expect(rec!.startedAt).toBeUndefined();
+      expect(rec!.nonce).toBeUndefined();
+      expect(rec!.ports).toBeUndefined();
+      expect(rec!.turnPhase).toBeUndefined();
+      expect(rec!.turnInProgress).toBeUndefined();
+      expect(rec!.attentionWindowActive).toBeUndefined();
+      expect(rec!.pairId).toBeUndefined();
+      expect(rec!.cwd).toBeUndefined();
+    });
+
+    test("readDaemonRecord keeps well-typed fields and a null pairId/cwd/stateDir", () => {
+      writeFileSync(
+        paths.daemonRecordFile,
+        JSON.stringify({
+          pid: 7,
+          phase: "ready",
+          proxyUrl: "ws://127.0.0.1:4501",
+          appServerUrl: "ws://127.0.0.1:4500",
+          ports: { appPort: 4500, proxyPort: 4501, controlPort: 4502 },
+          pairId: null,
+          cwd: null,
+          stateDir: null,
+          turnPhase: "idle",
+          turnInProgress: false,
+          attentionWindowActive: true,
+          startedAt: 1000,
+          nonce: "deadbeef",
+        }),
+      );
+      const rec = readDaemonRecord(paths.daemonRecordFile);
+      expect(rec!.proxyUrl).toBe("ws://127.0.0.1:4501");
+      expect(rec!.appServerUrl).toBe("ws://127.0.0.1:4500");
+      expect(rec!.ports).toEqual({ appPort: 4500, proxyPort: 4501, controlPort: 4502 });
+      expect(rec!.pairId).toBeNull();
+      expect(rec!.cwd).toBeNull();
+      expect(rec!.stateDir).toBeNull();
+      expect(rec!.turnPhase).toBe("idle");
+      expect(rec!.turnInProgress).toBe(false);
+      expect(rec!.attentionWindowActive).toBe(true);
+      expect(rec!.startedAt).toBe(1000);
+      expect(rec!.nonce).toBe("deadbeef");
+    });
+
+    test("readDaemonRecord sanitizes nested ports — drops non-numeric port entries", () => {
+      writeFileSync(
+        paths.daemonRecordFile,
+        JSON.stringify({
+          pid: 9,
+          phase: "ready",
+          ports: { appPort: 4500, proxyPort: "nope", controlPort: 4502 },
+        }),
+      );
+      const rec = readDaemonRecord(paths.daemonRecordFile);
+      expect(rec!.ports).toEqual({ appPort: 4500, controlPort: 4502 });
+    });
   });
 
   describe("synthesizeLegacyRecord (old daemon: daemon.pid + status.json)", () => {


### PR DESCRIPTION
## 深扫 round-2 · HIGH-1 + HIGH-2 + MEDIUM-3 + MEDIUM-5 + LOW-6

### HIGH-1 — 控制端口 bind 竞争抹除在役 daemon 身份（daemon.ts）
`startControlServer` 无 try/catch；输给在役 D1 的 D2 因 EADDRINUSE 退出，`process.on(exit)` 无条件 remove **共享** pid/status/token，且 D2 在 bind 前已覆写 daemon.pid + token → `pairDirDaemonAlive=false` → prune 删活 pair / kill 打不到 D1 / 前端 token 失配锁死。
**修复**：(a) bind 包 try/catch + `boundControlPort` 标志，EADDRINUSE→`process.exit(0)` 不做破坏性清理；(b) remove\* 改 **owner 感知**（`removePidFile` 需 `weWrotePid && pidFileOwnedByUs`；`removeStatusFile` 需 `boundControlPort`；`removeControlToken` 需 `weWroteToken`）；(c) pid + token 写入**延后到 bind 成功之后**，module-load 只 `generateControlToken` 不落盘。新增纯函数 `daemon-identity-ownership.ts`（严格整数 pid 匹配）。

### HIGH-2 — systemMessage id 跨重启碰撞被去重吞掉（daemon.ts）
`id=prefix_++n`（counter 每进程重置）→ 重启后 `system_ready_1` 被 bridge deduper（20min TTL，按 id）当旧 daemon 重复抑制。**修复**：per-process `SYSTEM_MSG_SALT=randomUUID().slice(0,8)`。

### MEDIUM-3 — token module-load 写入 → no-op killed 重生 clobber 共享 token。由 HIGH-1(c) 延后写入治本。

### MEDIUM-5 (#536 回归) — `readDaemonRecord` raw spread 未校验 daemon.json 字段；`cli/codex.ts` 对错类型 proxyUrl 调 `new URL` 崩 CLI。**修复**：逐字段 `typeof` 校验 + `sanitizePorts`；proxyUrl 加守卫，`proxyHealthUrl` 抛清晰错误（调用方 try/catch 优雅退出）。

### LOW-6 — uncaught/unhandledRejection 只 log 不退出 → 半死 daemon。**修复**：`shutdown(reason,1)` 后**无条件 `process.exit(1)`**（即使 shutdown 因 shuttingDown 提前返回或抛错也必退出），shutdown 失败也记日志。

### 测试 / Tests
+9（6 pid 文件 owner：same/different/whitespace/unreadable/non-integer/strict-integer；3 readDaemonRecord typeof 校验）。TDD RED→GREEN。全量 `bun test src` 1175 pass / 0 fail。bundle 重建，`verify:plugin-sync` clean。

### Cross-review（HIGH-risk → 2 连 clean 轮）
Round 1：2 fresh reviewers（逻辑/并发 + 集成/安全）均 **0 REAL**——实证 bind-race crux（无残留 pre-bind 共享写、D2-loses exit 全 no-op、Bun.serve 同步抛 EADDRINUSE、deferred token 写入无 event-loop yield 被 readyz 闸兜住、D1 文件端到端存活、0600 保留无密钥泄漏）。两轮 RECOMMEND 已折入（uncaught 后无条件 exit + auto-shutdown 日志）。Round 2 进行中。