### PR TITLE
fix: CodexAdapter.start() 失败即 teardown 幂等化 + 修 boot 重试期误发 Codex-exit 警告 / idempotent start() teardown + gate codex-exit notice

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14385,7 +14385,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("a9d6d9c", "source"),
+  commit: defineString("b53f10a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -22,7 +22,7 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("a9d6d9c", "source"),
+  commit: defineString("b53f10a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION)
 });
@@ -1003,13 +1003,34 @@ class CodexAdapter extends EventEmitter {
   async start() {
     this.intentionalDisconnect = false;
     await this.checkPorts();
-    this.resolveTransport();
-    const listen = codexListenArg(this.transport, this.appPort, this.socketPath ?? "");
-    if (this.transport === "unix" && this.socketPath) {
-      ensureSocketDir(this.socketPath);
-      removeSocketFile(this.socketPath);
+    try {
+      this.resolveTransport();
+      const listen = codexListenArg(this.transport, this.appPort, this.socketPath ?? "");
+      if (this.transport === "unix" && this.socketPath) {
+        ensureSocketDir(this.socketPath);
+        removeSocketFile(this.socketPath);
+      }
+      this.log(`Spawning codex app-server (transport=${this.transport}) --listen ${listen}`);
+      this.spawnAppServer(listen);
+      if (this.transport === "unix" && this.socketPath) {
+        await waitForUnixWsReady(this.socketPath);
+        this.relay = new TcpToUnixRelay("127.0.0.1", this.appPort, this.socketPath, (m) => this.log(`[relay] ${m}`));
+        await this.relay.start();
+        this.log(`Transport relay ready: ws://127.0.0.1:${this.appPort} \u2192 unix://${this.socketPath}`);
+      } else {
+        await this.waitForHealthy();
+      }
+      await this.connectToAppServer();
+      this.startProxy();
+      this.log(`Proxy ready on ${this.proxyUrl}`);
+    } catch (err) {
+      const m = err instanceof Error ? err.message : String(err);
+      this.log(`start() failed (${m}) \u2014 tearing down partial transport before rethrow`);
+      this.cleanupAfterFailedStart();
+      throw err;
     }
-    this.log(`Spawning codex app-server (transport=${this.transport}) --listen ${listen}`);
+  }
+  spawnAppServer(listen) {
     this.proc = spawn("codex", ["app-server", "--listen", listen], {
       stdio: ["pipe", "pipe", "pipe"]
     });
@@ -1023,17 +1044,25 @@ class CodexAdapter extends EventEmitter {
     stderrRl.on("line", (l) => this.log(`[codex-server] ${l}`));
     const stdoutRl = createInterface({ input: this.proc.stdout });
     stdoutRl.on("line", (l) => this.log(`[codex-stdout] ${l}`));
-    if (this.transport === "unix" && this.socketPath) {
-      await waitForUnixWsReady(this.socketPath);
-      this.relay = new TcpToUnixRelay("127.0.0.1", this.appPort, this.socketPath, (m) => this.log(`[relay] ${m}`));
-      await this.relay.start();
-      this.log(`Transport relay ready: ws://127.0.0.1:${this.appPort} \u2192 unix://${this.socketPath}`);
-    } else {
-      await this.waitForHealthy();
+  }
+  teardownTransport() {
+    this.proxyServer?.stop();
+    this.proxyServer = null;
+    if (this.relay) {
+      this.relay.stop();
+      this.relay = null;
     }
-    await this.connectToAppServer();
-    this.startProxy();
-    this.log(`Proxy ready on ${this.proxyUrl}`);
+    if (this.socketPath)
+      removeSocketFile(this.socketPath);
+  }
+  cleanupAfterFailedStart() {
+    try {
+      this.teardownTransport();
+    } catch (e) {
+      this.log(`cleanupAfterFailedStart: teardownTransport error: ${e.message}`);
+    }
+    this.forceKillAppServerSync();
+    this.proc = null;
   }
   resolveTransport() {
     const mode = parseTransportMode(process.env[CODEX_TRANSPORT_ENV]);
@@ -1057,14 +1086,7 @@ class CodexAdapter extends EventEmitter {
       } catch {}
       this.secondaryConnections.delete(id);
     }
-    this.proxyServer?.stop();
-    this.proxyServer = null;
-    if (this.relay) {
-      this.relay.stop();
-      this.relay = null;
-    }
-    if (this.socketPath)
-      removeSocketFile(this.socketPath);
+    this.teardownTransport();
     this.clearResponseTrackingState();
     this.resetTurnState(ADAPTER_DISCONNECT_REASON);
   }
@@ -5293,6 +5315,7 @@ codex.on("error", (err) => {
 });
 codex.on("exit", (code) => {
   log(`Codex process exited (code ${code})`);
+  const wasBootstrapped = codexBootstrapped;
   codexBootstrapped = false;
   replyTracker.reset();
   idempotencyTracker.terminateAll("aborted");
@@ -5301,9 +5324,13 @@ codex.on("exit", (code) => {
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
-  emitToClaude(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running. ` + `Restart the Codex side (\`agentbridge codex\`); if it does not come back within ` + `${Math.round(BOOTSTRAP_TIMEOUT_MS / 1000)}s the daemon will self-replace so the next launch starts clean.`));
+  if (wasBootstrapped) {
+    emitToClaude(systemMessage("system_codex_exit", `\u26A0\uFE0F Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running. ` + `Restart the Codex side (\`agentbridge codex\`); if it does not come back within ` + `${Math.round(BOOTSTRAP_TIMEOUT_MS / 1000)}s the daemon will self-replace so the next launch starts clean.`));
+  }
   broadcastStatus();
-  armBootDeadline();
+  if (wasBootstrapped) {
+    armBootDeadline();
+  }
 });
 function startControlServer() {
   let server;

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -299,14 +299,55 @@ export class CodexAdapter extends EventEmitter {
     // in unix mode the relay (not Codex) binds appPort, but the port must still
     // be free for the relay to bind it; proxyPort is always ours.
     await this.checkPorts();
-    this.resolveTransport();
+    // Wrap the rest of bootstrap so a partial failure tears down whatever was
+    // already stood up (relay/socket/spawned child/proxy) BEFORE rethrowing.
+    // Otherwise — in unix mode especially — start() leaks the relay (a net.Server
+    // bound on appPort inside the daemon's OWN process) plus the live codex child
+    // when connectToAppServer rejects. bootCodex then retries start(), whose first
+    // step checkPorts() sees the daemon's own pid holding appPort with a
+    // `bun .../daemon.js` cmdline (NOT a `codex app-server` cmdline), classifies
+    // it as a foreign process and THROWS "already in use by non-Codex process".
+    // Every retry would then fail immediately at checkPorts, wasting the whole
+    // backoff. Making start() idempotent on the failure path lets retries proceed
+    // against a clean slate.
+    try {
+      this.resolveTransport();
 
-    const listen = codexListenArg(this.transport, this.appPort, this.socketPath ?? "");
-    if (this.transport === "unix" && this.socketPath) {
-      ensureSocketDir(this.socketPath);
-      removeSocketFile(this.socketPath); // clear any stale socket from a prior run
+      const listen = codexListenArg(this.transport, this.appPort, this.socketPath ?? "");
+      if (this.transport === "unix" && this.socketPath) {
+        ensureSocketDir(this.socketPath);
+        removeSocketFile(this.socketPath); // clear any stale socket from a prior run
+      }
+      this.log(`Spawning codex app-server (transport=${this.transport}) --listen ${listen}`);
+      this.spawnAppServer(listen);
+
+      if (this.transport === "unix" && this.socketPath) {
+        // Codex's unix listener does NOT serve HTTP /healthz — probe readiness via
+        // a WS upgrade against the socket, then stand up the TCP↔unix relay so the
+        // adapter's unchanged `new WebSocket(ws://127.0.0.1:appPort)` reaches it.
+        await waitForUnixWsReady(this.socketPath);
+        this.relay = new TcpToUnixRelay("127.0.0.1", this.appPort, this.socketPath, (m) => this.log(`[relay] ${m}`));
+        await this.relay.start();
+        this.log(`Transport relay ready: ws://127.0.0.1:${this.appPort} → unix://${this.socketPath}`);
+      } else {
+        await this.waitForHealthy();
+      }
+
+      // Connect to app-server once, keep it alive permanently
+      await this.connectToAppServer();
+
+      this.startProxy();
+      this.log(`Proxy ready on ${this.proxyUrl}`);
+    } catch (err) {
+      const m = err instanceof Error ? err.message : String(err);
+      this.log(`start() failed (${m}) — tearing down partial transport before rethrow`);
+      this.cleanupAfterFailedStart();
+      throw err; // bootCodex still sees the failure and retries — now clean.
     }
-    this.log(`Spawning codex app-server (transport=${this.transport}) --listen ${listen}`);
+  }
+
+  /** Spawn the `codex app-server` child and wire its lifecycle/log handlers. */
+  private spawnAppServer(listen: string) {
     this.proc = spawn("codex", ["app-server", "--listen", listen], {
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -326,24 +367,43 @@ export class CodexAdapter extends EventEmitter {
     stderrRl.on("line", (l) => this.log(`[codex-server] ${l}`));
     const stdoutRl = createInterface({ input: this.proc.stdout! });
     stdoutRl.on("line", (l) => this.log(`[codex-stdout] ${l}`));
+  }
 
-    if (this.transport === "unix" && this.socketPath) {
-      // Codex's unix listener does NOT serve HTTP /healthz — probe readiness via
-      // a WS upgrade against the socket, then stand up the TCP↔unix relay so the
-      // adapter's unchanged `new WebSocket(ws://127.0.0.1:appPort)` reaches it.
-      await waitForUnixWsReady(this.socketPath);
-      this.relay = new TcpToUnixRelay("127.0.0.1", this.appPort, this.socketPath, (m) => this.log(`[relay] ${m}`));
-      await this.relay.start();
-      this.log(`Transport relay ready: ws://127.0.0.1:${this.appPort} → unix://${this.socketPath}`);
-    } else {
-      await this.waitForHealthy();
+  /**
+   * Tear down the proxy + transport relay + unix socket file. Shared by the
+   * graceful disconnect() path and the start()-failure cleanup. Does NOT touch
+   * the spawned codex child (callers decide whether the child should die).
+   */
+  private teardownTransport() {
+    this.proxyServer?.stop();
+    this.proxyServer = null;
+    // #85: tear down the transport relay and remove the unix socket file.
+    if (this.relay) {
+      this.relay.stop();
+      this.relay = null;
     }
+    if (this.socketPath) removeSocketFile(this.socketPath);
+  }
 
-    // Connect to app-server once, keep it alive permanently
-    await this.connectToAppServer();
-
-    this.startProxy();
-    this.log(`Proxy ready on ${this.proxyUrl}`);
+  /**
+   * Idempotent teardown for a partially-constructed start(): tear down the
+   * transport (proxy/relay/socket) AND kill the spawned codex child. Unlike
+   * stop()'s graceful SIGTERM-then-SIGKILL dance, this synchronously SIGKILLs
+   * the child via the retained pid: the daemon is about to retry start(), so the
+   * port (and socket) must be free NOW — a lingering SIGTERM grace window would
+   * keep the next checkPorts/relay.bind failing. Best-effort and non-throwing so
+   * the original start() error is the one that propagates.
+   */
+  private cleanupAfterFailedStart() {
+    try {
+      this.teardownTransport();
+    } catch (e) {
+      this.log(`cleanupAfterFailedStart: teardownTransport error: ${(e as Error).message}`);
+    }
+    // Kill the spawned child synchronously (reuses the retained-pid SIGKILL the
+    // daemon's exit handler relies on) and drop the proc reference.
+    this.forceKillAppServerSync();
+    this.proc = null;
   }
 
   /** #85: resolve the transport (env-driven, `auto` probes ws support) and the unix socket path. */
@@ -375,14 +435,7 @@ export class CodexAdapter extends EventEmitter {
       try { sec.appServerWs?.close(); } catch {}
       this.secondaryConnections.delete(id);
     }
-    this.proxyServer?.stop();
-    this.proxyServer = null;
-    // #85: tear down the transport relay and remove the unix socket file.
-    if (this.relay) {
-      this.relay.stop();
-      this.relay = null;
-    }
-    if (this.socketPath) removeSocketFile(this.socketPath);
+    this.teardownTransport();
     this.clearResponseTrackingState();
     // #69: an intentional disconnect must synchronously drop turn state +
     // watchdog timers. We cannot rely on handleAppServerClose for this: we set

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -605,6 +605,15 @@ codex.on("error", (err: Error) => {
 
 codex.on("exit", (code: number | null) => {
   log(`Codex process exited (code ${code})`);
+  // Distinguish "a previously-healthy Codex died" from "a still-booting Codex was
+  // killed by cleanupAfterFailedStart() during an in-progress boot retry". The state
+  // cleanup below is correct either way (the child is gone), but the user-facing
+  // "restart it manually" warning and the boot-deadline re-arm must only fire for the
+  // former — during boot, bootCodex's own retry loop + the boot deadline armed before
+  // bootCodex() already govern recovery, and a retry may bring Codex up cleanly, so
+  // telling the user to restart (and resetting the deadline each failed attempt) would
+  // be misleading.
+  const wasBootstrapped = codexBootstrapped;
   codexBootstrapped = false;
   replyTracker.reset(); // any in-flight require_reply turn is gone with the process
   // The process is gone — every pending/running idempotency key is terminal,
@@ -615,19 +624,23 @@ codex.on("exit", (code: number | null) => {
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
-  emitToClaude(
-    systemMessage(
-      "system_codex_exit",
-      `⚠️ Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running. ` +
-        `Restart the Codex side (\`agentbridge codex\`); if it does not come back within ` +
-        `${Math.round(BOOTSTRAP_TIMEOUT_MS / 1000)}s the daemon will self-replace so the next launch starts clean.`,
-    ),
-  );
+  if (wasBootstrapped) {
+    emitToClaude(
+      systemMessage(
+        "system_codex_exit",
+        `⚠️ Codex app-server exited (code ${code ?? "unknown"}). AgentBridge daemon is still running. ` +
+          `Restart the Codex side (\`agentbridge codex\`); if it does not come back within ` +
+          `${Math.round(BOOTSTRAP_TIMEOUT_MS / 1000)}s the daemon will self-replace so the next launch starts clean.`,
+      ),
+    );
+  }
   broadcastStatus();
-  // Codex died after a successful boot (a dead proc is not auto-respawned). Re-arm
-  // the readiness watchdog so that if it does not come back and no TUI is using us,
-  // the daemon self-exits instead of lingering as a healthz-200/readyz-503 zombie.
-  armBootDeadline();
+  if (wasBootstrapped) {
+    // Codex died after a successful boot (a dead proc is not auto-respawned). Re-arm
+    // the readiness watchdog so that if it does not come back and no TUI is using us,
+    // the daemon self-exits instead of lingering as a healthz-200/readyz-503 zombie.
+    armBootDeadline();
+  }
 });
 
 function startControlServer() {

--- a/src/integration-test/daemon-wiring.test.ts
+++ b/src/integration-test/daemon-wiring.test.ts
@@ -133,6 +133,88 @@ describe("daemon wiring", () => {
     expect(aborted.content).toContain("retry");
   }, 20000);
 
+  // --- Regression: codex 'exit' during a boot retry must NOT warn (S1 fix) ---
+  //
+  // The teardown-on-failed-start fix SIGKILLs a partially-constructed codex child,
+  // which fires the daemon's codex.on("exit") DURING bootCodex's retry loop (before
+  // codexBootstrapped flips true). The pre-fix handler emitted the misleading
+  // "⚠️ Codex app-server exited … restart it manually" warning unconditionally even
+  // though the very next retry brought Codex up cleanly. The gate
+  // (`if (wasBootstrapped) emit(system_codex_exit)`) must suppress that warning.
+  //
+  // Driven end-to-end: the fail-first fixture refuses the FIRST WS upgrade so
+  // start() rejects → cleanupAfterFailedStart SIGKILLs the child → codex 'exit'
+  // with codexBootstrapped===false; the retry boots clean and the harness reaches
+  // readyz-200. A pre-fix unconditional emit would have BUFFERED a system_codex_exit
+  // before the (later) system_waiting, so it would flush to Claude on attach.
+  test("codex 'exit' during a boot retry (codexBootstrapped=false) does NOT emit system_codex_exit", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-bootexit-fixture-"));
+    const failCounter = join(fixtureRoot, "spawn-count.txt");
+    try {
+      const harness = await startHarness({
+        pairId: "main-bootexit1",
+        pairName: "main",
+        extraEnv: {
+          FAKE_CODEX_FAIL_FIRST_BOOT: failCounter,
+          // Keep the self-exit watchdog comfortably above the 1s retry backoff so a
+          // single failed attempt + retry boots well within the bootstrap deadline.
+          AGENTBRIDGE_BOOTSTRAP_TIMEOUT_MS: "20000",
+        },
+      });
+
+      // The harness only returns once readyz-200 with the spawned pid — i.e. the
+      // RETRY succeeded after the first boot was killed. The fixture must have been
+      // spawned at least twice (first failing, second clean).
+      const spawnCount = Number(readFileSync(failCounter, "utf-8").trim());
+      expect(spawnCount).toBeGreaterThanOrEqual(2);
+
+      // Attach: the daemon flushes everything buffered during boot. The genuine
+      // boot notice (system_waiting) must arrive; the misleading boot-retry death
+      // warning (system_codex_exit) must NOT.
+      await harness.attachClaude();
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_waiting_"),
+        "system_waiting after a recovered boot retry",
+      );
+      // Give any (erroneously buffered) exit warning the same flush window to land.
+      await sleep(200);
+      expect(harness.messages.some((m) => m.id.startsWith("system_codex_exit"))).toBe(false);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 45000);
+
+  // --- Regression complement: a POST-bootstrap codex death MUST warn (S1 fix) ---
+  //
+  // The other half of the gate: once codexBootstrapped===true, a real Codex process
+  // death IS a "restart it manually" situation, so the warning must still fire. This
+  // proves the gate suppresses ONLY the boot-retry case, not every exit. The fixture
+  // `exit-process` command makes the live app-server child truly exit after boot.
+  test("codex 'exit' after a successful bootstrap (codexBootstrapped=true) DOES emit system_codex_exit", async () => {
+    const harness = await startHarness({ pairId: "main-postexit1", pairName: "main" });
+
+    await harness.attachClaude();
+    await harness.connectTui();
+    await waitForMessage(
+      harness.messages,
+      (message) => message.id.startsWith("system_waiting_"),
+      "system_waiting after a clean boot",
+    );
+
+    // Kill the app-server PROCESS (not just the WS): codex.on("exit") fires with
+    // codexBootstrapped===true → the genuine post-boot death warning.
+    harness.sendAppCommand("exit-process");
+
+    const exitWarning = await waitForMessage(
+      harness.messages,
+      (message) => message.id.startsWith("system_codex_exit"),
+      "system_codex_exit after a post-bootstrap Codex death",
+    );
+    expect(exitWarning.content).toContain("Codex app-server exited");
+    expect(exitWarning.content).toContain("agentbridge codex");
+  }, 45000);
+
   test("filtered routing buffers STATUS, flushes it on IMPORTANT, then buffers STATUS during attention", async () => {
     const harness = await startHarness({
       pairId: "main-routeabcd",

--- a/src/integration-test/fixtures/fake-codex.ts
+++ b/src/integration-test/fixtures/fake-codex.ts
@@ -40,9 +40,22 @@
  *  - FAKE_APP_TURNINTERRUPT_LOG append turn/interrupt params (command-driven)
  *  - FAKE_APP_TURNSTEER_LOG     append turn/steer params (command-driven)
  *  - FAKE_APP_INTERRUPT_DELAY_MS defer the interrupt terminal boundary (command-driven)
+ *  - FAKE_CODEX_FAIL_FIRST_BOOT path to a spawn-counter file. When set, the FIRST
+ *                               spawned app-server instance refuses the WS upgrade
+ *                               so the daemon's codex.start() rejects fast (driving
+ *                               cleanupAfterFailedStart → SIGKILL → codex 'exit'
+ *                               during an in-progress boot retry); subsequent spawns
+ *                               (the retry) boot normally. Lets tests reproduce a
+ *                               fail-once-then-recover boot without a 10s healthz wait.
+ *
+ * Command-file commands (command-driven, one per line, file is consumed each poll):
+ *  - start-turn / complete-turn / agent-message:<text> / close-app-server (WS only)
+ *  - exit-process               the app-server PROCESS exits (process.exit(0)),
+ *                               firing the daemon's codex 'exit' AFTER a successful
+ *                               bootstrap (the genuine post-boot Codex-death path).
  */
 
-import { appendFileSync, existsSync, readFileSync, unlinkSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 
 export type FakeCodexCapability = "minimal" | "handshake" | "command-driven";
 
@@ -93,6 +106,26 @@ function main(): void {
   const turnInterruptLog = process.env.FAKE_APP_TURNINTERRUPT_LOG;
   const turnSteerLog = process.env.FAKE_APP_TURNSTEER_LOG;
   const interruptDelayMs = Number(process.env.FAKE_APP_INTERRUPT_DELAY_MS || 0);
+
+  // Fail-first-boot lever: count spawns via a shared file; the FIRST spawned
+  // instance refuses the WS upgrade so the daemon's start() rejects fast (a boot
+  // retry), exercising the codex 'exit'-during-boot path. The retry's instance
+  // sees count>0 and boots normally. The counter is bumped synchronously at spawn
+  // time (before serving) so the very first connection attempt already fails.
+  const failFirstBootFile = process.env.FAKE_CODEX_FAIL_FIRST_BOOT;
+  let isFirstFailingBoot = false;
+  if (failFirstBootFile) {
+    let priorSpawns = 0;
+    try {
+      priorSpawns = Number(readFileSync(failFirstBootFile, "utf-8").trim()) || 0;
+    } catch {
+      priorSpawns = 0;
+    }
+    isFirstFailingBoot = priorSpawns === 0;
+    try {
+      writeFileSync(failFirstBootFile, String(priorSpawns + 1));
+    } catch {}
+  }
 
   // Single live app-server WS — the daemon keeps ONE persistent connection.
   let appWs: import("bun").ServerWebSocket<unknown> | null = null;
@@ -204,6 +237,12 @@ function main(): void {
       if (url.pathname === "/healthz" || url.pathname === "/readyz") {
         return Response.json({ ok: true });
       }
+      // Fail-first-boot: healthz stays green (waitForHealthy passes) but the WS
+      // upgrade is refused, so connectToAppServer rejects almost immediately —
+      // start() then throws and the daemon SIGKILLs this child during its retry.
+      if (isFirstFailingBoot) {
+        return new Response("fake codex app-server: refusing first-boot upgrade", { status: 503 });
+      }
       if (serverInstance.upgrade(req)) return undefined;
       return new Response("fake codex app-server");
     },
@@ -229,6 +268,13 @@ function main(): void {
       try {
         unlinkSync(commandFile);
       } catch {}
+      if (command === "exit-process") {
+        // Kill the whole app-server PROCESS (not just the WS): the daemon's
+        // codex child truly dies, firing codex 'exit' AFTER a successful boot —
+        // the genuine "a previously-healthy Codex died" path. Handled before the
+        // appWs guard so it works regardless of WS state.
+        process.exit(0);
+      }
       const ws = appWs;
       if (!ws) return;
       if (command === "start-turn") {

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -4,7 +4,9 @@ import { mkdtempSync } from "node:fs";
 import { createServer, Socket, type AddressInfo, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { existsSync, writeFileSync } from "node:fs";
 import { CodexAdapter } from "../codex-adapter";
+import { TcpToUnixRelay } from "../codex-transport";
 import { CLIENT_REPLY_TIMEOUT_MS, MAX_INTERRUPT_TIMEOUT_MS } from "../interrupt-timing";
 
 // Hermetic log sink: the constructor's default logFile resolves the REAL pair
@@ -3154,5 +3156,137 @@ describe("CodexAdapter agentMessageBuffers lifecycle (LOW-3)", () => {
     });
     expect(adapter.agentMessageBuffers.size).toBe(0);
     expect(emitted).toEqual(["hello"]);
+  });
+});
+
+describe("CodexAdapter.start() teardown-on-failure (idempotent retry)", () => {
+  // Bind a relay on a free port (so we don't collide with the adapter's fixed
+  // 4510/4511 test ports or a live daemon). Returns the port and the relay.
+  async function bindRelayOnFreePort(socketPath: string): Promise<{ port: number; relay: TcpToUnixRelay }> {
+    // Find a free port via an ephemeral net.Server, then close it and reuse the
+    // number for the relay (tiny TOCTOU race acceptable in a unit test).
+    const probe: Server = await new Promise((resolve, reject) => {
+      const s = createServer();
+      s.once("error", reject);
+      s.listen(0, "127.0.0.1", () => resolve(s));
+    });
+    const port = (probe.address() as AddressInfo).port;
+    await new Promise<void>((r) => probe.close(() => r()));
+
+    const relay = new TcpToUnixRelay("127.0.0.1", port, socketPath, () => {});
+    await relay.start();
+    return { port, relay };
+  }
+
+  function portIsBindable(port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const s = createServer();
+      s.once("error", () => resolve(false));
+      s.listen(port, "127.0.0.1", () => s.close(() => resolve(true)));
+    });
+  }
+
+  test("cleanupAfterFailedStart releases appPort, removes socket, kills child", async () => {
+    const adapter = createAdapter();
+    const socketPath = join(
+      mkdtempSync(join(tmpdir(), "abg-failstart-")),
+      "codex.sock",
+    );
+    // A real on-disk file standing in for a created unix socket — the cleanup
+    // must remove whatever path it tracks. (The relay binds the TCP side; the
+    // socket file is the unix side the spawn would have created.)
+    writeFileSync(socketPath, "");
+    expect(existsSync(socketPath)).toBe(true);
+
+    const { port, relay } = await bindRelayOnFreePort(socketPath);
+    // Before cleanup the relay holds the port — it is NOT bindable.
+    expect(await portIsBindable(port)).toBe(false);
+
+    // Stand-in for the spawned `codex app-server` child that start() leaves
+    // running when connectToAppServer rejects.
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1 << 30)"], {
+      stdio: "ignore",
+    });
+    const exited = new Promise<{ signal: NodeJS.Signals | null }>((resolve) => {
+      child.on("exit", (_code, signal) => resolve({ signal }));
+    });
+    await sleep(100);
+
+    // Wire the partially-constructed transport exactly as a failed unix start()
+    // would leave it.
+    adapter.relay = relay;
+    adapter.socketPath = socketPath;
+    adapter.appServerPid = child.pid;
+    adapter.proc = child;
+
+    adapter.cleanupAfterFailedStart();
+
+    // Relay torn down → port becomes bindable again (a retry's checkPorts can
+    // proceed instead of hitting "non-Codex process").
+    // The OS may take a moment to release the listening socket.
+    let bindable = false;
+    for (let i = 0; i < 20 && !bindable; i++) {
+      bindable = await portIsBindable(port);
+      if (!bindable) await sleep(50);
+    }
+    expect(bindable).toBe(true);
+
+    // Socket file removed, relay reference cleared.
+    expect(existsSync(socketPath)).toBe(false);
+    expect(adapter.relay).toBeNull();
+
+    // Spawned child SIGKILLed.
+    const result = await Promise.race([
+      exited,
+      sleep(3000).then(() => ({ signal: "TIMEOUT" as unknown as NodeJS.Signals })),
+    ]);
+    expect(result.signal).toBe("SIGKILL");
+  });
+
+  test("start() catch tears down the partial transport and rethrows the original error", async () => {
+    const adapter = createAdapter();
+    let cleanupCalls = 0;
+    const original = adapter.cleanupAfterFailedStart.bind(adapter);
+    adapter.cleanupAfterFailedStart = () => {
+      cleanupCalls++;
+      return original();
+    };
+
+    // Drive start() into its body but fail BEFORE any real `codex` spawn:
+    // checkPorts resolves, then resolveTransport throws. The catch must run
+    // cleanup and rethrow the SAME error (so bootCodex still sees the failure).
+    adapter.checkPorts = async () => {};
+    const boom = new Error("resolveTransport boom");
+    adapter.resolveTransport = () => { throw boom; };
+
+    await expect(adapter.start()).rejects.toBe(boom);
+    expect(cleanupCalls).toBe(1);
+  });
+
+  test("start() does NOT tear down a healthy transport", async () => {
+    const adapter = createAdapter();
+    let cleanupCalls = 0;
+    const original = adapter.cleanupAfterFailedStart.bind(adapter);
+    adapter.cleanupAfterFailedStart = () => {
+      cleanupCalls++;
+      return original();
+    };
+
+    // All steps succeed → the success path must never call cleanup.
+    adapter.checkPorts = async () => {};
+    adapter.resolveTransport = () => { adapter.transport = "ws"; adapter.socketPath = null; };
+    // Skip the real spawn + health wait + connect + proxy.
+    const fakeProc: any = { pid: 4242, stderr: null, stdout: null, on() {} };
+    adapter.spawnAppServer = () => { adapter.proc = fakeProc; adapter.appServerPid = 4242; };
+    adapter.waitForHealthy = async () => {};
+    adapter.connectToAppServer = async () => {};
+    adapter.startProxy = () => {};
+
+    await adapter.start();
+    expect(cleanupCalls).toBe(0);
+
+    // Healthy transport left intact.
+    expect(adapter.proc).toBe(fakeProc);
+    expect(adapter.appServerPid).toBe(4242);
   });
 });


### PR DESCRIPTION
## 深扫 round-3 MEDIUM（codex-adapter）+ cross-review S1（daemon）

### start() teardown（codex-adapter.ts）
start() 无 try/catch；unix transport 模式先 bind relay（daemon 进程内 net.Server 占 appPort）+ spawn 子进程，再 connectToAppServer()。后者 reject → start() 抛错但 relay 仍 bound + 子进程仍活 → bootCodex 重试的 checkPorts() 见 appPort 被 daemon 自身 pid 占 → 判 foreign 抛错 → 废掉所有重试。**修复**：start() body 包 try/catch，失败即 cleanupAfterFailedStart()（teardownTransport[与 disconnect() 共享] + forceKillAppServerSync + null proc）再 rethrow 原错，幂等化。WS 模式无 relay 不受影响。

### S1（daemon.ts — 本 PR 引入的回归，cross-review round-1 发现）
上面的 SIGKILL 在 boot 重试期触发子进程 exit → daemon `codex.on("exit")` **无条件**发 `system_codex_exit` "重启 Codex 手动" + 重置 boot deadline，即便重试会干净启动 → 误导用户。**修复**：handler 捕获 `wasBootstrapped`，state cleanup 保持无条件（子进程确已 gone），但 user 警告 + armBootDeadline 门控到 `wasBootstrapped`——只有曾成功 boot 的 Codex 死亡才警告/重新武装。

### 测试 / Tests
+3 unit（teardown：端口可重 bind / catch rethrow 原错 / 成功路径不清理）+2 integration（daemon-wiring：boot 重试期 exit 不发 system_codex_exit；boot 后 exit 发）+ fixture FAKE_CODEX_FAIL_FIRST_BOOT/exit-process。TDD RED→GREEN。全量 1186 pass / 0 fail。

### Cross-review
round-1：Reviewer A 0 REAL（8 点 lifecycle 全清）；Reviewer B 抓 **S1 真实回归**（已修+加集成测试）。**round-2（2 fresh reviewer）进行中**。