### PR TITLE
fix: CLI/config/state 三处硬化（信号退出码 + 空 XDG + 数值下界）/ CLI/config/state hardening

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13806,6 +13806,10 @@ function formatError2(error2) {
 import { mkdirSync, existsSync as existsSync2 } from "fs";
 import { join } from "path";
 import { homedir, platform } from "os";
+function resolveXdgStateBase(rawXdg = process.env.XDG_STATE_HOME) {
+  const xdgState = rawXdg && rawXdg.length > 0 ? rawXdg : join(homedir(), ".local", "state");
+  return join(xdgState, "agentbridge");
+}
 
 class StateDirResolver {
   stateDir;
@@ -13813,8 +13817,7 @@ class StateDirResolver {
     if (platform() === "darwin") {
       return join(homedir(), "Library", "Application Support", "AgentBridge");
     }
-    const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-    return join(xdgState, "agentbridge");
+    return resolveXdgStateBase(process.env.XDG_STATE_HOME);
   }
   constructor(envOverride) {
     const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
@@ -14382,7 +14385,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("47a6d3e", "source"),
+  commit: defineString("c6147e5", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -15545,13 +15548,13 @@ function normalizeConfig(raw) {
   return {
     version: typeof config2.version === "string" ? config2.version : DEFAULT_CONFIG.version,
     codex: {
-      appPort: normalizeInteger(codex.appPort ?? daemon.port, DEFAULT_CONFIG.codex.appPort),
-      proxyPort: normalizeInteger(codex.proxyPort ?? daemon.proxyPort, DEFAULT_CONFIG.codex.proxyPort)
+      appPort: normalizeBoundedInteger(codex.appPort ?? daemon.port, DEFAULT_CONFIG.codex.appPort, 1, 65535),
+      proxyPort: normalizeBoundedInteger(codex.proxyPort ?? daemon.proxyPort, DEFAULT_CONFIG.codex.proxyPort, 1, 65535)
     },
     turnCoordination: {
-      attentionWindowSeconds: normalizeInteger(turnCoordination.attentionWindowSeconds, DEFAULT_CONFIG.turnCoordination.attentionWindowSeconds)
+      attentionWindowSeconds: normalizeBoundedInteger(turnCoordination.attentionWindowSeconds, DEFAULT_CONFIG.turnCoordination.attentionWindowSeconds, 0, Number.MAX_SAFE_INTEGER)
     },
-    idleShutdownSeconds: normalizeInteger(config2.idleShutdownSeconds, DEFAULT_CONFIG.idleShutdownSeconds),
+    idleShutdownSeconds: normalizeBoundedInteger(config2.idleShutdownSeconds, DEFAULT_CONFIG.idleShutdownSeconds, 1, Number.MAX_SAFE_INTEGER),
     budget: normalizeBudgetConfig(config2.budget)
   };
 }

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -22,7 +22,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("47a6d3e", "source"),
+  commit: defineString("c6147e5", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -221,6 +221,10 @@ import { EventEmitter } from "events";
 import { mkdirSync as mkdirSync2, existsSync } from "fs";
 import { join } from "path";
 import { homedir, platform } from "os";
+function resolveXdgStateBase(rawXdg = process.env.XDG_STATE_HOME) {
+  const xdgState = rawXdg && rawXdg.length > 0 ? rawXdg : join(homedir(), ".local", "state");
+  return join(xdgState, "agentbridge");
+}
 
 class StateDirResolver {
   stateDir;
@@ -228,8 +232,7 @@ class StateDirResolver {
     if (platform() === "darwin") {
       return join(homedir(), "Library", "Application Support", "AgentBridge");
     }
-    const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-    return join(xdgState, "agentbridge");
+    return resolveXdgStateBase(process.env.XDG_STATE_HOME);
   }
   constructor(envOverride) {
     const override = envOverride ?? process.env.AGENTBRIDGE_STATE_DIR;
@@ -3516,13 +3519,13 @@ function normalizeConfig(raw) {
   return {
     version: typeof config.version === "string" ? config.version : DEFAULT_CONFIG.version,
     codex: {
-      appPort: normalizeInteger(codex.appPort ?? daemon.port, DEFAULT_CONFIG.codex.appPort),
-      proxyPort: normalizeInteger(codex.proxyPort ?? daemon.proxyPort, DEFAULT_CONFIG.codex.proxyPort)
+      appPort: normalizeBoundedInteger(codex.appPort ?? daemon.port, DEFAULT_CONFIG.codex.appPort, 1, 65535),
+      proxyPort: normalizeBoundedInteger(codex.proxyPort ?? daemon.proxyPort, DEFAULT_CONFIG.codex.proxyPort, 1, 65535)
     },
     turnCoordination: {
-      attentionWindowSeconds: normalizeInteger(turnCoordination.attentionWindowSeconds, DEFAULT_CONFIG.turnCoordination.attentionWindowSeconds)
+      attentionWindowSeconds: normalizeBoundedInteger(turnCoordination.attentionWindowSeconds, DEFAULT_CONFIG.turnCoordination.attentionWindowSeconds, 0, Number.MAX_SAFE_INTEGER)
     },
-    idleShutdownSeconds: normalizeInteger(config.idleShutdownSeconds, DEFAULT_CONFIG.idleShutdownSeconds),
+    idleShutdownSeconds: normalizeBoundedInteger(config.idleShutdownSeconds, DEFAULT_CONFIG.idleShutdownSeconds, 1, Number.MAX_SAFE_INTEGER),
     budget: normalizeBudgetConfig(config.budget)
   };
 }

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { constants as osConstants } from "node:os";
 import { MARKETPLACE_NAME, PLUGIN_NAME } from "../cli";
 import {
   MARKETPLACE_STEPS,
@@ -113,8 +114,8 @@ export async function runClaude(args: string[]) {
     env: process.env,
   });
 
-  child.on("exit", (code) => {
-    process.exit(code ?? 0);
+  child.on("exit", (code, signal) => {
+    process.exit(mapChildExitCode(code, signal));
   });
 
   child.on("error", (err) => {
@@ -126,6 +127,28 @@ export async function runClaude(args: string[]) {
     console.error(`Error starting Claude Code: ${err.message}`);
     process.exit(1);
   });
+}
+
+/**
+ * Map a reaped child's (code, signal) to the wrapper's own exit code.
+ *
+ * A signal-killed child is reaped with `code=null` and `signal` set, so a naive
+ * `code ?? 0` reports SUCCESS (0) for a signal-killed Claude — breaking
+ * scriptability and diverging from the codex wrapper. When a signal is present
+ * we exit with the conventional 128+N code (mirroring `src/cli/codex.ts`, which
+ * maps SIGINT→130 / SIGTERM→143 etc.). An unknown signal name still yields a
+ * non-zero 128 so a kill is never silently reported as success.
+ *
+ * Pure + exported so the mapping is unit-testable without spawning a process.
+ */
+export function mapChildExitCode(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): number {
+  if (signal) {
+    return 128 + (osConstants.signals[signal] ?? 0);
+  }
+  return code ?? 0;
 }
 
 /**

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -348,24 +348,38 @@ function normalizeConfig(raw: unknown): AgentBridgeConfig | null {
   return {
     version: typeof config.version === "string" ? config.version : DEFAULT_CONFIG.version,
     codex: {
-      appPort: normalizeInteger(
+      // Ports must be a valid TCP port (1..65535); a coercible negative/zero/
+      // out-of-range value falls back to the default instead of passing through.
+      appPort: normalizeBoundedInteger(
         codex.appPort ?? daemon.port,
         DEFAULT_CONFIG.codex.appPort,
+        1,
+        65535,
       ),
-      proxyPort: normalizeInteger(
+      proxyPort: normalizeBoundedInteger(
         codex.proxyPort ?? daemon.proxyPort,
         DEFAULT_CONFIG.codex.proxyPort,
+        1,
+        65535,
       ),
     },
     turnCoordination: {
-      attentionWindowSeconds: normalizeInteger(
+      // 0 = no attention window is legitimate; negatives are not.
+      attentionWindowSeconds: normalizeBoundedInteger(
         turnCoordination.attentionWindowSeconds,
         DEFAULT_CONFIG.turnCoordination.attentionWindowSeconds,
+        0,
+        Number.MAX_SAFE_INTEGER,
       ),
     },
-    idleShutdownSeconds: normalizeInteger(
+    // A negative idleShutdownSeconds becomes a negative *1000 ms timeout, which
+    // setTimeout clamps to 0 → the daemon self-shuts ~immediately after boot,
+    // before the Claude client attaches (即起即死). Floor at 1 second.
+    idleShutdownSeconds: normalizeBoundedInteger(
       config.idleShutdownSeconds,
       DEFAULT_CONFIG.idleShutdownSeconds,
+      1,
+      Number.MAX_SAFE_INTEGER,
     ),
     budget: normalizeBudgetConfig(config.budget),
   };

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -3,6 +3,26 @@ import { join } from "node:path";
 import { homedir, platform } from "node:os";
 
 /**
+ * Resolve the XDG state base directory, treating an EMPTY string as unset.
+ *
+ * The XDG spec's `${XDG_STATE_HOME:-~/.local/state}` (`:-`, not `:`) falls back
+ * when the variable is unset OR empty. A plain `??` only catches undefined/null,
+ * so `XDG_STATE_HOME=""` would slip through and `join("", "agentbridge")` would
+ * yield the RELATIVE path "agentbridge" — state files written under ./agentbridge
+ * relative to cwd (orphan daemon, port lockout, capability-token silently off).
+ *
+ * Exported (and parameterized on the raw env value) so the empty/unset fallback
+ * is unit-testable on any host platform, since {@link StateDirResolver.platformBaseDir}
+ * only reaches this branch off-darwin.
+ */
+export function resolveXdgStateBase(
+  rawXdg: string | undefined = process.env.XDG_STATE_HOME,
+): string {
+  const xdgState = rawXdg && rawXdg.length > 0 ? rawXdg : join(homedir(), ".local", "state");
+  return join(xdgState, "agentbridge");
+}
+
+/**
  * Resolves the shared runtime state directory for AgentBridge.
  *
  * macOS:  ~/Library/Application Support/AgentBridge
@@ -26,8 +46,7 @@ export class StateDirResolver {
     if (platform() === "darwin") {
       return join(homedir(), "Library", "Application Support", "AgentBridge");
     }
-    const xdgState = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-    return join(xdgState, "agentbridge");
+    return resolveXdgStateBase(process.env.XDG_STATE_HOME);
   }
 
   constructor(envOverride?: string) {

--- a/src/unit-test/cli.test.ts
+++ b/src/unit-test/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { compareVersions } from "../cli/init";
-import { checkOwnedFlagConflicts, warnIfPluginCacheMissing } from "../cli/claude";
+import { checkOwnedFlagConflicts, warnIfPluginCacheMissing, mapChildExitCode } from "../cli/claude";
 import {
   buildCodexArgs,
   parseAgentBridgeCodexArgs,
@@ -443,5 +443,35 @@ describe("CLI: resolveResumeTargets (abg resume)", () => {
       else process.env.AGENTBRIDGE_BASE_DIR = previousBase;
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("CLI claude: child exit-code mapping (signal-aware, mirrors codex wrapper)", () => {
+  test("normal exit code passes through", () => {
+    expect(mapChildExitCode(0, null)).toBe(0);
+    expect(mapChildExitCode(1, null)).toBe(1);
+    expect(mapChildExitCode(42, null)).toBe(42);
+  });
+
+  test("null code with no signal maps to 0", () => {
+    expect(mapChildExitCode(null, null)).toBe(0);
+  });
+
+  test("a signal-killed child reports 128+N, NOT 0 (the bug)", () => {
+    // A signal-killed child is reaped with code=null + signal set; the old
+    // `code ?? 0` wrongly reported 0. The wrapper must surface a non-zero,
+    // conventional 128+signal exit so scripts see the failure.
+    expect(mapChildExitCode(null, "SIGINT")).toBe(130); // 128 + 2
+    expect(mapChildExitCode(null, "SIGTERM")).toBe(143); // 128 + 15
+    expect(mapChildExitCode(null, "SIGKILL")).toBe(137); // 128 + 9
+  });
+
+  test("signal takes precedence over a present code (signal-killed is a failure)", () => {
+    expect(mapChildExitCode(0, "SIGTERM")).toBe(143);
+  });
+
+  test("unknown signal name still yields a non-zero exit (128 + 0 fallback)", () => {
+    // os.constants.signals[unknown] is undefined → 128 + 0 = 128, still non-zero.
+    expect(mapChildExitCode(null, "SIGNOPE" as NodeJS.Signals)).toBe(128);
   });
 });

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -497,6 +497,85 @@ describe("ConfigService — budget section", () => {
   });
 });
 
+describe("ConfigService — top-level numeric bounds (no negative/zero passthrough)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "agentbridge-numeric-bounds-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeRawConfig(raw: unknown) {
+    mkdirSync(join(tempDir, ".agentbridge"), { recursive: true });
+    writeFileSync(join(tempDir, ".agentbridge", "config.json"), JSON.stringify(raw));
+  }
+
+  test("negative idleShutdownSeconds falls back to default (prevents daemon self-shutdown)", () => {
+    const svc = new ConfigService(tempDir);
+    // A coercible negative passes shape-check; daemon.ts computes *1000 → -N ms,
+    // setTimeout clamps to 0 → daemon self-shuts ~immediately after boot. Must
+    // fall back to the default (30) instead of passing through.
+    writeRawConfig({ idleShutdownSeconds: -1 });
+    const config = expectParsed(svc);
+    expect(config.idleShutdownSeconds).toBe(DEFAULT_CONFIG.idleShutdownSeconds);
+  });
+
+  test("zero idleShutdownSeconds falls back to default (min 1)", () => {
+    const svc = new ConfigService(tempDir);
+    writeRawConfig({ idleShutdownSeconds: 0 });
+    const config = expectParsed(svc);
+    expect(config.idleShutdownSeconds).toBe(DEFAULT_CONFIG.idleShutdownSeconds);
+  });
+
+  test("positive idleShutdownSeconds is honored", () => {
+    const svc = new ConfigService(tempDir);
+    writeRawConfig({ idleShutdownSeconds: 120 });
+    const config = expectParsed(svc);
+    expect(config.idleShutdownSeconds).toBe(120);
+  });
+
+  test("negative attentionWindowSeconds falls back to default; zero is allowed (min 0)", () => {
+    const svc = new ConfigService(tempDir);
+    writeRawConfig({ turnCoordination: { attentionWindowSeconds: -5 } });
+    let config = expectParsed(svc);
+    expect(config.turnCoordination.attentionWindowSeconds).toBe(
+      DEFAULT_CONFIG.turnCoordination.attentionWindowSeconds,
+    );
+
+    // 0 is a legitimate "no attention window" value and must pass through.
+    writeRawConfig({ turnCoordination: { attentionWindowSeconds: 0 } });
+    config = expectParsed(svc);
+    expect(config.turnCoordination.attentionWindowSeconds).toBe(0);
+  });
+
+  test("out-of-range codex ports fall back to defaults (1..65535)", () => {
+    const svc = new ConfigService(tempDir);
+    writeRawConfig({ codex: { appPort: -1, proxyPort: 70000 } });
+    const config = expectParsed(svc);
+    expect(config.codex.appPort).toBe(DEFAULT_CONFIG.codex.appPort);
+    expect(config.codex.proxyPort).toBe(DEFAULT_CONFIG.codex.proxyPort);
+  });
+
+  test("zero codex ports fall back to defaults", () => {
+    const svc = new ConfigService(tempDir);
+    writeRawConfig({ codex: { appPort: 0, proxyPort: 0 } });
+    const config = expectParsed(svc);
+    expect(config.codex.appPort).toBe(DEFAULT_CONFIG.codex.appPort);
+    expect(config.codex.proxyPort).toBe(DEFAULT_CONFIG.codex.proxyPort);
+  });
+
+  test("in-range codex ports are honored", () => {
+    const svc = new ConfigService(tempDir);
+    writeRawConfig({ codex: { appPort: 4600, proxyPort: 4601 } });
+    const config = expectParsed(svc);
+    expect(config.codex.appPort).toBe(4600);
+    expect(config.codex.proxyPort).toBe(4601);
+  });
+});
+
 describe("applyBudgetEnvOverrides", () => {
   const base = {
     enabled: true,

--- a/src/unit-test/state-dir.test.ts
+++ b/src/unit-test/state-dir.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { StateDirResolver } from "../state-dir";
+import { isAbsolute, join } from "node:path";
+import { homedir, platform, tmpdir } from "node:os";
+import { StateDirResolver, resolveXdgStateBase } from "../state-dir";
 
 describe("StateDirResolver", () => {
   let tempDir: string;
@@ -52,5 +52,56 @@ describe("StateDirResolver", () => {
     // Just verify it doesn't throw and returns a non-empty string
     const resolver = new StateDirResolver();
     expect(resolver.dir.length).toBeGreaterThan(0);
+  });
+});
+
+describe("resolveXdgStateBase — XDG_STATE_HOME empty/unset handling (Linux)", () => {
+  // platformBaseDir's XDG branch only runs off-darwin, so test the pure helper
+  // directly with an explicit raw value — this exercises the bug on ANY host.
+  const expectedFallback = join(homedir(), ".local", "state", "agentbridge");
+
+  test("empty string falls back to ~/.local/state (absolute, NOT cwd-relative)", () => {
+    const base = resolveXdgStateBase("");
+    // The crux of the bug: join("", "agentbridge") returns the RELATIVE path
+    // "agentbridge". The fix must treat "" as unset and produce an absolute path.
+    expect(isAbsolute(base)).toBe(true);
+    expect(base).toBe(expectedFallback);
+  });
+
+  test("undefined (unset) falls back to ~/.local/state", () => {
+    const base = resolveXdgStateBase(undefined);
+    expect(isAbsolute(base)).toBe(true);
+    expect(base).toBe(expectedFallback);
+  });
+
+  test("non-empty value is honored", () => {
+    const custom = join(tmpdir(), "xdg-state-fixture");
+    expect(resolveXdgStateBase(custom)).toBe(join(custom, "agentbridge"));
+  });
+});
+
+describe("StateDirResolver.platformBaseDir — always absolute", () => {
+  let savedXdg: string | undefined;
+
+  beforeEach(() => {
+    savedXdg = process.env.XDG_STATE_HOME;
+  });
+
+  afterEach(() => {
+    if (savedXdg === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = savedXdg;
+  });
+
+  test("empty XDG_STATE_HOME never yields a cwd-relative base", () => {
+    process.env.XDG_STATE_HOME = "";
+    expect(isAbsolute(StateDirResolver.platformBaseDir())).toBe(true);
+  });
+
+  test("non-darwin: empty XDG_STATE_HOME resolves to ~/.local/state", () => {
+    if (platform() === "darwin") return; // XDG branch unreachable on macOS
+    process.env.XDG_STATE_HOME = "";
+    expect(StateDirResolver.platformBaseDir()).toBe(
+      join(homedir(), ".local", "state", "agentbridge"),
+    );
   });
 });


### PR DESCRIPTION
## 深扫 round-3 · 三项独立修复（1 MEDIUM + 2 LOW）

**FIX1 (LOW, cli/claude.ts)** — 子进程被信号杀死时仍 `exit 0`（exit handler 忽略 signal，code=null → `code ?? 0`=0）。抽纯函数 `mapChildExitCode(code, signal)`：signal 在场 → `128 + (osConstants.signals[signal] ?? 0)`（SIGINT→130/SIGTERM→143/SIGKILL→137/未知→128），否则 `code ?? 0`。对齐 codex wrapper 128+N 约定。

**FIX2 (MEDIUM, state-dir.ts)** — 空 `XDG_STATE_HOME` 经 `??` 不回落 → `join("","agentbridge")` 得相对路径 → daemon.pid/daemon.json/killed/control-token/registry 落 cwd 相对目录 → 孤儿 daemon / 端口锁死 / 能力令牌静默 OFF。抽 `resolveXdgStateBase(raw)`：`raw && raw.length>0 ? raw : ~/.local/state`，对齐构造器既有守卫与 `:-` 语义；darwin 早返回不变。

**FIX3 (LOW, config-service.ts)** — idleShutdownSeconds/attentionWindowSeconds/appPort/proxyPort 用无界 normalizeInteger，coercible 负值穿透；负 `idleShutdownSeconds*1000` → setTimeout 钳 0 → daemon 即起即死。改走 `normalizeBoundedInteger`（idle min1 / attentionWindow min0 / 端口 1..65535）越界回落默认。

### Cross-review
2 fresh reviewer 均 **0 REAL**。Reviewer A 重点实证 `mapChildExitCode` 运算符优先级——实际代码**有括号** `128 + (… ?? 0)`，未知信号→128 而非 NaN（防御成立）。Reviewer B 实证 config 后兼容：idleShutdownSeconds=0 非 "永不关" 哨兵（daemon.ts:107 无 disable 分支）、port 0 非 auto-assign、无合法大值被截。

### 测试 / Tests
+17（cli/state-dir/config-service，TDD RED→GREEN）。全量 1198 pass / 0 fail。verify:plugin-sync clean。