### PR TITLE
fix: 运行时 drift 检测改用源码树 codeHash 取代 commit stamp / runtime drift keys on source-tree codeHash instead of commit stamp

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14372,6 +14372,11 @@ function formatBytes(bytes) {
 var CONTRACT_VERSION = 1;
 
 // src/build-info.ts
+var CODE_HASH_SENTINEL = "source";
+function hasValidCodeHash(build) {
+  const hash = build?.codeHash;
+  return typeof hash === "string" && hash.length > 0 && hash !== CODE_HASH_SENTINEL;
+}
 function defineString(value, fallback) {
   return typeof value === "string" && value.length > 0 ? value : fallback;
 }
@@ -14385,14 +14390,22 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("b53f10a", "source"),
+  commit: defineString("956afd9", "source"),
   bundle: defineBundle("plugin"),
-  contractVersion: defineNumber(1, CONTRACT_VERSION)
+  contractVersion: defineNumber(1, CONTRACT_VERSION),
+  codeHash: defineString("6995f3d2a6ab", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)
     return false;
-  return a.version === b.version && a.commit === b.commit && a.contractVersion === b.contractVersion;
+  if (a.version !== b.version || a.contractVersion !== b.contractVersion)
+    return false;
+  if (hasValidCodeHash(a) && hasValidCodeHash(b))
+    return a.codeHash === b.codeHash;
+  return a.commit === b.commit;
+}
+function runtimeContractComparisonBasis(a, b) {
+  return hasValidCodeHash(a) && hasValidCodeHash(b) ? "codeHash" : "commit";
 }
 function compatibleContractVersion(a, b) {
   if (!a || !b)
@@ -14402,7 +14415,8 @@ function compatibleContractVersion(a, b) {
 function formatBuildInfo(build) {
   if (!build)
     return "<unknown>";
-  return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}`;
+  const codeHash = hasValidCodeHash(build) ? `/code-${build.codeHash}` : "";
+  return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}${codeHash}`;
 }
 
 // src/daemon-client.ts
@@ -14977,9 +14991,10 @@ function classifyDaemon(expectedPairId, status, buildInfo) {
         reason: "runtime build drift has a compatible contract and a live Codex TUI is attached"
       };
     }
+    const basis = runtimeContractComparisonBasis(status.build, buildInfo) === "codeHash" ? "compared by codeHash" : "compared by commit stamp; legacy build without codeHash";
     return {
       verdict: "replace-drifted",
-      reason: `runtime build ${formatBuildInfo(status.build)} does not match launcher ${formatBuildInfo(buildInfo)}`
+      reason: `runtime build ${formatBuildInfo(status.build)} does not match launcher ` + `${formatBuildInfo(buildInfo)} (${basis})`
     };
   }
   return { verdict: "reuse", reason: "daemon pair and runtime contract match" };

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -9,6 +9,11 @@ import { randomUUID as randomUUID4 } from "crypto";
 var CONTRACT_VERSION = 1;
 
 // src/build-info.ts
+var CODE_HASH_SENTINEL = "source";
+function hasValidCodeHash(build) {
+  const hash = build?.codeHash;
+  return typeof hash === "string" && hash.length > 0 && hash !== CODE_HASH_SENTINEL;
+}
 function defineString(value, fallback) {
   return typeof value === "string" && value.length > 0 ? value : fallback;
 }
@@ -22,9 +27,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("b53f10a", "source"),
+  commit: defineString("956afd9", "source"),
   bundle: defineBundle("plugin"),
-  contractVersion: defineNumber(1, CONTRACT_VERSION)
+  contractVersion: defineNumber(1, CONTRACT_VERSION),
+  codeHash: defineString("6995f3d2a6ab", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -32,7 +38,14 @@ function daemonStatusBuildInfo() {
 function sameRuntimeContract(a, b) {
   if (!a || !b)
     return false;
-  return a.version === b.version && a.commit === b.commit && a.contractVersion === b.contractVersion;
+  if (a.version !== b.version || a.contractVersion !== b.contractVersion)
+    return false;
+  if (hasValidCodeHash(a) && hasValidCodeHash(b))
+    return a.codeHash === b.codeHash;
+  return a.commit === b.commit;
+}
+function runtimeContractComparisonBasis(a, b) {
+  return hasValidCodeHash(a) && hasValidCodeHash(b) ? "codeHash" : "commit";
 }
 function compatibleContractVersion(a, b) {
   if (!a || !b)
@@ -42,7 +55,8 @@ function compatibleContractVersion(a, b) {
 function formatBuildInfo(build) {
   if (!build)
     return "<unknown>";
-  return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}`;
+  const codeHash = hasValidCodeHash(build) ? `/code-${build.codeHash}` : "";
+  return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}${codeHash}`;
 }
 
 // src/daemon-record.ts
@@ -2954,9 +2968,10 @@ function classifyDaemon(expectedPairId, status, buildInfo) {
         reason: "runtime build drift has a compatible contract and a live Codex TUI is attached"
       };
     }
+    const basis = runtimeContractComparisonBasis(status.build, buildInfo) === "codeHash" ? "compared by codeHash" : "compared by commit stamp; legacy build without codeHash";
     return {
       verdict: "replace-drifted",
-      reason: `runtime build ${formatBuildInfo(status.build)} does not match launcher ${formatBuildInfo(buildInfo)}`
+      reason: `runtime build ${formatBuildInfo(status.build)} does not match launcher ` + `${formatBuildInfo(buildInfo)} (${basis})`
     };
   }
   return { verdict: "reuse", reason: "daemon pair and runtime contract match" };

--- a/scripts/build-bundles.mjs
+++ b/scripts/build-bundles.mjs
@@ -2,7 +2,11 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { chmodSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const { computeCodeHash } = require("./code-hash.cjs");
 
 const repoRoot = resolve(new URL("..", import.meta.url).pathname);
 const pkg = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf-8"));
@@ -57,12 +61,25 @@ function gitCommit() {
   }
 }
 
+// Stamp-independent code identity (see scripts/code-hash.cjs): the SAME value
+// for every target of this build, and for any rebuild of identical source —
+// regardless of git sha or AGENTBRIDGE_BUILD_COMMIT_OVERRIDE. Computed once
+// per build invocation.
+let cachedCodeHash = null;
+function codeHash() {
+  if (cachedCodeHash === null) {
+    cachedCodeHash = computeCodeHash(repoRoot);
+  }
+  return cachedCodeHash;
+}
+
 function defineArgs(bundle) {
   const defines = {
     __AGENTBRIDGE_BUILD_VERSION__: pkg.version,
     __AGENTBRIDGE_BUILD_COMMIT__: gitCommit(),
     __AGENTBRIDGE_BUILD_BUNDLE__: bundle,
     __AGENTBRIDGE_CONTRACT_VERSION__: CONTRACT_VERSION,
+    __AGENTBRIDGE_BUILD_CODEHASH__: codeHash(),
   };
   return Object.entries(defines).flatMap(([key, value]) => [
     "--define",

--- a/scripts/code-hash.cjs
+++ b/scripts/code-hash.cjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Build-input code hash — the stamp-independent code identity behind
+ * `BUILD_INFO.codeHash` (`__AGENTBRIDGE_BUILD_CODEHASH__`).
+ *
+ * Why this exists: the embedded commit stamp is a chicken-and-egg — a bundle
+ * committed in commit X can only ever embed X's PARENT, so under squash-merge
+ * the stamp ALWAYS lags master by one even when the code is byte-identical.
+ * Runtime drift detection that compares stamps therefore replace-wars healthy
+ * daemons (live incident). The fix: hash the BUILD INPUTS instead of stamping
+ * the build OUTPUT, so two builds of the same source get the same identity no
+ * matter which sha (or AGENTBRIDGE_BUILD_COMMIT_OVERRIDE) stamped them.
+ *
+ * Hash inputs (everything that can change bundle bytes, nothing that can't):
+ *   - src non-test .ts files   (the code that gets bundled)
+ *   - package.json             (require()d at runtime by cli/update-notifier;
+ *                               dependency ranges change what gets bundled)
+ *   - bun.lock                 (exact dependency versions are bundled in)
+ *   - the bun version          (a different bundler emits different bytes)
+ * Excluded: src/unit-test/**, src/integration-test/**, *.test.ts — tests never
+ * enter a bundle, so test-only edits must not move the daemon's code identity.
+ * Also (by construction) excluded: git sha, commit override, bundle kind —
+ * these are stamps ABOUT the build, not inputs TO it. This is the same
+ * normalization contract verify-plugin-sync.cjs applies byte-wise (rebuild with
+ * the stamp pinned, then compare content), expressed at the input side.
+ *
+ * Same per-build value for every target (cli/daemon/bridge-plugin/daemon-plugin):
+ * the launcher (cli.js / bridge-server.js) and the daemon (daemon.js) are
+ * DIFFERENT entrypoints, so per-artifact output hashes could never be compared
+ * across the launcher↔daemon /healthz boundary — a source-tree identity can.
+ */
+const { createHash } = require("node:crypto");
+const { existsSync, readdirSync, readFileSync } = require("node:fs");
+const { join, resolve } = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const REPO_ROOT = resolve(__dirname, "..");
+const CODE_HASH_HEX_LENGTH = 12;
+/** Test-only directories under src/ — never bundled, never hashed. */
+const EXCLUDED_SRC_DIRS = new Set(["unit-test", "integration-test"]);
+/** Non-src files whose content changes bundle bytes. */
+const EXTRA_INPUT_FILES = ["package.json", "bun.lock"];
+
+/**
+ * Pure: deterministic sha256 over (path, content) entries, truncated to
+ * 12 hex. Entries are canonically sorted by path and joined with NUL
+ * separators, so the digest is independent of enumeration order and immune
+ * to path/content concatenation ambiguity. Does not mutate `entries`.
+ */
+function computeCodeHashFromEntries(entries) {
+  const sorted = [...entries].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  const hash = createHash("sha256");
+  for (const entry of sorted) {
+    hash.update(entry.path, "utf-8");
+    hash.update("\0");
+    hash.update(entry.content);
+    hash.update("\0");
+  }
+  return hash.digest("hex").slice(0, CODE_HASH_HEX_LENGTH);
+}
+
+/**
+ * Enumerate the build-input files of a repo checkout, as sorted POSIX-style
+ * paths relative to `repoRoot` (stable across platforms and readdir order).
+ * Fails fast when a required input is missing — a silent partial hash would
+ * make two genuinely different builds compare equal.
+ */
+function listCodeHashInputFiles(repoRoot) {
+  const srcRoot = join(repoRoot, "src");
+  if (!existsSync(srcRoot)) {
+    throw new Error(`code-hash: required build input directory src/ not found under ${repoRoot}`);
+  }
+
+  const files = [];
+  const walk = (relDir) => {
+    for (const entry of readdirSync(join(repoRoot, relDir), { withFileTypes: true })) {
+      const rel = `${relDir}/${entry.name}`;
+      if (entry.isDirectory()) {
+        if (EXCLUDED_SRC_DIRS.has(entry.name)) continue;
+        walk(rel);
+      } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+        files.push(rel);
+      }
+    }
+  };
+  walk("src");
+
+  for (const extra of EXTRA_INPUT_FILES) {
+    if (!existsSync(join(repoRoot, extra))) {
+      throw new Error(`code-hash: required build input ${extra} not found under ${repoRoot}`);
+    }
+    files.push(extra);
+  }
+
+  files.sort();
+  return files;
+}
+
+/**
+ * The bundler is itself a build input: the same source compiled by a different
+ * bun emits different bytes. Resolved once per process; injectable via
+ * opts.bunVersion for tests. Fails fast — every caller is about to run
+ * `bun build` anyway, so a missing bun is a hard error either way.
+ */
+let cachedBunVersion = null;
+function resolveBunVersion() {
+  if (cachedBunVersion !== null) return cachedBunVersion;
+  try {
+    cachedBunVersion = execFileSync("bun", ["--version"], {
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch (error) {
+    throw new Error(`code-hash: cannot resolve bun version (it is a build input): ${error.message}`);
+  }
+  return cachedBunVersion;
+}
+
+/**
+ * The source-tree code identity for a repo checkout. Same value for every
+ * build target of one source state; stable across git shas / commit overrides.
+ */
+function computeCodeHash(repoRoot, opts = {}) {
+  const bunVersion = opts.bunVersion ?? resolveBunVersion();
+  const entries = listCodeHashInputFiles(repoRoot).map((path) => ({
+    path,
+    content: readFileSync(join(repoRoot, path)),
+  }));
+  // Virtual entry: "<...>" cannot collide with a real relative path.
+  entries.push({ path: "<bun-version>", content: Buffer.from(bunVersion, "utf-8") });
+  return computeCodeHashFromEntries(entries);
+}
+
+module.exports = { computeCodeHash, computeCodeHashFromEntries, listCodeHashInputFiles };
+
+if (require.main === module) {
+  process.stdout.write(`${computeCodeHash(REPO_ROOT)}\n`);
+}

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -4,6 +4,7 @@ declare const __AGENTBRIDGE_BUILD_VERSION__: string | undefined;
 declare const __AGENTBRIDGE_BUILD_COMMIT__: string | undefined;
 declare const __AGENTBRIDGE_BUILD_BUNDLE__: "source" | "dist" | "plugin" | undefined;
 declare const __AGENTBRIDGE_CONTRACT_VERSION__: number | undefined;
+declare const __AGENTBRIDGE_BUILD_CODEHASH__: string | undefined;
 
 export type AgentBridgeBundleKind = "source" | "dist" | "plugin";
 
@@ -12,6 +13,24 @@ export interface AgentBridgeBuildInfo {
   commit: string;
   bundle: AgentBridgeBundleKind;
   contractVersion: number;
+  /**
+   * Deterministic hash of the BUILD-INPUT source tree (scripts/code-hash.cjs):
+   * sha256 over src non-test .ts files + package.json + bun.lock + bun version,
+   * truncated to 12 hex. Unlike the commit stamp it does not move when only the
+   * git sha moves (squash-merge re-stamps), so it is the authoritative code
+   * identity for drift detection. OPTIONAL because legacy daemons predate the
+   * field; "source" is the unstamped sentinel (dev/source mode).
+   */
+  codeHash?: string;
+}
+
+/** Sentinel for an unstamped (source-mode) build — never a valid code identity. */
+const CODE_HASH_SENTINEL = "source";
+
+/** A codeHash is a usable code identity only when present, non-empty and not the sentinel. */
+export function hasValidCodeHash(build: AgentBridgeBuildInfo | null | undefined): boolean {
+  const hash = build?.codeHash;
+  return typeof hash === "string" && hash.length > 0 && hash !== CODE_HASH_SENTINEL;
 }
 
 function defineString(value: string | undefined, fallback: string): string {
@@ -47,6 +66,15 @@ export const BUILD_INFO: AgentBridgeBuildInfo = Object.freeze({
     typeof __AGENTBRIDGE_CONTRACT_VERSION__ === "number" ? __AGENTBRIDGE_CONTRACT_VERSION__ : undefined,
     CONTRACT_VERSION,
   ),
+  // The fallback MUST be the literal "source" (== CODE_HASH_SENTINEL), not the
+  // constant: bundlers keep the literal inline, which preserves the extractable
+  // stamp shape `codeHash: defineString("<hash>", "source")` that doctor's
+  // artifact-alignment check (and the code-hash build test) regex out of
+  // bundles — exactly like the commit stamp's `defineString("<sha>", "source")`.
+  codeHash: defineString(
+    typeof __AGENTBRIDGE_BUILD_CODEHASH__ === "string" ? __AGENTBRIDGE_BUILD_CODEHASH__ : undefined,
+    "source",
+  ),
 });
 
 export function daemonStatusBuildInfo(): AgentBridgeBuildInfo {
@@ -59,7 +87,8 @@ export function sameBuildInfo(a: AgentBridgeBuildInfo | null | undefined, b: Age
     a.version === b.version &&
     a.commit === b.commit &&
     a.bundle === b.bundle &&
-    a.contractVersion === b.contractVersion
+    a.contractVersion === b.contractVersion &&
+    a.codeHash === b.codeHash
   );
 }
 
@@ -70,20 +99,48 @@ export function sameBuildInfo(a: AgentBridgeBuildInfo | null | undefined, b: Age
  * artifacts built from the same source for the same pair and same control port,
  * so a daemon launched by one must NOT be treated as "drifted" by the other —
  * otherwise the two launchers replace-war each other's daemon on every
- * `ensureRunning` and the Codex TUI can never stay up. Drift that actually
- * matters (a real code change) moves version/commit/contractVersion, which this
- * still detects.
+ * `ensureRunning` and the Codex TUI can never stay up.
+ *
+ * Code identity truth table (after version/contractVersion equality, which is
+ * always required):
+ *
+ *   | a.codeHash | b.codeHash | decided by              | result            |
+ *   |------------|------------|-------------------------|-------------------|
+ *   | valid      | valid      | codeHash (commit IGNORED)| codeHash equality |
+ *   | valid      | missing/sentinel | commit stamp (fallback) | commit equality |
+ *   | missing/sentinel | valid | commit stamp (fallback) | commit equality   |
+ *   | missing/sentinel | missing/sentinel | commit stamp (fallback) | commit equality |
+ *
+ * Why: the committed plugin bundle's commit stamp ALWAYS lags the squash-merged
+ * master sha by one (a bundle committed in X can only embed X's parent), so two
+ * byte-identical builds routinely carry different stamps — comparing stamps made
+ * launchers replace-war perfectly healthy daemons (live incident). The codeHash
+ * is a hash of the build-input source tree and is stable across re-stamps; when
+ * both sides have one it is authoritative. Legacy builds (no codeHash) keep the
+ * historical stamp comparison so old daemons stay classifiable.
  */
 export function sameRuntimeContract(
   a: AgentBridgeBuildInfo | null | undefined,
   b: AgentBridgeBuildInfo | null | undefined,
 ): boolean {
   if (!a || !b) return false;
-  return (
-    a.version === b.version &&
-    a.commit === b.commit &&
-    a.contractVersion === b.contractVersion
-  );
+  if (a.version !== b.version || a.contractVersion !== b.contractVersion) return false;
+  if (hasValidCodeHash(a) && hasValidCodeHash(b)) return a.codeHash === b.codeHash;
+  return a.commit === b.commit;
+}
+
+/**
+ * Which identity {@link sameRuntimeContract} used (or would use) for the code
+ * comparison — "codeHash" only when BOTH sides carry a valid one, otherwise the
+ * legacy "commit" stamp fallback. Surfaced in drift logs/doctor output so a
+ * verdict is auditable: a commit-basis drift on a legacy build may be a
+ * squash-lag false positive, a codeHash-basis drift never is.
+ */
+export function runtimeContractComparisonBasis(
+  a: AgentBridgeBuildInfo | null | undefined,
+  b: AgentBridgeBuildInfo | null | undefined,
+): "codeHash" | "commit" {
+  return hasValidCodeHash(a) && hasValidCodeHash(b) ? "codeHash" : "commit";
 }
 
 /**
@@ -104,5 +161,6 @@ export function compatibleContractVersion(
 
 export function formatBuildInfo(build: AgentBridgeBuildInfo | null | undefined): string {
   if (!build) return "<unknown>";
-  return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}`;
+  const codeHash = hasValidCodeHash(build) ? `/code-${build.codeHash}` : "";
+  return `${build.version}/${build.commit}/${build.bundle}/contract-v${build.contractVersion}${codeHash}`;
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,7 +1,14 @@
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { pluginCacheRoot } from "./plugin-cache";
-import { BUILD_INFO, formatBuildInfo, sameRuntimeContract } from "../build-info";
+import {
+  BUILD_INFO,
+  formatBuildInfo,
+  hasValidCodeHash,
+  runtimeContractComparisonBasis,
+  sameRuntimeContract,
+  type AgentBridgeBuildInfo,
+} from "../build-info";
 import { cliInvocationName } from "../cli-invocation";
 import { ConfigService } from "../config-service";
 import { fetchDaemonStatus } from "../daemon-status";
@@ -252,23 +259,19 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
         ? "app-server 未返回可解析的版本号（userAgent 异常）。若刚升级过 Codex，请核对 codex-adapter 的 version-coupling checklist。"
         : undefined,
   });
+  const drift = buildDrift === true ? describeBuildDrift(health?.build, BUILD_INFO, cli) : null;
   checks.push({
     name: "build drift",
     status: buildDrift === false ? "ok" : buildDrift === true ? "fail" : "skip",
     detail:
       buildDrift === false
         ? `runtime matches launcher ${formatBuildInfo(BUILD_INFO)}`
-        : buildDrift === true
-          ? `runtime ${formatBuildInfo(health?.build)} differs from launcher ${formatBuildInfo(BUILD_INFO)}`
+        : drift
+          ? drift.detail
           : launcherStamped
             ? "n/a — daemon not running"
             : "n/a — launcher running from source (unstamped)",
-    hint:
-      buildDrift === true
-        ? "daemon 运行的是旧构建（通常由旧版 CLI 或未重开的 Claude Code 窗口启动）。" +
-          `没有进行中的 Codex 会话时，运行 \`${cli} kill\` 后重新 \`${cli} claude\` 即可对齐；` +
-          "有活跃会话则等收尾后再重启——版本差异不会强杀活跃会话，可以继续用。"
-        : undefined,
+    hint: drift?.hint,
   });
   checks.push(artifactAlignmentCheck());
   checks.push({
@@ -364,40 +367,58 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
 }
 
 /**
- * Cross-artifact build alignment. Three deployables each embed a build commit
- * (global CLI dist, Claude Code plugin cache, this launcher); when they split,
- * launchers replace-war each other's daemons — the failure mode behind several
- * live incidents. None of the existing guards compared the artifacts directly;
- * this check makes a split visible BEFORE it costs a daemon.
+ * Drift annotation for the "build drift" check: surface WHICH identity decided
+ * the verdict (same basis as sameRuntimeContract). A codeHash-basis drift is a
+ * real code difference; a commit-stamp-basis drift involves a legacy build
+ * without codeHash, where the squash-merge stamp lag can produce a false
+ * positive on byte-identical code. Pure (no I/O) so the wording is testable.
  */
-function artifactAlignmentCheck(): DoctorCheck {
-  const stamps: Array<{ label: string; commit: string }> = [];
-  if (BUILD_INFO.commit !== "source") {
-    stamps.push({ label: `launcher(${BUILD_INFO.bundle})`, commit: BUILD_INFO.commit });
+export function describeBuildDrift(
+  runtime: AgentBridgeBuildInfo | null | undefined,
+  launcher: AgentBridgeBuildInfo,
+  cli = "abg",
+): { detail: string; hint: string } {
+  const basis = runtimeContractComparisonBasis(runtime, launcher);
+  const baseDetail = `runtime ${formatBuildInfo(runtime)} differs from launcher ${formatBuildInfo(launcher)}`;
+  const baseHint =
+    "daemon 运行的是旧构建（通常由旧版 CLI 或未重开的 Claude Code 窗口启动）。" +
+    `没有进行中的 Codex 会话时，运行 \`${cli} kill\` 后重新 \`${cli} claude\` 即可对齐；` +
+    "有活跃会话则等收尾后再重启——版本差异不会强杀活跃会话，可以继续用。";
+  if (basis === "codeHash") {
+    return { detail: `${baseDetail} [compared by codeHash — real code difference]`, hint: baseHint };
   }
-  const bin = Bun.which("agentbridge") ?? Bun.which("abg");
-  if (bin) {
-    try {
-      const commit = extractBundleCommit(realpathSync(bin));
-      if (commit) stamps.push({ label: "global-cli", commit });
-    } catch {}
-  }
-  const cacheRoot = pluginCacheRoot();
-  try {
-    for (const version of readdirSync(cacheRoot)) {
-      const commit = extractBundleCommit(join(cacheRoot, version, "server", "daemon.js"));
-      if (commit) stamps.push({ label: `plugin-cache@${version}`, commit });
-    }
-  } catch {}
-  // Inside a repo checkout, the committed bundle is a fourth artifact (the dev
-  // marketplace loads it directly). A repo ahead of the installed artifacts is
-  // the "forgot install:global" state — exactly what this check should expose.
-  const repoBundle = join(process.cwd(), "plugins", "agentbridge", "server", "daemon.js");
-  if (existsSync(repoBundle)) {
-    const commit = extractBundleCommit(repoBundle);
-    if (commit) stamps.push({ label: "repo-bundle", commit });
-  }
+  return {
+    detail: `${baseDetail} [compared by commit stamp — legacy build without codeHash]`,
+    hint:
+      baseHint +
+      "（注意：本判定基于 commit stamp 口径——有一侧是缺 codeHash 的旧构建；squash 合并会让 stamp 滞后一格，" +
+      "源码一致时也可能误报。升级两端到带 codeHash 的构建后将按代码内容判定。）",
+  };
+}
 
+/** One deployed artifact's embedded identity stamps. */
+export interface ArtifactStamp {
+  label: string;
+  commit: string;
+  /** null on legacy artifacts built before codeHash stamping. */
+  codeHash: string | null;
+}
+
+/** Usable code identity: present, non-empty, not the "source" sentinel. */
+function isUsableCodeHash(hash: string | null): hash is string {
+  return typeof hash === "string" && hash.length > 0 && hash !== "source";
+}
+
+/**
+ * Pure alignment verdict over collected artifact stamps — same code-identity
+ * basis as the runtime drift detection (sameRuntimeContract): when EVERY
+ * artifact carries a codeHash, compare codeHashes and ignore the commit stamps
+ * entirely (the stamps legitimately differ across squash-merge re-stamps of
+ * identical code — the live doctor false positive). Only when a legacy
+ * artifact lacks a codeHash do we fall back to the historical stamp
+ * comparison, annotated as such.
+ */
+export function evaluateArtifactAlignment(stamps: ArtifactStamp[]): DoctorCheck {
   if (stamps.length < 2) {
     return {
       name: "artifact alignment",
@@ -405,25 +426,98 @@ function artifactAlignmentCheck(): DoctorCheck {
       detail: "n/a — fewer than two stamped artifacts found",
     };
   }
-  const commits = new Set(stamps.map((s) => s.commit));
-  const rendered = stamps.map((s) => `${s.label}=${s.commit}`).join(", ");
-  if (commits.size === 1) {
-    return { name: "artifact alignment", status: "ok", detail: rendered };
+
+  if (stamps.every((stamp) => isUsableCodeHash(stamp.codeHash))) {
+    const rendered = stamps.map((stamp) => `${stamp.label}=${stamp.codeHash}`).join(", ");
+    if (new Set(stamps.map((stamp) => stamp.codeHash)).size === 1) {
+      return { name: "artifact alignment", status: "ok", detail: `codeHash basis: ${rendered}` };
+    }
+    return {
+      name: "artifact alignment",
+      status: "fail",
+      detail: `deployed artifacts contain DIFFERENT code (codeHash basis): ${rendered}`,
+      hint:
+        "部署物代码分裂会导致互相替换 daemon（杀掉活会话）。在仓库目录运行 `bun run install:global` " +
+        "一次性对齐全局 CLI 与插件缓存，然后关闭并重开仍在使用旧插件的 Claude Code 窗口。",
+    };
+  }
+
+  // Legacy fallback: at least one artifact predates codeHash stamping.
+  const rendered = stamps.map((stamp) => `${stamp.label}=${stamp.commit}`).join(", ");
+  if (new Set(stamps.map((stamp) => stamp.commit)).size === 1) {
+    return {
+      name: "artifact alignment",
+      status: "ok",
+      detail: `legacy commit-stamp basis: ${rendered}`,
+    };
   }
   return {
     name: "artifact alignment",
     status: "fail",
-    detail: `deployed artifacts are at DIFFERENT builds: ${rendered}`,
+    detail: `deployed artifacts are at DIFFERENT builds (legacy commit-stamp basis): ${rendered}`,
     hint:
+      "（stamp 口径：存在缺 codeHash 的旧部署物，且 squash 合并会让 stamp 滞后一格，源码一致时也可能误报。）" +
       "部署物版本分裂会导致互相替换 daemon（杀掉活会话）。在仓库目录运行 `bun run install:global` " +
-      "一次性对齐全局 CLI 与插件缓存，然后关闭并重开仍在使用旧插件的 Claude Code 窗口。",
+      "一次性对齐全局 CLI 与插件缓存并升级到带 codeHash 的构建，然后关闭并重开仍在使用旧插件的 Claude Code 窗口；" +
+      "对齐后此检查将按代码内容（codeHash）判定，stamp 滞后不再误报。",
   };
 }
 
-function extractBundleCommit(path: string): string | null {
+/**
+ * Cross-artifact build alignment. Three deployables each embed build identity
+ * stamps (global CLI dist, Claude Code plugin cache, this launcher); when they
+ * split, launchers replace-war each other's daemons — the failure mode behind
+ * several live incidents. Collection happens here (I/O); the verdict lives in
+ * the pure {@link evaluateArtifactAlignment}.
+ */
+function artifactAlignmentCheck(): DoctorCheck {
+  const stamps: ArtifactStamp[] = [];
+  if (BUILD_INFO.commit !== "source") {
+    stamps.push({
+      label: `launcher(${BUILD_INFO.bundle})`,
+      commit: BUILD_INFO.commit,
+      codeHash: hasValidCodeHash(BUILD_INFO) ? (BUILD_INFO.codeHash ?? null) : null,
+    });
+  }
+  const bin = Bun.which("agentbridge") ?? Bun.which("abg");
+  if (bin) {
+    try {
+      const stamp = extractBundleStamp(realpathSync(bin));
+      if (stamp) stamps.push({ label: "global-cli", ...stamp });
+    } catch {}
+  }
+  const cacheRoot = pluginCacheRoot();
   try {
-    const match = readFileSync(path, "utf-8").match(/commit:\s*defineString\("([^"]+)",\s*"source"\)/);
-    return match ? match[1]! : null;
+    for (const version of readdirSync(cacheRoot)) {
+      const stamp = extractBundleStamp(join(cacheRoot, version, "server", "daemon.js"));
+      if (stamp) stamps.push({ label: `plugin-cache@${version}`, ...stamp });
+    }
+  } catch {}
+  // Inside a repo checkout, the committed bundle is a fourth artifact (the dev
+  // marketplace loads it directly). A repo ahead of the installed artifacts is
+  // the "forgot install:global" state — exactly what this check should expose.
+  const repoBundle = join(process.cwd(), "plugins", "agentbridge", "server", "daemon.js");
+  if (existsSync(repoBundle)) {
+    const stamp = extractBundleStamp(repoBundle);
+    if (stamp) stamps.push({ label: "repo-bundle", ...stamp });
+  }
+
+  return evaluateArtifactAlignment(stamps);
+}
+
+/**
+ * Extract both embedded identity stamps from a built bundle. The commit stamp
+ * is required (its absence means "not a stamped AgentBridge bundle", matching
+ * the old extractBundleCommit contract); the codeHash stamp is null on legacy
+ * bundles built before codeHash stamping.
+ */
+function extractBundleStamp(path: string): { commit: string; codeHash: string | null } | null {
+  try {
+    const text = readFileSync(path, "utf-8");
+    const commit = text.match(/commit:\s*defineString\("([^"]+)",\s*"source"\)/)?.[1] ?? null;
+    if (!commit) return null;
+    const codeHash = text.match(/codeHash:\s*defineString\("([^"]+)",\s*"source"\)/)?.[1] ?? null;
+    return { commit, codeHash };
   } catch {
     return null;
   }

--- a/src/daemon-lifecycle.ts
+++ b/src/daemon-lifecycle.ts
@@ -2,7 +2,13 @@ import { spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync, openSync, closeSync, constants } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { atomicWriteJson, atomicWriteText } from "./atomic-json";
-import { BUILD_INFO, compatibleContractVersion, formatBuildInfo, sameRuntimeContract } from "./build-info";
+import {
+  BUILD_INFO,
+  compatibleContractVersion,
+  formatBuildInfo,
+  runtimeContractComparisonBasis,
+  sameRuntimeContract,
+} from "./build-info";
 import { StateDirResolver } from "./state-dir";
 import { parsePositiveIntEnv } from "./env-utils";
 import { isAgentBridgeDaemon, isAgentBridgeProcess, isProcessAlive } from "./process-lifecycle";
@@ -94,9 +100,18 @@ export function classifyDaemon(
         reason: "runtime build drift has a compatible contract and a live Codex TUI is attached",
       };
     }
+    // Surface WHICH identity decided the verdict: a codeHash-basis drift is a
+    // real code difference; a commit-stamp-basis drift on a legacy build (no
+    // codeHash on one side) may be the squash-merge stamp lag.
+    const basis =
+      runtimeContractComparisonBasis(status.build, buildInfo) === "codeHash"
+        ? "compared by codeHash"
+        : "compared by commit stamp; legacy build without codeHash";
     return {
       verdict: "replace-drifted",
-      reason: `runtime build ${formatBuildInfo(status.build)} does not match launcher ${formatBuildInfo(buildInfo)}`,
+      reason:
+        `runtime build ${formatBuildInfo(status.build)} does not match launcher ` +
+        `${formatBuildInfo(buildInfo)} (${basis})`,
     };
   }
 

--- a/src/unit-test/build-info.test.ts
+++ b/src/unit-test/build-info.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
   BUILD_INFO,
   daemonStatusBuildInfo,
+  formatBuildInfo,
+  hasValidCodeHash,
+  runtimeContractComparisonBasis,
   sameBuildInfo,
   sameRuntimeContract,
   type AgentBridgeBuildInfo,
@@ -13,6 +16,9 @@ const base: AgentBridgeBuildInfo = {
   bundle: "dist",
   contractVersion: 1,
 };
+
+// A stamped build that ALSO carries the build-input code hash (new builds).
+const hashed: AgentBridgeBuildInfo = { ...base, codeHash: "abc123def456" };
 
 describe("build info", () => {
   test("exposes stable runtime build metadata for daemon status", () => {
@@ -28,6 +34,7 @@ describe("build info", () => {
       commit: BUILD_INFO.commit,
       bundle: BUILD_INFO.bundle,
       contractVersion: BUILD_INFO.contractVersion,
+      codeHash: BUILD_INFO.codeHash,
     });
   });
 
@@ -44,5 +51,73 @@ describe("build info", () => {
     expect(sameRuntimeContract(base, { ...base, contractVersion: 2 })).toBe(false);
     expect(sameRuntimeContract(base, null)).toBe(false);
     expect(sameRuntimeContract(base, { ...base })).toBe(true);
+  });
+});
+
+/**
+ * codeHash identity truth table — the squash-merge stamp-lag fix.
+ *
+ * A bundle committed in commit X can only ever embed X's PARENT as its commit
+ * stamp, so under squash-merge the stamp lags the master sha by exactly one
+ * even though the CODE is byte-identical. When BOTH sides carry a valid
+ * codeHash (hash of the build-input source tree), code identity is decided by
+ * codeHash and the commit stamp is IGNORED. Legacy builds without a codeHash
+ * fall back to the historical commit-stamp comparison.
+ */
+describe("sameRuntimeContract codeHash identity (squash stamp-lag fix)", () => {
+  test("identical codeHash with DIFFERENT commit stamps is the same contract (reuse)", () => {
+    // The release-blocker scenario: PR-branch stamp vs squash-merged master
+    // stamp, identical source — must NOT be classified as drift.
+    expect(sameRuntimeContract(hashed, { ...hashed, commit: "fffffff" })).toBe(true);
+  });
+
+  test("different codeHash with the SAME commit stamp is drift", () => {
+    expect(sameRuntimeContract(hashed, { ...hashed, codeHash: "000000000000" })).toBe(false);
+  });
+
+  test("one side missing codeHash falls back to commit comparison (both branches)", () => {
+    const legacy = { ...base }; // no codeHash field at all (old daemon)
+    expect(sameRuntimeContract(hashed, { ...legacy })).toBe(true); // commit equal → reuse
+    expect(sameRuntimeContract(hashed, { ...legacy, commit: "deadbee" })).toBe(false); // commit differs → drift
+    expect(sameRuntimeContract(legacy, { ...hashed, commit: "deadbee" })).toBe(false); // symmetric
+    expect(sameRuntimeContract(legacy, { ...hashed })).toBe(true);
+  });
+
+  test("sentinel/empty codeHash is not a valid identity and falls back to commit", () => {
+    const sourceMode = { ...base, codeHash: "source" };
+    expect(sameRuntimeContract(sourceMode, { ...sourceMode })).toBe(true);
+    expect(sameRuntimeContract(sourceMode, { ...sourceMode, commit: "deadbee" })).toBe(false);
+    const empty = { ...base, codeHash: "" };
+    expect(sameRuntimeContract(empty, { ...empty, commit: "deadbee" })).toBe(false);
+    // valid on one side + sentinel on the other → still the commit fallback
+    expect(sameRuntimeContract(hashed, { ...base, codeHash: "source" })).toBe(true);
+    expect(sameRuntimeContract(hashed, { ...base, codeHash: "source", commit: "deadbee" })).toBe(false);
+  });
+
+  test("version/contractVersion mismatch is never the same contract even with identical codeHash", () => {
+    expect(sameRuntimeContract(hashed, { ...hashed, version: "9.9.9" })).toBe(false);
+    expect(sameRuntimeContract(hashed, { ...hashed, contractVersion: base.contractVersion + 1 })).toBe(false);
+  });
+
+  test("hasValidCodeHash rejects null/missing/empty/sentinel and accepts a real hash", () => {
+    expect(hasValidCodeHash(hashed)).toBe(true);
+    expect(hasValidCodeHash(base)).toBe(false);
+    expect(hasValidCodeHash({ ...base, codeHash: "" })).toBe(false);
+    expect(hasValidCodeHash({ ...base, codeHash: "source" })).toBe(false);
+    expect(hasValidCodeHash(null)).toBe(false);
+    expect(hasValidCodeHash(undefined)).toBe(false);
+  });
+
+  test("runtimeContractComparisonBasis reports which identity decided the verdict", () => {
+    expect(runtimeContractComparisonBasis(hashed, { ...hashed, commit: "fffffff" })).toBe("codeHash");
+    expect(runtimeContractComparisonBasis(hashed, base)).toBe("commit");
+    expect(runtimeContractComparisonBasis(base, base)).toBe("commit");
+    expect(runtimeContractComparisonBasis(null, hashed)).toBe("commit");
+  });
+
+  test("formatBuildInfo surfaces a valid codeHash and omits the sentinel", () => {
+    expect(formatBuildInfo(hashed)).toContain("abc123def456");
+    expect(formatBuildInfo(base)).not.toContain("code-");
+    expect(formatBuildInfo({ ...base, codeHash: "source" })).not.toContain("code-");
   });
 });

--- a/src/unit-test/code-hash.test.ts
+++ b/src/unit-test/code-hash.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ROOT = process.cwd();
+// Same require-based loading as release-chain.test.ts uses for bundle-commit.cjs:
+// scripts/ is outside the tsconfig include, so the module is consumed untyped.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { computeCodeHash, computeCodeHashFromEntries, listCodeHashInputFiles } = require(
+  join(ROOT, "scripts/code-hash.cjs"),
+);
+
+/** Shape every stamped bundle must expose so doctor/extractors can read the hash. */
+const CODEHASH_STAMP_RE = /codeHash:\s*defineString\("([^"]+)",\s*"source"\)/;
+
+function seedFakeRepo(root: string) {
+  mkdirSync(join(root, "src", "sub"), { recursive: true });
+  mkdirSync(join(root, "src", "unit-test"), { recursive: true });
+  mkdirSync(join(root, "src", "integration-test"), { recursive: true });
+  writeFileSync(join(root, "src", "a.ts"), "export const a = 1;\n");
+  writeFileSync(join(root, "src", "sub", "b.ts"), "export const b = 2;\n");
+  writeFileSync(join(root, "src", "inline.test.ts"), "// colocated test\n");
+  writeFileSync(join(root, "src", "unit-test", "x.test.ts"), "// unit test\n");
+  writeFileSync(join(root, "src", "integration-test", "y.test.ts"), "// integration test\n");
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "fake", version: "1.0.0" }));
+  writeFileSync(join(root, "bun.lock"), "lockfile-v1\n");
+}
+
+describe("computeCodeHashFromEntries (pure normalization + hash)", () => {
+  const entries = [
+    { path: "src/a.ts", content: "export const a = 1;\n" },
+    { path: "src/b.ts", content: "export const b = 2;\n" },
+  ];
+
+  test("emits a 12-hex digest", () => {
+    expect(computeCodeHashFromEntries(entries)).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  test("is order-independent (entries are canonically sorted)", () => {
+    const reversed = [...entries].reverse();
+    expect(computeCodeHashFromEntries(reversed)).toBe(computeCodeHashFromEntries(entries));
+  });
+
+  test("is content-sensitive", () => {
+    const mutated = [entries[0]!, { path: "src/b.ts", content: "export const b = 3;\n" }];
+    expect(computeCodeHashFromEntries(mutated)).not.toBe(computeCodeHashFromEntries(entries));
+  });
+
+  test("is path-sensitive (swapping contents between paths changes the hash)", () => {
+    const swapped = [
+      { path: "src/a.ts", content: entries[1]!.content },
+      { path: "src/b.ts", content: entries[0]!.content },
+    ];
+    expect(computeCodeHashFromEntries(swapped)).not.toBe(computeCodeHashFromEntries(entries));
+  });
+
+  test("does not mutate its input (immutability)", () => {
+    const input = [...entries].reverse();
+    const snapshot = [...input];
+    computeCodeHashFromEntries(input);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("listCodeHashInputFiles (build-input enumeration)", () => {
+  test("real repo: includes build inputs, excludes every test file", () => {
+    const files: string[] = listCodeHashInputFiles(ROOT);
+    expect(files).toContain("src/build-info.ts");
+    expect(files).toContain("src/daemon-lifecycle.ts");
+    expect(files).toContain("package.json");
+    expect(files).toContain("bun.lock");
+    expect(files.some((f) => f.includes("unit-test/"))).toBe(false);
+    expect(files.some((f) => f.includes("integration-test/"))).toBe(false);
+    expect(files.some((f) => f.endsWith(".test.ts"))).toBe(false);
+    // Canonical order so the hash is stable across platforms/readdir order.
+    expect(files).toEqual([...files].sort());
+  });
+
+  test("fails fast when a required build input is missing", () => {
+    const root = mkdtempSync(join(tmpdir(), "abg-codehash-missing-"));
+    try {
+      seedFakeRepo(root);
+      rmSync(join(root, "bun.lock"));
+      expect(() => listCodeHashInputFiles(root)).toThrow(/bun\.lock/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("computeCodeHash (source-tree identity)", () => {
+  test("is deterministic; sensitive to source/package/lock/bun-version; blind to tests", () => {
+    const root = mkdtempSync(join(tmpdir(), "abg-codehash-repo-"));
+    try {
+      seedFakeRepo(root);
+      const opts = { bunVersion: "1.0.0" };
+      const baseline = computeCodeHash(root, opts);
+      expect(baseline).toMatch(/^[0-9a-f]{12}$/);
+      expect(computeCodeHash(root, opts)).toBe(baseline); // deterministic
+
+      // Test-only edits must NOT move the hash (tests never enter the bundles).
+      writeFileSync(join(root, "src", "unit-test", "x.test.ts"), "// changed unit test\n");
+      writeFileSync(join(root, "src", "inline.test.ts"), "// changed colocated test\n");
+      expect(computeCodeHash(root, opts)).toBe(baseline);
+
+      // Any real source change MUST move the hash.
+      writeFileSync(join(root, "src", "a.ts"), "export const a = 42;\n");
+      const afterSource = computeCodeHash(root, opts);
+      expect(afterSource).not.toBe(baseline);
+
+      // Dependency surface changes move the hash (deps are bundled in).
+      writeFileSync(join(root, "bun.lock"), "lockfile-v2\n");
+      const afterLock = computeCodeHash(root, opts);
+      expect(afterLock).not.toBe(afterSource);
+
+      writeFileSync(join(root, "package.json"), JSON.stringify({ name: "fake", version: "2.0.0" }));
+      const afterPkg = computeCodeHash(root, opts);
+      expect(afterPkg).not.toBe(afterLock);
+
+      // The bundler itself is a build input: a different bun emits different bytes.
+      expect(computeCodeHash(root, { bunVersion: "9.9.9" })).not.toBe(afterPkg);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * Build integration: the invariant the whole fix rests on — two builds of the
+ * SAME source with DIFFERENT commit stamps embed the SAME codeHash. This is
+ * the squash-merge scenario (PR-branch sha vs squash-merged master sha).
+ */
+describe("build-bundles codeHash stamping", () => {
+  test("two builds with different commit overrides embed the same non-sentinel codeHash", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "abg-codehash-build-"));
+    try {
+      const hashes: string[] = [];
+      for (const override of ["feedc0de", "deadbeef"]) {
+        const outfile = join(tempDir, `daemon-${override}.js`);
+        const result = spawnSync(
+          "node",
+          ["scripts/build-bundles.mjs", "daemon-plugin", "--outfile", outfile],
+          {
+            cwd: ROOT,
+            encoding: "utf-8",
+            env: { ...process.env, AGENTBRIDGE_BUILD_COMMIT_OVERRIDE: override },
+          },
+        );
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        const bundle = readFileSync(outfile, "utf-8");
+        expect(bundle).toContain(`"${override}"`); // commit override still honored
+        const match = bundle.match(CODEHASH_STAMP_RE);
+        expect(match, "bundle must carry an extractable codeHash stamp").not.toBeNull();
+        hashes.push(match![1]!);
+      }
+      expect(hashes[0]).toBe(hashes[1]!); // different stamps, same code → same codeHash
+      expect(hashes[0]).toMatch(/^[0-9a-f]{12}$/);
+      expect(hashes[0]).not.toBe("source");
+      // And the embedded value is exactly the current source tree's identity.
+      expect(hashes[0]).toBe(computeCodeHash(ROOT));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/src/unit-test/daemon-lifecycle.test.ts
+++ b/src/unit-test/daemon-lifecycle.test.ts
@@ -49,6 +49,8 @@ describe("classifyDaemon", () => {
     name: string;
     expectedPairId: string | null;
     status: DaemonStatus | null;
+    /** Launcher-side build info; defaults to BUILD_INFO (the historical shape). */
+    launcher?: AgentBridgeBuildInfo;
     expectedVerdict:
       | "reuse"
       | "reuse-despite-drift"
@@ -123,15 +125,70 @@ describe("classifyDaemon", () => {
       status: status({ pairId: "mine", build: undefined, tuiConnected: true }),
       expectedVerdict: "replace-drifted",
     },
+    // ── codeHash identity (squash-merge stamp-lag fix) ──────────────────────
+    // The committed plugin bundle's stamp always lags the squash-merged master
+    // sha by one, so the LIVE incident was: launcher and daemon run byte-identical
+    // code, yet commit-stamp comparison kills the healthy daemon in a loop.
+    {
+      name: "squash-lagged commit stamp with identical codeHash reuses without a TUI",
+      expectedPairId: "mine",
+      status: status({
+        pairId: "mine",
+        build: build({ commit: "pr-branch-sha", codeHash: "feedfacecafe" }),
+        tuiConnected: false,
+      }),
+      launcher: build({ commit: "master-sha", codeHash: "feedfacecafe" }),
+      expectedVerdict: "reuse",
+    },
+    {
+      name: "identical commit stamp but different codeHash is real drift and replaced",
+      expectedPairId: "mine",
+      status: status({
+        pairId: "mine",
+        build: build({ commit: "same-sha", codeHash: "000000000000" }),
+        tuiConnected: false,
+      }),
+      launcher: build({ commit: "same-sha", codeHash: "feedfacecafe" }),
+      expectedVerdict: "replace-drifted",
+    },
+    {
+      name: "legacy daemon without codeHash still falls back to commit-stamp drift",
+      expectedPairId: "mine",
+      status: status({
+        pairId: "mine",
+        build: build({ commit: "old-build", codeHash: undefined }),
+        tuiConnected: false,
+      }),
+      launcher: build({ commit: "new-build", codeHash: "feedfacecafe" }),
+      expectedVerdict: "replace-drifted",
+    },
   ];
 
   for (const testCase of cases) {
     test(testCase.name, () => {
-      const result = classifyDaemon(testCase.expectedPairId, testCase.status, BUILD_INFO);
+      const result = classifyDaemon(testCase.expectedPairId, testCase.status, testCase.launcher ?? BUILD_INFO);
       expect(result.verdict).toBe(testCase.expectedVerdict);
       expect(result.reason.length).toBeGreaterThan(0);
     });
   }
+
+  test("replace-drifted reason names the comparison basis (codeHash vs commit stamp)", () => {
+    const codeHashDrift = classifyDaemon(
+      "mine",
+      status({ pairId: "mine", build: build({ commit: "same-sha", codeHash: "000000000000" }) }),
+      build({ commit: "same-sha", codeHash: "feedfacecafe" }),
+    );
+    expect(codeHashDrift.verdict).toBe("replace-drifted");
+    expect(codeHashDrift.reason).toContain("codeHash");
+
+    const stampDrift = classifyDaemon(
+      "mine",
+      status({ pairId: "mine", build: build({ commit: "old-build", codeHash: undefined }) }),
+      build({ commit: "new-build", codeHash: "feedfacecafe" }),
+    );
+    expect(stampDrift.verdict).toBe("replace-drifted");
+    expect(stampDrift.reason).toContain("commit stamp");
+  });
 
   test("matrix covers every daemon lifecycle verdict", () => {
     expect(new Set(cases.map((testCase) => testCase.expectedVerdict))).toEqual(new Set([

--- a/src/unit-test/doctor.test.ts
+++ b/src/unit-test/doctor.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { runDoctor } from "../cli/doctor";
+import { describeBuildDrift, evaluateArtifactAlignment, runDoctor } from "../cli/doctor";
 import { derivePairId, writeRegistry } from "../pair-registry";
+import type { AgentBridgeBuildInfo } from "../build-info";
 
 const ENV_KEYS = [
   "AGENTBRIDGE_BASE_DIR",
@@ -280,5 +281,78 @@ describe("doctor command", () => {
       rmSync(root, { recursive: true, force: true });
       rmSync(base, { recursive: true, force: true });
     }
+  });
+});
+
+/**
+ * Artifact alignment must use the same code-identity basis as the runtime
+ * drift detection (codeHash when available, commit stamp as legacy fallback) —
+ * otherwise doctor keeps reporting the squash-lag FAIL the runtime fix removed
+ * (observed live: repo-bundle=b53f10a FAIL on byte-identical code).
+ */
+describe("evaluateArtifactAlignment (codeHash basis)", () => {
+  test("aligned codeHash with DIFFERENT commit stamps is OK (squash stamp lag)", () => {
+    const check = evaluateArtifactAlignment([
+      { label: "launcher(dist)", commit: "aaa1111", codeHash: "feedfacecafe" },
+      { label: "repo-bundle", commit: "bbb2222", codeHash: "feedfacecafe" },
+    ]);
+    expect(check.status).toBe("ok");
+    expect(check.detail).toContain("feedfacecafe");
+  });
+
+  test("split codeHash FAILs even when commit stamps agree", () => {
+    const check = evaluateArtifactAlignment([
+      { label: "launcher(dist)", commit: "aaa1111", codeHash: "feedfacecafe" },
+      { label: "repo-bundle", commit: "aaa1111", codeHash: "000000000000" },
+    ]);
+    expect(check.status).toBe("fail");
+    expect(check.hint).toBeDefined();
+  });
+
+  test("legacy artifact without codeHash falls back to the stamp basis, annotated", () => {
+    const split = evaluateArtifactAlignment([
+      { label: "launcher(dist)", commit: "aaa1111", codeHash: "feedfacecafe" },
+      { label: "plugin-cache@0.1.0", commit: "bbb2222", codeHash: null },
+    ]);
+    expect(split.status).toBe("fail");
+    expect(split.detail).toContain("stamp"); // basis is visible in the output
+    expect(split.hint).toContain("squash"); // may be a stamp-lag false positive
+
+    const aligned = evaluateArtifactAlignment([
+      { label: "launcher(dist)", commit: "aaa1111", codeHash: "feedfacecafe" },
+      { label: "plugin-cache@0.1.0", commit: "aaa1111", codeHash: null },
+    ]);
+    expect(aligned.status).toBe("ok");
+  });
+
+  test("fewer than two stamped artifacts skips", () => {
+    expect(evaluateArtifactAlignment([]).status).toBe("skip");
+    expect(
+      evaluateArtifactAlignment([{ label: "launcher(dist)", commit: "aaa1111", codeHash: null }]).status,
+    ).toBe("skip");
+  });
+});
+
+describe("describeBuildDrift (basis annotation)", () => {
+  const launcher: AgentBridgeBuildInfo = {
+    version: "0.1.12",
+    commit: "master-sha",
+    bundle: "dist",
+    contractVersion: 1,
+    codeHash: "feedfacecafe",
+  };
+
+  test("codeHash-basis drift is annotated as a real code difference", () => {
+    const runtime = { ...launcher, codeHash: "000000000000" };
+    const described = describeBuildDrift(runtime, launcher);
+    expect(described.detail).toContain("codeHash");
+    expect(described.detail).not.toContain("stamp");
+  });
+
+  test("commit-stamp-basis drift (legacy daemon) is annotated as possibly squash-lag", () => {
+    const runtime = { ...launcher, commit: "pr-branch-sha", codeHash: undefined };
+    const described = describeBuildDrift(runtime, launcher);
+    expect(described.detail).toContain("stamp");
+    expect(described.hint).toContain("squash");
   });
 });


### PR DESCRIPTION
## Release blocker（用户真机实测撞上）

bundle 内嵌 `BUILD_INFO.commit = git rev-parse HEAD`。**squash-merge 下提交进 master 的 plugin bundle commit stamp 必然滞后一格**（bundle 装不下自己所在 commit 的 sha）。运行时 `sameRuntimeContract` 原用 commit 判等 → `classifyDaemon` 把"代码完全相同、仅 stamp 不同"的健康 daemon 判 `replace-drifted` → CLI launcher 反复 kill daemon → Codex app-server 起不来、**用户实测连不上**（live incident）。

## 修复
- **scripts/code-hash.cjs（新）**：`computeCodeHash` = sha256(src 非测试 .ts + package.json + bun.lock + bun 版本) 截 12 hex，确定性、与 git sha / commit-override 无关。
- **build-bundles.mjs**：注入 `__AGENTBRIDGE_BUILD_CODEHASH__`，同一次构建 4 产物（dist/cli.js、dist/daemon.js、plugin bridge-server.js、plugin daemon.js）**同一个值**（本 PR 为 `6995f3d2a6ab`）。
- **build-info.ts**：`sameRuntimeContract` 改为 version+contractVersion 必须等、双方有效 codeHash 时只比 codeHash 忽略 commit、缺失回落比 commit（兼容旧 daemon）。**version/contractVersion 无条件先于 codeHash 短路——codeHash 绝不放宽 contract/安全 gate**。
- **doctor.ts**：artifact-alignment + build-drift 同口径，根治用户实测的 `repo-bundle=b53f10a FAIL` 误报。

## Cross-review（高危 launcher-kill 路径 → 2 连 clean）
- **设计审**：Codex 7 条对抗设计攻击（runtimeCodeHash 谱系 / 逃生门 / determinism / 归一化 / 兼容 / 安全 / 自指）——其中 P0（必须 daemon 谱系 hash 回填 launcher+daemon，不能各产物 hash 自己）直接定型了方案。
- **代码审**：4 个全新 reviewer **2 连 clean、全 0 REAL**——亲测确定性（双 commit-override 同 hash、抹 commit 后字节相同）、穷举所有影响 bundle 字节的输入全入 hash、安全 gate 不被绕过、兼容双向（old×new 回落 commit）、release 链零回归。
- 逃生门 `ALLOW_BUILD_DRIFT` 对 contract-mismatch 收窄裁为**独立 follow-up**（既有行为、非本 PR 引入、不阻塞）。

## 兼容 + 验证
- 旧 daemon（无 codeHash 字段）× 新 launcher → 回落比 commit = 现行为；新 daemon × 旧 launcher（忽略未知 JSON 字段）→ 旧逻辑判等。rolling upgrade 两向安全。
- typecheck 绿；全量 `bun test src` **1239 pass / 0 fail**；`verify:plugin-sync` in-sync；`check-plugin-versions` aligned；release 正则仍正确提取 commit。

## 真实验证
本机已手动对齐三处 bundle（修复前用户 Codex 反复被 kill→连不上，对齐后稳连）；并经 Claude×Codex live 对话 E2E（reply/turn/steer/busy-guard/marker 全 PASS）。