### PR TITLE
chore(release): v0.1.14

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "agentbridge",
       "description": "Bridge Claude Code and Codex through a shared daemon, push channel delivery, and reply/get_messages tools.",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "author": {
         "name": "AgentBridge Contributors",
         "email": "raysonmeng@qq.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raysonmeng/agentbridge",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Bridge between Claude Code and Codex — bidirectional agent communication via MCP Channel + JSON-RPC",
   "type": "module",
   "packageManager": "bun@1.3.11",

--- a/plugins/agentbridge/.claude-plugin/plugin.json
+++ b/plugins/agentbridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentbridge",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Bridge Claude Code and Codex with a shared daemon, push channel delivery, and bidirectional reply tooling.",
   "author": {
     "name": "AgentBridge Contributors",

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14511,11 +14511,11 @@ function defineNumber(value, fallback) {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 var BUILD_INFO = Object.freeze({
-  version: defineString("0.1.13", "0.0.0-source"),
-  commit: defineString("dfc093b", "source"),
+  version: defineString("0.1.14", "0.0.0-source"),
+  commit: defineString("a7c46a9", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("6dd30dc80352", "source")
+  codeHash: defineString("e05d18c3cc72", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -26,11 +26,11 @@ function defineNumber(value, fallback) {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 var BUILD_INFO = Object.freeze({
-  version: defineString("0.1.13", "0.0.0-source"),
-  commit: defineString("dfc093b", "source"),
+  version: defineString("0.1.14", "0.0.0-source"),
+  commit: defineString("a7c46a9", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("6dd30dc80352", "source")
+  codeHash: defineString("e05d18c3cc72", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };


### PR DESCRIPTION
Patch 发布，承载 #160（budget v3 P1：燃尽率纯消费端 + 5h 窗口预测展示）。

Patch release carrying #160 (budget v3 P1: burn-rate pure-consumer + 5h-windows projection).

## 改动 / Changes
- bump 三处版本号到 0.1.14（package.json + plugin.json + marketplace.json，`scripts/bump-version.mjs` 自动同步）
- 重建插件 bundle（bridge-server.js + daemon.js，从 a7c46a9 重建）

## 验收 / Verification
- `bun run check` 通过：typecheck + 1291 tests + plugin-sync + version-align at 0.1.14
- 5 文件改动，无 src/ 变更
- 基于 master `a7c46a9` (#160)

## 背景 / Context
`Release on merge` workflow 自 06-10 起被人工 disabled，未自动 bump #158/#159/#160。本 PR 手动补发 0.1.14；workflow 已重新 enable（之后合 master 应恢复自动 bump）。

The `Release on merge` workflow was `disabled_manually` since 06-10, skipping auto-bump for #158/#159/#160. This PR manually cuts 0.1.14; the workflow has been re-enabled (future master merges should auto-bump).