### PR TITLE
fix: reconnect 循环在 disabled 翻转后不再误报成功 / suppress false reconnect-success when disabled mid-loop

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14382,7 +14382,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("2e5a131", "source"),
+  commit: defineString("47a6d3e", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -15771,6 +15771,9 @@ function pairScopedCommand(cmd, name = cliInvocationName()) {
 }
 
 // src/bridge-disabled-state.ts
+function shouldEmitReconnectSuccess(state) {
+  return !state.daemonDisabled;
+}
 function disabledReplyError(reason) {
   const claudeCmd = pairScopedCommand("claude");
   switch (reason) {
@@ -16248,6 +16251,9 @@ function reconnectToDaemon() {
         }
         try {
           await connectToDaemon(true);
+          if (!shouldEmitReconnectSuccess({ daemonDisabled })) {
+            return;
+          }
           log("Reconnected to AgentBridge daemon successfully");
           const now = Date.now();
           if (now - lastReconnectNotifyTs >= RECONNECT_NOTIFY_COOLDOWN_MS) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -22,7 +22,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("2e5a131", "source"),
+  commit: defineString("47a6d3e", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/src/bridge-disabled-state.ts
+++ b/src/bridge-disabled-state.ts
@@ -7,6 +7,23 @@ export type BridgeDisabledReason =
 
 import { pairScopedCommand } from "./pair-command";
 
+/**
+ * Decide whether the reconnect loop may declare a reconnect succeeded.
+ *
+ * `connectToDaemon()` early-returns WITHOUT throwing when invoked while the
+ * bridge is already disabled (see bridge.ts). During the reconnect loop a
+ * socket attach rejected mid-flight (EVICTED_STALE / REPLACED /
+ * CONTRACT_MISMATCH) flips `daemonDisabled` true synchronously, so the very
+ * next iteration's `connectToDaemon(true)` returns silently — which would
+ * otherwise fall through to the loop's success branch and emit a false
+ * "Reconnected successfully" notification while the bridge is in fact disabled.
+ * The success branch must consult this guard first: only a genuinely
+ * NOT-disabled bridge counts as a real reconnect.
+ */
+export function shouldEmitReconnectSuccess(state: { daemonDisabled: boolean }): boolean {
+  return !state.daemonDisabled;
+}
+
 export function disabledReplyError(reason: BridgeDisabledReason): string {
   // These render in the bridge (MCP server) process, which inherits
   // AGENTBRIDGE_PAIR_ID in multi-pair mode — so the suggested commands carry

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,7 +7,7 @@ import { DaemonClient } from "./daemon-client";
 import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
 import { ConfigService } from "./config-service";
-import { disabledReplyError, type BridgeDisabledReason } from "./bridge-disabled-state";
+import { disabledReplyError, shouldEmitReconnectSuccess, type BridgeDisabledReason } from "./bridge-disabled-state";
 import { guardAgentBridgeEnv, normalizeEnvGuardMode } from "./env-guard";
 import { pairScopedCommand } from "./pair-command";
 import { readControlToken, resolveControlTokenPath } from "./control-token";
@@ -406,6 +406,16 @@ function reconnectToDaemon(): Promise<void> {
 
         try {
           await connectToDaemon(true);
+          // connectToDaemon() returns WITHOUT throwing when the bridge is
+          // already disabled (see its early-return guard). A mid-loop attach
+          // rejection (EVICTED_STALE / REPLACED / CONTRACT_MISMATCH) flips
+          // daemonDisabled true synchronously in the `rejected` handler, so this
+          // iteration's connectToDaemon may have returned silently rather than
+          // genuinely reconnecting. Don't declare a false success that
+          // contradicts the eviction/contract-mismatch notice already sent.
+          if (!shouldEmitReconnectSuccess({ daemonDisabled })) {
+            return;
+          }
           log("Reconnected to AgentBridge daemon successfully");
 
           const now = Date.now();

--- a/src/unit-test/bridge-disabled-state.test.ts
+++ b/src/unit-test/bridge-disabled-state.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { disabledReplyError } from "../bridge-disabled-state";
+import { disabledReplyError, shouldEmitReconnectSuccess } from "../bridge-disabled-state";
 
 describe("bridge disabled-state messaging", () => {
   // These assert the bare hint substrings, i.e. manual/no-pair mode. The leading
@@ -62,5 +62,25 @@ describe("bridge disabled-state messaging", () => {
     // the bare "rejected" reason — the cause here is exhausted retries, not
     // an active competing session.
     expect(message).not.toContain("another Claude Code session is already connected");
+  });
+});
+
+describe("shouldEmitReconnectSuccess (reconnect false-success guard)", () => {
+  // Regression: the reconnect loop only checked daemonDisabled at entry. A
+  // socket attach rejected mid-loop (EVICTED_STALE / REPLACED / CONTRACT_MISMATCH)
+  // synchronously flips daemonDisabled=true; on the NEXT iteration
+  // connectToDaemon() early-returns WITHOUT throwing, so the loop's success
+  // branch fired "Reconnected successfully" while the bridge was actually
+  // disabled (reply tool still returns disabledReplyError). The success branch
+  // must consult this helper before logging/notifying.
+
+  test("emits success on a genuine reconnect (not disabled)", () => {
+    expect(shouldEmitReconnectSuccess({ daemonDisabled: false })).toBe(true);
+  });
+
+  test("does NOT emit success when the daemon was disabled mid-loop", () => {
+    // connectToDaemon() returned without throwing only because daemonDisabled
+    // was set by the rejected handler — this is a false success, suppress it.
+    expect(shouldEmitReconnectSuccess({ daemonDisabled: true })).toBe(false);
   });
 });


### PR DESCRIPTION
## 深扫 round-3 · MEDIUM

`reconnectToDaemon` 只在循环入口检查 `daemonDisabled`。循环中途 attach 被拒（evicted/replaced/contract-mismatch）→ rejected handler 同步置 `daemonDisabled=true` → 下一轮 `connectToDaemon(true)` 命中 disabled **早返回不抛错** → 落入成功分支误打 "Reconnected successfully" + 推 `system_daemon_reconnected`，与驱逐通知矛盾（此时 reply 实际返回 `disabledReplyError`）。

### 修复 / Fix
抽纯函数 `shouldEmitReconnectSuccess({daemonDisabled})`，成功分支 log/通知前早返回。不改 `connectToDaemon` 静默返回契约（ready 初连依赖）。早返回仍走 finally 清 `reconnectTask`，后续合法重连可重新武装；`daemonDisabled=false` 时字节级不变。

### Cross-review
2 fresh reviewer 均 **0 REAL**。Reviewer B 五轴 ship-ready（system_daemon_reconnected 无消费者、reconnectTask finally 清理、recovery poller 正交、bundle 仅 bridge-server.js）。Reviewer A 0 REAL + RECOMMEND（守卫**位置**与 mid-loop-rejection 集成测试未 pin → backlog）。

### 测试 / Tests
2 new（helper TDD RED→GREEN）。全量 1183 pass / 0 fail。verify:plugin-sync clean。

### Backlog（reviewer RECOMMEND，非阻塞）
集成测试：spawn daemon → 触发 reconnect loop → 中途 REJECT → 断言无 system_daemon_reconnected 且 reply 仍 disabled。