### PR TITLE
fix: resume 对 pending 线程现场补验 rollout 并升级 / promote pending threads on read

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14390,10 +14390,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.13", "0.0.0-source"),
-  commit: defineString("a54f243", "source"),
+  commit: defineString("6b96f15", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("e1fd67d07c62", "source")
+  codeHash: defineString("191049553049", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -27,10 +27,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.13", "0.0.0-source"),
-  commit: defineString("a54f243", "source"),
+  commit: defineString("6b96f15", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("e1fd67d07c62", "source")
+  codeHash: defineString("191049553049", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -27,6 +27,7 @@ import { appendRotatingLog } from "../rotating-log";
 import { applyPairEnv, parsePairFlag, type PairResolution } from "../pair-resolver";
 import { StderrRingBuffer } from "../stderr-ring-buffer";
 import {
+  readRawCurrentThread,
   readUsableCurrentThread,
   type CurrentThreadState,
 } from "../thread-state";
@@ -179,11 +180,21 @@ export function resolveCodexResumeArgs(
   const current = readUsableCurrentThread(identity, env);
   if (parsed.resumeCurrent) {
     if (!current) {
+      // Surface an identity-matched pending record so the user can act on it:
+      // the threadId is real, only its rollout file could not be verified.
+      // Records from another pair/cwd are NOT hinted — resuming them here
+      // would cross-wire projects.
+      const raw = readRawCurrentThread(identity.stateDir);
+      const pending =
+        raw && raw.status === "pending" && raw.pairId === identity.pairId && raw.cwd === identity.cwd
+          ? raw
+          : null;
       return {
         rest: parsed.rest,
         mode: "resume-current",
-        error:
-          "No verified current Codex thread for this pair. Start a new one with `abg codex --new`, or resume a specific thread with `abg codex resume <threadId>`.",
+        error: pending
+          ? `No verified current Codex thread for this pair. Found a pending (unverified) thread ${pending.threadId} — its Codex rollout file was not found. Try \`abg codex resume ${pending.threadId}\`, or start fresh with \`abg codex --new\`.`
+          : "No verified current Codex thread for this pair. Start a new one with `abg codex --new`, or resume a specific thread with `abg codex resume <threadId>`.",
       };
     }
     return {

--- a/src/thread-state.ts
+++ b/src/thread-state.ts
@@ -198,9 +198,34 @@ export function readUsableCurrentThread(
 ): CurrentThreadState | null {
   const state = readRawCurrentThread(identity.stateDir);
   if (!state) return null;
-  if (state.status !== "current") return null;
+  // Identity checks come FIRST: a record from another pair or cwd is never
+  // usable here and must never be promoted/repaired by this reader.
   if (state.pairId !== identity.pairId) return null;
   if (state.cwd !== identity.cwd) return null;
+
+  if (state.status === "pending") {
+    // The daemon's rollout-retry window is short (~5s); Codex often writes the
+    // rollout file later. Re-verify on the spot so a long-lived session is not
+    // permanently locked out of resume by a slow first flush.
+    const rolloutPath = findCodexRolloutFile(state.threadId, env);
+    if (!rolloutPath) return null;
+
+    const promoted: CurrentThreadState = {
+      ...state,
+      status: "current",
+      rolloutPath,
+      rolloutVerifiedAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    try {
+      atomicWriteJson(identity.stateDir.currentThreadFile, promoted);
+    } catch {
+      // Persisting the promotion is best-effort: the rollout file itself was
+      // just verified, so resume can proceed on the in-memory state — a disk
+      // hiccup must not break the resume path. Doctor can report it later.
+    }
+    return promoted;
+  }
 
   if (state.rolloutPath && existsSync(state.rolloutPath)) return state;
 

--- a/src/unit-test/cli.test.ts
+++ b/src/unit-test/cli.test.ts
@@ -10,7 +10,10 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { StateDirResolver } from "../state-dir";
-import { promoteCurrentThreadIfRolloutExists } from "../thread-state";
+import {
+  promoteCurrentThreadIfRolloutExists,
+  writePendingCurrentThread,
+} from "../thread-state";
 
 describe("CLI: version comparison", () => {
   test("equal versions return 0", () => {
@@ -348,6 +351,100 @@ describe("CLI: AgentBridge Codex resume args", () => {
     } finally {
       process.chdir(previousCwd);
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("resume-current error surfaces a pending thread id with an explicit resume hint", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-cli-resume-"));
+    const codexHome = mkdtempSync(join(tmpdir(), "agentbridge-codex-home-"));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(root);
+      const pair = makePair(root);
+      const cwd = process.cwd();
+      // Pending record for THIS pair + cwd, but no rollout file anywhere:
+      // promotion cannot happen, yet the user deserves the threadId.
+      writePendingCurrentThread(
+        { stateDir: pair.stateDir, pairId: pair.pairId, pairName: pair.name, cwd },
+        "thread-pending-1",
+        "test",
+      );
+
+      const result = resolveCodexResumeArgs(
+        parseAgentBridgeCodexArgs(["resume-current"]),
+        pair,
+        { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+      );
+      expect(result.mode).toBe("resume-current");
+      expect(result.error).toContain("No verified current Codex thread");
+      expect(result.error).toContain("thread-pending-1");
+      expect(result.error).toContain("abg codex resume thread-pending-1");
+      expect(result.error).toContain("abg codex --new");
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("resume-current error omits the pending hint when the record belongs to another cwd", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-cli-resume-"));
+    const codexHome = mkdtempSync(join(tmpdir(), "agentbridge-codex-home-"));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(root);
+      const pair = makePair(root);
+      // Same pair, different cwd — hinting this threadId would cross-wire projects.
+      writePendingCurrentThread(
+        { stateDir: pair.stateDir, pairId: pair.pairId, pairName: pair.name, cwd: join(root, "elsewhere") },
+        "thread-foreign",
+        "test",
+      );
+
+      const result = resolveCodexResumeArgs(
+        parseAgentBridgeCodexArgs(["resume-current"]),
+        pair,
+        { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+      );
+      expect(result.mode).toBe("resume-current");
+      expect(result.error).toContain("No verified current Codex thread");
+      expect(result.error).not.toContain("thread-foreign");
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("resume-current promotes a pending thread whose rollout now exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentbridge-cli-resume-"));
+    const codexHome = mkdtempSync(join(tmpdir(), "agentbridge-codex-home-"));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(root);
+      const pair = makePair(root);
+      const cwd = process.cwd();
+      writePendingCurrentThread(
+        { stateDir: pair.stateDir, pairId: pair.pairId, pairName: pair.name, cwd },
+        "thread-late-cli",
+        "test",
+      );
+      const sessionsDir = join(codexHome, "sessions", "2026", "06", "02");
+      mkdirSync(sessionsDir, { recursive: true });
+      writeFileSync(join(sessionsDir, "rollout-thread-late-cli.jsonl"), "{}\n", "utf-8");
+
+      const result = resolveCodexResumeArgs(
+        parseAgentBridgeCodexArgs(["resume-current"]),
+        pair,
+        { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+      );
+      expect(result.mode).toBe("resume-current");
+      expect(result.error).toBeUndefined();
+      expect(result.rest).toEqual(["resume", "thread-late-cli"]);
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
     }
   });
 });

--- a/src/unit-test/thread-state.test.ts
+++ b/src/unit-test/thread-state.test.ts
@@ -110,6 +110,129 @@ describe("thread-state", () => {
     }
   });
 
+  test("pending thread with an existing rollout is promoted to current on read", () => {
+    const root = tempDir("agentbridge-thread-state-");
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      const id = identity(root, codexHome);
+      // Daemon gave up within its 5s retry window — state is left pending …
+      writePendingCurrentThread(id, "thread-late", "test");
+
+      // … but the rollout file shows up later (Codex kept running).
+      const sessionsDir = join(codexHome, "sessions", "2026", "06", "02");
+      mkdirSync(sessionsDir, { recursive: true });
+      const rolloutPath = join(sessionsDir, "rollout-thread-late.jsonl");
+      writeFileSync(rolloutPath, "{}\n", "utf-8");
+
+      const usable = readUsableCurrentThread(id, id.env);
+      expect(usable).not.toBeNull();
+      expect(usable?.status).toBe("current");
+      expect(usable?.threadId).toBe("thread-late");
+      expect(usable?.rolloutPath).toBe(rolloutPath);
+      expect(usable?.rolloutVerifiedAt).toBeTruthy();
+
+      // The promotion must be persisted (atomically) — re-read from disk.
+      const persisted = readRawCurrentThread(id.stateDir);
+      expect(persisted?.status).toBe("current");
+      expect(persisted?.rolloutPath).toBe(rolloutPath);
+      expect(persisted?.rolloutVerifiedAt).toBeTruthy();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("pending thread without a rollout stays pending on disk and unusable", () => {
+    const root = tempDir("agentbridge-thread-state-");
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      const id = identity(root, codexHome);
+      writePendingCurrentThread(id, "thread-no-rollout", "test");
+
+      expect(readUsableCurrentThread(id, id.env)).toBeNull();
+
+      const persisted = readRawCurrentThread(id.stateDir);
+      expect(persisted?.status).toBe("pending");
+      expect(persisted?.threadId).toBe("thread-no-rollout");
+      expect(persisted?.rolloutPath).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("pending thread with mismatched pairId is not promoted even when the rollout exists", () => {
+    const root = tempDir("agentbridge-thread-state-");
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      const id = identity(root, codexHome);
+      writePendingCurrentThread(id, "thread-other-pair", "test");
+
+      const sessionsDir = join(codexHome, "sessions", "2026", "06", "02");
+      mkdirSync(sessionsDir, { recursive: true });
+      writeFileSync(join(sessionsDir, "rollout-thread-other-pair.jsonl"), "{}\n", "utf-8");
+
+      const otherPair = { ...id, pairId: "other-87654321" };
+      expect(readUsableCurrentThread(otherPair, id.env)).toBeNull();
+      // Identity check wins: the record must remain untouched (still pending).
+      expect(readRawCurrentThread(id.stateDir)?.status).toBe("pending");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("pending thread with mismatched cwd is not promoted even when the rollout exists", () => {
+    const root = tempDir("agentbridge-thread-state-");
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      const id = identity(root, codexHome);
+      writePendingCurrentThread(id, "thread-other-cwd", "test");
+
+      const sessionsDir = join(codexHome, "sessions", "2026", "06", "02");
+      mkdirSync(sessionsDir, { recursive: true });
+      writeFileSync(join(sessionsDir, "rollout-thread-other-cwd.jsonl"), "{}\n", "utf-8");
+
+      const otherCwd = { ...id, cwd: join(root, "elsewhere") };
+      expect(readUsableCurrentThread(otherCwd, id.env)).toBeNull();
+      expect(readRawCurrentThread(id.stateDir)?.status).toBe("pending");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("current thread with a stale rolloutPath is repaired by re-finding the rollout", () => {
+    const root = tempDir("agentbridge-thread-state-");
+    const codexHome = tempDir("agentbridge-codex-home-");
+    try {
+      const sessionsDir = join(codexHome, "sessions", "2026", "06", "02");
+      mkdirSync(sessionsDir, { recursive: true });
+      const oldPath = join(sessionsDir, "rollout-thread-moved.jsonl");
+      writeFileSync(oldPath, "{}\n", "utf-8");
+
+      const id = identity(root, codexHome);
+      const state = promoteCurrentThreadIfRolloutExists(id, "thread-moved", "test", id.env);
+      expect(state.status).toBe("current");
+      expect(state.rolloutPath).toBe(oldPath);
+
+      // Codex relocated the rollout (e.g. archive layout change).
+      const newDir = join(codexHome, "sessions", "2026", "06", "03");
+      mkdirSync(newDir, { recursive: true });
+      const newPath = join(newDir, "rollout-thread-moved.jsonl");
+      writeFileSync(newPath, "{}\n", "utf-8");
+      rmSync(oldPath);
+
+      const usable = readUsableCurrentThread(id, id.env);
+      expect(usable?.status).toBe("current");
+      expect(usable?.rolloutPath).toBe(newPath);
+      expect(readRawCurrentThread(id.stateDir)?.rolloutPath).toBe(newPath);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
   test("findCodexRolloutFile returns null when sessions are absent", () => {
     const codexHome = tempDir("agentbridge-codex-home-");
     try {


### PR DESCRIPTION
## 用户实测事故
`abg resume codex` 报 "No verified current Codex thread"，但 `current-thread.json` 里 threadId 明明在、status 卡 **pending**。根因：daemon 仅在线程启动后 **5 秒窗口**（20×250ms）找 Codex rollout 文件，找不到留 pending 且**永不补验**——`readUsableCurrentThread` 对非 current 直接 null，即使 rollout 后来早已存在。

## 修复
- **thread-state.ts**：身份校验（pairId/cwd）前置；pending 分支现场 `findCodexRolloutFile`，找到即不可变升级（current + rolloutPath + rolloutVerifiedAt）+ `atomicWriteJson` 原子写回（try/catch，写盘失败静默降级仍放行，幂等可重试）；找不到维持 pending。既有 current-修复逻辑不变。
- **cli/codex.ts**：resume-current 失败时若有**身份匹配**的 pending 记录，报错附 threadId + 可操作命令（`abg codex resume <id>` / `abg codex --new`）；跨 pair/cwd 不泄漏。

**行为变化点（预期、用户可感知）**：bare `abg codex` auto-resume 对 "pending 但 rollout 后到" 的线程，过去静默开新线程，现在升级并恢复。
注：修复生效于 CLI 构建路径（dist/cli.js）；plugin bundle 中该函数本就 tree-shaken，bundle 仅 stamp 变化。

## Cross-review（2 全新 reviewer 一轮双 0 REAL）
- 行为矩阵穷举无意外变化；"过期 pending 误升级"被 daemon threadChanged 整体覆盖语义排除。
- 跨进程竞态：250ms 自愈、触发需极端时序、与 master repair 路径同窗口——评为可接受。
- doctor 写盘副作用为 master 既有（repair 路径本就写盘且无 try/catch），新路径反而更安全。
- 实证 codex 原生 resume 失败会显式报错不破坏状态 → hint 真实可操作；与 CLAUDE.md 上游 resume bug 备忘不矛盾。

## 测试
+8（升级且持久化 / 无 rollout 不动 / pairId/cwd 不匹配 / current 回归锁定 / hint 含 id / 跨 cwd 不泄漏 / resume-current 放行）。TDD RED→GREEN（3 核心用例实现前 fail）。全量 **1247 pass / 0 fail**。verify:plugin-sync clean。

## Backlog（reviewer RECOMMEND，非阻塞）
- thread-state.ts:241 既有 repair 写回补 try/catch（doctor 抗只读 FS，master 遗留）
- 跨进程写回 CAS 加固（写前重读比对 threadId）
- cli.test.ts 补 pairId-mismatch hint 抑制测试；身份匹配谓词提取共享 helper
- readUsableCurrentThread 下沉到 resume 分支内（passthrough 路径省目录扫描）