### PR TITLE
fix: 损坏 registry 时 abg pairs prune/list 降级磁盘扫描而非崩溃 / degrade pairs prune/list on corrupt registry

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14385,7 +14385,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("c6147e5", "source"),
+  commit: defineString("a9d6d9c", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -22,7 +22,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("c6147e5", "source"),
+  commit: defineString("a9d6d9c", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/src/cli/pairs.ts
+++ b/src/cli/pairs.ts
@@ -5,6 +5,9 @@ import {
   detectLegacyRootDaemon,
   listPairDirs,
   pairDirDaemonAlive,
+  PairError,
+  pairsRootDir,
+  removeOrphanPairDirIgnoringRegistry,
   removePairEntryAndDir,
   removeUnregisteredPairDir,
   validatePairId,
@@ -34,6 +37,27 @@ interface PairRow {
   threadId: string | null;
   threadStatus: string | null;
   threadUpdatedAt: string | null;
+}
+
+/**
+ * The registry is exactly the state that gets corrupted when things go wrong — a
+ * duplicate slot / duplicate pairId (a manual edit or downgrade-then-upgrade)
+ * makes `readRegistry` throw PAIR_REGISTRY_CORRUPT. The recovery commands
+ * (`abg pairs` / `abg pairs prune`) must not crash on the very thing they exist
+ * to clean up, so they catch THIS error (by code, never by string match) and
+ * degrade to the disk-scan reclamation that does not need a parseable registry —
+ * mirroring `abg kill --all` (see cli/kill.ts). Any other error still propagates.
+ */
+function isRegistryCorruptError(error: unknown): error is PairError {
+  return error instanceof PairError && error.code === "PAIR_REGISTRY_CORRUPT";
+}
+
+/** Best-effort registry file path for the degraded notice (prefers the error's own path). */
+function registryPathForNotice(base: string, error: PairError): string {
+  const fromDetails = error.details?.path;
+  return typeof fromDetails === "string" && fromDetails.length > 0
+    ? fromDetails
+    : join(pairsRootDir(base), "registry.json");
 }
 
 export async function runPairs(args: string[] = []) {
@@ -174,10 +198,35 @@ async function runPrune(args: string[]) {
   // Classify reclaimable entries up front so the orphan-dir pass can SKIP the
   // dirs that the entry pass will reclaim — otherwise a stranded entry's dir is
   // double-reported (once as "registered" in Kept, once as a reclaimed entry).
-  const reclaimable = classifyReclaimableEntries(base);
+  //
+  // The registry is the very thing prune exists to repair, so a CORRUPT registry
+  // (duplicate slot/pairId from a manual edit or downgrade-then-upgrade) must NOT
+  // crash the command — `classifyReclaimableEntries` funnels through `readRegistry`
+  // which throws PAIR_REGISTRY_CORRUPT. Degrade like `abg kill --all`: report the
+  // registry path, then run the registry-free disk-scan reclamation (orphan dirs)
+  // that needs no parseable registry. The entry pass is skipped (it cannot run
+  // without a readable registry) and `registryReadable=false` switches the dir
+  // pass to a membership-check-free delete.
+  let reclaimable: ReclaimableEntry[];
+  let registryReadable = true;
+  try {
+    reclaimable = classifyReclaimableEntries(base);
+  } catch (error) {
+    if (!isRegistryCorruptError(error)) throw error;
+    registryReadable = false;
+    reclaimable = [];
+    console.error(
+      `⚠️  pair registry 不可读（${error.message}）——` +
+        `位于 ${registryPathForNotice(base, error)}。` +
+        `跳过 registry 条目回收，降级为磁盘扫描清理孤儿目录（无需可解析的 registry）。` +
+        `修复或删除该文件后可恢复完整 prune。`,
+    );
+    // Scriptability: a degraded run is not a clean success.
+    process.exitCode = 2;
+  }
   const reclaimableIds = new Set(reclaimable.map((c) => c.entry.pairId.toLowerCase()));
 
-  const dirResult = pruneOrphanDirs(base, apply, reclaimableIds);
+  const dirResult = pruneOrphanDirs(base, apply, reclaimableIds, registryReadable);
   const entryResult = await pruneReclaimableEntries(reclaimable, base, apply);
   // The orphan-dir prune may itself perform locked deletes; await it after we
   // have its (synchronously-built) plan so both passes report coherently.
@@ -195,13 +244,24 @@ interface OrphanDirResult {
  * Reclaim orphan pair state dirs (dir exists, no registry entry, not live).
  * `reclaimableIds` are the lowercased pairIds the ENTRY pass will reclaim — their
  * dirs are skipped here so they are not also reported as "registered" Kept dirs.
+ *
+ * `registryReadable=false` is the corrupt-registry degradation: `listPairs` would
+ * itself throw, so we treat the registered set as empty and switch the `--apply`
+ * delete to {@link removeOrphanPairDirIgnoringRegistry} (liveness gate only, no
+ * registry membership read). This is the registry-free disk-scan reclamation the
+ * recovery command must still offer when the registry cannot be parsed.
  */
 async function pruneOrphanDirs(
   base: string,
   apply: boolean,
   reclaimableIds: ReadonlySet<string>,
+  registryReadable: boolean,
 ): Promise<OrphanDirResult> {
-  const registered = new Set(listPairs(base).map((pair) => pair.pairId.toLowerCase()));
+  // On a corrupt registry `listPairs` throws — degrade to an empty registered set
+  // so the disk scan can still surface (and, under --apply, reclaim) orphan dirs.
+  const registered = registryReadable
+    ? new Set(listPairs(base).map((pair) => pair.pairId.toLowerCase()))
+    : new Set<string>();
   const removed: string[] = [];
   const kept: Array<{ name: string; reason: string }> = [];
 
@@ -245,7 +305,13 @@ async function pruneOrphanDirs(
       // daemon start for this id cannot race the orphan check — under the lock
       // removeUnregisteredPairDir re-verifies membership AND liveness before it
       // removes anything (the initial gates above are just a cheap pre-filter).
-      const outcome = await removeUnregisteredPairDir(base, id);
+      //
+      // On a corrupt registry the membership re-check is impossible (readRegistry
+      // throws under the lock too), so degrade to the liveness-only delete — still
+      // locked, still refusing any live daemon's dir.
+      const outcome = registryReadable
+        ? await removeUnregisteredPairDir(base, id)
+        : await removeOrphanPairDirIgnoringRegistry(base, id);
       if (outcome.removed) {
         removed.push(name);
       } else if (outcome.reason === "registered") {
@@ -373,7 +439,26 @@ function printPruneSummary(dirResult: OrphanDirResult, entryResult: EntryReclaim
 
 async function collectRows(): Promise<PairRow[]> {
   const base = computeBaseDir();
-  const rows = await Promise.all(listPairs(base).map((pair) => rowForPair(base, pair)));
+  // The list command is itself a recovery aid, so a CORRUPT registry (duplicate
+  // slot/pairId) must not crash it — `listPairs` funnels through `readRegistry`
+  // which throws PAIR_REGISTRY_CORRUPT. Degrade like `abg kill --all`: report the
+  // registry path, then enumerate the on-disk pair dirs (disk scan) so the user
+  // can still see — and clean up — what is on disk.
+  let rows: PairRow[];
+  try {
+    rows = await Promise.all(listPairs(base).map((pair) => rowForPair(base, pair)));
+  } catch (error) {
+    if (!isRegistryCorruptError(error)) throw error;
+    console.error(
+      `⚠️  pair registry 不可读（${error.message}）——` +
+        `位于 ${registryPathForNotice(base, error)}。` +
+        `降级为磁盘扫描列出 ${pairsRootDir(base)} 下的 pair 目录（slot/name/cwd 等需 registry 的字段显示为 -）。` +
+        `修复或删除该文件后可恢复完整列表；用 \`abg pairs prune\` 清理孤儿目录。`,
+    );
+    // Scriptability: a degraded list is not a clean success.
+    process.exitCode = 2;
+    rows = await collectDiskScanRows(base);
+  }
   const legacy = detectLegacyRootDaemon(base);
   if (legacy) {
     rows.push({
@@ -414,6 +499,56 @@ async function rowForPair(base: string, pair: PairEntry): Promise<PairRow> {
     ports,
     source: pair.source,
     cwd: pair.cwd,
+    running,
+    pid: typeof record?.pid === "number" ? record.pid : null,
+    threadId: thread?.threadId ?? null,
+    threadStatus: thread?.status ?? null,
+    threadUpdatedAt: thread?.updatedAt ?? null,
+  };
+}
+
+/**
+ * Degraded row source for a CORRUPT registry: enumerate the on-disk pair dirs
+ * (no registry read) and read each daemon's own advertised record from disk. The
+ * registry-only fields (slot / friendly name / source / registered cwd) are not
+ * available, so they render as `-` / 0 — the dir name (pairId) plus liveness is
+ * still enough for the user to act (`abg pairs prune`, `abg kill --all`).
+ */
+async function collectDiskScanRows(base: string): Promise<PairRow[]> {
+  const names = listPairDirsSafe(base);
+  return Promise.all(names.map((name) => rowForDiskScanDir(base, name)));
+}
+
+function listPairDirsSafe(base: string): string[] {
+  try {
+    return listPairDirs(base);
+  } catch {
+    return [];
+  }
+}
+
+async function rowForDiskScanDir(base: string, dirName: string): Promise<PairRow> {
+  const stateDir = new StateDirResolver(join(base, "pairs", dirName));
+  // Read the daemon's own advertised record from disk to recover ports/pid — the
+  // slot→port arithmetic needs a registry entry we cannot read here.
+  const record = new DaemonLifecycle({ stateDir, controlPort: 0, log: () => {} }).readDaemonRecord();
+  const ports: PairPorts = {
+    appPort: record?.ports?.appPort ?? 0,
+    proxyPort: record?.ports?.proxyPort ?? 0,
+    controlPort: record?.ports?.controlPort ?? 0,
+  };
+  const running =
+    ports.controlPort > 0
+      ? await new DaemonLifecycle({ stateDir, controlPort: ports.controlPort, log: () => {} }).isHealthy()
+      : false;
+  const thread = readRawCurrentThread(stateDir);
+  return {
+    pairId: dirName,
+    name: "-",
+    slot: null,
+    ports,
+    source: "cwd",
+    cwd: "-",
     running,
     pid: typeof record?.pid === "number" ? record.pid : null,
     threadId: thread?.threadId ?? null,

--- a/src/pair-registry.ts
+++ b/src/pair-registry.ts
@@ -1012,6 +1012,37 @@ export async function removeUnregisteredPairDir(
   });
 }
 
+/**
+ * Degraded variant of {@link removeUnregisteredPairDir} for a CORRUPT registry.
+ *
+ * When the registry is unparseable (duplicate slot/pairId, malformed entry) the
+ * recovery tooling cannot do the "is this id registered?" membership check —
+ * `readRegistry` itself throws. This variant deliberately SKIPS that check (the
+ * registry truth is unavailable) and removes the dir purely on the liveness gate:
+ * still under the registry lock (so a concurrent daemon start serializes), and
+ * still refusing to delete a dir whose daemon is alive. It exists ONLY for the
+ * corrupt-registry degradation path in `abg pairs prune` — the normal path keeps
+ * using {@link removeUnregisteredPairDir}, which honours registry membership.
+ *
+ * Trade-off: without the registry we cannot tell a still-registered pair from an
+ * orphan, so a corrupt-registry `--apply` could reap a dir whose entry would have
+ * survived a manual fix. That is acceptable here — the liveness gate already
+ * protects any RUNNING pair, the user explicitly asked to reclaim, and the
+ * alternative (the command crashing outright) leaves the broken registry
+ * un-cleanable. The dry run shows exactly which dirs would be removed first.
+ */
+export async function removeOrphanPairDirIgnoringRegistry(
+  base: string,
+  pairId: string,
+): Promise<{ removed: boolean; reason?: "live" }> {
+  return withRegistryLock(base, () => {
+    if (pairDirDaemonAlive(base, pairId)) {
+      return { removed: false, reason: "live" as const };
+    }
+    return { removed: removePairDir(base, pairId) };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Entry-level reclamation (P1 #9)
 //

--- a/src/unit-test/pair-registry.test.ts
+++ b/src/unit-test/pair-registry.test.ts
@@ -32,6 +32,7 @@ import {
   probePortFree,
   readRegistry,
   RECLAIMABLE_MIN_AGE_MS,
+  removeOrphanPairDirIgnoringRegistry,
   removePairDir,
   removePairEntry,
   removePairEntryAndDir,
@@ -270,6 +271,32 @@ describe("readRegistry / writeRegistry", () => {
     const files = readdirSync(join(base, "pairs"));
     const tmpFiles = files.filter((f) => f.includes(".tmp."));
     expect(tmpFiles).toEqual([]);
+  });
+
+  test("duplicate slot throws PAIR_REGISTRY_CORRUPT carrying the registry path", () => {
+    // writeRegistry only serializes — the duplicate guard lives in readRegistry.
+    writeRegistry(base, { version: 1, pairs: [entry(0, "alpha"), entry(0, "beta")] });
+    const regPath = join(base, "pairs", "registry.json");
+    try {
+      readRegistry(base);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      expect((err as PairError).code).toBe("PAIR_REGISTRY_CORRUPT");
+      // The CLI degradation surfaces this path to the user — assert it is present.
+      expect((err as PairError).details?.path).toBe(regPath);
+    }
+  });
+
+  test("duplicate lowercased pairId throws PAIR_REGISTRY_CORRUPT", () => {
+    writeRegistry(base, { version: 1, pairs: [entry(0, "Alpha"), entry(1, "alpha")] });
+    try {
+      readRegistry(base);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PairError);
+      expect((err as PairError).code).toBe("PAIR_REGISTRY_CORRUPT");
+    }
   });
 });
 
@@ -843,6 +870,24 @@ describe("removePairEntryAndDir / removeUnregisteredPairDir — locked atomic cl
     expect(existsSync(join(base, "pairs", registered))).toBe(true);
 
     expect(await removeUnregisteredPairDir(base, live)).toEqual({ removed: false, reason: "live" });
+    expect(existsSync(join(base, "pairs", live))).toBe(true);
+  });
+
+  test("removeOrphanPairDirIgnoringRegistry removes a dead dir on the liveness gate alone (corrupt-registry path)", async () => {
+    const dead = "main-dead0001";
+    const live = "main-live0005";
+    for (const id of [dead, live]) mkdirSync(join(base, "pairs", id), { recursive: true });
+    writeFileSync(join(base, "pairs", live, "daemon.pid"), `${process.pid}\n`, "utf-8");
+    // Deliberately corrupt the registry: this delete path must NOT read it.
+    mkdirSync(join(base, "pairs"), { recursive: true });
+    writeFileSync(join(base, "pairs", "registry.json"), "{ not valid json", "utf-8");
+
+    // A dead dir is removed without ANY registry read (readRegistry would throw).
+    expect(await removeOrphanPairDirIgnoringRegistry(base, dead)).toEqual({ removed: true });
+    expect(existsSync(join(base, "pairs", dead))).toBe(false);
+
+    // A live dir is still protected by the liveness gate, even with no registry truth.
+    expect(await removeOrphanPairDirIgnoringRegistry(base, live)).toEqual({ removed: false, reason: "live" });
     expect(existsSync(join(base, "pairs", live))).toBe(true);
   });
 

--- a/src/unit-test/pairs-corrupt-registry.test.ts
+++ b/src/unit-test/pairs-corrupt-registry.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPairs } from "../cli/pairs";
+import { writeRegistry, type PairEntry } from "../pair-registry";
+
+/**
+ * Regression: a corrupt registry (duplicate slot / duplicate lowercased pairId)
+ * must NOT crash the recovery commands `abg pairs prune` and `abg pairs` (list).
+ *
+ * `readRegistry` deliberately throws PAIR_REGISTRY_CORRUPT on a duplicate slot/id
+ * (so two pairs never silently share ports). Every registry-reading path funnels
+ * through it, so the cleanup tooling meant to FIX a broken registry must degrade
+ * gracefully — print the registry path + run the disk-scan reclamation that does
+ * not need a parseable registry — exactly like `abg kill --all` already does.
+ */
+
+function pairEntry(slot: number, pairId: string, cwd = `/tmp/${pairId}`): PairEntry {
+  return {
+    pairId,
+    slot,
+    cwd,
+    name: pairId.split("-")[0],
+    source: "cwd",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("abg pairs against a corrupt (duplicate) registry", () => {
+  let base: string;
+  let savedBase: string | undefined;
+  let savedState: string | undefined;
+  let logs: string[];
+  let errs: string[];
+  let exitCode: number | undefined;
+  let origLog: typeof console.log;
+  let origErr: typeof console.error;
+
+  beforeEach(() => {
+    savedBase = process.env.AGENTBRIDGE_BASE_DIR;
+    savedState = process.env.AGENTBRIDGE_STATE_DIR;
+    base = mkdtempSync(join(tmpdir(), "abg-pairs-corrupt-"));
+    process.env.AGENTBRIDGE_BASE_DIR = base;
+    delete process.env.AGENTBRIDGE_STATE_DIR;
+
+    logs = [];
+    errs = [];
+    origLog = console.log;
+    origErr = console.error;
+    console.log = (...a: unknown[]) => void logs.push(a.map(String).join(" "));
+    console.error = (...a: unknown[]) => void errs.push(a.map(String).join(" "));
+    exitCode = undefined;
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    console.error = origErr;
+    const restore = (k: string, v: string | undefined) => {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    };
+    restore("AGENTBRIDGE_BASE_DIR", savedBase);
+    restore("AGENTBRIDGE_STATE_DIR", savedState);
+    // Reset to 0 (not undefined): the degraded prune/list path sets process.exitCode = 2,
+    // and Bun — unlike Node — does NOT treat `process.exitCode = undefined` as a reset to
+    // 0, so leaving it undefined leaks exit code 2 to the whole `bun test` run.
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+    void exitCode;
+  });
+
+  /** Write a registry whose JSON parses fine but trips readRegistry's duplicate guard. */
+  function seedDuplicateSlotRegistry() {
+    // Two distinct ids on the SAME slot — readRegistry throws PAIR_REGISTRY_CORRUPT.
+    writeRegistry(base, {
+      version: 1,
+      // Cast: writeRegistry only serializes; the duplicate guard lives in readRegistry.
+      pairs: [pairEntry(0, "alpha-0000aaaa"), pairEntry(0, "beta-1111bbbb")] as PairEntry[],
+    });
+  }
+
+  function seedDuplicatePairIdRegistry() {
+    // Same lowercased pairId on different slots — also a corrupt registry.
+    writeRegistry(base, {
+      version: 1,
+      pairs: [pairEntry(0, "Alpha-0000aaaa"), pairEntry(1, "alpha-0000aaaa")] as PairEntry[],
+    });
+  }
+
+  /** Drop an orphan pair-dir on disk so the disk-scan path has something to find. */
+  function seedOrphanDir(id: string) {
+    mkdirSync(join(base, "pairs", id), { recursive: true });
+  }
+
+  test("`abg pairs` (list) does not crash on a duplicate-slot registry; reports the path + degrades to disk scan", async () => {
+    seedDuplicateSlotRegistry();
+    seedOrphanDir("gamma-2222cccc");
+
+    await expect(runPairs([])).resolves.toBeUndefined();
+
+    const out = [...logs, ...errs].join("\n");
+    // Readable error that names the registry file so the user can find/fix it.
+    expect(out).toContain(join(base, "pairs", "registry.json"));
+    // Degraded to a disk scan — the on-disk pair dir is surfaced.
+    expect(out).toContain("gamma-2222cccc");
+  });
+
+  test("`abg pairs` (list, --json) does not crash on a duplicate-pairId registry", async () => {
+    seedDuplicatePairIdRegistry();
+    seedOrphanDir("delta-3333dddd");
+
+    await expect(runPairs(["--json"])).resolves.toBeUndefined();
+    const out = [...logs, ...errs].join("\n");
+    expect(out).toContain(join(base, "pairs", "registry.json"));
+  });
+
+  test("`abg pairs prune` (dry run) does not crash on a duplicate-slot registry; reports the path + lists disk-scan reclaimable dirs", async () => {
+    seedDuplicateSlotRegistry();
+    seedOrphanDir("gamma-2222cccc");
+
+    await expect(runPairs(["prune"])).resolves.toBeUndefined();
+
+    const out = [...logs, ...errs].join("\n");
+    expect(out).toContain(join(base, "pairs", "registry.json"));
+    // The disk-scan reclamation offers the orphan dir even though the registry is unreadable.
+    expect(out).toContain("gamma-2222cccc");
+    // It must not have crashed with a non-degrading global error.
+    expect(process.exitCode === 1).toBe(false);
+  });
+
+  test("`abg pairs prune --apply` does not crash on a duplicate-slot registry and removes the orphan dir", async () => {
+    seedDuplicateSlotRegistry();
+    seedOrphanDir("gamma-2222cccc");
+
+    await expect(runPairs(["prune", "--apply"])).resolves.toBeUndefined();
+
+    const out = [...logs, ...errs].join("\n");
+    expect(out).toContain(join(base, "pairs", "registry.json"));
+    // The orphan dir is actually removed by the disk-scan path under --apply.
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(join(base, "pairs", "gamma-2222cccc"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## 深扫 round-3 · LOW/MEDIUM

`readRegistry` 对重复 slot/pairId 故意抛 `PAIR_REGISTRY_CORRUPT`。`abg pairs prune` / `prune --apply` / `pairs`(list) 经 readRegistry 但**无 try/catch** → 损坏 registry（手改 / 降级再升级）令这些恢复命令全部崩溃——本该修 registry 的工具自身不可用。`kill --all` 早已降级，`pairs rm` 已有 try/catch；本修补 prune 和 list。

### 修复 / Fix
- `pair-registry.ts`：新增 `removeOrphanPairDirIgnoringRegistry` —— 锁内仅走 liveness gate + removePairDir，**不读 registry**（withRegistryLock 不解析 registry）。
- `cli/pairs.ts`：`isRegistryCorruptError`（按 `PairError.code`）+ `registryPathForNotice`；runPrune/collectRows 包 try/catch，损坏时 stderr 报路径 + `exitCode=2` + 降级磁盘扫描（`--json` stdout 保持合法 JSON）。非损坏错误一律 re-throw。

### Cross-review
2 fresh reviewer 均 **0 REAL**。Reviewer A **端到端实证**：损坏 registry 下 `prune --apply` 保护活 pair 目录、仅删死孤儿（liveness gate = `process.kill(pid,0)` 纯 OS 探测）。Reviewer B：normal path 字节级不变、锁不重入、多 pair 无路径穿越、bundle in-sync、非损坏错误正确 re-throw。

### 测试 / Tests
+7（list/--json/prune-dry/prune-apply under duplicate slot+pairId；liveness gate；details.path）。TDD RED→GREEN。全量 1188 pass / 0 fail。

### Backlog（reviewer RECOMMEND，非阻塞）
CLI 全路径 prune --apply 集成测试（现 live-dir 保护仅函数级 + 手测）；--json test 加 JSON.parse 断言。