### PR TITLE
feat(cli): update-notifier 交互化 + install:global 活跃会话守卫 / interactive update prompt + active-session install guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ agent_bridge/
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | Override daemon entry point (used by plugin bundles) |
 | `NO_UPDATE_NOTIFIER` | unset | Set to any value to disable the "update available" notice (ecosystem-standard opt-out) |
 | `AGENTBRIDGE_NO_UPDATE_NOTIFIER` | unset | Namespaced opt-out for the update notice (same effect as `NO_UPDATE_NOTIFIER`) |
+| `AGENTBRIDGE_UPDATE_PROMPT` | unset | Set to `0` to disable the interactive update prompt and keep pure notice-only behavior |
 | `AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS` | `86400000` | How often `abg claude`/`abg codex` may check npm for a newer version (default once/day). The notice is otherwise printed from cache — zero network on most runs |
 
 ### Update notifications
@@ -278,7 +279,7 @@ agent_bridge/
   Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)
 ```
 
-The check is best-effort and never blocks, delays, or fails your command: the notice is printed from a cached result, the npm check runs at most once per day in the background, and any network/registry failure is silently ignored. It is suppressed automatically for non-interactive (piped) output and in CI, and can be disabled with `NO_UPDATE_NOTIFIER=1`. The notifier never installs anything — it only shows you the command.
+The check is best-effort: the notice is printed from a cached result, the npm check runs at most once per day in the background, and any network/registry failure is silently ignored. On an interactive TTY, a cached update prompts before launch; answering `y` runs `npm install -g @raysonmeng/agentbridge@latest`, while `N` (or no answer within 15 seconds) records that version as dismissed and continues launching. Non-interactive output and CI never prompt, and the notice can be disabled with `NO_UPDATE_NOTIFIER=1` or kept notice-only with `AGENTBRIDGE_UPDATE_PROMPT=0`.
 
 ### State Directory
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -253,6 +253,7 @@ agent_bridge/
 | `AGENTBRIDGE_DAEMON_ENTRY` | `./daemon.ts` | 覆盖 daemon 入口（插件包使用） |
 | `NO_UPDATE_NOTIFIER` | 未设置 | 设为任意值即关闭「有新版本」提示（生态通用 opt-out） |
 | `AGENTBRIDGE_NO_UPDATE_NOTIFIER` | 未设置 | 命名空间化的关闭开关（效果同 `NO_UPDATE_NOTIFIER`） |
+| `AGENTBRIDGE_UPDATE_PROMPT` | 未设置 | 设为 `0` 可关闭交互询问，恢复纯打印提示 |
 | `AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS` | `86400000` | `abg claude`/`abg codex` 多久查一次 npm 新版本（默认每天一次）。其余时候只读缓存打印，大多数调用零网络 |
 
 ### 更新提示
@@ -265,7 +266,7 @@ agent_bridge/
   Plugin: /plugin marketplace update agentbridge   (then /reload-plugins)
 ```
 
-该检查是 best-effort,绝不阻塞/拖慢/弄坏你的命令:提示从缓存打印,npm 检查每天最多在后台跑一次,任何网络/registry 失败都静默忽略。非交互(管道)输出和 CI 下自动抑制,可用 `NO_UPDATE_NOTIFIER=1` 关闭。notifier 永远不会自动安装任何东西——只告诉你升级命令。
+该检查是 best-effort：提示从缓存打印，npm 检查每天最多在后台跑一次，任何网络/registry 失败都静默忽略。交互式 TTY 下，命中缓存更新会在启动前询问；输入 `y` 会运行 `npm install -g @raysonmeng/agentbridge@latest`，输入 `N`（或 15 秒内无应答）会记住本版本已拒绝并继续启动。非交互(管道)输出和 CI 下绝不询问，可用 `NO_UPDATE_NOTIFIER=1` 关闭提示，或用 `AGENTBRIDGE_UPDATE_PROMPT=0` 保持纯打印。
 
 ### 状态目录
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -121,11 +121,21 @@ global package, so afterward `npm install -g @raysonmeng/agentbridge@latest`
 cleanly overrides whatever you installed — there is no leftover `bun link` symlink
 to conflict with.
 
-Both install modes (via `scripts/install-global.mjs`) first stop registered
-AgentBridge daemons and managed Codex TUIs directly (`install-safety.cjs
-stop-running`) using a scrubbed install environment, then replace the package.
-Local installs also rebuild `dist/` and plugin bundles, verify required
-artifacts on disk, pack a tarball, and verify the tarball before installing it.
+Both install modes (via `scripts/install-global.mjs`) use the same four-step
+sequence:
+
+1. Preflight active Claude frontends and managed Codex TUIs. If any are running,
+   the installer asks on a TTY, refuses in non-TTY mode, or continues with
+   `--force`.
+2. Build/verify/install succeeds. Local mode rebuilds `dist/` and plugin
+   bundles, verifies required artifacts on disk, packs a tarball, and verifies
+   the tarball before installing it; npm mode verifies `latest` exists and
+   installs it.
+3. Only after the install succeeds, call `install-safety.cjs stop-running` using
+   a scrubbed install environment.
+4. Print the post-install reminder to restart affected AgentBridge/Claude
+   windows.
+
 Use `node scripts/install-global.mjs local --dry-run` to inspect the sequence
 without stopping anything.
 
@@ -135,8 +145,8 @@ Stopping all running AgentBridge daemons/TUIs is destructive, so it is **not**
 triggered by arbitrary installs. There are exactly two paths that stop them:
 
 1. **The intentional installer** — `scripts/install-global.mjs` (`bun run
-   install:global:*`) calls `install-safety.cjs stop-running` directly, in both
-   `local` and `npm` modes.
+   install:global:*`) calls `install-safety.cjs stop-running` directly in both
+   `local` and `npm` modes. It now preflights active sessions before doing so.
 2. **An explicit global self-install via npm `postinstall`** — `scripts/postinstall.cjs`
    stops running daemons **only** when it detects an explicit global signal:
    - `npm_config_global=true` (i.e. `npm install -g …`), or
@@ -154,8 +164,8 @@ for the two intentional paths above.
 
 停掉所有运行中的 daemon/TUI 是破坏性操作,因此**不会**被任意安装触发。只有两条路径会停:
 (1) **有意安装器** `scripts/install-global.mjs`(`bun run install:global:*`)在 `local` 与
-`npm` 两种模式下都直接调用 `install-safety.cjs stop-running`;(2) **经 npm `postinstall`
-的显式全局自安装**——`scripts/postinstall.cjs` 仅在检测到显式全局信号时才停
+`npm` 两种模式下直接调用 `install-safety.cjs stop-running`,且现在会先前置检测活跃会话;
+(2) **经 npm `postinstall` 的显式全局自安装**——`scripts/postinstall.cjs` 仅在检测到显式全局信号时才停
 (`npm_config_global=true` / `npm_config_location=global` / `AGENTBRIDGE_POSTINSTALL_STOP=1`;
 `AGENTBRIDGE_POSTINSTALL_STOP=0` 强制不停,优先级最高)。**任意 `.tgz` / 传递依赖安装
 不会停掉运行中的 daemon**——非全局 `npm install`、或被当作他人依赖拉入时,所有运行中的

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14512,10 +14512,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.14", "0.0.0-source"),
-  commit: defineString("a7c46a9", "source"),
+  commit: defineString("85ad89b", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("e05d18c3cc72", "source")
+  codeHash: defineString("866b1b46195a", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -27,10 +27,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.14", "0.0.0-source"),
-  commit: defineString("a7c46a9", "source"),
+  commit: defineString("85ad89b", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("e05d18c3cc72", "source")
+  codeHash: defineString("866b1b46195a", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };

--- a/scripts/install-global.d.mts
+++ b/scripts/install-global.d.mts
@@ -1,5 +1,33 @@
 /** Type declarations for the testable helpers exported by install-global.mjs. */
 
+export interface ActiveInstallPairInfo {
+  pairId?: string;
+  pairName?: string;
+  cwd?: string;
+  stateDir?: string;
+  proxyUrl?: string;
+}
+
+export interface ActiveInstallSession {
+  kind: "claude-frontend" | "codex-tui";
+  pid: number;
+  command: string;
+  remoteUrl?: string | null;
+  pair: ActiveInstallPairInfo & { label: string };
+}
+
+export function detectActiveInstallSessionsFromPsOutput(
+  psOutput: string,
+  pairInfos?: ActiveInstallPairInfo[],
+): ActiveInstallSession[];
+
+export function decideInstallPreflight(opts: {
+  activeSessionCount: number;
+  force: boolean;
+  dryRun: boolean;
+  isTTY: boolean;
+}): { action: "allow" | "prompt" | "block"; reason: string };
+
 /** Derive the install prefix from a resolved bin path like `<prefix>/bin/<name>`. */
 export function installPrefixFromBinPath(binPath: string | null | undefined): string | null;
 

--- a/scripts/install-global.mjs
+++ b/scripts/install-global.mjs
@@ -3,11 +3,16 @@
  * Install AgentBridge globally in a way that is convenient for local testing.
  *
  * Modes:
- *   local  build + verify this checkout, pack it, install the tarball (`--force`),
- *          THEN stop running daemons and sync the Claude Code plugin
- *   npm    verify npm latest exists, install latest (`--force`), THEN stop daemons
+ *   local  preflight active sessions, build + verify this checkout, pack it,
+ *          install the tarball (`--force`), THEN stop running daemons and sync
+ *          the Claude Code plugin
+ *   npm    preflight active sessions, verify npm latest exists, install latest
+ *          (`--force`), THEN stop daemons
  *
  * Ordering invariant (downtime + failure safety):
+ *   - active Claude frontends / Codex TUIs are detected before build/npm work
+ *     and require explicit confirmation (or `--force`) because stop-running will
+ *     disconnect them once the install succeeds.
  *   - `npm install -g --force` is a full replace, so no separate `npm uninstall`
  *     is needed — dropping it removes the window where no binary is on PATH.
  *   - stop-running fires AFTER the install succeeds, so the old daemon keeps
@@ -23,11 +28,12 @@
  * falling back to npm's default when nothing is installed yet.
  */
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { homedir, platform, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join } from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { createInterface } from "node:readline";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const require = createRequire(import.meta.url);
@@ -38,10 +44,13 @@ const packageName = pkg.name;
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
 const skipPlugin = args.includes("--skip-plugin");
+const force = args.includes("--force");
 const mode = args.find((arg) => !arg.startsWith("-"));
+const PAIR_BASE_PORT = 4500;
+const PAIR_SLOT_STRIDE = 10;
 
 function usage() {
-  process.stderr.write(`Usage: node scripts/install-global.mjs <local|npm> [--dry-run] [--skip-plugin]
+  process.stderr.write(`Usage: node scripts/install-global.mjs <local|npm> [--dry-run] [--skip-plugin] [--force]
 
 Examples:
   bun run install:global:local   # build this checkout, replace the global install, sync the Claude Code plugin
@@ -49,7 +58,250 @@ Examples:
 
 Options:
   --skip-plugin   local mode only: skip the Claude Code plugin sync (\`dev\`) step
+  --force         install even when active AgentBridge frontends/Codex TUIs are running
 `);
+}
+
+function parsePsProcessList(output) {
+  const entries = [];
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/^\s*(\d+)\s+(.+?)\s*$/);
+    if (!match) continue;
+    const pid = Number.parseInt(match[1], 10);
+    if (!Number.isFinite(pid)) continue;
+    entries.push({ pid, command: match[2] });
+  }
+  return entries;
+}
+
+function extractRemoteUrl(command) {
+  const tokens = command.trim().split(/\s+/);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token === "--remote" && tokens[i + 1]) return tokens[i + 1];
+    if (token?.startsWith("--remote=")) return token.slice("--remote=".length);
+  }
+  return null;
+}
+
+function invokesCodexBinary(command) {
+  const tokens = command.trim().split(/\s+/);
+  const exe = tokens[0] ? basename(tokens[0]) : "";
+  if (exe === "codex") return true;
+  if ((exe === "node" || exe === "bun") && tokens[1]) {
+    return basename(tokens[1]) === "codex";
+  }
+  return false;
+}
+
+function commandMatchesManagedCodexTui(command) {
+  if (!invokesCodexBinary(command)) return false;
+  if (!command.includes("tui_app_server")) return false;
+  return extractRemoteUrl(command) !== null;
+}
+
+function commandMatchesBridgeFrontend(command) {
+  return (
+    /(?:^|[\s/\\])bridge-server\.js(?:\s|$)/.test(command) &&
+    (command.includes("agentbridge") || command.includes("agent_bridge"))
+  );
+}
+
+function proxyUrlForSlot(slot) {
+  if (!Number.isInteger(slot) || slot < 0) return null;
+  return `ws://127.0.0.1:${PAIR_BASE_PORT + slot * PAIR_SLOT_STRIDE + 1}`;
+}
+
+function pairSummary(pair) {
+  if (!pair) return { label: "unknown" };
+  const label = pair.pairName && pair.pairId
+    ? `${pair.pairName} (${pair.pairId})`
+    : pair.pairId ?? pair.proxyUrl ?? "unknown";
+  return {
+    label,
+    pairId: pair.pairId,
+    pairName: pair.pairName,
+    cwd: pair.cwd,
+    stateDir: pair.stateDir,
+    proxyUrl: pair.proxyUrl,
+  };
+}
+
+function pairForRemoteUrl(remoteUrl, pairInfos) {
+  return pairInfos.find((pair) => pair.proxyUrl === remoteUrl) ?? null;
+}
+
+export function detectActiveInstallSessionsFromPsOutput(psOutput, pairInfos = []) {
+  const sessions = [];
+  for (const entry of parsePsProcessList(psOutput)) {
+    if (entry.pid === process.pid) continue;
+    if (commandMatchesBridgeFrontend(entry.command)) {
+      sessions.push({
+        kind: "claude-frontend",
+        pid: entry.pid,
+        command: entry.command,
+        pair: pairSummary(null),
+      });
+      continue;
+    }
+    if (commandMatchesManagedCodexTui(entry.command)) {
+      const remoteUrl = extractRemoteUrl(entry.command);
+      sessions.push({
+        kind: "codex-tui",
+        pid: entry.pid,
+        command: entry.command,
+        remoteUrl,
+        pair: pairSummary(pairForRemoteUrl(remoteUrl, pairInfos)),
+      });
+    }
+  }
+  return sessions;
+}
+
+export function decideInstallPreflight({ activeSessionCount, force, dryRun, isTTY }) {
+  if (dryRun) return { action: "allow", reason: "dry-run" };
+  if (activeSessionCount === 0) return { action: "allow", reason: "no-active-sessions" };
+  if (force) return { action: "allow", reason: "force" };
+  if (isTTY) return { action: "prompt", reason: "tty" };
+  return { action: "block", reason: "non-tty" };
+}
+
+function platformBaseDir(env = process.env) {
+  if (platform() === "darwin") {
+    return join(homedir(), "Library", "Application Support", "AgentBridge");
+  }
+  const xdg = env.XDG_STATE_HOME && env.XDG_STATE_HOME.length > 0
+    ? env.XDG_STATE_HOME
+    : join(homedir(), ".local", "state");
+  return join(xdg, "agentbridge");
+}
+
+function computeBaseDir(env = process.env) {
+  return env.AGENTBRIDGE_BASE_DIR || env.AGENTBRIDGE_STATE_DIR || platformBaseDir(env);
+}
+
+function readJsonIfPresent(path) {
+  try {
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function pairInfoFromStatusFile(stateDir) {
+  const status = readJsonIfPresent(join(stateDir, "daemon.json")) ?? readJsonIfPresent(join(stateDir, "status.json"));
+  if (!status || typeof status !== "object") return null;
+  const proxyUrl = typeof status.proxyUrl === "string" ? status.proxyUrl : null;
+  if (!proxyUrl) return null;
+  return {
+    pairId: typeof status.pairId === "string" ? status.pairId : undefined,
+    pairName: undefined,
+    cwd: typeof status.cwd === "string" ? status.cwd : undefined,
+    stateDir,
+    proxyUrl,
+  };
+}
+
+function readPairInfos(baseDir = computeBaseDir()) {
+  const pairsRoot = join(baseDir, "pairs");
+  const byProxy = new Map();
+  const registry = readJsonIfPresent(join(pairsRoot, "registry.json"));
+  if (registry && Array.isArray(registry.pairs)) {
+    for (const entry of registry.pairs) {
+      if (!entry || typeof entry !== "object") continue;
+      const pairId = typeof entry.pairId === "string" ? entry.pairId : undefined;
+      const proxyUrl = proxyUrlForSlot(entry.slot);
+      if (!pairId || !proxyUrl) continue;
+      byProxy.set(proxyUrl, {
+        pairId,
+        pairName: typeof entry.name === "string" ? entry.name : undefined,
+        cwd: typeof entry.cwd === "string" ? entry.cwd : undefined,
+        stateDir: join(pairsRoot, pairId),
+        proxyUrl,
+      });
+    }
+  }
+
+  try {
+    for (const dirent of readdirSync(pairsRoot, { withFileTypes: true })) {
+      if (!dirent.isDirectory()) continue;
+      const stateDir = join(pairsRoot, dirent.name);
+      const fromStatus = pairInfoFromStatusFile(stateDir);
+      if (!fromStatus) continue;
+      const existing = byProxy.get(fromStatus.proxyUrl);
+      byProxy.set(fromStatus.proxyUrl, { ...fromStatus, ...existing });
+    }
+  } catch {
+    // Missing/corrupt state is diagnostic-only; ps command lines remain enough
+    // to block safely.
+  }
+  return [...byProxy.values()];
+}
+
+function readActiveInstallSessions() {
+  let output = "";
+  try {
+    output = spawnSync("ps", ["-axo", "pid=,command="], { encoding: "utf-8" }).stdout ?? "";
+  } catch {
+    return [];
+  }
+  return detectActiveInstallSessionsFromPsOutput(output, readPairInfos());
+}
+
+function renderActiveInstallSessions(sessions) {
+  return sessions
+    .map((session) => {
+      const kind = session.kind === "codex-tui" ? "Codex TUI" : "Claude frontend";
+      const remote = session.remoteUrl ? ` remote=${session.remoteUrl}` : "";
+      const cwd = session.pair.cwd ? ` cwd=${session.pair.cwd}` : "";
+      return `  - pid ${session.pid}: ${kind}; pair=${session.pair.label}${remote}${cwd}`;
+    })
+    .join("\n");
+}
+
+function askContinueWithActiveSessions() {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    rl.question("Active sessions will be disconnected. Continue? (y/N) ", (answer) => {
+      rl.close();
+      resolve(/^y(?:es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+async function runInstallPreflight() {
+  const sessions = readActiveInstallSessions();
+  const decision = decideInstallPreflight({
+    activeSessionCount: sessions.length,
+    force,
+    dryRun,
+    isTTY: Boolean(process.stdin.isTTY && process.stderr.isTTY),
+  });
+  if (decision.action === "allow") {
+    if (decision.reason === "force" && sessions.length > 0) {
+      process.stderr.write(
+        "install-global: --force set; continuing even though active sessions may be disconnected:\n" +
+          `${renderActiveInstallSessions(sessions)}\n`,
+      );
+    }
+    return;
+  }
+  if (sessions.length > 0) {
+    process.stderr.write(
+      "install-global: active AgentBridge sessions detected:\n" +
+        `${renderActiveInstallSessions(sessions)}\n`,
+    );
+  }
+  if (decision.action === "block") {
+    process.stderr.write("install-global: refusing to continue in non-TTY mode; re-run with --force to proceed.\n");
+    process.exit(1);
+  }
+  const ok = await askContinueWithActiveSessions();
+  if (!ok) {
+    process.stderr.write("install-global: cancelled; no changes made.\n");
+    process.exit(1);
+  }
 }
 
 /**
@@ -99,6 +351,12 @@ function printDry(cmd, commandArgs, suffix = "") {
   process.stdout.write(`$ ${commandLine(cmd, commandArgs)}${suffix}\n`);
 }
 
+function printDryPreflight() {
+  process.stdout.write(
+    "# preflight: check active AgentBridge frontends/Codex TUIs; prompt on TTY, refuse in non-TTY (use --force to skip)\n",
+  );
+}
+
 function run(cmd, commandArgs, options = {}) {
   const { allowFailure = false, cwd = root, captureStdout = false, envExtra = {} } = options;
   process.stdout.write(`$ ${commandLine(cmd, commandArgs)}\n`);
@@ -146,9 +404,10 @@ function reportPrefix(prefix) {
   }
 }
 
-function installLocal() {
+async function installLocal() {
   const prefix = dryRun ? resolveInstallPrefix() : null;
   if (dryRun) {
+    printDryPreflight();
     reportPrefix(prefix);
     printDry("bun", ["run", "prepublishOnly"]);
     printDry("node", ["scripts/install-safety.cjs", "verify-built"]);
@@ -162,6 +421,7 @@ function installLocal() {
     return;
   }
 
+  await runInstallPreflight();
   const target = resolveInstallPrefix();
   reportPrefix(target);
   const env = prefixEnv(target);
@@ -243,10 +503,11 @@ function warnAboutSurvivingFrontends() {
   );
 }
 
-function installNpm() {
+async function installNpm() {
   const spec = `${packageName}@latest`;
   const prefix = dryRun ? resolveInstallPrefix() : null;
   if (dryRun) {
+    printDryPreflight();
     reportPrefix(prefix);
     printDry("npm", ["view", spec, "version"]);
     printDry("npm", ["install", "-g", "--force", spec]);
@@ -254,6 +515,7 @@ function installNpm() {
     return;
   }
 
+  await runInstallPreflight();
   const target = resolveInstallPrefix();
   reportPrefix(target);
   const env = prefixEnv(target);
@@ -274,9 +536,9 @@ const invokedDirectly =
   process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (invokedDirectly) {
   if (mode === "local" || mode === "source") {
-    installLocal();
+    await installLocal();
   } else if (mode === "npm" || mode === "registry") {
-    installNpm();
+    await installNpm();
   } else {
     usage();
     process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,12 +66,13 @@ export function parseTopLevel(args: string[]): { command: string | undefined; re
 }
 
 async function main(command: string | undefined, restArgs: string[]) {
-  // Best-effort, non-blocking update notice. Fully guarded — never blocks,
-  // delays, or fails the command (see src/update-notifier.ts).
+  // Best-effort update notice. On an interactive TTY it may prompt before the
+  // launcher starts; non-interactive/suppressed runs keep the pure notice path.
   if (command && NOTIFY_COMMANDS.has(command)) {
     try {
       const { maybeNotifyUpdate } = await import("./update-notifier");
-      maybeNotifyUpdate({ refresh: REFRESH_COMMANDS.has(command) });
+      const decision = await maybeNotifyUpdate({ refresh: REFRESH_COMMANDS.has(command) });
+      if (decision === "updated") process.exit(0);
     } catch {
       // ignore — the notifier must never affect the command
     }

--- a/src/unit-test/install-global-script.test.ts
+++ b/src/unit-test/install-global-script.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { installPrefixFromBinPath, resolveInstallPrefix } from "../../scripts/install-global.mjs";
+import {
+  decideInstallPreflight,
+  detectActiveInstallSessionsFromPsOutput,
+  installPrefixFromBinPath,
+  resolveInstallPrefix,
+} from "../../scripts/install-global.mjs";
 
 const SCRIPT = join(process.cwd(), "scripts/install-global.mjs");
 const PACKAGE_NAME = "@raysonmeng/agentbridge";
@@ -25,7 +30,8 @@ function runRealWithStubs(
   mode: string,
   extraArgs: string[],
   failWhen: string,
-): { status: number | null; record: string[] } {
+  psOutput = "",
+): { status: number | null; record: string[]; stdout: string; stderr: string } {
   const dir = mkdtempSync(join(tmpdir(), "install-global-stub-"));
   const recordFile = join(dir, "record.log");
   const binDir = join(dir, "bin");
@@ -39,6 +45,10 @@ joined="$name $*"
 if [ -n "$FAIL_WHEN" ] && [[ "$joined" == *"$FAIL_WHEN"* ]]; then
   exit 1
 fi
+if [ "$name" = "ps" ]; then
+  printf "%s" "$PS_OUTPUT"
+  exit 0
+fi
 # 'npm pack' parses stdout for the tarball name — emit a plausible one so the
 # local-mode flow can proceed past packing in the success-path-up-to-install case.
 if [ "$name" = "npm" ] && [ "$1" = "pack" ]; then
@@ -48,7 +58,7 @@ exit 0
 `;
   const { mkdirSync } = require("node:fs") as typeof import("node:fs");
   mkdirSync(binDir, { recursive: true });
-  for (const name of ["npm", "node", "bun"]) {
+  for (const name of ["npm", "node", "bun", "ps"]) {
     const p = join(binDir, name);
     writeFileSync(p, stub);
     chmodSync(p, 0o755);
@@ -63,6 +73,7 @@ exit 0
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
         RECORD_FILE: recordFile,
         FAIL_WHEN: failWhen,
+        PS_OUTPUT: psOutput,
       },
     });
     let record: string[] = [];
@@ -71,7 +82,12 @@ exit 0
     } catch {
       record = [];
     }
-    return { status: res.exitCode, record };
+    return {
+      status: res.exitCode,
+      record,
+      stdout: res.stdout.toString(),
+      stderr: res.stderr.toString(),
+    };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -104,6 +120,64 @@ function dryRunCommands(mode: string, extraArgs: string[] = []): string[] {
 }
 
 describe("scripts/install-global.mjs", () => {
+  test("detects active Claude frontends and managed Codex TUIs from ps output", () => {
+    const sessions = detectActiveInstallSessionsFromPsOutput(
+      `
+        101 /Users/x/.claude/plugins/agentbridge/server/bridge-server.js
+        102 /usr/local/bin/codex --enable tui_app_server --remote ws://127.0.0.1:4511
+        103 /usr/local/bin/codex app-server --listen ws://127.0.0.1:4500
+        104 /bin/zsh -c echo codex --enable tui_app_server --remote ws://127.0.0.1:4511
+      `,
+      [
+        {
+          pairId: "work-a1b2c3d4",
+          pairName: "work",
+          cwd: "/repo/work",
+          stateDir: "/state/pairs/work-a1b2c3d4",
+          proxyUrl: "ws://127.0.0.1:4511",
+        },
+      ],
+    );
+
+    expect(sessions).toMatchObject([
+      {
+        kind: "claude-frontend",
+        pid: 101,
+        pair: { label: "unknown" },
+      },
+      {
+        kind: "codex-tui",
+        pid: 102,
+        remoteUrl: "ws://127.0.0.1:4511",
+        pair: {
+          label: "work (work-a1b2c3d4)",
+          pairId: "work-a1b2c3d4",
+          pairName: "work",
+          cwd: "/repo/work",
+        },
+      },
+    ]);
+  });
+
+  test("preflight decision blocks active sessions before install unless forced or dry-run", () => {
+    expect(decideInstallPreflight({ activeSessionCount: 1, force: false, dryRun: false, isTTY: false })).toEqual({
+      action: "block",
+      reason: "non-tty",
+    });
+    expect(decideInstallPreflight({ activeSessionCount: 1, force: true, dryRun: false, isTTY: false })).toEqual({
+      action: "allow",
+      reason: "force",
+    });
+    expect(decideInstallPreflight({ activeSessionCount: 1, force: false, dryRun: true, isTTY: false })).toEqual({
+      action: "allow",
+      reason: "dry-run",
+    });
+    expect(decideInstallPreflight({ activeSessionCount: 0, force: false, dryRun: false, isTTY: false })).toEqual({
+      action: "allow",
+      reason: "no-active-sessions",
+    });
+  });
+
   test("local mode builds, verifies and INSTALLS before stopping anything, then syncs the plugin", () => {
     // Ordering contract (P1 downtime reduction):
     //   - stop-running comes AFTER `npm install` succeeds, so the old daemon
@@ -129,6 +203,18 @@ describe("scripts/install-global.mjs", () => {
     const stopIdx = commands.findIndex((l) => l.includes("stop-running"));
     expect(installIdx).toBeGreaterThanOrEqual(0);
     expect(stopIdx).toBeGreaterThan(installIdx);
+  });
+
+  test("dry-run output includes the active-session preflight as the first plan step", () => {
+    const res = runDry("npm");
+    expect(res.status).toBe(0);
+    const lines = res.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    expect(lines[0]).toContain("preflight");
+    expect(lines[0]).toContain("--force");
+    expect(lines.findIndex((line) => line.startsWith("$ npm view"))).toBeGreaterThan(0);
   });
 
   test("local mode --skip-plugin omits the plugin sync step (stop-running still last)", () => {
@@ -177,6 +263,22 @@ describe("scripts/install-global.mjs", () => {
     expect(recordHasStop(record)).toBe(false);
   });
 
+  test("npm mode: active sessions in non-TTY abort BEFORE npm view unless --force is passed", () => {
+    const activePs = "501 /usr/local/bin/codex --enable tui_app_server --remote ws://127.0.0.1:4501\n";
+    const { status, record, stderr } = runRealWithStubs("npm", [], "", activePs);
+
+    expect(status).toBe(1);
+    expect(record).toEqual(["ps -axo pid=,command="]);
+    expect(record.some((l) => l.startsWith("npm view"))).toBe(false);
+    expect(recordHasStop(record)).toBe(false);
+    expect(stderr).toContain("--force");
+
+    const forced = runRealWithStubs("npm", ["--force"], "", activePs);
+    expect(forced.status).toBe(0);
+    expect(forced.record.some((l) => l.startsWith("npm view"))).toBe(true);
+    expect(recordHasStop(forced.record)).toBe(true);
+  });
+
   test("npm mode: a failed `npm install` aborts BEFORE stop-running (daemon untouched)", () => {
     const { status, record } = runRealWithStubs("npm", [], "install -g --force");
     expect(status).not.toBe(0);
@@ -205,6 +307,22 @@ describe("scripts/install-global.mjs", () => {
     // Nothing destructive ran: no install, no stop-running.
     expect(record.some((l) => l.startsWith("npm install"))).toBe(false);
     expect(recordHasStop(record)).toBe(false);
+  });
+
+  test("local mode: active sessions in non-TTY abort BEFORE build unless --force is passed", () => {
+    const activePs = "601 /Users/x/.claude/plugins/agentbridge/server/bridge-server.js\n";
+    const { status, record, stderr } = runRealWithStubs("local", ["--skip-plugin"], "", activePs);
+
+    expect(status).toBe(1);
+    expect(record).toEqual(["ps -axo pid=,command="]);
+    expect(record.some((l) => l.startsWith("bun run prepublishOnly"))).toBe(false);
+    expect(recordHasStop(record)).toBe(false);
+    expect(stderr).toContain("--force");
+
+    const forced = runRealWithStubs("local", ["--skip-plugin", "--force"], "", activePs);
+    expect(forced.status).toBe(0);
+    expect(forced.record.some((l) => l.startsWith("bun run prepublishOnly"))).toBe(true);
+    expect(recordHasStop(forced.record)).toBe(true);
   });
 
   test("local mode: a failed `npm install` aborts BEFORE stop-running (daemon untouched)", () => {

--- a/src/unit-test/update-notifier.test.ts
+++ b/src/unit-test/update-notifier.test.ts
@@ -84,36 +84,44 @@ describe("isUpdateCheckSuppressed", () => {
 });
 
 describe("maybeNotifyUpdate — printing", () => {
-  test("prints when cache has a newer stable version", () => {
+  test("prints when cache has a newer stable version", async () => {
     const sd = freshStateDir();
     writeCacheFile(sd, { lastCheckMs: 1000, latest: "0.2.0" });
     const out: string[] = [];
-    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m), now: () => 1000 });
+    await maybeNotifyUpdate({
+      current: "0.1.6",
+      stateDir: sd,
+      isTTY: true,
+      env: CLEAN_ENV,
+      print: (m) => out.push(m),
+      now: () => 1000,
+      promptUpdate: async () => false,
+    });
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("0.1.6");
     expect(out[0]).toContain("0.2.0");
   });
 
-  test("does NOT print when latest is equal/older/prerelease or cache absent", () => {
+  test("does NOT print when latest is equal/older/prerelease or cache absent", async () => {
     const out: string[] = [];
-    const run = (cache: UpdateCache | null, current = "0.1.6") => {
+    const run = async (cache: UpdateCache | null, current = "0.1.6") => {
       const sd = freshStateDir();
       if (cache) writeCacheFile(sd, cache);
-      maybeNotifyUpdate({ current, stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m), now: () => 1000 });
+      await maybeNotifyUpdate({ current, stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m), now: () => 1000 });
     };
-    run({ lastCheckMs: 1, latest: "0.1.6" }); // equal
-    run({ lastCheckMs: 1, latest: "0.1.5" }); // older
-    run({ lastCheckMs: 1, latest: "0.2.0-beta.1" }); // prerelease
-    run({ lastCheckMs: 1, latest: null }); // unknown
-    run(null); // no cache file
+    await run({ lastCheckMs: 1, latest: "0.1.6" }); // equal
+    await run({ lastCheckMs: 1, latest: "0.1.5" }); // older
+    await run({ lastCheckMs: 1, latest: "0.2.0-beta.1" }); // prerelease
+    await run({ lastCheckMs: 1, latest: null }); // unknown
+    await run(null); // no cache file
     expect(out).toHaveLength(0);
   });
 
-  test("does NOT print when suppressed even if a newer version is cached", () => {
+  test("does NOT print when suppressed even if a newer version is cached", async () => {
     const sd = freshStateDir();
     writeCacheFile(sd, { lastCheckMs: 1, latest: "9.9.9" });
     const out: string[] = [];
-    maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: { CI: "1" } as any, print: (m) => out.push(m) });
+    await maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: { CI: "1" } as any, print: (m) => out.push(m) });
     expect(out).toHaveLength(0);
   });
 
@@ -126,6 +134,117 @@ describe("maybeNotifyUpdate — printing", () => {
       maybeNotifyUpdate({ current: "0.1.6", stateDir: sd, isTTY: true, env: CLEAN_ENV, print: (m) => out.push(m) }),
     ).not.toThrow();
     expect(out).toHaveLength(0);
+  });
+});
+
+describe("maybeNotifyUpdate — interactive prompt", () => {
+  test("confirmed update runs npm install globally and asks caller to exit", async () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1, latest: "0.2.0" });
+    const out: string[] = [];
+    const installs: string[][] = [];
+
+    const decision = await maybeNotifyUpdate({
+      current: "0.1.6",
+      stateDir: sd,
+      isTTY: true,
+      inputIsTTY: true,
+      env: CLEAN_ENV,
+      print: (m) => out.push(m),
+      promptUpdate: async () => true,
+      installUpdate: (cmd, args) => {
+        installs.push([cmd, ...args]);
+        return { ok: true };
+      },
+    });
+
+    expect(decision).toBe("updated");
+    expect(installs).toEqual([["npm", "install", "-g", `${PACKAGE_NAME}@latest`]]);
+    expect(out.join("\n")).toContain("请重新运行命令");
+    expect(out.join("\n")).toContain("/plugin marketplace update agentbridge");
+  });
+
+  test("declined update records dismissedVersion and the same version only prints a short notice", async () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1, latest: "0.2.0" });
+    const out: string[] = [];
+
+    const decision = await maybeNotifyUpdate({
+      current: "0.1.6",
+      stateDir: sd,
+      isTTY: true,
+      inputIsTTY: true,
+      env: CLEAN_ENV,
+      print: (m) => out.push(m),
+      promptUpdate: async () => false,
+    });
+
+    expect(decision).toBe("continue");
+    expect(readCacheFile(sd).dismissedVersion).toBe("0.2.0");
+
+    const secondOut: string[] = [];
+    await maybeNotifyUpdate({
+      current: "0.1.6",
+      stateDir: sd,
+      isTTY: true,
+      inputIsTTY: true,
+      env: CLEAN_ENV,
+      print: (m) => secondOut.push(m),
+      promptUpdate: async () => {
+        throw new Error("dismissed versions must not prompt again");
+      },
+    });
+
+    expect(secondOut).toHaveLength(1);
+    expect(secondOut[0]).toContain("0.2.0");
+    expect(secondOut[0]).not.toContain("CLI:");
+  });
+
+  test("AGENTBRIDGE_UPDATE_PROMPT=0 keeps pure notice behavior without prompting or dismissing", async () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1, latest: "0.2.0" });
+    const out: string[] = [];
+
+    const decision = await maybeNotifyUpdate({
+      current: "0.1.6",
+      stateDir: sd,
+      isTTY: true,
+      inputIsTTY: true,
+      env: { AGENTBRIDGE_UPDATE_PROMPT: "0" } as any,
+      print: (m) => out.push(m),
+      promptUpdate: async () => {
+        throw new Error("prompt disabled");
+      },
+      installUpdate: () => {
+        throw new Error("install disabled");
+      },
+    });
+
+    expect(decision).toBe("continue");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("CLI:");
+    expect(readCacheFile(sd).dismissedVersion).toBeUndefined();
+  });
+
+  test("failed confirmed update warns and continues without dismissing the version", async () => {
+    const sd = freshStateDir();
+    writeCacheFile(sd, { lastCheckMs: 1, latest: "0.2.0" });
+    const out: string[] = [];
+
+    const decision = await maybeNotifyUpdate({
+      current: "0.1.6",
+      stateDir: sd,
+      isTTY: true,
+      inputIsTTY: true,
+      env: CLEAN_ENV,
+      print: (m) => out.push(m),
+      promptUpdate: async () => true,
+      installUpdate: () => ({ ok: false, status: 1 }),
+    });
+
+    expect(decision).toBe("continue");
+    expect(out.join("\n")).toContain("update failed");
+    expect(readCacheFile(sd).dismissedVersion).toBeUndefined();
   });
 });
 

--- a/src/update-notifier.ts
+++ b/src/update-notifier.ts
@@ -5,14 +5,18 @@
  * be correct-by-construction:
  *   - ZERO network on most runs: a notice is printed from a cached `latest`
  *     (populated by a prior run); the network is hit at most once per `interval`.
- *   - NEVER blocks / delays / fails the command: printing is sync from cache; the
- *     daily refresh is fired un-awaited and only on long-lived launchers (claude/
- *     codex) whose parent process outlives the fetch — one-shot commands never
- *     keep a pending fetch alive past their own exit.
+ *   - PROMPTS only for a cached upgrade on an interactive TTY. The prompt
+ *     defaults to "no" after a short timeout so unattended launchers continue.
+ *     Confirming runs the npm global update with inherited stdio; a successful
+ *     update asks the user to rerun the command, while a failed update warns and
+ *     continues the original launch.
+ *   - NON-INTERACTIVE remains non-blocking: CI, non-TTY, test, and opt-out envs
+ *     never prompt; `AGENTBRIDGE_UPDATE_PROMPT=0` keeps the old pure notice.
  *   - SILENT on any failure (offline, 404, proxy, malformed JSON, timeout).
  *   - SUPPRESSED for non-TTY/CI/test and via opt-out env vars.
  *   - STABLE-only: never nags about prereleases or downgrades (see version-utils).
- *   - READ-ONLY: it only prints the upgrade command; it never installs anything.
+ *   - DISMISSIBLE per version: saying no records `dismissedVersion`, so the same
+ *     version only gets a short reminder; a newer version asks again.
  *
  * npm is queried as the single authoritative source: the user running `abg`
  * installed the CLI from npm, and `scripts/check-plugin-versions.js` keeps the
@@ -22,6 +26,8 @@
  */
 
 import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline";
 import { atomicWriteJson } from "./atomic-json";
 import { StateDirResolver } from "./state-dir";
 import { isStableUpgrade, isStableVersion } from "./version-utils";
@@ -34,6 +40,7 @@ const REGISTRY_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NA
 const ABBREVIATED_ACCEPT = "application/vnd.npm.install-v1+json";
 const DEFAULT_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // once per day
 const FETCH_TIMEOUT_MS = 2500;
+export const DEFAULT_UPDATE_PROMPT_TIMEOUT_MS = 15_000;
 const CHECK_INTERVAL_ENV = "AGENTBRIDGE_UPDATE_CHECK_INTERVAL_MS";
 
 export interface UpdateCache {
@@ -41,7 +48,19 @@ export interface UpdateCache {
   lastCheckMs: number;
   /** Last-known stable `latest` from npm, or null if never/failed. */
   latest: string | null;
+  /** Stable latest version the user declined; the same version will not prompt again. */
+  dismissedVersion?: string | null;
 }
+
+export type UpdateNotifierDecision = "continue" | "updated";
+
+export interface UpdateInstallResult {
+  ok: boolean;
+  status?: number | null;
+  error?: Error;
+}
+
+export type UpdateInstaller = (cmd: string, args: string[]) => UpdateInstallResult;
 
 export interface NotifierDeps {
   /** Installed version. Defaults to the build-time package version. */
@@ -55,6 +74,11 @@ export interface NotifierDeps {
   env?: NodeJS.ProcessEnv;
   print?: (msg: string) => void;
   fetchImpl?: typeof fetch;
+  /** Whether stdin can be used for an interactive prompt (defaults to stdin.isTTY). */
+  inputIsTTY?: boolean;
+  promptTimeoutMs?: number;
+  promptUpdate?: (opts: { current: string; latest: string; timeoutMs: number }) => Promise<boolean>;
+  installUpdate?: UpdateInstaller;
 }
 
 /** Installed version, inlined at build time by Bun's bundler (see printVersion). */
@@ -84,6 +108,7 @@ function readCache(stateDir: StateDirResolver): UpdateCache | null {
     return {
       lastCheckMs: parsed.lastCheckMs,
       latest: typeof parsed.latest === "string" ? parsed.latest : null,
+      dismissedVersion: typeof parsed.dismissedVersion === "string" ? parsed.dismissedVersion : undefined,
     };
   } catch {
     return null; // missing / corrupt → treat as "no cache, recheck"
@@ -133,7 +158,11 @@ export async function refreshUpdateCache(deps: NotifierDeps = {}): Promise<void>
   try {
     const latest = await fetchLatest(fetchImpl);
     const prev = readCache(stateDir);
-    writeCache(stateDir, { lastCheckMs: now(), latest: latest ?? prev?.latest ?? null });
+    writeCache(stateDir, {
+      lastCheckMs: now(),
+      latest: latest ?? prev?.latest ?? null,
+      dismissedVersion: prev?.dismissedVersion,
+    });
   } catch {
     // never throw
   }
@@ -152,31 +181,113 @@ export function buildUpdateNotice(current: string, latest: string, isTTY: boolea
   ].join("\n");
 }
 
+export function buildDismissedUpdateNotice(current: string, latest: string, isTTY: boolean): string {
+  const yellow = isTTY ? "\x1b[33m" : "";
+  const bold = isTTY ? "\x1b[1m" : "";
+  const reset = isTTY ? "\x1b[0m" : "";
+  return `${yellow}⚠ AgentBridge update available: ${bold}${current}${reset}${yellow} → ${bold}${latest}${reset} (previously dismissed)`;
+}
+
 function checkIntervalMs(env: NodeJS.ProcessEnv): number {
   // Read from the injected env (not process.env) so the deps.env DI contract
   // holds end-to-end and the interval is overridable/testable.
   return parsePositiveIntEnv(CHECK_INTERVAL_ENV, DEFAULT_CHECK_INTERVAL_MS, undefined, env);
 }
 
+function updatePromptDisabled(env: NodeJS.ProcessEnv): boolean {
+  return env.AGENTBRIDGE_UPDATE_PROMPT === "0";
+}
+
+function defaultInstallUpdate(cmd: string, args: string[]): UpdateInstallResult {
+  const res = spawnSync(cmd, args, { stdio: "inherit" });
+  if (res.error) return { ok: false, status: res.status, error: res.error };
+  return { ok: res.status === 0, status: res.status };
+}
+
+function defaultPromptUpdate(opts: { current: string; latest: string; timeoutMs: number }): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const finish = (answer: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      rl.close();
+      resolve(answer);
+    };
+    timer = setTimeout(() => {
+      process.stderr.write("\n");
+      finish(false);
+    }, opts.timeoutMs);
+    timer.unref?.();
+    rl.question(`Update AgentBridge now? [y/N] `, (answer) => {
+      finish(/^y(?:es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+function recordDismissal(stateDir: StateDirResolver, cache: UpdateCache, latest: string): void {
+  writeCache(stateDir, {
+    ...cache,
+    latest,
+    dismissedVersion: latest,
+  });
+}
+
 /**
- * Best-effort update notice. Synchronously prints a notice from the cached
- * `latest` (if a newer stable version exists), then — only when `refresh` is set
- * — fires an un-awaited daily refresh. NEVER throws, blocks, or changes exit code.
+ * Best-effort update notice. Prints a notice from cached `latest` (if a newer
+ * stable version exists). On an interactive TTY, it may prompt before the command
+ * starts; otherwise it keeps the old non-blocking notice behavior. NEVER throws.
  */
-export function maybeNotifyUpdate(deps: NotifierDeps = {}): void {
+export async function maybeNotifyUpdate(deps: NotifierDeps = {}): Promise<UpdateNotifierDecision> {
   try {
     const env = deps.env ?? process.env;
     const isTTY = deps.isTTY ?? Boolean(process.stderr.isTTY);
-    if (isUpdateCheckSuppressed(env, isTTY)) return;
+    if (isUpdateCheckSuppressed(env, isTTY)) return "continue";
 
     const current = deps.current ?? getCurrentVersion();
     const stateDir = deps.stateDir ?? new StateDirResolver();
     const now = deps.now ?? Date.now;
     const print = deps.print ?? ((m: string) => process.stderr.write(m + "\n"));
+    const inputIsTTY = deps.inputIsTTY ?? Boolean(process.stdin.isTTY);
+    const promptTimeoutMs = deps.promptTimeoutMs ?? DEFAULT_UPDATE_PROMPT_TIMEOUT_MS;
 
     const cache = readCache(stateDir);
     if (cache?.latest && isStableUpgrade(current, cache.latest)) {
-      print(buildUpdateNotice(current, cache.latest, isTTY));
+      if (cache.dismissedVersion === cache.latest) {
+        print(buildDismissedUpdateNotice(current, cache.latest, isTTY));
+      } else {
+        print(buildUpdateNotice(current, cache.latest, isTTY));
+        if (!updatePromptDisabled(env) && inputIsTTY) {
+          const promptUpdate = deps.promptUpdate ?? defaultPromptUpdate;
+          let accepted = false;
+          try {
+            accepted = await promptUpdate({ current, latest: cache.latest, timeoutMs: promptTimeoutMs });
+          } catch {
+            accepted = false;
+          }
+          if (accepted) {
+            const installUpdate = deps.installUpdate ?? defaultInstallUpdate;
+            const cmd = "npm";
+            const args = ["install", "-g", `${PACKAGE_NAME}@latest`];
+            const result = installUpdate(cmd, args);
+            if (result.ok) {
+              print("AgentBridge CLI updated. 请重新运行命令。");
+              print("Plugin: in Claude, run `/plugin marketplace update agentbridge` and then `/reload-plugins`.");
+              return "updated";
+            }
+            const detail = result.error?.message
+              ? ` (${result.error.message})`
+              : typeof result.status === "number"
+                ? ` (exit ${result.status})`
+                : "";
+            print(`⚠ AgentBridge update failed${detail}; continuing with the current command.`);
+          } else {
+            recordDismissal(stateDir, cache, cache.latest);
+          }
+        }
+      }
     }
 
     // Daily refresh — only on long-lived launchers (deps.refresh), where the
@@ -185,7 +296,9 @@ export function maybeNotifyUpdate(deps: NotifierDeps = {}): void {
     if (deps.refresh && (!cache || now() - cache.lastCheckMs >= checkIntervalMs(env))) {
       void refreshUpdateCache({ stateDir, now, fetchImpl: deps.fetchImpl }).catch(() => {});
     }
+    return "continue";
   } catch {
     // The notifier must never affect the command it precedes.
+    return "continue";
   }
 }


### PR DESCRIPTION
## 概要 / Summary

两个 CLI 交互守卫，修两个真实体验问题：

**⑥ update-notifier 交互化** — 启动（`abg claude/codex/resume` 等）检测到新版本时，从「只打一行提示继续跑」改为**交互询问是否更新**：
- TTY 且未抑制 → 打印 notice 后 prompt（`y`/`N`，默认 `N`，**15 秒超时默认 N** 继续启动）。
- `y` → 实跑 `npm install -g @raysonmeng/agentbridge@latest`（透传 stdio），成功提示重跑命令并 `exit 0`；失败警告后继续启动（不 brick）。
- `N`/超时 → 继续启动 + 记住该版本拒绝（`dismissedVersion` 按版本键，新版本重新问）。
- 非 TTY / CI / `NO_UPDATE_NOTIFIER` / `AGENTBRIDGE_NO_UPDATE_NOTIFIER` → **完全维持原纯打印行为**，绝不 prompt 绝不阻塞。
- 新增 `AGENTBRIDGE_UPDATE_PROMPT=0` 回到纯打印。

**⑦ install:global 活跃会话守卫** — 修「`install:global` 直接 kill 运行中 daemon 导致活跃 Codex TUI 当场掉线」：
- 在**任何实际动作之前**（local build / npm view 之前）preflight 检测活跃 Claude 前端（`bridge-server.js`）+ Codex TUI（复用 `process-lifecycle.ts` 严格 matcher）。
- 发现活跃会话 → TTY 询问默认 `N`（拒绝则 `exit 1` 什么都不动）；非 TTY 拒绝并提示 `--force`；`--force` 跳过守卫。
- **防 brick 不变量原样保留**：`preflight → build/verify/install 成功 → stop-running → 事后提示`。dry-run 零检测、计划里展示 preflight。

## Cross-review（项目硬规矩）

Codex 实现（TDD），Claude 派 2 个全新正交 reviewer + 对抗验证：**9 findings → 0 真实 issue**（全部 FALSE_POSITIVE / RECOMMEND）。防 brick 不变量、TUI matcher 准确性、五条抑制路径绝不阻塞、bundle 同步均逐条实证。

## 测试 / Test plan

- `bun run check`：typecheck + `bun test src` **1300 pass / 0 fail** + plugin-sync + version-align。
- update-notifier 22 测试 + install-global-script 29 测试覆盖：五条抑制路径、15s 超时、dismissedVersion 记忆、preflight 拒绝/--force/非 TTY、防 brick 顺序断言保留、dry-run 零检测。
- [ ] E2E（手动）：① 旧版本启动 `abg claude` 看交互 prompt + y/N/超时三路径；② 活跃 Codex TUI 时跑 `bun run install:global` 应被守卫拦下询问。