### PR TITLE
chore(release): v0.1.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "agentbridge",
       "description": "Bridge Claude Code and Codex through a shared daemon, push channel delivery, and reply/get_messages tools.",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "author": {
         "name": "AgentBridge Contributors",
         "email": "raysonmeng@qq.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raysonmeng/agentbridge",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Bridge between Claude Code and Codex — bidirectional agent communication via MCP Channel + JSON-RPC",
   "type": "module",
   "packageManager": "bun@1.3.11",

--- a/plugins/agentbridge/.claude-plugin/plugin.json
+++ b/plugins/agentbridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentbridge",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Bridge Claude Code and Codex with a shared daemon, push channel delivery, and bidirectional reply tooling.",
   "author": {
     "name": "AgentBridge Contributors",

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14389,11 +14389,11 @@ function defineNumber(value, fallback) {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 var BUILD_INFO = Object.freeze({
-  version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("956afd9", "source"),
+  version: defineString("0.1.13", "0.0.0-source"),
+  commit: defineString("a54f243", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("6995f3d2a6ab", "source")
+  codeHash: defineString("e1fd67d07c62", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -26,11 +26,11 @@ function defineNumber(value, fallback) {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 var BUILD_INFO = Object.freeze({
-  version: defineString("0.1.12", "0.0.0-source"),
-  commit: defineString("956afd9", "source"),
+  version: defineString("0.1.13", "0.0.0-source"),
+  commit: defineString("a54f243", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("6995f3d2a6ab", "source")
+  codeHash: defineString("e1fd67d07c62", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };


### PR DESCRIPTION
## Release v0.1.13（v0.1.8 以来全部修复）

合并后 master 的 `package.json` version 变化将自动触发 **auto-release**（RELEASE_PAT 建 GitHub Release）→ **publish.yml**（NPM_TOKEN `npm publish`）。

### 内容（~38 PR）
- **协议三件**：turn/interrupt + turn_started ACK + 注入幂等、steer expectedTurnId、契约版本协商 CLOSE 4006、投递去重 LRU/TTL、routeCodexMessage 路由矩阵
- **daemon 身份/生命周期**：daemon.json 单身份、bind 竞争 ownership 健壮性簇、classifyDaemon 表驱动、process-lifecycle 收敛、BoundedMessageBuffer、atomic-json
- **budget 协调**：自适应轮询、classifyPoll 状态机、paused 指纹、quota-source schema 协商
- **安全**：CSWSH Origin 守卫、控制端能力令牌、attach 守卫、interrupt 路径 TOCTOU
- **CLI/UX**：abg resume、abg logs、pairs prune 条目级 + 损坏 registry 降级、config fail-loud、init 旅程、信号退出码/空 XDG/数值下界硬化
- **codex-adapter**：turn-key 对称清除、start() teardown 幂等
- **两轮合并后深度扫描**：round-2（8 项）+ round-3（7 项）
- **codeHash drift 根治**（本批 release blocker）：运行时身份改用源码树 codeHash，根治 squash 滞后 stamp 误判反复 kill daemon

### 验证
全量 `bun test src` **1239 pass / 0 fail**、typecheck 绿、verify:plugin-sync in-sync、三 manifest aligned 0.1.13。全部修复经 2-reviewer 交叉审 + 本机 Claude×Codex live E2E。