### PR TITLE
fix(budget): probe 候选优先级——node probe.mjs(v2) 优先于 bash budget-probe(v1)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14512,10 +14512,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.15", "0.0.0-source"),
-  commit: defineString("85ad89b", "source"),
+  commit: defineString("89d4c9a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("71ce81854ec9", "source")
+  codeHash: defineString("7b8ff13f1afa", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -27,10 +27,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.15", "0.0.0-source"),
-  commit: defineString("85ad89b", "source"),
+  commit: defineString("89d4c9a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("71ce81854ec9", "source")
+  codeHash: defineString("7b8ff13f1afa", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -4741,12 +4741,12 @@ class QuotaSource {
       return candidates;
     }
     const binDir = join5(this.homeDir, ".budget-guard/bin");
-    const installedBudgetProbe = join5(binDir, "budget-probe");
-    if (existsSync5(installedBudgetProbe))
-      add(installedBudgetProbe, "budget-probe");
     const installedProbeMjs = join5(binDir, "probe.mjs");
     if (existsSync5(installedProbeMjs))
       add(installedProbeMjs, "probe-mjs");
+    const installedBudgetProbe = join5(binDir, "budget-probe");
+    if (existsSync5(installedBudgetProbe))
+      add(installedBudgetProbe, "budget-probe");
     return candidates;
   }
   async fetchAgent(candidates, agent) {

--- a/src/budget/quota-source.ts
+++ b/src/budget/quota-source.ts
@@ -461,10 +461,10 @@ export class QuotaSource {
     }
 
     const binDir = join(this.homeDir, ".budget-guard/bin");
-    const installedBudgetProbe = join(binDir, "budget-probe");
-    if (existsSync(installedBudgetProbe)) add(installedBudgetProbe, "budget-probe");
     const installedProbeMjs = join(binDir, "probe.mjs");
     if (existsSync(installedProbeMjs)) add(installedProbeMjs, "probe-mjs");
+    const installedBudgetProbe = join(binDir, "budget-probe");
+    if (existsSync(installedBudgetProbe)) add(installedBudgetProbe, "budget-probe");
     return candidates;
   }
 

--- a/src/unit-test/quota-source.test.ts
+++ b/src/unit-test/quota-source.test.ts
@@ -395,7 +395,7 @@ describe("QuotaSource", () => {
     expect(unknownVersionLines[0]).toContain("999");
   });
 
-  test("uses installed budget-probe when env probes are unset", async () => {
+  test("falls back to installed budget-probe when installed probe.mjs is absent", async () => {
     tempHome = mkdtempSync(join(tmpdir(), "agentbridge-quota-source-test-"));
     const installed = join(tempHome, ".budget-guard/bin/budget-probe");
     mkdirSync(join(tempHome, ".budget-guard/bin"), { recursive: true });
@@ -429,7 +429,7 @@ describe("QuotaSource", () => {
     ]);
   });
 
-  test("falls back per agent from installed budget-probe to installed probe.mjs", async () => {
+  test("prefers installed probe.mjs over installed budget-probe so v2 burn fields are preserved", async () => {
     tempHome = mkdtempSync(join(tmpdir(), "agentbridge-quota-source-test-"));
     const binDir = join(tempHome, ".budget-guard/bin");
     const budgetProbe = join(binDir, "budget-probe");
@@ -444,17 +444,7 @@ describe("QuotaSource", () => {
       homeDir: tempHome,
       runner: async (command, args) => {
         calls.push({ command, args });
-        if (command === budgetProbe && args[1] === "claude") {
-          return {
-            stdout: JSON.stringify({
-              ok: false,
-              error: "schema",
-              message: "no Claude usage buckets found",
-              buckets: [],
-            }),
-          };
-        }
-        if (command === budgetProbe && args[1] === "codex") {
+        if (command === budgetProbe) {
           return {
             stdout: JSON.stringify({
               ok: true,
@@ -470,8 +460,70 @@ describe("QuotaSource", () => {
         return {
           stdout: JSON.stringify({
             ok: true,
+            probe_schema: 2,
             util: 22,
             warn_util: 22,
+            fetched_at: NOW,
+            buckets: [
+              {
+                id: "five_hour",
+                util: 22,
+                reset_epoch: NOW + 1200,
+                burn_rate_pct_per_hour: 1.25,
+                burn_confident: true,
+                runway_seconds: 1800,
+                depleted_at_epoch: NOW + 1800,
+              },
+            ],
+          }),
+        };
+      },
+    });
+
+    const result = await source.fetchBoth();
+    expect(result?.claude?.gateUtil).toBe(22);
+    expect(result?.codex?.gateUtil).toBe(22);
+    expect(result?.claude?.fiveHour).toMatchObject({
+      util: 22,
+      resetEpoch: NOW + 1200,
+      burnRate: 1.25,
+      burnConfident: true,
+      runwaySeconds: 1800,
+      depletedAtEpoch: NOW + 1800,
+    });
+    expect(calls).toEqual([
+      { command: probeMjs, args: ["claude", "probe"] },
+      { command: probeMjs, args: ["codex", "probe"] },
+    ]);
+  });
+
+  test("falls back per agent from installed probe.mjs to installed budget-probe when probe.mjs fails", async () => {
+    tempHome = mkdtempSync(join(tmpdir(), "agentbridge-quota-source-test-"));
+    const binDir = join(tempHome, ".budget-guard/bin");
+    const budgetProbe = join(binDir, "budget-probe");
+    const probeMjs = join(binDir, "probe.mjs");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(budgetProbe, "#!/bin/sh\n", "utf-8");
+    writeFileSync(probeMjs, "#!/usr/bin/env node\n", "utf-8");
+
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const source = new QuotaSource({
+      env: {},
+      homeDir: tempHome,
+      runner: async (command, args) => {
+        calls.push({ command, args });
+        if (command === probeMjs && args[0] === "claude") {
+          return { stdout: "" };
+        }
+        if (command === probeMjs && args[0] === "codex") {
+          throw new Error("probe.mjs failed");
+        }
+        return {
+          stdout: JSON.stringify({
+            ok: true,
+            util: 24,
+            hard_util: 24,
+            warn_util: 24,
             fetched_at: NOW,
             reset_epoch: NOW + 1200,
             buckets: [],
@@ -481,12 +533,14 @@ describe("QuotaSource", () => {
     });
 
     const result = await source.fetchBoth();
-    expect(result?.claude?.gateUtil).toBe(22);
+    expect(result?.claude?.gateUtil).toBe(24);
     expect(result?.codex?.gateUtil).toBe(24);
-    expect(calls).toContainEqual({ command: budgetProbe, args: ["--agent", "claude"] });
-    expect(calls).toContainEqual({ command: budgetProbe, args: ["--agent", "codex"] });
-    expect(calls).toContainEqual({ command: probeMjs, args: ["claude", "probe"] });
-    expect(calls).not.toContainEqual({ command: probeMjs, args: ["codex", "probe"] });
+    expect(calls).toEqual([
+      { command: probeMjs, args: ["claude", "probe"] },
+      { command: probeMjs, args: ["codex", "probe"] },
+      { command: budgetProbe, args: ["--agent", "claude"] },
+      { command: budgetProbe, args: ["--agent", "codex"] },
+    ]);
   });
 
   test("uses probe.mjs argument form only when explicitly configured", async () => {


### PR DESCRIPTION
## 概要 / Summary

修复一个**端到端命门 bug**：bridge 永远拿不到 guard 的 v2 burn 字段 →「5h 窗口」「runway」预测永不出数。

guard 安装后 `~/.budget-guard/bin` 同时有 bash `budget-probe`（probe_schema v1，无 burn 字段）和 node `probe.mjs`（v2，含 `burn_rate_pct_per_hour/burn_confident/runway_seconds/depleted_at_epoch/five_hour_windows_left`）。修复前 `findProbeCandidates` 先加 budget-probe，`fetchAgent`「第一个 usable 就 return」→ bash v1 先返回 usable → **永不 fallback 到 probe.mjs** → bridge 永远拿不到 burn 字段。

## 修复 / Fix

`src/budget/quota-source.ts` `findProbeCandidates`：调换候选顺序，**probe.mjs(v2) 先于 budget-probe(v1)**。理由：bash budget-probe 无 EWMA/history 能力，burn 字段只能 node 产，probe.mjs 是数据源真相。
- `fetchAgent`「第一个 usable 就 return」语义**不变** → probe.mjs 优先拿 v2 含 burn。
- probe.mjs 缺失/空输出/抛错 → 正确 fallback budget-probe（向后兼容老安装/纯 bash 环境）。
- explicit env（`AGENTBRIDGE_QUOTA_PROBE/BUDGET_PROBE`）路径不受影响（早 return）。

## Cross-review（项目硬规矩）

Codex 实现（TDD），Claude 派 2 个全新正交 reviewer + 对抗验证：**0 真实 issue**。验证者做了**变异测试**——把候选顺序改回 buggy 的 budget-probe-first，定向测试立即失败（gateUtil expected 22/received 24）；改回 probe.mjs-first → 35 pass，证明测试有真实区分力、非假绿。

## 测试 / Test plan

- `bun run typecheck && bun test src`：**1301 pass / 0 fail**；`verify:plugin-sync` in sync。
- 既有两测试改为新优先级语义（toContainEqual 升级为 toEqual 精确序列断言）+ 新增 probe.mjs 失败 fallback 测试。
- 关键测试：两 probe 都装 → 断言 `fiveHour` 带 `burnRate/burnConfident/runwaySeconds/depletedAtEpoch` + 只调 probe.mjs。

## 配套 / Context

- 与 guard `agent-quota-guard` 大 PR #1（已合 main c257035，产出 probe_schema:2）配套。两者到位后「5h 窗口」展示才真出数。