### PR TITLE
feat(budget): v3 P1 燃尽率纯消费端 + 5h 窗口预测 / v3 P1 burn-rate pure-consumer + 5h-windows projection

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13863,7 +13863,48 @@ class StateDirResolver {
   }
 }
 
+// src/budget/types.ts
+var STALE_MAX_AGE_SEC = 600;
+
+// src/budget/budget-state.ts
+function isDecisionGrade(usage, now) {
+  if (!usage)
+    return false;
+  const freshWindow = usage.fiveHour !== null && usage.fiveHour.resetEpoch > now || usage.weekly !== null && usage.weekly.resetEpoch > now;
+  if (!freshWindow)
+    return false;
+  if (usage.fetchedAt > 0 && now - usage.fetchedAt > STALE_MAX_AGE_SEC)
+    return false;
+  return true;
+}
+
+// src/budget/burn-view.ts
+function agentWeeklyFiveHourWindowsLeft(usage, now) {
+  if (!usage || usage.stale || !usage.ok)
+    return null;
+  if (!isDecisionGrade(usage, now))
+    return null;
+  const weekly = usage.weekly;
+  if (!weekly || weekly.resetEpoch <= now)
+    return null;
+  if (weekly.burnConfident !== true)
+    return null;
+  if (weekly.runwaySeconds === undefined)
+    return null;
+  return weekly.fiveHourWindowsLeft ?? null;
+}
+
 // src/budget/render.ts
+var DEFAULT_GUARD_HARD_PCT = 92;
+function resolveGuardHardHint(env = process.env) {
+  const raw = env.AGENTBRIDGE_GUARD_HARD_HINT;
+  if (raw === undefined || raw.trim() === "")
+    return DEFAULT_GUARD_HARD_PCT;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1 || parsed > 100)
+    return DEFAULT_GUARD_HARD_PCT;
+  return parsed;
+}
 function formatEpoch(epochSeconds) {
   if (!epochSeconds || epochSeconds <= 0)
     return "\u672A\u77E5";
@@ -13897,17 +13938,98 @@ function formatAgent(name, usage, snapshotAt) {
   }
   return `${name}\uFF1A${parts.join(" \xB7 ")}`;
 }
+var WINDOW_LABELS = {
+  fiveHour: "5h \u7A97\u53E3",
+  weekly: "\u5468\u7A97\u53E3"
+};
+var RESET_TRUNCATION_EPSILON_SEC = 60;
+function formatDuration(seconds) {
+  const totalMinutes = Math.max(0, Math.round(seconds / 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0)
+    return `${minutes}\u5206\u949F`;
+  return `${hours}\u5C0F\u65F6${minutes}\u5206\u949F`;
+}
+function formatClockTime(epochSeconds) {
+  const date4 = new Date(epochSeconds * 1000);
+  const hh = String(date4.getHours()).padStart(2, "0");
+  const mm = String(date4.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+function formatWindowRate(label, rate) {
+  if (!rate)
+    return null;
+  if (!rate.confident)
+    return `${label} \u91C7\u6837\u4E2D`;
+  return `${label} \u2248${rate.pctPerHour.toFixed(2)}%/h`;
+}
+function formatRunwaySegment(runway, basisWindow, snapshotAt) {
+  const truncatedByReset = basisWindow !== null && basisWindow.resetEpoch > 0 && snapshotAt + runway.seconds >= basisWindow.resetEpoch - RESET_TRUNCATION_EPSILON_SEC;
+  const clock = runway.depletedAtEpoch ? formatClockTime(runway.depletedAtEpoch) : null;
+  let clockNote;
+  if (clock) {
+    clockNote = truncatedByReset ? `\u81F3 ${clock} \u7A97\u53E3\u5237\u65B0\u5373\u622A\u65AD\uFF0C` : `\u81F3 ${clock}\uFF0C`;
+  } else {
+    clockNote = truncatedByReset ? "\u7A97\u53E3\u5237\u65B0\u5373\u622A\u65AD\uFF0C" : "";
+  }
+  return `\u7EA6\u53EF\u518D\u5DE5\u4F5C ${formatDuration(runway.seconds)}\uFF08${clockNote}${WINDOW_LABELS[runway.basis]}\u4E3A\u7EA6\u675F\uFF09`;
+}
+function formatBurnRateLine(name, usage, rates, runway, snapshotAt, guardHardPct) {
+  const parts = [
+    formatWindowRate("5h", rates.fiveHour),
+    formatWindowRate("\u5468", rates.weekly)
+  ].filter((part) => part !== null);
+  if (parts.length === 0 && !runway)
+    return null;
+  if (runway) {
+    const basisWindow = usage ? usage[runway.basis] : null;
+    parts.push(formatRunwaySegment(runway, basisWindow, snapshotAt));
+  }
+  if (guardHardPct !== null) {
+    parts.push(`\u5916\u5C42 guard \u786C\u7EBF ${guardHardPct}%\uFF08v3 \u4E0D\u53EF\u8D8A\u8FC7\uFF1Brunway \u4E3A\u4E2D\u6027\u53E3\u5F84\uFF0CClaude \u4F1A\u5148\u5728\u786C\u7EBF\u88AB\u5916\u5C42\u505C\u4F4F\uFF09`);
+  }
+  return `${name} \u71C3\u5C3D\u7387\uFF1A${parts.join(" \xB7 ")}`;
+}
+function formatFiveHourWindowsLeftLine(snapshot) {
+  const values = [];
+  const claude = agentWeeklyFiveHourWindowsLeft(snapshot.claude, snapshot.updatedAt);
+  const codex = agentWeeklyFiveHourWindowsLeft(snapshot.codex, snapshot.updatedAt);
+  if (claude !== null)
+    values.push(["Claude", claude]);
+  if (codex !== null)
+    values.push(["Codex", codex]);
+  if (values.length === 0)
+    return null;
+  const unique = [...new Set(values.map(([, value]) => value.toFixed(1)))];
+  if (unique.length === 1)
+    return `\u6309\u5F53\u524D\u8282\u594F\uFF0C\u5468\u989D\u5EA6\u8FD8\u591F ~${unique[0]} \u4E2A 5h \u7A97\u53E3`;
+  const byAgent = values.map(([name, value]) => `${name} ~${value.toFixed(1)}`).join(" / ");
+  return `\u6309\u5F53\u524D\u8282\u594F\uFF0C\u5468\u989D\u5EA6\u8FD8\u591F ${byAgent} \u4E2A 5h \u7A97\u53E3`;
+}
 var PHASE_LABELS = {
   normal: "normal\uFF08\u6B63\u5E38\uFF09",
   balance: "balance\uFF08\u9700\u5747\u8861\uFF09",
   parallel: "parallel\uFF08\u5EFA\u8BAE\u5E76\u884C\u63D0\u901F\uFF09",
   paused: "paused\uFF08\u9884\u7B97\u5E72\u9884\u4E2D\uFF09"
 };
-function renderBudgetSnapshot(snapshot) {
+function renderBudgetSnapshot(snapshot, options = {}) {
+  const guardHardPct = options.guardHardPct ?? resolveGuardHardHint();
   const lines = [];
   lines.push(`\u3010\u9884\u7B97\u5FEB\u7167 \xB7 \u8D26\u53F7\u7EA7\u3011\u9636\u6BB5\uFF1A${PHASE_LABELS[snapshot.phase]} \xB7 \u66F4\u65B0\u4E8E ${formatEpoch(snapshot.updatedAt)}`);
   lines.push(formatAgent("Claude", snapshot.claude, snapshot.updatedAt));
   lines.push(formatAgent("Codex", snapshot.codex, snapshot.updatedAt));
+  if (snapshot.burnRate) {
+    const claudeLine = formatBurnRateLine("Claude", snapshot.claude, snapshot.burnRate.claude, snapshot.runway?.claude ?? null, snapshot.updatedAt, guardHardPct);
+    if (claudeLine)
+      lines.push(claudeLine);
+    const codexLine = formatBurnRateLine("Codex", snapshot.codex, snapshot.burnRate.codex, snapshot.runway?.codex ?? null, snapshot.updatedAt, null);
+    if (codexLine)
+      lines.push(codexLine);
+  }
+  const fiveHourWindowsLeftLine = formatFiveHourWindowsLeftLine(snapshot);
+  if (fiveHourWindowsLeftLine)
+    lines.push(fiveHourWindowsLeftLine);
   if (snapshot.claude && snapshot.codex) {
     const abs = Math.abs(snapshot.driftPct);
     if (abs > 0) {
@@ -14390,10 +14512,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.13", "0.0.0-source"),
-  commit: defineString("6b96f15", "source"),
+  commit: defineString("dfc093b", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("191049553049", "source")
+  codeHash: defineString("6dd30dc80352", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)
@@ -15424,7 +15546,8 @@ var DEFAULT_BUDGET_CONFIG = {
     full: null,
     balanced: { effort: "medium" },
     eco: { effort: "low" }
-  }
+  },
+  strategy: "conserve"
 };
 var DEFAULT_CONFIG = {
   version: "1.0",
@@ -15502,6 +15625,9 @@ function normalizeBoundedInteger(value, fallback, min, max) {
     return fallback;
   return parsed;
 }
+function normalizeStrategy(value, fallback) {
+  return value === "conserve" || value === "maximize" ? value : fallback;
+}
 function normalizeBoolean(value, fallback) {
   if (typeof value === "boolean")
     return value;
@@ -15550,7 +15676,8 @@ function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
       timeWindowSec: normalizeBoundedInteger(parallel.timeWindowSec, fallback.parallel.timeWindowSec, 60, 604800)
     },
     codexTierControl: normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) && codexTiers.full !== null,
-    codexTiers
+    codexTiers,
+    strategy: normalizeStrategy(budget.strategy, fallback.strategy)
   };
 }
 function normalizeConfig(raw) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -27,10 +27,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.13", "0.0.0-source"),
-  commit: defineString("6b96f15", "source"),
+  commit: defineString("dfc093b", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("191049553049", "source")
+  codeHash: defineString("6dd30dc80352", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -3401,7 +3401,8 @@ var DEFAULT_BUDGET_CONFIG = {
     full: null,
     balanced: { effort: "medium" },
     eco: { effort: "low" }
-  }
+  },
+  strategy: "conserve"
 };
 var DEFAULT_CONFIG = {
   version: "1.0",
@@ -3479,6 +3480,9 @@ function normalizeBoundedInteger(value, fallback, min, max) {
     return fallback;
   return parsed;
 }
+function normalizeStrategy(value, fallback) {
+  return value === "conserve" || value === "maximize" ? value : fallback;
+}
 function normalizeBoolean(value, fallback) {
   if (typeof value === "boolean")
     return value;
@@ -3527,7 +3531,8 @@ function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
       timeWindowSec: normalizeBoundedInteger(parallel.timeWindowSec, fallback.parallel.timeWindowSec, 60, 604800)
     },
     codexTierControl: normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) && codexTiers.full !== null,
-    codexTiers
+    codexTiers,
+    strategy: normalizeStrategy(budget.strategy, fallback.strategy)
   };
 }
 function applyBudgetEnvOverrides(budget, env = process.env) {
@@ -3542,7 +3547,8 @@ function applyBudgetEnvOverrides(budget, env = process.env) {
       timeWindowSec: env.AGENTBRIDGE_BUDGET_PARALLEL_TIME_WINDOW_SEC ?? budget.parallel.timeWindowSec
     },
     codexTierControl: env.AGENTBRIDGE_BUDGET_CODEX_TIER_CONTROL ?? budget.codexTierControl,
-    codexTiers: budget.codexTiers
+    codexTiers: budget.codexTiers,
+    strategy: env.AGENTBRIDGE_BUDGET_STRATEGY ?? budget.strategy
   };
   return normalizeBudgetConfig(overlay, budget);
 }
@@ -4038,6 +4044,54 @@ function classifyPoll(prev, state, cfg) {
   return { next: prev, effect: { kind: "none" } };
 }
 
+// src/budget/burn-view.ts
+function windowBurnRate(window) {
+  if (!window || window.burnRate === undefined)
+    return null;
+  return {
+    pctPerHour: window.burnRate,
+    confident: window.burnConfident === true
+  };
+}
+function agentBurnRates(usage) {
+  if (!usage)
+    return { fiveHour: null, weekly: null };
+  return {
+    fiveHour: windowBurnRate(usage.fiveHour),
+    weekly: windowBurnRate(usage.weekly)
+  };
+}
+function agentRunway(usage, now) {
+  if (!usage || usage.stale || !usage.ok)
+    return null;
+  if (!isDecisionGrade(usage, now))
+    return null;
+  let best = null;
+  const candidates = [
+    ["fiveHour", usage.fiveHour],
+    ["weekly", usage.weekly]
+  ];
+  for (const [basis, window] of candidates) {
+    if (!window || window.resetEpoch <= now)
+      continue;
+    if (window.burnConfident !== true)
+      continue;
+    if (window.runwaySeconds === undefined)
+      continue;
+    if (best === null || window.runwaySeconds < best.seconds) {
+      best = {
+        seconds: window.runwaySeconds,
+        basis,
+        depletedAtEpoch: window.depletedAtEpoch ?? null
+      };
+    }
+  }
+  return best;
+}
+function hasAnyBurnSignal(rates, runway) {
+  return rates.claude.fiveHour !== null || rates.claude.weekly !== null || rates.codex.fiveHour !== null || rates.codex.weekly !== null || runway.claude !== null || runway.codex !== null;
+}
+
 // src/budget/budget-coordinator.ts
 var LOW_UTIL_PCT = 50;
 var NEAR_PAUSE_MARGIN_PCT = 10;
@@ -4348,8 +4402,22 @@ class BudgetCoordinator {
       resumeAfterEpoch: paused ? this.fpState.resumeEpoch ?? state.pause.resumeAfterEpoch : null,
       parallelRecommended: paused ? false : state.parallel.recommended,
       codexTier: state.effort.codexTier,
-      claudeAdvice: state.effort.claudeAdvice
+      claudeAdvice: state.effort.claudeAdvice,
+      ...this.burnRateSnapshotFields(state)
     };
+  }
+  burnRateSnapshotFields(state) {
+    const rates = {
+      claude: agentBurnRates(state.perAgent.claude),
+      codex: agentBurnRates(state.perAgent.codex)
+    };
+    const runway = {
+      claude: agentRunway(state.perAgent.claude, state.now),
+      codex: agentRunway(state.perAgent.codex, state.now)
+    };
+    if (!hasAnyBurnSignal(rates, runway))
+      return {};
+    return { burnRate: rates, runway };
   }
 }
 
@@ -4358,6 +4426,57 @@ import { execFile } from "child_process";
 import { existsSync as existsSync5 } from "fs";
 import { homedir as homedir2 } from "os";
 import { basename, join as join5 } from "path";
+function parseBurnFields(record) {
+  const group = {};
+  let any = false;
+  const takeNumber = (value, min) => {
+    if (value === undefined)
+      return "absent";
+    if (typeof value !== "number" || !Number.isFinite(value))
+      return "invalid";
+    if (min === "zero" && value < 0)
+      return "invalid";
+    if (min === "positive" && value <= 0)
+      return "invalid";
+    return value;
+  };
+  const burnRate = takeNumber(record.burn_rate_pct_per_hour ?? record.burnRatePctPerHour, "zero");
+  if (burnRate === "invalid")
+    return null;
+  if (burnRate !== "absent") {
+    group.burnRate = burnRate;
+    any = true;
+  }
+  const confidentRaw = record.burn_confident ?? record.burnConfident;
+  if (confidentRaw !== undefined) {
+    if (typeof confidentRaw !== "boolean")
+      return null;
+    group.burnConfident = confidentRaw;
+    any = true;
+  }
+  const runwaySeconds = takeNumber(record.runway_seconds ?? record.runwaySeconds, "zero");
+  if (runwaySeconds === "invalid")
+    return null;
+  if (runwaySeconds !== "absent") {
+    group.runwaySeconds = runwaySeconds;
+    any = true;
+  }
+  const depletedAtEpoch = takeNumber(record.depleted_at_epoch ?? record.depletedAtEpoch, "positive");
+  if (depletedAtEpoch === "invalid")
+    return null;
+  if (depletedAtEpoch !== "absent") {
+    group.depletedAtEpoch = depletedAtEpoch;
+    any = true;
+  }
+  const fiveHourWindowsLeft = takeNumber(record.five_hour_windows_left ?? record.fiveHourWindowsLeft, "zero");
+  if (fiveHourWindowsLeft === "invalid")
+    return null;
+  if (fiveHourWindowsLeft !== "absent") {
+    group.fiveHourWindowsLeft = fiveHourWindowsLeft;
+    any = true;
+  }
+  return any ? group : null;
+}
 var DEFAULT_TIMEOUT_MS = 1e4;
 var MAX_BUFFER = 1024 * 1024;
 function defaultRunner(command, args, options) {
@@ -4419,7 +4538,8 @@ function normalizeBucket(value, fetchedAt) {
     id,
     util: clamp(util, 0, 100),
     resetEpoch: Math.max(0, resetEpoch),
-    resetAfterSeconds: resetAfter === null ? null : Math.max(0, resetAfter)
+    resetAfterSeconds: resetAfter === null ? null : Math.max(0, resetAfter),
+    burn: parseBurnFields(bucket)
   };
 }
 function normalizeTopLevelBucket(record, util, fetchedAt) {
@@ -4432,13 +4552,27 @@ function normalizeTopLevelBucket(record, util, fetchedAt) {
     id: "top_level",
     util: clamp(util, 0, 100),
     resetEpoch: Math.max(0, resetEpoch),
-    resetAfterSeconds: resetAfter === null ? null : Math.max(0, resetAfter)
+    resetAfterSeconds: resetAfter === null ? null : Math.max(0, resetAfter),
+    burn: parseBurnFields(record)
   };
 }
 function toWindow(bucket) {
   if (!bucket)
     return null;
-  return { util: bucket.util, resetEpoch: bucket.resetEpoch };
+  const window = { util: bucket.util, resetEpoch: bucket.resetEpoch };
+  if (bucket.burn) {
+    if (bucket.burn.burnRate !== undefined)
+      window.burnRate = bucket.burn.burnRate;
+    if (bucket.burn.burnConfident !== undefined)
+      window.burnConfident = bucket.burn.burnConfident;
+    if (bucket.burn.runwaySeconds !== undefined)
+      window.runwaySeconds = bucket.burn.runwaySeconds;
+    if (bucket.burn.depletedAtEpoch !== undefined)
+      window.depletedAtEpoch = bucket.burn.depletedAtEpoch;
+    if (bucket.burn.fiveHourWindowsLeft !== undefined)
+      window.fiveHourWindowsLeft = bucket.burn.fiveHourWindowsLeft;
+  }
+  return window;
 }
 function bucketSortKey(bucket) {
   if (bucket.resetAfterSeconds !== null)
@@ -4518,10 +4652,11 @@ function normalizeTolerantProbeRecord(record) {
   };
 }
 var PROBE_SCHEMA_PARSERS = {
-  "1": normalizeTolerantProbeRecord
+  "1": normalizeTolerantProbeRecord,
+  "2": normalizeTolerantProbeRecord
 };
 function schemaVersionKey(record) {
-  const value = record.schema_version ?? record.schemaVersion;
+  const value = record.schema_version ?? record.schemaVersion ?? record.probe_schema ?? record.probeSchema;
   if (typeof value === "number" && Number.isFinite(value))
     return String(value);
   if (typeof value === "string" && value.trim() !== "")
@@ -5119,7 +5254,7 @@ function ensureBudgetCoordinatorStarted() {
   if (!BUDGET_CONFIG.enabled)
     return;
   if (!budgetCoordinator) {
-    log(`Budget coordinator config: pollSeconds=${BUDGET_CONFIG.pollSeconds} pauseAt=${BUDGET_CONFIG.pauseAt} ` + `resumeBelow=${BUDGET_CONFIG.resumeBelow} syncDriftPct=${BUDGET_CONFIG.syncDriftPct} ` + `parallel=${BUDGET_CONFIG.parallel.minRemainingPct}%/${BUDGET_CONFIG.parallel.timeWindowSec}s ` + `codexTierControl=${BUDGET_CONFIG.codexTierControl} ` + `codexTiersFull=${BUDGET_CONFIG.codexTiers.full ? "configured" : "missing"}`);
+    log(`Budget coordinator config: pollSeconds=${BUDGET_CONFIG.pollSeconds} pauseAt=${BUDGET_CONFIG.pauseAt} ` + `resumeBelow=${BUDGET_CONFIG.resumeBelow} syncDriftPct=${BUDGET_CONFIG.syncDriftPct} ` + `parallel=${BUDGET_CONFIG.parallel.minRemainingPct}%/${BUDGET_CONFIG.parallel.timeWindowSec}s ` + `codexTierControl=${BUDGET_CONFIG.codexTierControl} ` + `codexTiersFull=${BUDGET_CONFIG.codexTiers.full ? "configured" : "missing"} ` + `strategy=${BUDGET_CONFIG.strategy}`);
     budgetCoordinator = new BudgetCoordinator({
       source: createQuotaSource({ log }),
       config: BUDGET_CONFIG,

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -4,6 +4,7 @@ import {
   INITIAL_FINGERPRINT_STATE,
   type FingerprintState,
 } from "./budget-fingerprint";
+import { agentBurnRates, agentRunway, hasAnyBurnSignal } from "./burn-view";
 import type {
   AgentName,
   AgentUsage,
@@ -427,6 +428,27 @@ export class BudgetCoordinator {
       parallelRecommended: paused ? false : state.parallel.recommended,
       codexTier: state.effort.codexTier,
       claudeAdvice: state.effort.claudeAdvice,
+      ...this.burnRateSnapshotFields(state),
     };
+  }
+
+  /**
+   * v3 P1 burn fields (display-only, layered amendment): pass the guard's
+   * decision-grade probe fields through verbatim — the bridge selects (min
+   * across windows) but never computes. Absent entirely when the probe
+   * carries no burn signal (old guard / not enough samples), keeping the
+   * legacy snapshot shape for old consumers.
+   */
+  private burnRateSnapshotFields(state: BudgetState): Pick<BudgetSnapshot, "burnRate" | "runway"> | Record<never, never> {
+    const rates = {
+      claude: agentBurnRates(state.perAgent.claude),
+      codex: agentBurnRates(state.perAgent.codex),
+    };
+    const runway = {
+      claude: agentRunway(state.perAgent.claude, state.now),
+      codex: agentRunway(state.perAgent.codex, state.now),
+    };
+    if (!hasAnyBurnSignal(rates, runway)) return {};
+    return { burnRate: rates, runway };
   }
 }

--- a/src/budget/burn-view.ts
+++ b/src/budget/burn-view.ts
@@ -1,0 +1,103 @@
+/**
+ * Burn-rate CONSUMPTION layer (budget v3 §3.3, layered amendment).
+ *
+ * agent-quota-guard owns collection, EWMA estimation, confidence gating and
+ * persistence; its probe emits decision-grade per-bucket fields
+ * (`burn_rate_pct_per_hour` / `burn_confident` / `runway_seconds` /
+ * `depleted_at_epoch` / `five_hour_windows_left`). This module only projects
+ * those fields — already validated by quota-source — into the snapshot shapes.
+ * Two hard constraints (Codex acceptance):
+ *
+ *  1. Missing fields / old schema / non-numeric / stale / reset-unknown all
+ *     degrade to conserve: no runway is ever fabricated (no runway → no line).
+ *  2. The bridge NEVER recomputes burn rates or runways — selection (minimum
+ *     across windows) is the only operation performed here.
+ */
+
+import { isDecisionGrade } from "./budget-state";
+import type {
+  AgentBurnRates,
+  AgentUsage,
+  BudgetWindow,
+  BudgetWindowKey,
+  BurnRate,
+  RunwayEstimate,
+} from "./types";
+
+/** Project one window's guard burn fields into the BurnRate display shape. */
+export function windowBurnRate(window: BudgetWindow | null): BurnRate | null {
+  if (!window || window.burnRate === undefined) return null;
+  return {
+    pctPerHour: window.burnRate,
+    // Absent burn_confident is NOT confidence — constraint #1.
+    confident: window.burnConfident === true,
+  };
+}
+
+/** Per-agent burn rates straight off the probe windows. */
+export function agentBurnRates(usage: AgentUsage | null): AgentBurnRates {
+  if (!usage) return { fiveHour: null, weekly: null };
+  return {
+    fiveHour: windowBurnRate(usage.fiveHour),
+    weekly: windowBurnRate(usage.weekly),
+  };
+}
+
+/**
+ * Agent-level runway: the MINIMUM `runway_seconds` across windows that are
+ * decision-grade (fresh reset, non-stale record per isDecisionGrade) and
+ * carry a confident guard rate. Pure selection — never arithmetic on rates.
+ * Null when no window qualifies (constraint #1: conserve, render no line).
+ */
+export function agentRunway(usage: AgentUsage | null, now: number): RunwayEstimate | null {
+  // Constraint #1 spells out stale explicitly; isDecisionGrade covers
+  // freshness (window reset + fetchedAt age) but not the probe's stale/ok
+  // flags, so both gates apply.
+  if (!usage || usage.stale || !usage.ok) return null;
+  if (!isDecisionGrade(usage, now)) return null;
+
+  let best: RunwayEstimate | null = null;
+  const candidates: Array<[BudgetWindowKey, BudgetWindow | null]> = [
+    ["fiveHour", usage.fiveHour],
+    ["weekly", usage.weekly],
+  ];
+  for (const [basis, window] of candidates) {
+    if (!window || window.resetEpoch <= now) continue; // reset-unknown/expired → conserve
+    if (window.burnConfident !== true) continue;
+    if (window.runwaySeconds === undefined) continue;
+    if (best === null || window.runwaySeconds < best.seconds) {
+      best = {
+        seconds: window.runwaySeconds,
+        basis,
+        depletedAtEpoch: window.depletedAtEpoch ?? null,
+      };
+    }
+  }
+  return best;
+}
+
+/** Weekly 5h-window count, gated by the same freshness/confidence rules as runway. */
+export function agentWeeklyFiveHourWindowsLeft(usage: AgentUsage | null, now: number): number | null {
+  if (!usage || usage.stale || !usage.ok) return null;
+  if (!isDecisionGrade(usage, now)) return null;
+  const weekly = usage.weekly;
+  if (!weekly || weekly.resetEpoch <= now) return null;
+  if (weekly.burnConfident !== true) return null;
+  if (weekly.runwaySeconds === undefined) return null;
+  return weekly.fiveHourWindowsLeft ?? null;
+}
+
+/** True when either agent carries any burn signal worth a snapshot field. */
+export function hasAnyBurnSignal(
+  rates: { claude: AgentBurnRates; codex: AgentBurnRates },
+  runway: { claude: RunwayEstimate | null; codex: RunwayEstimate | null },
+): boolean {
+  return (
+    rates.claude.fiveHour !== null ||
+    rates.claude.weekly !== null ||
+    rates.codex.fiveHour !== null ||
+    rates.codex.weekly !== null ||
+    runway.claude !== null ||
+    runway.codex !== null
+  );
+}

--- a/src/budget/quota-source.ts
+++ b/src/budget/quota-source.ts
@@ -40,6 +40,84 @@ interface RawBucket {
   util: number;
   resetEpoch: number;
   resetAfterSeconds: number | null;
+  /** v3 layered amendment: guard burn fields (consume-only), all-or-nothing group. */
+  burn: BurnFieldGroup | null;
+}
+
+/**
+ * Decision-grade burn fields from the guard probe (v3 layered amendment).
+ * The bridge never computes these — it only validates and passes them on.
+ */
+interface BurnFieldGroup {
+  burnRate?: number;
+  burnConfident?: boolean;
+  runwaySeconds?: number;
+  depletedAtEpoch?: number;
+  fiveHourWindowsLeft?: number;
+}
+
+/**
+ * Parse the optional guard burn-field group off one bucket record.
+ *
+ * Strictness contract (Codex acceptance constraint #1): these fields are
+ * decision-grade and producer-controlled, so unlike the tolerant numeric
+ * parsing elsewhere we accept ONLY well-typed values — numbers must be finite
+ * and non-negative (depleted_at_epoch strictly positive), burn_confident must
+ * be a real boolean. Any PRESENT-but-invalid field poisons the entire group
+ * (conserve degradation: no fabricated runway beats a wrong one). Absent
+ * fields are fine individually — the guard omits what it cannot estimate.
+ */
+function parseBurnFields(record: Record<string, unknown>): BurnFieldGroup | null {
+  const group: BurnFieldGroup = {};
+  let any = false;
+
+  const takeNumber = (value: unknown, min: "zero" | "positive"): number | "invalid" | "absent" => {
+    if (value === undefined) return "absent";
+    if (typeof value !== "number" || !Number.isFinite(value)) return "invalid";
+    if (min === "zero" && value < 0) return "invalid";
+    if (min === "positive" && value <= 0) return "invalid";
+    return value;
+  };
+
+  const burnRate = takeNumber(record.burn_rate_pct_per_hour ?? record.burnRatePctPerHour, "zero");
+  if (burnRate === "invalid") return null;
+  if (burnRate !== "absent") {
+    group.burnRate = burnRate;
+    any = true;
+  }
+
+  const confidentRaw = record.burn_confident ?? record.burnConfident;
+  if (confidentRaw !== undefined) {
+    if (typeof confidentRaw !== "boolean") return null;
+    group.burnConfident = confidentRaw;
+    any = true;
+  }
+
+  const runwaySeconds = takeNumber(record.runway_seconds ?? record.runwaySeconds, "zero");
+  if (runwaySeconds === "invalid") return null;
+  if (runwaySeconds !== "absent") {
+    group.runwaySeconds = runwaySeconds;
+    any = true;
+  }
+
+  const depletedAtEpoch = takeNumber(record.depleted_at_epoch ?? record.depletedAtEpoch, "positive");
+  if (depletedAtEpoch === "invalid") return null;
+  if (depletedAtEpoch !== "absent") {
+    group.depletedAtEpoch = depletedAtEpoch;
+    any = true;
+  }
+
+  const fiveHourWindowsLeft = takeNumber(
+    record.five_hour_windows_left ?? record.fiveHourWindowsLeft,
+    "zero",
+  );
+  if (fiveHourWindowsLeft === "invalid") return null;
+  if (fiveHourWindowsLeft !== "absent") {
+    group.fiveHourWindowsLeft = fiveHourWindowsLeft;
+    any = true;
+  }
+
+  return any ? group : null;
 }
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -121,6 +199,7 @@ function normalizeBucket(value: unknown, fetchedAt: number): RawBucket | null {
     util: clamp(util, 0, 100),
     resetEpoch: Math.max(0, resetEpoch),
     resetAfterSeconds: resetAfter === null ? null : Math.max(0, resetAfter),
+    burn: parseBurnFields(bucket),
   };
 }
 
@@ -141,12 +220,23 @@ function normalizeTopLevelBucket(record: Record<string, unknown>, util: number, 
     util: clamp(util, 0, 100),
     resetEpoch: Math.max(0, resetEpoch),
     resetAfterSeconds: resetAfter === null ? null : Math.max(0, resetAfter),
+    burn: parseBurnFields(record),
   };
 }
 
 function toWindow(bucket: RawBucket | null | undefined): BudgetWindow | null {
   if (!bucket) return null;
-  return { util: bucket.util, resetEpoch: bucket.resetEpoch };
+  const window: BudgetWindow = { util: bucket.util, resetEpoch: bucket.resetEpoch };
+  if (bucket.burn) {
+    // Spread only present fields — `toEqual`-style consumers and JSON
+    // serialization must not see explicit-undefined keys.
+    if (bucket.burn.burnRate !== undefined) window.burnRate = bucket.burn.burnRate;
+    if (bucket.burn.burnConfident !== undefined) window.burnConfident = bucket.burn.burnConfident;
+    if (bucket.burn.runwaySeconds !== undefined) window.runwaySeconds = bucket.burn.runwaySeconds;
+    if (bucket.burn.depletedAtEpoch !== undefined) window.depletedAtEpoch = bucket.burn.depletedAtEpoch;
+    if (bucket.burn.fiveHourWindowsLeft !== undefined) window.fiveHourWindowsLeft = bucket.burn.fiveHourWindowsLeft;
+  }
+  return window;
 }
 
 function bucketSortKey(bucket: RawBucket): number {
@@ -260,10 +350,15 @@ function normalizeTolerantProbeRecord(record: Record<string, unknown>): AgentUsa
 
 const PROBE_SCHEMA_PARSERS: Record<string, ProbeParser> = {
   "1": normalizeTolerantProbeRecord,
+  // v3 layered amendment: probe_schema 2 adds the optional per-bucket burn
+  // fields; the tolerant parser already consumes them by presence, so the
+  // version is recognized (no unknown-schema log) but never strictly required.
+  "2": normalizeTolerantProbeRecord,
 };
 
 function schemaVersionKey(record: Record<string, unknown>): string | null {
-  const value = record.schema_version ?? record.schemaVersion;
+  const value =
+    record.schema_version ?? record.schemaVersion ?? record.probe_schema ?? record.probeSchema;
   if (typeof value === "number" && Number.isFinite(value)) return String(value);
   if (typeof value === "string" && value.trim() !== "") return value.trim();
   return null;

--- a/src/budget/render.ts
+++ b/src/budget/render.ts
@@ -6,7 +6,37 @@
  * User-facing text is Chinese per project convention.
  */
 
-import type { AgentUsage, BudgetSnapshot } from "./types";
+import { agentWeeklyFiveHourWindowsLeft } from "./burn-view";
+import type {
+  AgentBurnRates,
+  AgentUsage,
+  BudgetSnapshot,
+  BudgetWindowKey,
+  BurnRate,
+  RunwayEstimate,
+} from "./types";
+
+/**
+ * Default outer quota-guard hard line (the user's agent-quota-guard
+ * BUDGET_HARD default). Display-only context for the v3 Q7 annotation —
+ * never feeds any pause/resume decision.
+ */
+export const DEFAULT_GUARD_HARD_PCT = 92;
+
+/**
+ * Resolve the guard hard-line DISPLAY hint: AGENTBRIDGE_GUARD_HARD_HINT
+ * overrides the default 92; invalid or out-of-range values fall back. Only
+ * affects rendering (Q7 enhanced-B), never the strategy layer.
+ */
+export function resolveGuardHardHint(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.AGENTBRIDGE_GUARD_HARD_HINT;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_GUARD_HARD_PCT;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1 || parsed > 100) return DEFAULT_GUARD_HARD_PCT;
+  return parsed;
+}
 
 function formatEpoch(epochSeconds: number | null | undefined): string {
   if (!epochSeconds || epochSeconds <= 0) return "未知";
@@ -43,6 +73,125 @@ function formatAgent(name: string, usage: AgentUsage | null, snapshotAt: number)
   return `${name}：${parts.join(" · ")}`;
 }
 
+const WINDOW_LABELS: Record<BudgetWindowKey, string> = {
+  fiveHour: "5h 窗口",
+  weekly: "周窗口",
+};
+
+/**
+ * Tolerance for "runway truncated by the window reset": the guard's neutral
+ * runway_seconds is reset-truncated, so when it lands within this many
+ * seconds of the basis window's reset, the binding constraint is the refresh
+ * itself, not depletion — annotate accordingly instead of implying the quota
+ * runs out.
+ */
+const RESET_TRUNCATION_EPSILON_SEC = 60;
+
+/** Format a duration as 「X小时Y分钟」 (minutes rounded; <1h shows 「Y分钟」). */
+export function formatDuration(seconds: number): string {
+  const totalMinutes = Math.max(0, Math.round(seconds / 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `${minutes}分钟`;
+  return `${hours}小时${minutes}分钟`;
+}
+
+/** Format an epoch as a LOCAL-timezone wall-clock 「HH:MM」. */
+export function formatClockTime(epochSeconds: number): string {
+  const date = new Date(epochSeconds * 1000);
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+function formatWindowRate(label: string, rate: BurnRate | null): string | null {
+  if (!rate) return null;
+  if (!rate.confident) return `${label} 采样中`;
+  return `${label} ≈${rate.pctPerHour.toFixed(2)}%/h`;
+}
+
+/**
+ * The runway display segment. All numbers are the guard's verbatim fields
+ * (constraint #2: the bridge never recomputes) — this function only formats:
+ *  - duration from runway_seconds;
+ *  - 「至 HH:MM」 from depleted_at_epoch (local clock; omitted when absent);
+ *  - the reset-truncation note when runway_seconds ends at the basis
+ *    window's reset (refresh un-blocks before depletion would).
+ */
+function formatRunwaySegment(
+  runway: RunwayEstimate,
+  basisWindow: AgentUsage["fiveHour"],
+  snapshotAt: number,
+): string {
+  const truncatedByReset =
+    basisWindow !== null &&
+    basisWindow.resetEpoch > 0 &&
+    snapshotAt + runway.seconds >= basisWindow.resetEpoch - RESET_TRUNCATION_EPSILON_SEC;
+
+  const clock = runway.depletedAtEpoch ? formatClockTime(runway.depletedAtEpoch) : null;
+  let clockNote: string;
+  if (clock) {
+    clockNote = truncatedByReset ? `至 ${clock} 窗口刷新即截断，` : `至 ${clock}，`;
+  } else {
+    clockNote = truncatedByReset ? "窗口刷新即截断，" : "";
+  }
+  return `约可再工作 ${formatDuration(runway.seconds)}（${clockNote}${WINDOW_LABELS[runway.basis]}为约束）`;
+}
+
+/**
+ * One burn-rate/runway line per agent (v3 P1, layered amendment). Returns
+ * null when the agent has no rate data at all — legacy snapshots (and old
+ * guard probes without the burn fields) render exactly as before.
+ *
+ * Claude guard annotation (Q7, honesty-first choice): the guard's
+ * runway_seconds is the NEUTRAL "to 100%" estimate, but quota-guard
+ * hard-stops the Claude process at its own hard line (default 92%) first.
+ * Rather than scaling the number ourselves (a proportional fold assumes
+ * linear burn AND breaks when the runway is reset-truncated — effectively a
+ * recomputation, which constraint #2 forbids), we display the guard's number
+ * untouched and state the caveat explicitly.
+ */
+function formatBurnRateLine(
+  name: string,
+  usage: AgentUsage | null,
+  rates: AgentBurnRates,
+  runway: RunwayEstimate | null,
+  snapshotAt: number,
+  guardHardPct: number | null,
+): string | null {
+  const parts = [
+    formatWindowRate("5h", rates.fiveHour),
+    formatWindowRate("周", rates.weekly),
+  ].filter((part): part is string => part !== null);
+  if (parts.length === 0 && !runway) return null;
+
+  if (runway) {
+    const basisWindow = usage ? usage[runway.basis] : null;
+    parts.push(formatRunwaySegment(runway, basisWindow, snapshotAt));
+  }
+  if (guardHardPct !== null) {
+    parts.push(
+      `外层 guard 硬线 ${guardHardPct}%（v3 不可越过；runway 为中性口径，Claude 会先在硬线被外层停住）`,
+    );
+  }
+  return `${name} 燃尽率：${parts.join(" · ")}`;
+}
+
+function formatFiveHourWindowsLeftLine(snapshot: BudgetSnapshot): string | null {
+  const values: Array<[string, number]> = [];
+  const claude = agentWeeklyFiveHourWindowsLeft(snapshot.claude, snapshot.updatedAt);
+  const codex = agentWeeklyFiveHourWindowsLeft(snapshot.codex, snapshot.updatedAt);
+  if (claude !== null) values.push(["Claude", claude]);
+  if (codex !== null) values.push(["Codex", codex]);
+  if (values.length === 0) return null;
+
+  const unique = [...new Set(values.map(([, value]) => value.toFixed(1)))];
+  if (unique.length === 1) return `按当前节奏，周额度还够 ~${unique[0]} 个 5h 窗口`;
+
+  const byAgent = values.map(([name, value]) => `${name} ~${value.toFixed(1)}`).join(" / ");
+  return `按当前节奏，周额度还够 ${byAgent} 个 5h 窗口`;
+}
+
 const PHASE_LABELS: Record<BudgetSnapshot["phase"], string> = {
   normal: "normal（正常）",
   balance: "balance（需均衡）",
@@ -52,11 +201,42 @@ const PHASE_LABELS: Record<BudgetSnapshot["phase"], string> = {
 };
 
 /** Render a budget snapshot as readable Chinese text. */
-export function renderBudgetSnapshot(snapshot: BudgetSnapshot): string {
+export function renderBudgetSnapshot(
+  snapshot: BudgetSnapshot,
+  options: { guardHardPct?: number } = {},
+): string {
+  const guardHardPct = options.guardHardPct ?? resolveGuardHardHint();
   const lines: string[] = [];
   lines.push(`【预算快照 · 账号级】阶段：${PHASE_LABELS[snapshot.phase]} · 更新于 ${formatEpoch(snapshot.updatedAt)}`);
   lines.push(formatAgent("Claude", snapshot.claude, snapshot.updatedAt));
   lines.push(formatAgent("Codex", snapshot.codex, snapshot.updatedAt));
+
+  // v3 P1 (layered amendment): burn-rate / runway lines, present only when the
+  // guard probe supplied the optional decision-grade fields. The guard-hardline
+  // annotation applies to the CLAUDE side only — quota-guard supervises the
+  // Claude process; Codex has no such bound.
+  if (snapshot.burnRate) {
+    const claudeLine = formatBurnRateLine(
+      "Claude",
+      snapshot.claude,
+      snapshot.burnRate.claude,
+      snapshot.runway?.claude ?? null,
+      snapshot.updatedAt,
+      guardHardPct,
+    );
+    if (claudeLine) lines.push(claudeLine);
+    const codexLine = formatBurnRateLine(
+      "Codex",
+      snapshot.codex,
+      snapshot.burnRate.codex,
+      snapshot.runway?.codex ?? null,
+      snapshot.updatedAt,
+      null,
+    );
+    if (codexLine) lines.push(codexLine);
+  }
+  const fiveHourWindowsLeftLine = formatFiveHourWindowsLeftLine(snapshot);
+  if (fiveHourWindowsLeftLine) lines.push(fiveHourWindowsLeftLine);
 
   if (snapshot.claude && snapshot.codex) {
     const abs = Math.abs(snapshot.driftPct);

--- a/src/budget/types.ts
+++ b/src/budget/types.ts
@@ -22,6 +22,29 @@ export interface BudgetWindow {
   util: number;
   /** Unix seconds when this window resets; 0 if unknown. */
   resetEpoch: number;
+  /**
+   * v3 layered amendment (§3.3): decision-grade burn fields produced by
+ * agent-quota-guard's probe and passed through verbatim. AgentBridge NEVER
+ * computes burn rates itself — these are consume-only. The group is absent
+ * when the guard omitted them (old probe / not enough samples) or when any
+ * of them failed strict validation (the whole group is dropped together).
+   */
+  /** Guard EWMA burn rate (probe `burn_rate_pct_per_hour`), pct/h, ≥0. */
+  burnRate?: number;
+  /** Guard confidence gate (probe `burn_confident`). */
+  burnConfident?: boolean;
+  /**
+   * Guard runway in seconds (probe `runway_seconds`), neutral semantics:
+   * time to 100% util, truncated at the window reset.
+   */
+  runwaySeconds?: number;
+  /** Unix seconds when the guard projects depletion (probe `depleted_at_epoch`). */
+  depletedAtEpoch?: number;
+  /**
+   * Guard weekly-window projection (probe `five_hour_windows_left`): how many
+   * 5h windows the weekly runway can cover at the current burn rate.
+   */
+  fiveHourWindowsLeft?: number;
 }
 
 /** How confidently AgentBridge mapped raw probe buckets to known quota windows. */
@@ -68,6 +91,51 @@ export type BudgetPhase = "normal" | "balance" | "parallel" | "paused";
 
 export type CodexTier = "full" | "balanced" | "eco";
 
+/**
+ * Budget strategy selector (v3). P1 parses and validates this key but the
+ * decision path is hard-wired to conserve behavior — `maximize` is consumed
+ * ONLY by `abg doctor` (Q7 guard-hardline warning) until P2 lands.
+ */
+export type BudgetStrategy = "conserve" | "maximize";
+
+/** Identifies one of the two quota windows tracked per agent. */
+export type BudgetWindowKey = "fiveHour" | "weekly";
+
+/**
+ * Burn rate for one agent × window (v3 §3.3, layered amendment): a pure
+ * CONSUMPTION shape over the guard's probe fields. Collection / EWMA /
+ * confidence all live in agent-quota-guard; the bridge never recomputes.
+ * Percentage points of quota consumed per hour, account-wide.
+ */
+export interface BurnRate {
+  /** Guard burn rate (probe `burn_rate_pct_per_hour`). */
+  pctPerHour: number;
+  /** Guard confidence gate (probe `burn_confident`); false/absent → 采样中. */
+  confident: boolean;
+}
+
+/** Per-agent burn rates, one slot per identifiable window. */
+export interface AgentBurnRates {
+  fiveHour: BurnRate | null;
+  weekly: BurnRate | null;
+}
+
+/**
+ * "How long can this agent keep working" estimate (v3 §3.3, layered
+ * amendment): selected — not computed — from the guard's `runway_seconds`
+ * fields: the minimum across decision-grade windows with a confident rate.
+ * Neutral semantics inherited from the guard: time to 100%, truncated at
+ * the window reset.
+ */
+export interface RunwayEstimate {
+  /** Guard `runway_seconds` of the binding window, passed through verbatim. */
+  seconds: number;
+  /** Which window produced the binding (shortest) runway. */
+  basis: BudgetWindowKey;
+  /** Guard `depleted_at_epoch` of the binding window; null when omitted. */
+  depletedAtEpoch: number | null;
+}
+
 /** Budget section of AgentBridgeConfig (defaults in config-service.ts). */
 export interface BudgetConfig {
   enabled: boolean;
@@ -89,6 +157,15 @@ export interface BudgetConfig {
   codexTierControl: boolean;
   /** Tier → override mapping; `full` must be configured for tier control to activate. */
   codexTiers: CodexTierMap;
+  /**
+   * v3 strategy selector. P1: parse-and-validate only — behavior is always
+   * conserve; the value is consumed solely by the doctor Q7 check.
+   *
+   * NOTE (layered amendment): burn-rate collection moved to agent-quota-guard;
+   * the former `burnRate.{enabled,sampleCap}` config keys are gone. Display
+   * follows probe field presence — no toggle needed.
+   */
+  strategy: BudgetStrategy;
 }
 
 /** Pure-function output of computeBudgetState(). */
@@ -144,6 +221,18 @@ export interface BudgetSnapshot {
   codexTier: CodexTier;
   /** Advisory for Claude-side subagent model tiering when its budget is tight; null when none. */
   claudeAdvice: string | null;
+  /**
+   * v3 P1 (optional — absent on legacy daemons and when the guard probe does
+   * not provide burn fields, so old consumers deserialize unchanged):
+   * per-agent per-window burn rates passed through from the guard probe.
+   */
+  burnRate?: { claude: AgentBurnRates; codex: AgentBurnRates };
+  /**
+   * v3 P1 (optional, same compatibility contract as burnRate): guard-provided
+   * remaining work time per agent; null until the guard reports a confident
+   * rate on at least one decision-grade window.
+   */
+  runway?: { claude: RunwayEstimate | null; codex: RunwayEstimate | null };
 }
 
 /** Optional per-turn overrides injected into Codex turn/start (sticky on the thread). */

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -10,7 +10,9 @@ import {
   type AgentBridgeBuildInfo,
 } from "../build-info";
 import { cliInvocationName } from "../cli-invocation";
-import { ConfigService } from "../config-service";
+import { ConfigService, applyBudgetEnvOverrides } from "../config-service";
+import { resolveGuardHardHint } from "../budget/render";
+import type { BudgetStrategy } from "../budget/types";
 import { fetchDaemonStatus } from "../daemon-status";
 import { inspectAgentBridgeEnv } from "../env-guard";
 import {
@@ -217,6 +219,7 @@ async function buildDoctorReport(pair: PairResolution, registered: boolean): Pro
       : `环境变量与当前目录不匹配：请在正确的项目目录里重新运行 \`${cli} claude\`，不要复用其他目录的会话环境。`,
   });
   checks.push(configParseabilityCheck(cwd, cli));
+  checks.push(budgetStrategyGuardCheck(cwd));
   checks.push({
     name: "daemon health",
     status: health ? "ok" : "warn",
@@ -555,6 +558,64 @@ function configParseabilityCheck(cwd: string, cli: string): DoctorCheck {
       ? `parsed at ${desc.path} — custom values in effect`
       : `parsed at ${desc.path} — all values match defaults`,
   };
+}
+
+/**
+ * Default v3 maximize target utilization (design §3.1). P1 does not parse the
+ * maximize parameter block yet (that lands with P2), so the doctor check
+ * compares the guard hard line against this design default.
+ */
+export const V3_DEFAULT_TARGET_UTIL = 97;
+
+/**
+ * Pure verdict for the v3 Q7 enhanced-B doctor check: with strategy=maximize,
+ * the OUTER quota-guard hard line (default 92, the guard's BUDGET_HARD
+ * default) hard-stops the Claude process BEFORE v3's targetUtil — the
+ * 92→targetUtil band is unreachable until the user raises the guard line.
+ * v3 never crosses or bypasses the guard (REAL-3); this check makes that
+ * boundary visible instead of letting runway displays mislead.
+ */
+export function evaluateBudgetStrategyGuard(
+  strategy: BudgetStrategy,
+  guardHardPct: number,
+  targetUtilPct: number = V3_DEFAULT_TARGET_UTIL,
+): DoctorCheck {
+  if (strategy !== "maximize") {
+    return {
+      name: "budget strategy",
+      status: "ok",
+      detail: "strategy=conserve — v2-equivalent budget behavior (v3 maximize is opt-in)",
+    };
+  }
+  if (guardHardPct >= targetUtilPct) {
+    return {
+      name: "budget strategy",
+      status: "ok",
+      detail:
+        `strategy=maximize — outer guard hard line ${guardHardPct}% covers targetUtil ${targetUtilPct}%`,
+    };
+  }
+  return {
+    name: "budget strategy",
+    status: "warn",
+    detail:
+      `strategy=maximize but the outer quota-guard hard line (${guardHardPct}%) is below ` +
+      `targetUtil (${targetUtilPct}%) — the ${guardHardPct}→${targetUtilPct} band is unreachable for Claude`,
+    hint:
+      "v3 不可越过外层 quota-guard 硬线：Claude 侧达到 guard 硬线时进程会被外层强停，" +
+      `maximize 的 ${guardHardPct}%→${targetUtilPct}% 区间实际烧不到。想真正用到 targetUtil，` +
+      "需自行调高 quota-guard 的 BUDGET_HARD（本仓库不代改外层配置）；展示侧已按 guard 线收口。",
+  };
+}
+
+/**
+ * IO shell: read the project budget config (with env overrides, matching what
+ * the daemon would run with) and the guard hard-line display hint.
+ */
+function budgetStrategyGuardCheck(cwd: string): DoctorCheck {
+  const config = new ConfigService(cwd).loadOrDefault();
+  const budget = applyBudgetEnvOverrides(config.budget);
+  return evaluateBudgetStrategyGuard(budget.strategy, resolveGuardHardHint());
 }
 
 function logCheck(name: string, path: string, cli: string): DoctorCheck {

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -1,7 +1,7 @@
 import { readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { atomicWriteJson } from "./atomic-json";
-import type { BudgetConfig, CodexTierMap, CodexTurnOverrides } from "./budget/types";
+import type { BudgetConfig, BudgetStrategy, CodexTierMap, CodexTurnOverrides } from "./budget/types";
 
 /** Machine-readable project config schema. */
 export interface AgentBridgeConfig {
@@ -38,6 +38,10 @@ const DEFAULT_BUDGET_CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
+  // v3 P1: strategy is parse-and-validate only (behavior stays conserve; the
+  // value feeds the doctor Q7 guard-hardline check). Burn-rate data is
+  // consumed from the guard probe — no collection config on this side.
+  strategy: "conserve",
 };
 
 const DEFAULT_CONFIG: AgentBridgeConfig = {
@@ -212,6 +216,37 @@ function normalizeBoundedInteger(
   return parsed;
 }
 
+/**
+ * Bounded validation for FRACTIONAL config parameters (v3 Q6 consensus:
+ * upcoming keys like reserveSlopePctPerHour are decimals, so the ×10-integer
+ * hack is rejected in favor of first-class number support). Signature mirrors
+ * {@link normalizeBoundedInteger}; unlike normalizeInteger's coercion, an
+ * empty/whitespace string falls back instead of coercing to 0.
+ */
+export function normalizeBoundedNumber(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  let parsed: number;
+  if (typeof value === "number") {
+    parsed = value;
+  } else if (typeof value === "string" && value.trim() !== "") {
+    parsed = Number(value);
+  } else {
+    return fallback;
+  }
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < min || parsed > max) return fallback;
+  return parsed;
+}
+
+/** v3 strategy selector: anything but the two known literals falls back. */
+function normalizeStrategy(value: unknown, fallback: BudgetStrategy): BudgetStrategy {
+  return value === "conserve" || value === "maximize" ? value : fallback;
+}
+
 function normalizeBoolean(value: unknown, fallback: boolean): boolean {
   if (typeof value === "boolean") return value;
   // Accept common env-var spellings ("1"/"0") alongside JSON-ish "true"/"false".
@@ -306,6 +341,7 @@ function normalizeBudgetConfig(
       normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) &&
       codexTiers.full !== null,
     codexTiers,
+    strategy: normalizeStrategy(budget.strategy, fallback.strategy),
   };
 }
 
@@ -333,6 +369,7 @@ export function applyBudgetEnvOverrides(
     // Tier mapping is file-config only (nested structure doesn't fit env vars);
     // re-normalization re-applies the full-restore activation rule.
     codexTiers: budget.codexTiers,
+    strategy: env.AGENTBRIDGE_BUDGET_STRATEGY ?? budget.strategy,
   };
   return normalizeBudgetConfig(overlay, budget);
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -234,7 +234,11 @@ function ensureBudgetCoordinatorStarted() {
       `codexTierControl=${BUDGET_CONFIG.codexTierControl} ` +
       // Normalization degrades tier control to false when the sticky-restore
       // point is missing; surface that state so the degrade is diagnosable.
-      `codexTiersFull=${BUDGET_CONFIG.codexTiers.full ? "configured" : "missing"}`,
+      `codexTiersFull=${BUDGET_CONFIG.codexTiers.full ? "configured" : "missing"} ` +
+      // v3 P1: strategy is parse-only (behavior stays conserve). Burn-rate
+      // data is CONSUMED from the guard probe (layered amendment) — the
+      // daemon collects nothing.
+      `strategy=${BUDGET_CONFIG.strategy}`,
     );
     budgetCoordinator = new BudgetCoordinator({
       source: createQuotaSource({ log }),

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -20,6 +20,7 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
+  strategy: "conserve",
 };
 
 type FetchResult = { claude: AgentUsage | null; codex: AgentUsage | null } | null;
@@ -975,5 +976,126 @@ describe("decision-grade data guards (stale cache / expired windows)", () => {
     await (coordinator as any).pollOnce();
     coordinator.stop();
     expect(coordinator.getCodexTurnOverrides()).toEqual({ effort: "low" });
+  });
+});
+
+describe("BudgetCoordinator — guard burn-field passthrough (v3 P1, layered amendment)", () => {
+  // The bridge is a pure consumer: rates/runway come verbatim from the guard's
+  // probe fields on each window; the coordinator only selects the minimum
+  // runway across decision-grade confident windows.
+
+  test("snapshot passes guard burn fields through and selects the binding runway", async () => {
+    const claude = usage({
+      fiveHour: {
+        util: 20,
+        resetEpoch: NOW + 3600,
+        burnRate: 1.2,
+        burnConfident: true,
+        runwaySeconds: 1800,
+        depletedAtEpoch: NOW + 1800,
+      },
+      weekly: {
+        util: 20,
+        resetEpoch: NOW + 500_000,
+        burnRate: 0.5,
+        burnConfident: true,
+        runwaySeconds: 7200,
+        depletedAtEpoch: NOW + 7200,
+      },
+    });
+    const source = new FakeSource([{ claude, codex: usage() }]);
+    const { coordinator } = makeCoordinator(source, longPollConfig());
+    await coordinator.start();
+    coordinator.stop();
+
+    const snapshot = coordinator.getSnapshot();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.burnRate?.claude.fiveHour).toEqual({ pctPerHour: 1.2, confident: true });
+    expect(snapshot!.burnRate?.claude.weekly).toEqual({ pctPerHour: 0.5, confident: true });
+    expect(snapshot!.burnRate?.codex).toEqual({ fiveHour: null, weekly: null });
+    // Minimum across windows: 1800s (fiveHour) < 7200s (weekly).
+    expect(snapshot!.runway?.claude).toEqual({
+      seconds: 1800,
+      basis: "fiveHour",
+      depletedAtEpoch: NOW + 1800,
+    });
+    expect(snapshot!.runway?.codex).toBeNull();
+  });
+
+  test("legacy probe output without burn fields keeps the legacy snapshot shape", async () => {
+    const source = new FakeSource([{ claude: usage(), codex: usage() }]);
+    const { coordinator } = makeCoordinator(source, longPollConfig());
+    await coordinator.start();
+    coordinator.stop();
+
+    const snapshot = coordinator.getSnapshot();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.burnRate).toBeUndefined();
+    expect(snapshot!.runway).toBeUndefined();
+  });
+
+  test("non-confident window passes the rate through but never yields a runway (conserve)", async () => {
+    const claude = usage({
+      fiveHour: {
+        util: 20,
+        resetEpoch: NOW + 3600,
+        burnRate: 1.2,
+        burnConfident: false,
+        runwaySeconds: 1800,
+      },
+    });
+    const source = new FakeSource([{ claude, codex: usage() }]);
+    const { coordinator } = makeCoordinator(source, longPollConfig());
+    await coordinator.start();
+    coordinator.stop();
+
+    const snapshot = coordinator.getSnapshot();
+    expect(snapshot!.burnRate?.claude.fiveHour).toEqual({ pctPerHour: 1.2, confident: false });
+    expect(snapshot!.runway?.claude).toBeNull();
+  });
+
+  test("stale records never yield a runway even with confident guard fields (conserve)", async () => {
+    const claude = usage({
+      stale: true,
+      // fetchedAt far in the past → fails isDecisionGrade's freshness check.
+      fetchedAt: NOW - 100_000,
+      fiveHour: {
+        util: 20,
+        resetEpoch: NOW + 3600,
+        burnRate: 1.2,
+        burnConfident: true,
+        runwaySeconds: 1800,
+        depletedAtEpoch: NOW + 1800,
+      },
+    });
+    const source = new FakeSource([{ claude, codex: usage() }]);
+    const { coordinator } = makeCoordinator(source, longPollConfig());
+    await coordinator.start();
+    coordinator.stop();
+
+    const snapshot = coordinator.getSnapshot();
+    // Rate is display-grade (like stale util itself); runway is decision-adjacent → dropped.
+    expect(snapshot!.burnRate?.claude.fiveHour).toEqual({ pctPerHour: 1.2, confident: true });
+    expect(snapshot!.runway?.claude).toBeNull();
+  });
+
+  test("reset-unknown window (resetEpoch 0) never yields a runway (conserve)", async () => {
+    const claude = usage({
+      fiveHour: {
+        util: 20,
+        resetEpoch: 0,
+        burnRate: 1.2,
+        burnConfident: true,
+        runwaySeconds: 1800,
+      },
+    });
+    const source = new FakeSource([{ claude, codex: usage() }]);
+    const { coordinator } = makeCoordinator(source, longPollConfig());
+    await coordinator.start();
+    coordinator.stop();
+
+    const snapshot = coordinator.getSnapshot();
+    expect(snapshot!.burnRate?.claude.fiveHour).toEqual({ pctPerHour: 1.2, confident: true });
+    expect(snapshot!.runway?.claude).toBeNull();
   });
 });

--- a/src/unit-test/budget-fingerprint.test.ts
+++ b/src/unit-test/budget-fingerprint.test.ts
@@ -23,6 +23,7 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
+  strategy: "conserve",
 };
 
 function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {

--- a/src/unit-test/budget-render.test.ts
+++ b/src/unit-test/budget-render.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { renderBudgetSnapshot, BUDGET_UNAVAILABLE_TEXT } from "../budget/render";
-import type { AgentUsage, BudgetSnapshot } from "../budget/types";
+import {
+  renderBudgetSnapshot,
+  resolveGuardHardHint,
+  formatDuration,
+  formatClockTime,
+  BUDGET_UNAVAILABLE_TEXT,
+} from "../budget/render";
+import type { AgentUsage, BudgetSnapshot, BurnRate } from "../budget/types";
 
 function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {
   return {
@@ -155,5 +161,213 @@ describe("renderBudgetSnapshot — claudeAdvice", () => {
 
   test("omits the advice line when null", () => {
     expect(renderBudgetSnapshot(snapshot({ claudeAdvice: null }))).not.toContain("Claude 建议：");
+  });
+});
+
+describe("formatDuration（分钟取整，<1 小时只显分钟）", () => {
+  test("boundaries", () => {
+    expect(formatDuration(0)).toBe("0分钟");
+    expect(formatDuration(29)).toBe("0分钟"); // rounds down
+    expect(formatDuration(90)).toBe("2分钟"); // rounds up
+    expect(formatDuration(59 * 60)).toBe("59分钟");
+    expect(formatDuration(3599)).toBe("1小时0分钟"); // rounding carries into the hour
+    expect(formatDuration(3600)).toBe("1小时0分钟");
+    expect(formatDuration(9000)).toBe("2小时30分钟");
+    expect(formatDuration(-5)).toBe("0分钟"); // defensive clamp
+  });
+});
+
+describe("formatClockTime（本地时区 HH:MM）", () => {
+  test("formats a local wall-clock time with zero padding", () => {
+    // Construct the epoch FROM local components so the test is TZ-agnostic.
+    const epoch = Math.floor(new Date(2026, 5, 11, 8, 5).getTime() / 1000);
+    expect(formatClockTime(epoch)).toBe("08:05");
+  });
+
+  test("crosses midnight into the next local day", () => {
+    const epoch = Math.floor(new Date(2026, 5, 12, 0, 7).getTime() / 1000);
+    expect(formatClockTime(epoch)).toBe("00:07");
+  });
+});
+
+describe("renderBudgetSnapshot — burn rate & runway (v3 P1, layered amendment)", () => {
+  const NOW = 1_780_711_700; // == snapshot().updatedAt
+  const NO_RATES = { fiveHour: null, weekly: null };
+
+  function burnRate(overrides: Partial<BurnRate> = {}): BurnRate {
+    return { pctPerHour: 1.2, confident: true, ...overrides };
+  }
+
+  test("legacy snapshot without the optional fields renders no burn-rate lines", () => {
+    const text = renderBudgetSnapshot(snapshot());
+    expect(text).not.toContain("燃尽率");
+    expect(text).not.toContain("约可再工作");
+    expect(text).not.toContain("guard 硬线");
+  });
+
+  test("confident rates render per-window rate, duration + local clock + basis, and the Claude guard annotation", () => {
+    // 3.2h = 11520s; depletion well before the weekly reset → no truncation note.
+    const depletedAt = NOW + 11_520;
+    const snap = snapshot({
+      burnRate: {
+        claude: { fiveHour: burnRate(), weekly: burnRate({ pctPerHour: 0.8 }) },
+        codex: NO_RATES,
+      },
+      runway: {
+        claude: { seconds: 11_520, basis: "weekly", depletedAtEpoch: depletedAt },
+        codex: null,
+      },
+    });
+    const text = renderBudgetSnapshot(snap);
+    expect(text).toContain("Claude 燃尽率：5h ≈1.20%/h · 周 ≈0.80%/h");
+    expect(text).toContain(
+      `约可再工作 3小时12分钟（至 ${formatClockTime(depletedAt)}，周窗口为约束）`,
+    );
+    // Honesty-first Q7 wording: the number is the guard's NEUTRAL runway,
+    // never rescaled by the bridge (constraint #2) — the caveat is textual.
+    expect(text).toContain("外层 guard 硬线 92%（v3 不可越过；runway 为中性口径，Claude 会先在硬线被外层停住）");
+    expect(text).not.toContain("窗口刷新即截断");
+  });
+
+  test("runway ending at the basis window reset gets the truncation note", () => {
+    // usage(): claude fiveHour resetEpoch 1_780_750_000 → 38300s after NOW.
+    const resetEpoch = 1_780_750_000;
+    const seconds = resetEpoch - NOW; // exactly reset-truncated
+    const snap = snapshot({
+      burnRate: { claude: { fiveHour: burnRate(), weekly: null }, codex: NO_RATES },
+      runway: {
+        claude: { seconds, basis: "fiveHour", depletedAtEpoch: resetEpoch },
+        codex: null,
+      },
+    });
+    const text = renderBudgetSnapshot(snap);
+    expect(text).toContain(`至 ${formatClockTime(resetEpoch)} 窗口刷新即截断，5h 窗口为约束`);
+  });
+
+  test("runway without depleted_at_epoch omits the clock part (consume-only, no fabrication)", () => {
+    const snap = snapshot({
+      burnRate: { claude: { fiveHour: burnRate(), weekly: null }, codex: NO_RATES },
+      runway: {
+        claude: { seconds: 1800, basis: "fiveHour", depletedAtEpoch: null },
+        codex: null,
+      },
+    });
+    const text = renderBudgetSnapshot(snap);
+    expect(text).toContain("约可再工作 30分钟（5h 窗口为约束）");
+    expect(text).not.toContain("至 ");
+  });
+
+  test("Codex line renders runway but never the guard-hardline annotation", () => {
+    const depletedAt = NOW + 23_400; // 6.5h
+    const snap = snapshot({
+      burnRate: {
+        claude: NO_RATES,
+        codex: { fiveHour: burnRate({ pctPerHour: 2.1 }), weekly: null },
+      },
+      runway: {
+        claude: null,
+        codex: { seconds: 23_400, basis: "fiveHour", depletedAtEpoch: depletedAt },
+      },
+    });
+    const text = renderBudgetSnapshot(snap);
+    const codexLine = text.split("\n").find((line) => line.startsWith("Codex 燃尽率"));
+    expect(codexLine).toBeDefined();
+    expect(codexLine!).toContain("约可再工作 6小时30分钟");
+    expect(codexLine!).not.toContain("guard 硬线");
+    // Claude has no data → no Claude burn-rate line, hence no guard annotation at all.
+    expect(text).not.toContain("guard 硬线");
+  });
+
+  test("non-confident window renders 采样中 instead of a rate, and no runway", () => {
+    const snap = snapshot({
+      burnRate: {
+        claude: { fiveHour: burnRate({ confident: false }), weekly: null },
+        codex: NO_RATES,
+      },
+      runway: { claude: null, codex: null },
+    });
+    const text = renderBudgetSnapshot(snap);
+    expect(text).toContain("5h 采样中");
+    expect(text).not.toContain("约可再工作");
+  });
+
+  test("renders guard-provided weekly five-hour window count when present", () => {
+    const text = renderBudgetSnapshot(
+      snapshot({
+        claude: usage({
+          weekly: {
+            util: 19,
+            resetEpoch: 1_781_193_812,
+            burnConfident: true,
+            runwaySeconds: 43_200,
+            fiveHourWindowsLeft: 2.4,
+          },
+        }),
+      }),
+    );
+    expect(text).toContain("按当前节奏，周额度还够 ~2.4 个 5h 窗口");
+  });
+
+  test("omits weekly five-hour window count when the guard field is absent", () => {
+    const text = renderBudgetSnapshot(snapshot());
+    expect(text).not.toContain("周额度还够");
+  });
+
+  test("omits weekly five-hour window count when the weekly runway is absent", () => {
+    const text = renderBudgetSnapshot(
+      snapshot({
+        claude: usage({
+          weekly: {
+            util: 19,
+            resetEpoch: 1_781_193_812,
+            burnConfident: true,
+            fiveHourWindowsLeft: 2.4,
+          },
+        }),
+      }),
+    );
+    expect(text).not.toContain("周额度还够");
+  });
+
+  test("omits weekly five-hour window count from stale cached data", () => {
+    const text = renderBudgetSnapshot(
+      snapshot({
+        claude: usage({
+          stale: true,
+          weekly: {
+            util: 19,
+            resetEpoch: NOW + 3600,
+            burnConfident: true,
+            runwaySeconds: 1800,
+            fiveHourWindowsLeft: 3.1,
+          },
+        }),
+        burnRate: {
+          claude: { fiveHour: null, weekly: burnRate() },
+          codex: NO_RATES,
+        },
+        runway: { claude: null, codex: null },
+      }),
+    );
+    expect(text).toContain("（缓存数据）");
+    expect(text).not.toContain("约可再工作");
+    expect(text).not.toContain("周额度还够");
+  });
+});
+
+describe("resolveGuardHardHint", () => {
+  test("defaults to 92 (quota-guard BUDGET_HARD default)", () => {
+    expect(resolveGuardHardHint({})).toBe(92);
+  });
+
+  test("AGENTBRIDGE_GUARD_HARD_HINT overrides the display value", () => {
+    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "85" })).toBe(85);
+  });
+
+  test("invalid or out-of-range hints fall back to 92", () => {
+    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "abc" })).toBe(92);
+    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "150" })).toBe(92);
+    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "0" })).toBe(92);
+    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "" })).toBe(92);
   });
 });

--- a/src/unit-test/budget-state.test.ts
+++ b/src/unit-test/budget-state.test.ts
@@ -20,6 +20,7 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
+  strategy: "conserve",
 };
 
 function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -6,6 +6,7 @@ import {
   ConfigService,
   DEFAULT_CONFIG,
   applyBudgetEnvOverrides,
+  normalizeBoundedNumber,
   type AgentBridgeConfig,
 } from "../config-service";
 
@@ -390,6 +391,7 @@ describe("ConfigService — budget section", () => {
         balanced: { effort: "medium" },
         eco: { effort: "low" },
       },
+      strategy: "conserve",
     });
   });
 
@@ -429,6 +431,8 @@ describe("ConfigService — budget section", () => {
         balanced: { effort: "medium" }, // unspecified tier keeps the default
         eco: { effort: "minimal" },
       },
+      // v3 P1 keys absent in the raw file normalize to defaults.
+      strategy: "conserve",
     });
   });
 
@@ -590,6 +594,7 @@ describe("applyBudgetEnvOverrides", () => {
       balanced: { effort: "medium" },
       eco: { effort: "low" },
     },
+    strategy: "conserve" as const,
   };
 
   test("env values override the base config", () => {
@@ -644,6 +649,7 @@ describe("applyBudgetEnvOverrides — boolean spellings", () => {
       balanced: { effort: "medium" },
       eco: { effort: "low" },
     },
+    strategy: "conserve" as const,
   };
 
   test('accepts "0"/"1" alongside "true"/"false"', () => {
@@ -660,5 +666,121 @@ describe("applyBudgetEnvOverrides — boolean spellings", () => {
       AGENTBRIDGE_BUDGET_ENABLED: "yes",
     });
     expect(result.enabled).toBe(true);
+  });
+});
+
+describe("ConfigService — budget v3 P1 keys (strategy, parse-only)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "agentbridge-budget-v3-config-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeRawConfig(raw: unknown) {
+    mkdirSync(join(tempDir, ".agentbridge"), { recursive: true });
+    writeFileSync(join(tempDir, ".agentbridge", "config.json"), JSON.stringify(raw));
+  }
+
+  function loadBudget(svc: ConfigService) {
+    const result = svc.load();
+    expect(result.state).toBe("parsed");
+    if (result.state !== "parsed") throw new Error("unreachable");
+    return result.config.budget;
+  }
+
+  test("strategy=maximize is parsed and preserved (consumed only by doctor in P1)", () => {
+    const svc = new ConfigService(tempDir);
+    writeRawConfig({ budget: { strategy: "maximize" } });
+    expect(loadBudget(svc).strategy).toBe("maximize");
+  });
+
+  test("invalid strategy values fall back to conserve", () => {
+    const svc = new ConfigService(tempDir);
+    writeRawConfig({ budget: { strategy: "yolo" } });
+    expect(loadBudget(svc).strategy).toBe("conserve");
+    writeRawConfig({ budget: { strategy: 42 } });
+    expect(loadBudget(svc).strategy).toBe("conserve");
+  });
+
+  test("legacy burnRate keys in the raw file are ignored (layered amendment: collection moved to the guard)", () => {
+    const svc = new ConfigService(tempDir);
+    writeRawConfig({ budget: { strategy: "maximize", burnRate: { enabled: false, sampleCap: 100 } } });
+    const budget = loadBudget(svc);
+    expect(budget.strategy).toBe("maximize");
+    expect("burnRate" in budget).toBe(false);
+  });
+});
+
+describe("normalizeBoundedNumber (Q6 — fractional config params)", () => {
+  test("accepts fractional values in range", () => {
+    expect(normalizeBoundedNumber(0.4, 1, 0, 5)).toBe(0.4);
+    expect(normalizeBoundedNumber(5, 1, 0, 5)).toBe(5);
+    expect(normalizeBoundedNumber(0, 1, 0, 5)).toBe(0);
+  });
+
+  test("accepts numeric strings (env-style)", () => {
+    expect(normalizeBoundedNumber("0.7", 1, 0, 5)).toBe(0.7);
+  });
+
+  test("NaN / non-numeric values fall back to the default", () => {
+    expect(normalizeBoundedNumber(Number.NaN, 1.5, 0, 5)).toBe(1.5);
+    expect(normalizeBoundedNumber("ninety", 1.5, 0, 5)).toBe(1.5);
+    expect(normalizeBoundedNumber(undefined, 1.5, 0, 5)).toBe(1.5);
+    expect(normalizeBoundedNumber(null, 1.5, 0, 5)).toBe(1.5);
+    expect(normalizeBoundedNumber({}, 1.5, 0, 5)).toBe(1.5);
+  });
+
+  test("out-of-range values fall back to the default", () => {
+    expect(normalizeBoundedNumber(5.1, 1.5, 0, 5)).toBe(1.5);
+    expect(normalizeBoundedNumber(-0.1, 1.5, 0, 5)).toBe(1.5);
+  });
+
+  test("empty string falls back to the default (does not coerce to 0)", () => {
+    expect(normalizeBoundedNumber("", 1.5, 0, 5)).toBe(1.5);
+    expect(normalizeBoundedNumber("   ", 1.5, 0, 5)).toBe(1.5);
+  });
+});
+
+describe("applyBudgetEnvOverrides — v3 P1 keys", () => {
+  const base = {
+    enabled: true,
+    pollSeconds: 60,
+    pauseAt: 90,
+    resumeBelow: 30,
+    syncDriftPct: 10,
+    parallel: { minRemainingPct: 60, timeWindowSec: 3600 },
+    codexTierControl: false,
+    codexTiers: {
+      full: { effort: "high" },
+      balanced: { effort: "medium" },
+      eco: { effort: "low" },
+    },
+    strategy: "conserve" as const,
+  };
+
+  test("AGENTBRIDGE_BUDGET_STRATEGY overrides the strategy", () => {
+    const result = applyBudgetEnvOverrides(base, {
+      AGENTBRIDGE_BUDGET_STRATEGY: "maximize",
+    });
+    expect(result.strategy).toBe("maximize");
+  });
+
+  test("invalid AGENTBRIDGE_BUDGET_STRATEGY keeps the base value", () => {
+    const result = applyBudgetEnvOverrides(base, {
+      AGENTBRIDGE_BUDGET_STRATEGY: "turbo",
+    });
+    expect(result.strategy).toBe("conserve");
+  });
+
+  test("v3 env keys leave the rest of the config untouched", () => {
+    const result = applyBudgetEnvOverrides(base, {
+      AGENTBRIDGE_BUDGET_STRATEGY: "maximize",
+    });
+    expect(result.pauseAt).toBe(90);
+    expect(result.resumeBelow).toBe(30);
   });
 });

--- a/src/unit-test/doctor.test.ts
+++ b/src/unit-test/doctor.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { describeBuildDrift, evaluateArtifactAlignment, runDoctor } from "../cli/doctor";
+import {
+  describeBuildDrift,
+  evaluateArtifactAlignment,
+  evaluateBudgetStrategyGuard,
+  runDoctor,
+} from "../cli/doctor";
 import { derivePairId, writeRegistry } from "../pair-registry";
 import type { AgentBridgeBuildInfo } from "../build-info";
 
@@ -91,6 +96,7 @@ describe("doctor command", () => {
         "pair registration",
         "env",
         "config.json",
+        "budget strategy", // v3 P1 Q7 enhanced-B check
         "daemon health",
         "daemon readiness",
         "codex app-server",
@@ -354,5 +360,32 @@ describe("describeBuildDrift (basis annotation)", () => {
     const described = describeBuildDrift(runtime, launcher);
     expect(described.detail).toContain("stamp");
     expect(described.hint).toContain("squash");
+  });
+});
+
+describe("evaluateBudgetStrategyGuard (v3 P1 Q7 enhanced-B)", () => {
+  test("strategy=conserve → ok (v2-equivalent behavior)", () => {
+    const check = evaluateBudgetStrategyGuard("conserve", 92);
+    expect(check.name).toBe("budget strategy");
+    expect(check.status).toBe("ok");
+    expect(check.detail).toContain("conserve");
+  });
+
+  test("strategy=maximize with guard hardline below targetUtil → warn", () => {
+    const check = evaluateBudgetStrategyGuard("maximize", 92);
+    expect(check.status).toBe("warn");
+    expect(check.detail).toContain("92");
+    expect(check.detail).toContain("97");
+    expect(check.hint).toContain("外层 quota-guard 硬线");
+  });
+
+  test("strategy=maximize with guard hardline at/above targetUtil → ok", () => {
+    expect(evaluateBudgetStrategyGuard("maximize", 97).status).toBe("ok");
+    expect(evaluateBudgetStrategyGuard("maximize", 98).status).toBe("ok");
+  });
+
+  test("custom targetUtil is honored", () => {
+    expect(evaluateBudgetStrategyGuard("maximize", 92, 90).status).toBe("ok");
+    expect(evaluateBudgetStrategyGuard("maximize", 89, 90).status).toBe("warn");
   });
 });

--- a/src/unit-test/quota-source.test.ts
+++ b/src/unit-test/quota-source.test.ts
@@ -582,3 +582,119 @@ describe("QuotaSource", () => {
     await expect(source.fetchBoth()).resolves.toEqual({ claude: null, codex: null });
   });
 });
+
+describe("quota-source — guard burn fields (v3 layered amendment)", () => {
+  const NOW2 = 1_700_000_000;
+
+  function bucketWith(extra: Record<string, unknown>) {
+    return {
+      ok: true,
+      util: 42,
+      warn_util: 42,
+      fetched_at: NOW2,
+      buckets: [
+        { id: "five_hour", util: 42, reset_epoch: NOW2 + 3600, ...extra },
+      ],
+    };
+  }
+
+  test("passes a complete field group through verbatim", () => {
+    const usage = normalizeProbeResult(
+      bucketWith({
+        burn_rate_pct_per_hour: 1.25,
+        burn_confident: true,
+        runway_seconds: 1800,
+        depleted_at_epoch: NOW2 + 1800,
+        five_hour_windows_left: 2.4,
+      }),
+    );
+    expect(usage!.fiveHour).toEqual({
+      util: 42,
+      resetEpoch: NOW2 + 3600,
+      burnRate: 1.25,
+      burnConfident: true,
+      runwaySeconds: 1800,
+      depletedAtEpoch: NOW2 + 1800,
+      fiveHourWindowsLeft: 2.4,
+    });
+  });
+
+  test("a negative burn rate poisons the WHOLE group (window itself survives)", () => {
+    const usage = normalizeProbeResult(
+      bucketWith({
+        burn_rate_pct_per_hour: -1,
+        burn_confident: true,
+        runway_seconds: 1800,
+      }),
+    );
+    expect(usage!.fiveHour).toEqual({ util: 42, resetEpoch: NOW2 + 3600 });
+  });
+
+  test("non-numeric runway_seconds poisons the group (strings are NOT tolerated here)", () => {
+    const usage = normalizeProbeResult(
+      bucketWith({ burn_rate_pct_per_hour: 1.25, runway_seconds: "1800" }),
+    );
+    expect(usage!.fiveHour).toEqual({ util: 42, resetEpoch: NOW2 + 3600 });
+  });
+
+  test("non-numeric five_hour_windows_left poisons the group (strings are NOT tolerated here)", () => {
+    const usage = normalizeProbeResult(
+      bucketWith({
+        burn_rate_pct_per_hour: 1.25,
+        burn_confident: true,
+        runway_seconds: 1800,
+        five_hour_windows_left: "2.4",
+      }),
+    );
+    expect(usage!.fiveHour).toEqual({ util: 42, resetEpoch: NOW2 + 3600 });
+  });
+
+  test("NaN burn rate and non-boolean burn_confident each poison the group", () => {
+    expect(
+      normalizeProbeResult(bucketWith({ burn_rate_pct_per_hour: Number.NaN }))!.fiveHour,
+    ).toEqual({ util: 42, resetEpoch: NOW2 + 3600 });
+    expect(
+      normalizeProbeResult(bucketWith({ burn_rate_pct_per_hour: 1, burn_confident: "yes" }))!.fiveHour,
+    ).toEqual({ util: 42, resetEpoch: NOW2 + 3600 });
+  });
+
+  test("partial group keeps the valid present fields (guard omits what it cannot estimate)", () => {
+    const usage = normalizeProbeResult(
+      bucketWith({ burn_rate_pct_per_hour: 0.8, burn_confident: false }),
+    );
+    expect(usage!.fiveHour).toEqual({
+      util: 42,
+      resetEpoch: NOW2 + 3600,
+      burnRate: 0.8,
+      burnConfident: false,
+    });
+  });
+
+  test("legacy probe output without burn fields parses exactly as before", () => {
+    const usage = normalizeProbeResult(bucketWith({}));
+    expect(usage!.fiveHour).toEqual({ util: 42, resetEpoch: NOW2 + 3600 });
+  });
+
+  test("top-level probe_schema 2 is tolerated and burn fields ride the top-level fallback", () => {
+    const usage = normalizeProbeResult({
+      ok: true,
+      probe_schema: 2,
+      util: 42,
+      fetched_at: NOW2,
+      reset_epoch: NOW2 + 3600,
+      burn_rate_pct_per_hour: 1.1,
+      burn_confident: true,
+      runway_seconds: 900,
+      depleted_at_epoch: NOW2 + 900,
+    });
+    expect(usage!.parsedVia).toBe("top-level");
+    expect(usage!.fiveHour).toEqual({
+      util: 42,
+      resetEpoch: NOW2 + 3600,
+      burnRate: 1.1,
+      burnConfident: true,
+      runwaySeconds: 900,
+      depletedAtEpoch: NOW2 + 900,
+    });
+  });
+});


### PR DESCRIPTION
## 概要 / Summary

budget 策略 v3 **P1** 落地：bridge 侧纯消费端改造 + 「还能用几个 5h 窗口」预测展示。配套 guard 侧 PR：`raysonmeng/agent-quota-guard#3`（产出 `probe_schema:2` 的 burn-rate/runway/`five_hour_windows_left`）。

bridge 不再自采燃尽率，改为**纯消费** guard 产出的字段，严格解析 + 展示，**决策路径零接触**（仅展示，绝不参与 pause/admission）。

Bridge becomes a **pure consumer** of guard's burn-rate / runway / derived fields (`probe_schema:2`): strict parse + display only, decision path untouched.

## 改动 / Changes

- 删 burn-history 自采层；新增 `src/budget/burn-view.ts` 投影（透传 + 选最短 runway + 严格 stale/decision-grade 门控）。
- `quota-source.ts` 严格解析：present-but-invalid **整组 burn group 丢弃**；缺字段 / 旧 schema(<2) / 非数值 / stale / reset-unknown 五种退化退 conserve。
- `render.ts`：runway 行「X小时Y分钟（至 HH:MM）」+ 截断注记；新增「按当前节奏，周额度还够 ~X.X 个 5h 窗口」——消费 guard 的 `five_hour_windows_left`，与 runway 行**同源 stale/decision-grade 门控**，绝不重算。
- 重建插件 bundle（`bridge-server.js` / `daemon.js`），`verify:plugin-sync` in sync。

## Cross-review（项目硬规矩）

Claude 编排、Codex 实现 impl A，走了 **2 轮**交叉审（共 4 个全新独立 reviewer + 对抗验证）：

- **Round 1**：2 真实 issue —— 插件 bundle 漂移（HIGH，bundle 是 impl A 前的中间产物）+ render 5h-windows 行绕过 stale 闸门（MEDIUM）。已修。
- **Round 2**：2 个全新 reviewer 复审「修复正确 + bundle 闭环 + 无回归」，**0 真实 issue**，通过。

## 测试 / Test plan

- `bun run check`：typecheck + `bun test src` **1291 pass / 0 fail** + plugin-sync + 版本对齐 `0.1.13`。
- 新增单测：5h-windows 严格解析 invalid-poison、渲染有/无字段、**stale 不渲染**、**缺 runwaySeconds 不渲染**、0 值正确渲染（`!== null`）。
- 决策路径零接触已 grep 实证（`burnRate`/`runway`/`fiveHourWindowsLeft` 在 `pauseTrigger`/`codexTierFor`/`budget-state` 零引用）。
- gate 等价性 reviewer 构造 10 正反样本实测（fresh+confident+有 runway → 渲染；stale/缺 runwaySeconds/not-confident → 隐藏）。
- [ ] E2E（手动）：真实 guard `probe_schema:2` 输出 → bridge budget 展示「5h 窗口」行 + stale-cache 下该行隐藏。

## 备注 / Notes

- 设计稿 `docs/design/budget-strategy-v3.md` 的 §3.3 分层版 / §8.1 修正案**未含在本 PR**（与 master #159 版有 24+/30− 交叠，将单独 docs PR 处理，避免冲突）。
- guard 侧 `five_hour_windows_left = runway_seconds / 18000`，仅 weekly + burn_confident + 有 runway 时输出。
