### PR TITLE
feat(budget): bridge guard-pending reader + resume-candidate detection (PR2)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14512,10 +14512,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("89d4c9a", "source"),
+  commit: defineString("1dc5e4f", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("1fc975838e46", "source")
+  codeHash: defineString("899ddecd2cf2", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env bun
 // @bun
+var __require = import.meta.require;
 
 // src/daemon.ts
-import { rmSync as rmSync2 } from "fs";
+import { existsSync as existsSync7, realpathSync, rmSync as rmSync2 } from "fs";
+import { homedir as homedir4 } from "os";
+import { join as join8 } from "path";
 import { randomUUID as randomUUID4 } from "crypto";
 
 // src/contract-version.ts
@@ -27,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("89d4c9a", "source"),
+  commit: defineString("1dc5e4f", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("1fc975838e46", "source")
+  codeHash: defineString("899ddecd2cf2", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -4043,6 +4046,31 @@ function classifyPoll(prev, state, cfg) {
   }
   return { next: prev, effect: { kind: "none" } };
 }
+function resumeCandidateSides(effect) {
+  switch (effect.kind) {
+    case "exit":
+      return sideToAgents(effect.previousSide);
+    case "enter":
+    case "hold-uncertain":
+      return sideToAgents(effect.side);
+    case "advise":
+    case "none":
+      return [];
+  }
+}
+function computeResumeCandidate(sides, state, cfg, signals) {
+  const candidate = {};
+  const detail = {};
+  for (const agent of sides) {
+    const windowRefreshed = canAgentResume(state.perAgent[agent], cfg, state.now);
+    const ready = windowRefreshed && signals.pendingExists[agent] && signals.tuiReady[agent] && signals.checkpointExists;
+    candidate[agent] = ready;
+    detail[agent] = { ready };
+  }
+  if (sides.length > 0)
+    candidate.detail = detail;
+  return candidate;
+}
 
 // src/budget/burn-view.ts
 function windowBurnRate(window) {
@@ -4181,9 +4209,11 @@ class BudgetCoordinator {
   now;
   scheduler;
   log;
+  resumeSignals;
   timer = null;
   running = false;
   fpState = INITIAL_FINGERPRINT_STATE;
+  resumeCandidate = {};
   latestSnapshot = null;
   pendingOverrideTier = null;
   pendingOverrides = null;
@@ -4199,6 +4229,7 @@ class BudgetCoordinator {
     this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
     this.scheduler = options.scheduler ?? REAL_BUDGET_POLL_SCHEDULER;
     this.log = options.log ?? (() => {});
+    this.resumeSignals = options.resumeSignals ?? null;
   }
   async start() {
     if (this.running || !this.config.enabled)
@@ -4223,6 +4254,13 @@ class BudgetCoordinator {
   }
   getSnapshot() {
     return this.latestSnapshot;
+  }
+  getResumeCandidate() {
+    const { detail, ...rest } = this.resumeCandidate;
+    return detail ? {
+      ...rest,
+      detail: Object.fromEntries(Object.entries(detail).map(([side, value]) => [side, { ...value }]))
+    } : { ...rest };
   }
   getCodexTurnOverrides() {
     if (!this.tierControlEnabled())
@@ -4291,6 +4329,7 @@ class BudgetCoordinator {
   applyState(state) {
     const { next, effect } = classifyPoll(this.fpState, state, this.config);
     this.fpState = next;
+    this.resumeCandidate = this.resumeSignals ? computeResumeCandidate(resumeCandidateSides(effect), state, this.config, this.resumeSignals()) : {};
     switch (effect.kind) {
       case "enter":
       case "hold-uncertain": {
@@ -4807,6 +4846,103 @@ function createQuotaSource(options) {
   return new QuotaSource(options);
 }
 
+// src/budget/pending-reader.ts
+import { join as join6 } from "path";
+function nodeFs() {
+  return __require("fs");
+}
+function cwdMatches(entryCwd, optsCwd) {
+  if (entryCwd === optsCwd)
+    return true;
+  try {
+    const fs2 = nodeFs();
+    return fs2.realpathSync(entryCwd) === fs2.realpathSync(optsCwd);
+  } catch {
+    return false;
+  }
+}
+function parsePendingPayload(value) {
+  const record = asRecord(value);
+  if (!record)
+    return null;
+  const sessionId = record.session_id;
+  if (typeof sessionId !== "string" || sessionId === "")
+    return null;
+  const util = asFiniteNumber(record.util);
+  if (util === null)
+    return null;
+  const warnUtil = numberOr(record.warn_util, util);
+  const resetEpoch = numberOr(record.reset_epoch ?? record.reset, 0);
+  const at = numberOr(record.at, 0);
+  const cwd = typeof record.cwd === "string" ? record.cwd : "";
+  const status = typeof record.status === "string" ? record.status : "";
+  const agent = record.agent === "claude" || record.agent === "codex" ? record.agent : null;
+  if (agent === null)
+    return null;
+  return { status, agent, sessionId, cwd, resetEpoch, util, warnUtil, at };
+}
+function resolveStateDir(homeDir) {
+  const override = process.env.BUDGET_STATE_DIR;
+  if (override && override.trim() !== "")
+    return override.trim();
+  return join6(homeDir, ".budget-guard");
+}
+function readPendingFile(path, log) {
+  let raw;
+  try {
+    raw = nodeFs().readFileSync(path, "utf-8");
+  } catch (error) {
+    log(`pending reader: skip unreadable ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+  const text = String(raw).trim();
+  if (text === "")
+    return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    log(`pending reader: skip malformed JSON ${path}`);
+    return null;
+  }
+  return parsePendingPayload(parsed);
+}
+function listScopeFiles(stateDir, agent, log) {
+  const pendingDir = join6(stateDir, "pending");
+  let names;
+  try {
+    names = nodeFs().readdirSync(pendingDir);
+  } catch {
+    return [];
+  }
+  const prefix = `${agent}_`;
+  return names.filter((name) => name.startsWith(prefix) && name.endsWith(".json")).map((name) => join6(pendingDir, name));
+}
+function readGuardPending(opts) {
+  const log = opts.log ?? (() => {});
+  const stateDir = resolveStateDir(opts.homeDir);
+  const paths = [
+    ...listScopeFiles(stateDir, opts.agent, log),
+    join6(stateDir, `pending_${opts.agent}.json`)
+  ];
+  const bySession = new Map;
+  for (const path of paths) {
+    const entry = readPendingFile(path, log);
+    if (!entry)
+      continue;
+    if (entry.agent !== opts.agent)
+      continue;
+    if (entry.status !== "paused")
+      continue;
+    if (opts.cwd !== undefined && !cwdMatches(entry.cwd, opts.cwd))
+      continue;
+    if (!bySession.has(entry.sessionId)) {
+      bySession.set(entry.sessionId, entry);
+    }
+  }
+  return [...bySession.values()];
+}
+
 // src/daemon-identity-ownership.ts
 import { readFileSync as readFileSync5 } from "fs";
 var defaultRead2 = (path) => readFileSync5(path, "utf-8");
@@ -4982,7 +5118,7 @@ import {
   readFileSync as readFileSync6
 } from "fs";
 import { homedir as homedir3 } from "os";
-import { basename as basename2, join as join6 } from "path";
+import { basename as basename2, join as join7 } from "path";
 function nowIso() {
   return new Date().toISOString();
 }
@@ -4991,7 +5127,7 @@ function threadTag(identity) {
   return `abg:${name}:${identity.cwd}`;
 }
 function codexHome(env = process.env) {
-  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join6(homedir3(), ".codex");
+  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join7(homedir3(), ".codex");
 }
 function readRawCurrentThread(stateDir) {
   try {
@@ -5003,7 +5139,7 @@ function readRawCurrentThread(stateDir) {
   return null;
 }
 function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
-  const sessionsDir = join6(codexHome(env), "sessions");
+  const sessionsDir = join7(codexHome(env), "sessions");
   if (!threadId || !existsSync6(sessionsDir))
     return null;
   const exactName = `rollout-${threadId}.jsonl`;
@@ -5019,7 +5155,7 @@ function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
     }
     for (const entry of entries) {
       visited++;
-      const path = join6(dir, entry.name);
+      const path = join7(dir, entry.name);
       if (entry.isDirectory()) {
         stack.push(path);
         continue;
@@ -5250,6 +5386,49 @@ function createPendingBackpressureBuffer() {
   });
 }
 var budgetCoordinator = null;
+function pairCwd() {
+  const raw = process.cwd();
+  try {
+    return realpathSync(raw);
+  } catch {
+    return raw;
+  }
+}
+function readResumeSignals() {
+  let tuiReadyCodex = false;
+  let tuiReadyClaude = false;
+  try {
+    tuiReadyCodex = tuiConnectionState.canReply();
+  } catch (error) {
+    log(`resume signal: codex tuiReady failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  try {
+    tuiReadyClaude = attachedClaude !== null;
+  } catch (error) {
+    log(`resume signal: claude tuiReady failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  let pendingCodex = false;
+  let pendingClaude = false;
+  try {
+    const home = homedir4();
+    const cwd = pairCwd();
+    pendingCodex = readGuardPending({ homeDir: home, agent: "codex", cwd, log }).length > 0;
+    pendingClaude = readGuardPending({ homeDir: home, agent: "claude", cwd, log }).length > 0;
+  } catch (error) {
+    log(`resume signal: pending read failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  let checkpointExists = false;
+  try {
+    checkpointExists = existsSync7(join8(pairCwd(), ".agent", "checkpoint.md"));
+  } catch (error) {
+    log(`resume signal: checkpoint stat failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return {
+    tuiReady: { codex: tuiReadyCodex, claude: tuiReadyClaude },
+    pendingExists: { codex: pendingCodex, claude: pendingClaude },
+    checkpointExists
+  };
+}
 function ensureBudgetCoordinatorStarted() {
   if (!BUDGET_CONFIG.enabled)
     return;
@@ -5265,7 +5444,8 @@ function ensureBudgetCoordinatorStarted() {
         log(`Budget intervention ${paused ? "ACTIVE" : "CLEARED"} ` + `(gate ${budgetCoordinator?.isGateClosed() ? "CLOSED" : "OPEN"})`);
       },
       onSnapshot: () => broadcastStatus(),
-      log
+      log,
+      resumeSignals: readResumeSignals
     });
   }
   budgetCoordinator.start();

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -1,8 +1,12 @@
 import { computeBudgetState, renderBudgetInterventionDirective } from "./budget-state";
 import {
   classifyPoll,
+  computeResumeCandidate,
+  resumeCandidateSides,
   INITIAL_FINGERPRINT_STATE,
   type FingerprintState,
+  type ResumeCandidate,
+  type ResumeSignals,
 } from "./budget-fingerprint";
 import { agentBurnRates, agentRunway, hasAnyBurnSignal } from "./burn-view";
 import type {
@@ -61,6 +65,14 @@ export interface BudgetCoordinatorOptions {
   now?: () => number;
   scheduler?: BudgetPollScheduler;
   log?: (message: string) => void;
+  /**
+   * PR2 (detection only): daemon-injected readiness signals for the resume
+   * candidate. Pulled once per poll after classifyPoll; the result is exposed
+   * read-only via getResumeCandidate(). Absent → candidate stays empty (no
+   * signals means nothing can be a candidate). The coordinator NEVER acts on
+   * this value (no emit/onPauseChange/inject) — that is PR3/PR4.
+   */
+  resumeSignals?: () => ResumeSignals;
 }
 
 const AGENT_LABEL: Record<AgentName, string> = {
@@ -146,6 +158,7 @@ export class BudgetCoordinator {
   private readonly now: () => number;
   private readonly scheduler: BudgetPollScheduler;
   private readonly log: (message: string) => void;
+  private readonly resumeSignals: (() => ResumeSignals) | null;
 
   private timer: BudgetPollTimer | null = null;
   private running = false;
@@ -153,6 +166,9 @@ export class BudgetCoordinator {
   // / resume bookkeeping). Replaces the former 4 mutable fields
   // (activeSides, lastDirectiveFingerprint, pauseReason, pauseResumeAfterEpoch).
   private fpState: FingerprintState = INITIAL_FINGERPRINT_STATE;
+  // PR2: latest per-side resume candidate (detection only — read-only exposure
+  // via getResumeCandidate(); the coordinator never acts on it).
+  private resumeCandidate: ResumeCandidate = {};
   private latestSnapshot: BudgetSnapshot | null = null;
   private pendingOverrideTier: CodexTier | null = null;
   private pendingOverrides: CodexTurnOverrides | null = null;
@@ -169,6 +185,7 @@ export class BudgetCoordinator {
     this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
     this.scheduler = options.scheduler ?? REAL_BUDGET_POLL_SCHEDULER;
     this.log = options.log ?? (() => {});
+    this.resumeSignals = options.resumeSignals ?? null;
   }
 
   async start(): Promise<void> {
@@ -196,6 +213,30 @@ export class BudgetCoordinator {
 
   getSnapshot(): BudgetSnapshot | null {
     return this.latestSnapshot;
+  }
+
+  /**
+   * PR2 read-only exposure of the latest per-side resume candidate. Returns a
+   * fresh copy so callers cannot mutate the coordinator's internal state. A side
+   * is `true` only when its window refreshed AND all daemon-injected signals
+   * (pending / TUI / checkpoint) held on the last poll. Detection only — the
+   * coordinator takes no action on this value (no emit/inject); PR3/PR4 own that.
+   */
+  getResumeCandidate(): ResumeCandidate {
+    // Deep-copy the per-side detail map AND each nested ResumeCandidateDetail,
+    // so a caller mutating the returned value — including an IN-PLACE flip like
+    // PR3's claim bookkeeping `result.detail.codex.ready = false` — cannot reach
+    // the coordinator's internal resumeCandidate. A shallow `{ ...detail }` would
+    // copy the outer map only, leaving each inner detail shared by reference.
+    const { detail, ...rest } = this.resumeCandidate;
+    return detail
+      ? {
+          ...rest,
+          detail: Object.fromEntries(
+            Object.entries(detail).map(([side, value]) => [side, { ...value }]),
+          ) as ResumeCandidate["detail"],
+        }
+      : { ...rest };
   }
 
   getCodexTurnOverrides(): CodexTurnOverrides | null {
@@ -287,6 +328,21 @@ export class BudgetCoordinator {
   private applyState(state: BudgetState): void {
     const { next, effect } = classifyPoll(this.fpState, state, this.config);
     this.fpState = next;
+
+    // PR2 (detection only): recompute the per-side resume candidate from the
+    // EFFECT, not the post-transition fingerprint. The hysteresis removes a side
+    // from `next.side` on the same poll its window refreshes, so the exit poll —
+    // exactly when a side becomes resumable — carries `next.side = null`.
+    // resumeCandidateSides() reads the recovered side off the exit effect (and
+    // the still-paused side off enter/hold), so the candidate lands on the right
+    // side. When no signal provider is wired the candidate stays empty — nothing
+    // can be a candidate without the readiness signals. This populates state
+    // only; the switch below is untouched, so the 50+ classifyPoll regression
+    // baseline (branch order / outcome shapes) is unaffected. NO emit /
+    // onPauseChange / inject here — that is PR3/PR4.
+    this.resumeCandidate = this.resumeSignals
+      ? computeResumeCandidate(resumeCandidateSides(effect), state, this.config, this.resumeSignals())
+      : {};
 
     switch (effect.kind) {
       case "enter":

--- a/src/budget/budget-fingerprint.ts
+++ b/src/budget/budget-fingerprint.ts
@@ -108,6 +108,50 @@ export interface ClassifyResult {
   effect: CoordinatorEffect;
 }
 
+/**
+ * Daemon-injected readiness signals for the resume-candidate reducer. The
+ * reducer stays pure — every probe is gathered by the daemon (TUI state, pending
+ * glob, checkpoint stat) and passed in, so this module performs no fs/socket IO.
+ *
+ * `tuiReady` and `pendingExists` are PER-SIDE: an earlier GLOBAL-OR shape
+ * (`codex ready || claude attached`) let one side's readiness leak onto the
+ * other, and a pending file from an UNRELATED repo falsely satisfied the
+ * pending predicate. Each side now carries its own boolean so the reducer can
+ * gate codex/claude independently. `checkpointExists` stays shared — the handoff
+ * checkpoint is a single per-pair artifact, not a per-agent one.
+ */
+export interface ResumeSignals {
+  /** tuiReady.codex = tuiConnectionState.canReply(); tuiReady.claude = attachedClaude != null. */
+  tuiReady: Record<AgentName, boolean>;
+  /** Per-side: a guard-pending record for THIS agent, scoped to the current pair cwd, exists. */
+  pendingExists: Record<AgentName, boolean>;
+  /** fs.existsSync(<pair cwd>/.agent/checkpoint.md) — shared across sides. */
+  checkpointExists: boolean;
+}
+
+/**
+ * Per-side resume-candidate detail (PR2 detection only). Only the sides passed
+ * to `computeResumeCandidate` get an entry; uncovered sides stay `undefined`
+ * (idle → both undefined). The richer shape (pending entry + checkpoint path) is
+ * carried so PR3's atomic claim need not re-read the guard/checkpoint files.
+ */
+export interface ResumeCandidateDetail {
+  /** All four predicates held: window refreshed AND per-side signals AND checkpoint. */
+  ready: boolean;
+}
+
+/**
+ * Per-side resume-candidate result. `codex`/`claude` are booleans for backward
+ * compatibility with the read-only `getResumeCandidate()` contract; the detail
+ * map exposes the richer per-side shape for PR3 without re-reading files.
+ */
+export interface ResumeCandidate {
+  codex?: boolean;
+  claude?: boolean;
+  /** Per-side detail for sides that were evaluated this poll. */
+  detail?: Partial<Record<AgentName, ResumeCandidateDetail>>;
+}
+
 // ---------------------------------------------------------------------------
 // Pure helpers (verbatim ports of the old coordinator private methods, now
 // parametrized by an explicit activeSides set instead of reading `this`).
@@ -319,4 +363,81 @@ export function classifyPoll(prev: FingerprintState, state: BudgetState, cfg: Bu
     };
   }
   return { next: prev, effect: { kind: "none" } };
+}
+
+/**
+ * Resolve the agent set whose resume-candidate must be evaluated this poll from
+ * the {@link classifyPoll} effect.
+ *
+ * CRITICAL: the candidate must hang off the EXITING side, not the post-exit
+ * fingerprint. `classifyPoll`'s hysteresis removes a side from `next.side` on
+ * the SAME poll its window refreshes (canAgentResume → true), so that poll takes
+ * the `exit` branch with `next.side = null`. Computing the candidate against
+ * `next.side` would therefore always yield `{}` on exactly the poll a side
+ * becomes resumable. Instead:
+ *   - exit  → evaluate the recovered `effect.previousSide`.
+ *   - enter / hold-uncertain → evaluate the still-paused `effect.side` (so a
+ *     side that is paused but not yet refreshed reports ready=false, matching
+ *     the "while paused, not a candidate" contract).
+ *   - advise / none → no side is paused → no candidate.
+ *
+ * NB: this uses only the CURRENT exit branch (whole-side recovery: single side
+ * or "both" → null). Per-side partial recovery (both → claude) is PR2.5; this
+ * function needs no change when that lands because it reads the effect, not the
+ * branch internals.
+ */
+export function resumeCandidateSides(effect: CoordinatorEffect): AgentName[] {
+  switch (effect.kind) {
+    case "exit":
+      return sideToAgents(effect.previousSide);
+    case "enter":
+    case "hold-uncertain":
+      return sideToAgents(effect.side);
+    case "advise":
+    case "none":
+      return [];
+  }
+}
+
+/**
+ * Pure resume-candidate reducer (PR2 — detection only, no emit/inject). For each
+ * EXPLICITLY supplied side, decides whether ALL four readiness predicates hold:
+ *
+ *   1. window refreshed — reuse the existing hysteresis `canAgentResume`
+ *      (decision-grade AND gateUtil < resumeBelow AND no live rate_limit). This
+ *      is the SINGLE source of truth for "window reset"; we deliberately do NOT
+ *      reinvent an epoch-diff detector (a second source would STALE-fork).
+ *   2. signals.pendingExists[side]   (per-side)
+ *   3. signals.tuiReady[side]        (per-side)
+ *   4. signals.checkpointExists      (shared)
+ *
+ * `sides` is supplied by the caller (see {@link resumeCandidateSides}) — the
+ * EXITING side on an exit poll, the still-paused side on an enter/hold poll. An
+ * empty `sides` yields `{}`. Each side is evaluated independently against its own
+ * usage and its own per-side signals, so "both paused, only codex refreshed"
+ * yields `{codex:true, claude:false}`.
+ *
+ * Fully pure: the signals are externally injected, so this function touches no
+ * fs/socket.
+ */
+export function computeResumeCandidate(
+  sides: readonly AgentName[],
+  state: BudgetState,
+  cfg: BudgetConfig,
+  signals: ResumeSignals,
+): ResumeCandidate {
+  const candidate: ResumeCandidate = {};
+  const detail: Partial<Record<AgentName, ResumeCandidateDetail>> = {};
+  for (const agent of sides) {
+    const windowRefreshed = canAgentResume(state.perAgent[agent], cfg, state.now);
+    const ready =
+      windowRefreshed &&
+      signals.pendingExists[agent] &&
+      signals.tuiReady[agent] &&
+      signals.checkpointExists;
+    candidate[agent] = ready;
+    detail[agent] = { ready };
+  }
+  if (sides.length > 0) candidate.detail = detail;
+  return candidate;
 }

--- a/src/budget/pending-reader.ts
+++ b/src/budget/pending-reader.ts
@@ -1,0 +1,254 @@
+/**
+ * Reader for agent-quota-guard's `pending` files (PR2: detection only — this
+ * module performs NO injection, emits nothing, and is consumed by the daemon's
+ * resume-candidate signal closure).
+ *
+ * Both writers (JS hook.mjs and bash budget_guard.sh) emit the CURRENT schema:
+ *     { status, agent, session_id, cwd, reset_epoch, util, warn_util, at }
+ *     Note: util === warn_util by contract (both = triggerUtil) — they are NOT
+ *     independent hard/warn readings. (PR1 normalized the bash writer to emit
+ *     reset_epoch + warn_util, so the two writers are schema-identical today.)
+ *
+ * The `?? .reset` / `?? .util` fallbacks below are DEFENSIVE compatibility for
+ * OLD/historical pending files that predate PR1 — a legacy bash writer used
+ * `reset` (not `reset_epoch`) and omitted `warn_util`:
+ *     resetEpoch = (.reset_epoch ?? .reset ?? 0)
+ *     warnUtil   = (.warn_util  ?? .util)
+ * They are not load-bearing for the current writers; they guard against a stale
+ * file left on disk from a prior guard version.
+ *
+ * File layout:
+ *   stateDir = process.env.BUDGET_STATE_DIR ?? join(homeDir, ".budget-guard")
+ *   per-scope: <stateDir>/pending/<agent>_<scope>.json
+ *              (scope name differs per writer — JS sha16 hex / Bash cksum int —
+ *               so the SAME (cwd,session) can land in two files)
+ *   legacy:    <stateDir>/pending_<agent>.json   (flat fallback)
+ * The reader globs pending/<agent>_*.json, adds the legacy flat file, and dedups
+ * by session_id.
+ *
+ * Resilience contract: every filesystem touch and every JSON.parse is wrapped in
+ * its own try/catch (ENOENT / TOCTOU / malformed / empty / array / scalar are all
+ * log-and-skip). The function NEVER throws.
+ *
+ * `homeDir` is injected (never `homedir()` directly) so tests can isolate to a
+ * throwaway temp dir without touching the real HOME — the same injection seam
+ * QuotaSource uses.
+ */
+import { join } from "node:path";
+import { asFiniteNumber, asRecord, numberOr } from "./quota-source";
+import type { AgentName } from "./types";
+
+/**
+ * Resolve the fs module via `require` at CALL time (not a static ESM import).
+ *
+ * In Bun the ESM namespace object (`import * as fs`) and the CJS object
+ * (`require("node:fs")`) are DISTINCT objects, and mutating one does not affect
+ * the other. Tests (and any runtime instrumentation) monkey-patch
+ * `require("node:fs").readFileSync` to simulate TOCTOU ENOENT; reading through
+ * the same require object honors that patch. A static `import { readFileSync }`
+ * would bind to a frozen namespace copy and silently ignore the patch.
+ */
+type FsModule = Pick<typeof import("node:fs"), "readFileSync" | "readdirSync" | "realpathSync">;
+function nodeFs(): FsModule {
+  return require("node:fs") as FsModule;
+}
+
+/**
+ * cwd equality that tolerates symlink / logical-path drift.
+ *
+ * The guard writer records `cwd` as whatever `process.cwd()` (node hook) or
+ * `$(pwd)` (bash hook) returns — neither is guaranteed to be a realpath, so it
+ * may be a symlink path (e.g. /tmp → /private/tmp on macOS, or a symlinked
+ * checkout). The daemon, by contrast, passes an already-realpath-resolved
+ * `opts.cwd`. A raw `===` between the two misses the match and yields a
+ * false-negative pendingExists=false.
+ *
+ * Match rule:
+ *   1. raw `entryCwd === optsCwd`            → true (cheap, no fs touch).
+ *   2. else `realpathSync(entryCwd) === realpathSync(optsCwd)` → true.
+ *   3. if EITHER realpathSync throws (ENOENT / perms / TOCTOU) → fall back to
+ *      the raw compare result (which was already false at step 1, so → false).
+ *
+ * Cross-repo isolation is preserved: two genuinely different directories have
+ * distinct realpaths, so step 2 still returns false for them.
+ */
+function cwdMatches(entryCwd: string, optsCwd: string): boolean {
+  if (entryCwd === optsCwd) return true;
+  try {
+    const fs = nodeFs();
+    return fs.realpathSync(entryCwd) === fs.realpathSync(optsCwd);
+  } catch {
+    // ENOENT (dir gone), EACCES, or any realpath failure → fall back to the raw
+    // compare, which already failed at the top (→ false). Never throw.
+    return false;
+  }
+}
+
+/** Parsed pending entry (camelCase internal shape). */
+export interface PendingEntry {
+  /** Pending status, typically "paused". */
+  status: string;
+  /** Which agent the guard paused. */
+  agent: AgentName;
+  /** Source field session_id; absent → the whole entry is null (it is the dedup key). */
+  sessionId: string;
+  /** Source field cwd. */
+  cwd: string;
+  /** (.reset_epoch ?? .reset ?? 0) — bash writer uses `reset`. */
+  resetEpoch: number;
+  /** Trigger utilization (.util). */
+  util: number;
+  /** (.warn_util ?? .util) — bash writer omits warn_util. */
+  warnUtil: number;
+  /** Epoch seconds (.at) the pause was written. */
+  at: number;
+}
+
+/**
+ * Pure parser over `unknown` (no IO — the test seam, mirroring
+ * normalizeProbeResult). Returns null (never throws) for any input that is not a
+ * usable pending record: non-object / array / null / missing session_id /
+ * non-finite util.
+ */
+export function parsePendingPayload(value: unknown): PendingEntry | null {
+  const record = asRecord(value);
+  if (!record) return null;
+
+  // session_id is the dedup key — a record without it is unusable.
+  const sessionId = record.session_id;
+  if (typeof sessionId !== "string" || sessionId === "") return null;
+
+  // util must be a real reading; a missing/non-finite util cannot be trusted.
+  const util = asFiniteNumber(record.util);
+  if (util === null) return null;
+
+  // (.warn_util ?? .util) — bash records have no warn_util.
+  const warnUtil = numberOr(record.warn_util, util);
+  // (.reset_epoch ?? .reset ?? 0) — bash records use `reset`.
+  const resetEpoch = numberOr(record.reset_epoch ?? record.reset, 0);
+  const at = numberOr(record.at, 0);
+  const cwd = typeof record.cwd === "string" ? record.cwd : "";
+  const status = typeof record.status === "string" ? record.status : "";
+  const agent = record.agent === "claude" || record.agent === "codex"
+    ? record.agent
+    : null;
+  if (agent === null) return null;
+
+  return { status, agent, sessionId, cwd, resetEpoch, util, warnUtil, at };
+}
+
+/** Resolve the guard state dir: BUDGET_STATE_DIR env override, else ~/.budget-guard. */
+function resolveStateDir(homeDir: string): string {
+  const override = process.env.BUDGET_STATE_DIR;
+  if (override && override.trim() !== "") return override.trim();
+  return join(homeDir, ".budget-guard");
+}
+
+/**
+ * Read one pending file and parse it. Every step (readFileSync, trim,
+ * JSON.parse, parsePendingPayload) is fault-isolated: ENOENT / TOCTOU /
+ * malformed JSON / empty / array / scalar all return null (log-and-skip),
+ * never throw.
+ */
+function readPendingFile(path: string, log: (msg: string) => void): PendingEntry | null {
+  let raw: string;
+  try {
+    // Require at call time so a monkey-patched fs.readFileSync (TOCTOU ENOENT in
+    // tests, or any runtime instrumentation) is honored — see nodeFs().
+    raw = nodeFs().readFileSync(path, "utf-8");
+  } catch (error) {
+    // ENOENT (TOCTOU — file unlinked between listing and read) and any other
+    // read failure are swallowed; the survivors are still returned.
+    log(`pending reader: skip unreadable ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+
+  const text = String(raw).trim();
+  if (text === "") return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    log(`pending reader: skip malformed JSON ${path}`);
+    return null;
+  }
+
+  return parsePendingPayload(parsed);
+}
+
+/** List per-scope pending files for the agent: pending/<agent>_*.json. */
+function listScopeFiles(stateDir: string, agent: AgentName, log: (msg: string) => void): string[] {
+  const pendingDir = join(stateDir, "pending");
+  let names: string[];
+  try {
+    names = nodeFs().readdirSync(pendingDir) as string[];
+  } catch {
+    // Missing pending dir is the common cold-start case — not an error.
+    return [];
+  }
+  const prefix = `${agent}_`;
+  return names
+    .filter((name) => name.startsWith(prefix) && name.endsWith(".json"))
+    .map((name) => join(pendingDir, name));
+}
+
+/**
+ * Read all guard pending records for one agent.
+ *
+ * Globs <stateDir>/pending/<agent>_*.json, appends the legacy flat
+ * <stateDir>/pending_<agent>.json, parses each (log-and-skip on any failure),
+ * and dedups by sessionId. Returns [] when nothing is readable; NEVER throws.
+ *
+ * Filtering (defense in depth — the filename prefix already scopes by agent, but
+ * a mislabeled or hand-edited file must not leak through):
+ *   - `entry.agent !== opts.agent`  → dropped (cross-agent record).
+ *   - `entry.status !== "paused"`   → dropped (only an active pause is a resume
+ *     signal; a stale "resumed"/"cleared" record must NOT count as pending).
+ *   - `opts.cwd` (when supplied)    → keep only entries whose `cwd` matches via
+ *     `cwdMatches`, so a pending file from an UNRELATED repo cannot satisfy this
+ *     pair's predicate. The match tolerates symlink / logical-path drift: a raw
+ *     compare first, then a `realpathSync` fallback (the guard writer may record
+ *     a symlink cwd while the daemon passes a realpath-resolved cwd). The
+ *     realpath touch is fault-isolated (any error → raw-compare fallback, never
+ *     throws); distinct repos keep distinct realpaths so cross-repo isolation
+ *     holds.
+ */
+export function readGuardPending(opts: {
+  homeDir: string;
+  agent: AgentName;
+  cwd?: string;
+  log?: (message: string) => void;
+}): PendingEntry[] {
+  const log = opts.log ?? (() => {});
+  const stateDir = resolveStateDir(opts.homeDir);
+
+  const paths = [
+    ...listScopeFiles(stateDir, opts.agent, log),
+    // Legacy flat fallback — always attempted (readPendingFile swallows ENOENT).
+    join(stateDir, `pending_${opts.agent}.json`),
+  ];
+
+  // Dedup by sessionId: the same (cwd,session) may be written under two scope
+  // names (JS sha16 vs Bash cksum) or under both a scope file and the legacy file.
+  const bySession = new Map<string, PendingEntry>();
+  for (const path of paths) {
+    const entry = readPendingFile(path, log);
+    if (!entry) continue;
+    // Cross-agent record (mislabeled file): reject — the prefix should already
+    // exclude these, but a hand-edited file could carry the wrong agent.
+    if (entry.agent !== opts.agent) continue;
+    // Only an active pause is a resume signal.
+    if (entry.status !== "paused") continue;
+    // Scope to the current pair's cwd when requested (cross-repo isolation).
+    // cwdMatches tolerates symlink / logical-path drift (raw compare first, then
+    // realpath fallback) so a guard-recorded symlink cwd still matches the
+    // daemon's realpath-resolved cwd; distinct repos keep distinct realpaths.
+    if (opts.cwd !== undefined && !cwdMatches(entry.cwd, opts.cwd)) continue;
+    if (!bySession.has(entry.sessionId)) {
+      bySession.set(entry.sessionId, entry);
+    }
+  }
+
+  return [...bySession.values()];
+}

--- a/src/budget/quota-source.ts
+++ b/src/budget/quota-source.ts
@@ -157,7 +157,7 @@ function argsFor(candidate: ProbeCandidate, agent: AgentName): string[] {
   return ["--agent", agent];
 }
 
-function asFiniteNumber(value: unknown): number | null {
+export function asFiniteNumber(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string" && value.trim() !== "") {
     const parsed = Number(value);
@@ -166,15 +166,15 @@ function asFiniteNumber(value: unknown): number | null {
   return null;
 }
 
-function numberOr(value: unknown, fallback: number): number {
+export function numberOr(value: unknown, fallback: number): number {
   return asFiniteNumber(value) ?? fallback;
 }
 
-function clamp(value: number, min: number, max: number): number {
+export function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
+export function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env bun
 
 import type { ServerWebSocket } from "bun";
-import { rmSync } from "node:fs";
+import { existsSync, realpathSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { BUILD_INFO, daemonStatusBuildInfo } from "./build-info";
 import { portFromUrl, type DaemonRecord } from "./daemon-record";
@@ -19,6 +21,8 @@ import { StateDirResolver } from "./state-dir";
 import { ConfigService, applyBudgetEnvOverrides } from "./config-service";
 import { BudgetCoordinator } from "./budget/budget-coordinator";
 import { createQuotaSource } from "./budget/quota-source";
+import { readGuardPending } from "./budget/pending-reader";
+import type { ResumeSignals } from "./budget/budget-fingerprint";
 import {
   CLOSE_CODE_REPLACED,
   CLOSE_CODE_EVICTED_STALE,
@@ -222,6 +226,83 @@ function createPendingBackpressureBuffer(): BoundedMessageBuffer {
 // claude_to_codex pause gate and snapshot exposure via DaemonStatus.budget.
 let budgetCoordinator: BudgetCoordinator | null = null;
 
+/**
+ * Resolve the current pair's cwd to its realpath for cross-repo pending
+ * isolation. Falls back to the raw cwd when realpath fails (e.g. a path that no
+ * longer exists) so a transient fs error never breaks signal gathering.
+ *
+ * NOTE (multi-pair): `process.cwd()` is the daemon's own working directory,
+ * which today equals the pair's project dir. PR3's injection path must resolve
+ * the cwd from the pair record instead of assuming process.cwd() once multiple
+ * pairs share a daemon.
+ */
+function pairCwd(): string {
+  const raw = process.cwd();
+  try {
+    return realpathSync(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * PR2 (detection only): gather the resume-readiness signals the coordinator's
+ * pure reducer needs. ALL IO lives here so the reducer stays pure. Called once
+ * per poll AFTER coordinator construction (first codex `ready`), so the
+ * hoisted-but-later-`const` references (tuiConnectionState / attachedClaude) are
+ * fully initialized by the time this runs. Every probe is fault-isolated: a
+ * transient fs/socket error degrades a SINGLE per-side signal to false rather
+ * than throwing into the poll loop.
+ *
+ * `tuiReady` and `pendingExists` are PER-SIDE (codex vs claude); `pendingExists`
+ * is additionally scoped to THIS pair's cwd so a pending file from an unrelated
+ * repo cannot falsely satisfy the predicate. `checkpointExists` is shared (one
+ * handoff checkpoint per pair).
+ */
+function readResumeSignals(): ResumeSignals {
+  // tuiReady, per side: codex = its TUI can accept a reply; claude = a frontend
+  // is attached. Each read is independently fault-isolated.
+  let tuiReadyCodex = false;
+  let tuiReadyClaude = false;
+  try {
+    tuiReadyCodex = tuiConnectionState.canReply();
+  } catch (error) {
+    log(`resume signal: codex tuiReady failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  try {
+    tuiReadyClaude = attachedClaude !== null;
+  } catch (error) {
+    log(`resume signal: claude tuiReady failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  // pendingExists, per side, scoped to this pair's cwd. readGuardPending never
+  // throws, but the cwd resolution and the call are still fault-isolated.
+  let pendingCodex = false;
+  let pendingClaude = false;
+  try {
+    const home = homedir();
+    const cwd = pairCwd();
+    pendingCodex = readGuardPending({ homeDir: home, agent: "codex", cwd, log }).length > 0;
+    pendingClaude = readGuardPending({ homeDir: home, agent: "claude", cwd, log }).length > 0;
+  } catch (error) {
+    log(`resume signal: pending read failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  // checkpointExists: the handoff checkpoint under the pair's project dir.
+  let checkpointExists = false;
+  try {
+    checkpointExists = existsSync(join(pairCwd(), ".agent", "checkpoint.md"));
+  } catch (error) {
+    log(`resume signal: checkpoint stat failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  return {
+    tuiReady: { codex: tuiReadyCodex, claude: tuiReadyClaude },
+    pendingExists: { codex: pendingCodex, claude: pendingClaude },
+    checkpointExists,
+  };
+}
+
 function ensureBudgetCoordinatorStarted() {
   if (!BUDGET_CONFIG.enabled) return;
   if (!budgetCoordinator) {
@@ -256,6 +337,14 @@ function ensureBudgetCoordinatorStarted() {
       },
       onSnapshot: () => broadcastStatus(),
       log,
+      // PR2 (detection only): daemon-side readiness signals for the resume
+      // candidate. Pure-reducer purity is preserved by gathering all IO here —
+      // the coordinator only reads the returned ResumeSignals. The closure
+      // returns PER-SIDE signals (tuiReady/pendingExists keyed by agent) plus a
+      // shared checkpointExists; per-side independence comes from those per-side
+      // booleans. Each read is fault-isolated so a transient fs error never
+      // breaks the poll loop.
+      resumeSignals: readResumeSignals,
     });
   }
   void budgetCoordinator.start();

--- a/src/unit-test/pending-reader.test.ts
+++ b/src/unit-test/pending-reader.test.ts
@@ -1,0 +1,462 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentName } from "../budget/types";
+// Module under test does NOT exist yet — this import is the RED driver.
+import {
+  parsePendingPayload,
+  readGuardPending,
+  type PendingEntry,
+} from "../budget/pending-reader";
+
+const tmpDirs: string[] = [];
+
+/** Create a throwaway HOME-like dir; NEVER touch the real HOME. */
+function tempHome(): string {
+  const dir = mkdtempSync(join(tmpdir(), "abg-pending-reader-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+/** Resolve the per-home `.budget-guard/pending` dir and make sure it exists. */
+function pendingDir(home: string): string {
+  const dir = join(home, ".budget-guard", "pending");
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Write a per-scope pending file: pending/<agent>_<scope>.json */
+function writeScopePending(home: string, agent: AgentName, scope: string, payload: unknown): string {
+  const dir = pendingDir(home);
+  const path = join(dir, `${agent}_${scope}.json`);
+  writeFileSync(path, typeof payload === "string" ? payload : JSON.stringify(payload), "utf-8");
+  return path;
+}
+
+/** Write a legacy flat pending file: <stateDir>/pending_<agent>.json */
+function writeLegacyPending(home: string, agent: AgentName, payload: unknown): string {
+  const dir = join(home, ".budget-guard");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `pending_${agent}.json`);
+  writeFileSync(path, typeof payload === "string" ? payload : JSON.stringify(payload), "utf-8");
+  return path;
+}
+
+/** A complete JS-writer (hook.mjs) pending record. util === warn_util by contract. */
+function jsPending(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    status: "paused",
+    agent: "claude",
+    session_id: "sess-js-1",
+    cwd: "/repo/project-a",
+    reset_epoch: 1_900_000_000,
+    util: 92,
+    warn_util: 92,
+    at: 1_899_990_000,
+    ...overrides,
+  };
+}
+
+/** A complete Bash-writer (budget_guard.sh) pending record. Note `reset`, no `warn_util`. */
+function bashPending(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    status: "paused",
+    agent: "codex",
+    session_id: "sess-bash-1",
+    cwd: "/repo/project-b",
+    reset: 1_900_000_500,
+    util: 88,
+    at: 1_899_990_500,
+    ...overrides,
+  };
+}
+
+// resolveStateDir prefers process.env.BUDGET_STATE_DIR over homeDir. If the host
+// (dev machine / CI running a real guard) has BUDGET_STATE_DIR set, the homeDir
+// injection these tests rely on for isolation is bypassed — tests would read a
+// foreign state dir and either fail or pass spuriously. Save + delete it before
+// each test and restore after, so isolation depends ONLY on the injected
+// homeDir. The env-override branch is exercised explicitly where it is the
+// subject under test.
+let savedBudgetStateDir: string | undefined;
+beforeEach(() => {
+  savedBudgetStateDir = process.env.BUDGET_STATE_DIR;
+  delete process.env.BUDGET_STATE_DIR;
+});
+
+afterEach(() => {
+  if (savedBudgetStateDir === undefined) {
+    delete process.env.BUDGET_STATE_DIR;
+  } else {
+    process.env.BUDGET_STATE_DIR = savedBudgetStateDir;
+  }
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("parsePendingPayload — JS schema", () => {
+  test("parses reset_epoch and warn_util straight through", () => {
+    const entry = parsePendingPayload(jsPending());
+    expect(entry).not.toBeNull();
+    expect(entry!.agent).toBe("claude");
+    expect(entry!.sessionId).toBe("sess-js-1");
+    expect(entry!.cwd).toBe("/repo/project-a");
+    expect(entry!.resetEpoch).toBe(1_900_000_000);
+    expect(entry!.util).toBe(92);
+    expect(entry!.warnUtil).toBe(92);
+    expect(entry!.at).toBe(1_899_990_000);
+  });
+
+  test("util === warn_util is preserved (not treated as independent hard/warn)", () => {
+    const entry = parsePendingPayload(jsPending({ util: 95, warn_util: 95 }));
+    expect(entry!.util).toBe(95);
+    expect(entry!.warnUtil).toBe(95);
+  });
+});
+
+describe("parsePendingPayload — Bash schema fallback", () => {
+  test("reads reset via (.reset_epoch ?? .reset) fallback", () => {
+    const entry = parsePendingPayload(bashPending());
+    expect(entry).not.toBeNull();
+    // Bash writer has no reset_epoch — must fall back to `reset`.
+    expect(entry!.resetEpoch).toBe(1_900_000_500);
+  });
+
+  test("reads warn via (.warn_util ?? .util) fallback when warn_util absent", () => {
+    const entry = parsePendingPayload(bashPending());
+    // No warn_util in bash record → falls back to util.
+    expect(entry!.warnUtil).toBe(88);
+    expect(entry!.util).toBe(88);
+  });
+
+  test("reset_epoch wins over reset when both somehow present", () => {
+    const entry = parsePendingPayload(bashPending({ reset_epoch: 1_911_111_111, reset: 1_900_000_500 }));
+    expect(entry!.resetEpoch).toBe(1_911_111_111);
+  });
+
+  test("warn_util wins over util when both present", () => {
+    const entry = parsePendingPayload(jsPending({ util: 90, warn_util: 92 }));
+    expect(entry!.warnUtil).toBe(92);
+    expect(entry!.util).toBe(90);
+  });
+});
+
+describe("parsePendingPayload — malformed / non-object inputs return null (no throw)", () => {
+  test("null returns null", () => {
+    expect(parsePendingPayload(null)).toBeNull();
+  });
+
+  test("undefined returns null", () => {
+    expect(parsePendingPayload(undefined)).toBeNull();
+  });
+
+  test("array returns null (asRecord rejects arrays)", () => {
+    expect(() => parsePendingPayload([jsPending()])).not.toThrow();
+    expect(parsePendingPayload([jsPending()])).toBeNull();
+  });
+
+  test("primitive number returns null", () => {
+    expect(parsePendingPayload(42)).toBeNull();
+  });
+
+  test("primitive string returns null", () => {
+    expect(parsePendingPayload("paused")).toBeNull();
+  });
+
+  test("object missing session_id returns null", () => {
+    const entry = parsePendingPayload(jsPending({ session_id: undefined }));
+    expect(entry).toBeNull();
+  });
+
+  test("non-finite util coerces to null entry (cannot trust the reading)", () => {
+    const entry = parsePendingPayload(jsPending({ util: "not-a-number", warn_util: "x" }));
+    expect(entry).toBeNull();
+  });
+});
+
+describe("readGuardPending — per-scope glob", () => {
+  test("reads a single per-scope JS pending file", () => {
+    const home = tempHome();
+    writeScopePending(home, "claude", "abc123def4567890", jsPending());
+
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].sessionId).toBe("sess-js-1");
+    expect(entries[0].resetEpoch).toBe(1_900_000_000);
+  });
+
+  test("globs pending/<agent>_*.json for the requested agent only", () => {
+    const home = tempHome();
+    // Two scopes for codex (JS sha16 + Bash cksum) → two files, distinct sessions.
+    writeScopePending(home, "codex", "deadbeefdeadbeef", bashPending({ session_id: "codex-A" }));
+    writeScopePending(home, "codex", "1234567890", bashPending({ session_id: "codex-B" }));
+    // A claude file that must NOT leak into codex results.
+    writeScopePending(home, "claude", "ffffffffffffffff", jsPending({ session_id: "claude-X" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "codex" });
+    const sessions = entries.map((e) => e.sessionId).sort();
+    expect(sessions).toEqual(["codex-A", "codex-B"]);
+  });
+
+  test("returns empty array when pending dir does not exist (no throw)", () => {
+    const home = tempHome(); // pending dir never created
+    expect(() => readGuardPending({ homeDir: home, agent: "claude" })).not.toThrow();
+    expect(readGuardPending({ homeDir: home, agent: "claude" })).toEqual([]);
+  });
+});
+
+describe("readGuardPending — legacy flat fallback", () => {
+  test("reads legacy pending_<agent>.json when present", () => {
+    const home = tempHome();
+    pendingDir(home); // dir exists but empty
+    writeLegacyPending(home, "claude", jsPending({ session_id: "legacy-1" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+    expect(entries.map((e) => e.sessionId)).toContain("legacy-1");
+  });
+
+  test("merges per-scope and legacy files for the same agent", () => {
+    const home = tempHome();
+    writeScopePending(home, "claude", "aaaa1111bbbb2222", jsPending({ session_id: "scope-1" }));
+    writeLegacyPending(home, "claude", jsPending({ session_id: "legacy-2" }));
+
+    const sessions = readGuardPending({ homeDir: home, agent: "claude" })
+      .map((e) => e.sessionId)
+      .sort();
+    expect(sessions).toEqual(["legacy-2", "scope-1"]);
+  });
+});
+
+describe("readGuardPending — dedup by session_id", () => {
+  test("same (cwd,session) written under two scope names dedups to one entry", () => {
+    const home = tempHome();
+    // JS sha16 scope and Bash cksum scope for the same session_id.
+    writeScopePending(home, "codex", "0123456789abcdef", bashPending({ session_id: "dup-sess" }));
+    writeScopePending(home, "codex", "987654321", bashPending({ session_id: "dup-sess" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "codex" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].sessionId).toBe("dup-sess");
+  });
+
+  test("legacy and per-scope sharing a session_id dedup to one entry", () => {
+    const home = tempHome();
+    writeScopePending(home, "claude", "cafebabecafebabe", jsPending({ session_id: "same-sess" }));
+    writeLegacyPending(home, "claude", jsPending({ session_id: "same-sess" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].sessionId).toBe("same-sess");
+  });
+});
+
+describe("readGuardPending — log-and-skip resilience (never throws)", () => {
+  test("malformed JSON file is skipped, valid sibling still read", () => {
+    const home = tempHome();
+    writeScopePending(home, "claude", "1111111111111111", "{ this is not json ]");
+    writeScopePending(home, "claude", "2222222222222222", jsPending({ session_id: "good-1" }));
+
+    let entries: PendingEntry[] = [];
+    expect(() => {
+      entries = readGuardPending({ homeDir: home, agent: "claude" });
+    }).not.toThrow();
+    expect(entries.map((e) => e.sessionId)).toEqual(["good-1"]);
+  });
+
+  test("empty file is skipped (trim yields '')", () => {
+    const home = tempHome();
+    writeScopePending(home, "claude", "3333333333333333", "");
+    writeScopePending(home, "claude", "4444444444444444", "   \n  ");
+    writeScopePending(home, "claude", "5555555555555555", jsPending({ session_id: "good-2" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+    expect(entries.map((e) => e.sessionId)).toEqual(["good-2"]);
+  });
+
+  test("array-shaped JSON file is skipped (asRecord rejects arrays)", () => {
+    const home = tempHome();
+    writeScopePending(home, "claude", "6666666666666666", [jsPending()]);
+    writeScopePending(home, "claude", "7777777777777777", jsPending({ session_id: "good-3" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+    expect(entries.map((e) => e.sessionId)).toEqual(["good-3"]);
+  });
+
+  test("non-object scalar JSON file is skipped", () => {
+    const home = tempHome();
+    writeScopePending(home, "claude", "8888888888888888", "12345");
+    writeScopePending(home, "claude", "9999999999999999", jsPending({ session_id: "good-4" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+    expect(entries.map((e) => e.sessionId)).toEqual(["good-4"]);
+  });
+});
+
+describe("readGuardPending — TOCTOU (file deleted after listing) is swallowed", () => {
+  test("ENOENT from readFileSync between listing and reading does not throw", () => {
+    const home = tempHome();
+    const dir = pendingDir(home);
+    // A real, valid file that survives.
+    writeScopePending(home, "claude", "survivor00000000", jsPending({ session_id: "survivor" }));
+    // A file that gets deleted AFTER directory listing but BEFORE read.
+    const doomed = writeScopePending(home, "claude", "doomed0000000000", jsPending({ session_id: "doomed" }));
+
+    // Monkey-patch readFileSync: first call to the doomed path throws ENOENT
+    // (simulating the file being unlinked mid-iteration), other calls pass through.
+    const fs = require("node:fs");
+    const original = fs.readFileSync;
+    const enoent = Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+    fs.readFileSync = (path: unknown, ...rest: unknown[]) => {
+      if (typeof path === "string" && path === doomed) throw enoent;
+      return original(path, ...rest);
+    };
+
+    let entries: PendingEntry[] = [];
+    try {
+      expect(() => {
+        entries = readGuardPending({ homeDir: home, agent: "claude" });
+      }).not.toThrow();
+    } finally {
+      fs.readFileSync = original;
+    }
+    void dir;
+    expect(entries.map((e) => e.sessionId)).toEqual(["survivor"]);
+  });
+});
+
+describe("readGuardPending — agent / status / cwd filtering", () => {
+  test("entry with a mismatched agent field is dropped", () => {
+    const home = tempHome();
+    // File NAMED for codex but whose payload claims claude → must be rejected.
+    writeScopePending(home, "codex", "agentmismatch0000", jsPending({ session_id: "wrong-agent", agent: "claude" }));
+    writeScopePending(home, "codex", "rightagent000000", bashPending({ session_id: "right-agent", agent: "codex" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "codex" });
+    expect(entries.map((e) => e.sessionId)).toEqual(["right-agent"]);
+  });
+
+  test("non-paused status records are dropped (only active pauses count)", () => {
+    const home = tempHome();
+    writeScopePending(home, "codex", "resumedstatus000", bashPending({ session_id: "resumed-1", status: "resumed" }));
+    writeScopePending(home, "codex", "clearedstatus000", bashPending({ session_id: "cleared-1", status: "cleared" }));
+    writeScopePending(home, "codex", "pausedstatus0000", bashPending({ session_id: "paused-1", status: "paused" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "codex" });
+    expect(entries.map((e) => e.sessionId)).toEqual(["paused-1"]);
+  });
+
+  test("cwd filter keeps only entries whose cwd matches (cross-repo isolation)", () => {
+    const home = tempHome();
+    writeScopePending(home, "codex", "thisrepo00000000", bashPending({ session_id: "this-repo", cwd: "/repo/this" }));
+    writeScopePending(home, "codex", "otherrepo0000000", bashPending({ session_id: "other-repo", cwd: "/repo/other" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "codex", cwd: "/repo/this" });
+    expect(entries.map((e) => e.sessionId)).toEqual(["this-repo"]);
+  });
+
+  test("no cwd filter → entries from any cwd are kept (backward compatible)", () => {
+    const home = tempHome();
+    writeScopePending(home, "codex", "repoa00000000000", bashPending({ session_id: "repo-a", cwd: "/repo/a" }));
+    writeScopePending(home, "codex", "repob00000000000", bashPending({ session_id: "repo-b", cwd: "/repo/b" }));
+
+    const sessions = readGuardPending({ homeDir: home, agent: "codex" }).map((e) => e.sessionId).sort();
+    expect(sessions).toEqual(["repo-a", "repo-b"]);
+  });
+
+  test("symlink cwd matches when opts.cwd is the realpath (logical-path tolerant)", () => {
+    // The guard writer records `cwd` as whatever process.cwd()/$(pwd) returns —
+    // which may be a SYMLINK path (e.g. /tmp → /private/tmp on macOS, or a
+    // symlinked checkout). The daemon resolves its own cwd via realpath. A raw
+    // string compare misses this and yields a false-negative pendingExists=false.
+    const realRoot = mkdtempSync(join(tmpdir(), "abg-pending-realdir-"));
+    tmpDirs.push(realRoot);
+    // The actual project dir lives under the resolved (realpath) root.
+    const realProject = join(realpathSync(realRoot), "project");
+    mkdirSync(realProject, { recursive: true });
+    // A symlink pointing at the real project; this is what the guard writer saw.
+    const linkRoot = mkdtempSync(join(tmpdir(), "abg-pending-link-"));
+    tmpDirs.push(linkRoot);
+    const symlinkPath = join(linkRoot, "project-link");
+    symlinkSync(realProject, symlinkPath, "dir");
+
+    const home = tempHome();
+    // entry.cwd = the SYMLINK path (what the guard recorded).
+    writeScopePending(home, "codex", "symlinkcwd000000", bashPending({ session_id: "via-symlink", cwd: symlinkPath }));
+
+    // opts.cwd = the REALPATH (what the daemon resolved). Raw `!==` compare fails;
+    // a realpath-aware match must keep this entry.
+    const entries = readGuardPending({ homeDir: home, agent: "codex", cwd: realProject });
+    expect(entries.map((e) => e.sessionId)).toEqual(["via-symlink"]);
+  });
+
+  test("cross-repo entry still excluded even with realpath-aware match (distinct realpaths)", () => {
+    // Two genuinely different real directories must NOT collide just because the
+    // match got smarter — the realpath of one is not the realpath of the other.
+    const homeProjects = mkdtempSync(join(tmpdir(), "abg-pending-crossrepo-"));
+    tmpDirs.push(homeProjects);
+    const root = realpathSync(homeProjects);
+    const thisRepo = join(root, "this");
+    const otherRepo = join(root, "other");
+    mkdirSync(thisRepo, { recursive: true });
+    mkdirSync(otherRepo, { recursive: true });
+
+    const home = tempHome();
+    writeScopePending(home, "codex", "crossthis0000000", bashPending({ session_id: "this-repo", cwd: thisRepo }));
+    writeScopePending(home, "codex", "crossother000000", bashPending({ session_id: "other-repo", cwd: otherRepo }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "codex", cwd: thisRepo });
+    expect(entries.map((e) => e.sessionId)).toEqual(["this-repo"]);
+  });
+});
+
+describe("readGuardPending — homeDir injection isolation", () => {
+  test("only reads under the injected homeDir, never the real HOME", () => {
+    const home = tempHome();
+    writeScopePending(home, "claude", "abcdef0123456789", jsPending({ session_id: "isolated" }));
+
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+    // Every cwd we wrote lives under our fixture; nothing from the real machine.
+    expect(entries.every((e) => typeof e.cwd === "string")).toBe(true);
+    expect(entries.map((e) => e.sessionId)).toEqual(["isolated"]);
+  });
+});
+
+describe("readGuardPending — BUDGET_STATE_DIR env override", () => {
+  /**
+   * Write a per-scope pending file directly under an EXPLICIT state dir
+   * (<stateDir>/pending/<agent>_<scope>.json), bypassing the homeDir layout.
+   */
+  function writeScopePendingAtStateDir(stateDir: string, agent: AgentName, scope: string, payload: unknown): string {
+    const dir = join(stateDir, "pending");
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, `${agent}_${scope}.json`);
+    writeFileSync(path, typeof payload === "string" ? payload : JSON.stringify(payload), "utf-8");
+    return path;
+  }
+
+  test("BUDGET_STATE_DIR overrides homeDir for the state dir resolution", () => {
+    // homeDir points at an EMPTY fixture (no pending) — if it were used, the read
+    // would return []. The override state dir holds the only pending file.
+    const home = tempHome();
+    pendingDir(home); // exists but empty under the home layout
+
+    const stateDir = mkdtempSync(join(tmpdir(), "abg-pending-statedir-"));
+    tmpDirs.push(stateDir);
+    writeScopePendingAtStateDir(stateDir, "claude", "envoverride00000", jsPending({ session_id: "from-env" }));
+
+    process.env.BUDGET_STATE_DIR = stateDir;
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+    // Resolution used the env override, not homeDir's empty pending dir.
+    expect(entries.map((e) => e.sessionId)).toEqual(["from-env"]);
+  });
+
+  test("whitespace-only BUDGET_STATE_DIR is ignored, falling back to homeDir", () => {
+    // resolveStateDir treats a blank/whitespace override as absent.
+    const home = tempHome();
+    writeScopePending(home, "claude", "blankoverride000", jsPending({ session_id: "from-home" }));
+
+    process.env.BUDGET_STATE_DIR = "   ";
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+    expect(entries.map((e) => e.sessionId)).toEqual(["from-home"]);
+  });
+});

--- a/src/unit-test/resume-candidate-e2e.test.ts
+++ b/src/unit-test/resume-candidate-e2e.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import { BudgetCoordinator } from "../budget/budget-coordinator";
+import type { ResumeSignals } from "../budget/budget-fingerprint";
+import type { AgentUsage, BudgetConfig } from "../budget/types";
+
+/**
+ * TDD RED — end-to-end resume-candidate detection driven through the real
+ * BudgetCoordinator poll loop (NOT the pure reducer in isolation).
+ *
+ * Why this exists: the existing resume-candidate.test.ts exercises the pure
+ * `computeResumeCandidate` with a HAND-FORGED combination (a paused fpState +
+ * an already-refreshed BudgetState) that the production reducer `classifyPoll`
+ * can NEVER produce in a single poll — a paused state fed a refreshed reading
+ * exits immediately, leaving `next.side = null`. That hand-forge masks the
+ * CRITICAL bug.
+ *
+ * The bug: budget-coordinator.applyState() calls
+ *   computeResumeCandidate(next, state, ...)
+ * with `next` = the POST-transition fingerprint. On the very poll where the
+ * window refreshes, classifyPoll takes the exit branch and returns
+ * `next.side = null`, so computeResumeCandidate iterates `sideToAgents(null) = []`
+ * and yields `{}`. Result: getResumeCandidate() is empty on EXACTLY the poll
+ * that should report the just-recovered side as resumable.
+ *
+ * Expected contract (what the fix must satisfy): on the refresh poll that exits
+ * a codex pause, getResumeCandidate().codex === true (the candidate must hang
+ * off the EXITING side — effect.previousSide / prev.side — not the post-exit
+ * next.side, which is null).
+ *
+ * This test is RED today: poll1 (the refresh poll) returns an empty candidate.
+ */
+
+const NOW = 1_700_000_000;
+
+const CONFIG: BudgetConfig = {
+  enabled: true,
+  // Long poll so start() does NOT auto-fire a second poll while we drive each
+  // poll explicitly; we advance the loop via pollOnce() to assert per-poll.
+  pollSeconds: 300,
+  pauseAt: 90,
+  resumeBelow: 30,
+  syncDriftPct: 10,
+  parallel: { minRemainingPct: 60, timeWindowSec: 3600 },
+  codexTierControl: false,
+  codexTiers: {
+    full: { effort: "high" },
+    balanced: { effort: "medium" },
+    eco: { effort: "low" },
+  },
+  strategy: "conserve",
+};
+
+type FetchResult = { claude: AgentUsage | null; codex: AgentUsage | null } | null;
+
+/** Healthy decision-grade reading: gateUtil 20 < resumeBelow 30, fresh windows. */
+function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {
+  const gateUtil = overrides.gateUtil ?? 20;
+  const warnUtil = overrides.warnUtil ?? gateUtil;
+  return {
+    ok: true,
+    stale: false,
+    gateUtil,
+    warnUtil,
+    fiveHour: { util: gateUtil, resetEpoch: NOW + 3600 },
+    weekly: { util: warnUtil, resetEpoch: NOW + 500_000 },
+    remaining: 100 - gateUtil,
+    rateLimitedUntil: 0,
+    fetchedAt: NOW,
+    parsedVia: "id-match",
+    ...overrides,
+  };
+}
+
+class FakeSource {
+  calls = 0;
+  private last: FetchResult;
+
+  constructor(private readonly results: FetchResult[]) {
+    this.last = results[results.length - 1] ?? null;
+  }
+
+  async fetchBoth(): Promise<FetchResult> {
+    const result = this.results[this.calls] ?? this.last;
+    this.calls += 1;
+    this.last = result;
+    return result;
+  }
+}
+
+describe("BudgetCoordinator.getResumeCandidate — end-to-end via pollOnce (RED)", () => {
+  test("codex paused on poll0, window refreshes on poll1 → poll1 candidate reports codex resumable", async () => {
+    // poll0: codex gateUtil 95 (>= pauseAt 90) → enters codex pause.
+    // poll1: codex window refreshes to gateUtil 20 (< resumeBelow 30) → exits.
+    const source = new FakeSource([
+      { claude: usage(), codex: usage({ gateUtil: 95, warnUtil: 95, remaining: 5 }) },
+      { claude: usage(), codex: usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }) },
+    ]);
+
+    // Codex-side signals all satisfied (tuiReady + pendingExists + checkpointExists).
+    const resumeSignals = (): ResumeSignals => ({
+      tuiReady: { codex: true, claude: true },
+      pendingExists: { codex: true, claude: true },
+      checkpointExists: true,
+    });
+
+    const coordinator = new BudgetCoordinator({
+      source: source as unknown as { fetchBoth: FakeSource["fetchBoth"] },
+      config: CONFIG,
+      emit: () => {},
+      onPauseChange: () => {},
+      now: () => NOW,
+      resumeSignals,
+    });
+
+    // poll0 (start() fires the first pollOnce): enter codex pause.
+    await coordinator.start();
+    expect(coordinator.isPaused()).toBe(true);
+    expect(coordinator.getSnapshot()?.pauseSide).toBe("codex");
+    // While paused (not yet refreshed), codex is NOT a resume candidate.
+    expect(coordinator.getResumeCandidate().codex).not.toBe(true);
+
+    // poll1: codex window refreshed → pause exits this poll.
+    await (coordinator as unknown as { pollOnce: () => Promise<void> }).pollOnce();
+    coordinator.stop();
+
+    // Pause has cleared (sanity: this IS the refresh/exit poll).
+    expect(coordinator.isPaused()).toBe(false);
+
+    // CRITICAL contract: on the refresh poll, the just-recovered codex side must
+    // be reported as a resume candidate. Today this is `undefined` because the
+    // candidate is computed against the post-exit next.side (null) instead of
+    // the exiting previousSide.
+    const candidate = coordinator.getResumeCandidate();
+    expect(candidate.codex).toBe(true);
+    // Richer per-side detail is exposed for PR3's atomic claim.
+    expect(candidate.detail?.codex?.ready).toBe(true);
+  });
+
+  test("getResumeCandidate returns a defensive copy — mutating it does not change internal state", async () => {
+    const source = new FakeSource([
+      { claude: usage(), codex: usage({ gateUtil: 95, warnUtil: 95, remaining: 5 }) },
+      { claude: usage(), codex: usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }) },
+    ]);
+    const resumeSignals = (): ResumeSignals => ({
+      tuiReady: { codex: true, claude: true },
+      pendingExists: { codex: true, claude: true },
+      checkpointExists: true,
+    });
+    const coordinator = new BudgetCoordinator({
+      source: source as unknown as { fetchBoth: FakeSource["fetchBoth"] },
+      config: CONFIG,
+      emit: () => {},
+      onPauseChange: () => {},
+      now: () => NOW,
+      resumeSignals,
+    });
+
+    await coordinator.start();
+    await (coordinator as unknown as { pollOnce: () => Promise<void> }).pollOnce();
+    coordinator.stop();
+
+    const first = coordinator.getResumeCandidate();
+    expect(first.codex).toBe(true);
+    // Mutate the returned object and its nested detail map.
+    first.codex = false;
+    if (first.detail) {
+      first.detail.codex = { ready: false };
+      first.detail.claude = { ready: true };
+    }
+
+    // A fresh read is unaffected: the coordinator handed back a copy.
+    const second = coordinator.getResumeCandidate();
+    expect(second.codex).toBe(true);
+    expect(second.detail?.codex?.ready).toBe(true);
+    expect(second.detail?.claude).toBeUndefined();
+  });
+
+  test("getResumeCandidate deep-copies nested detail — mutating an inner field in place does not leak", async () => {
+    // Regression guard for PR3's atomic claim path, which flips `ready` IN PLACE
+    // (e.g. `result.detail.codex.ready = false`) rather than replacing the whole
+    // detail object. A shallow `{ ...detail }` copies the outer map only, so each
+    // inner ResumeCandidateDetail stays shared by reference — an in-place flip
+    // would pollute the coordinator's internal resumeCandidate.detail.codex.
+    const source = new FakeSource([
+      { claude: usage(), codex: usage({ gateUtil: 95, warnUtil: 95, remaining: 5 }) },
+      { claude: usage(), codex: usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }) },
+    ]);
+    const resumeSignals = (): ResumeSignals => ({
+      tuiReady: { codex: true, claude: true },
+      pendingExists: { codex: true, claude: true },
+      checkpointExists: true,
+    });
+    const coordinator = new BudgetCoordinator({
+      source: source as unknown as { fetchBoth: FakeSource["fetchBoth"] },
+      config: CONFIG,
+      emit: () => {},
+      onPauseChange: () => {},
+      now: () => NOW,
+      resumeSignals,
+    });
+
+    await coordinator.start();
+    await (coordinator as unknown as { pollOnce: () => Promise<void> }).pollOnce();
+    coordinator.stop();
+
+    const first = coordinator.getResumeCandidate();
+    expect(first.detail?.codex?.ready).toBe(true);
+    // Mutate the INNER field in place (do NOT replace the whole detail object).
+    if (first.detail?.codex) {
+      first.detail.codex.ready = false;
+    }
+
+    // A fresh read must still see ready === true: the inner detail was deep-copied.
+    const second = coordinator.getResumeCandidate();
+    expect(second.detail?.codex?.ready).toBe(true);
+  });
+});

--- a/src/unit-test/resume-candidate.test.ts
+++ b/src/unit-test/resume-candidate.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+import { computeBudgetState } from "../budget/budget-state";
+import {
+  classifyPoll,
+  computeResumeCandidate,
+  resumeCandidateSides,
+  INITIAL_FINGERPRINT_STATE,
+  type ResumeCandidate,
+  type ResumeSignals,
+} from "../budget/budget-fingerprint";
+import type { AgentName, AgentUsage, BudgetConfig, BudgetState } from "../budget/types";
+
+const NOW = 1_700_000_000;
+
+const CONFIG: BudgetConfig = {
+  enabled: true,
+  pollSeconds: 60,
+  pauseAt: 90,
+  resumeBelow: 30,
+  syncDriftPct: 10,
+  parallel: { minRemainingPct: 60, timeWindowSec: 3600 },
+  codexTierControl: false,
+  codexTiers: {
+    full: { effort: "high" },
+    balanced: { effort: "medium" },
+    eco: { effort: "low" },
+  },
+  strategy: "conserve",
+};
+
+/** Decision-grade probe with healthy (resumable) defaults — gateUtil 20 < resumeBelow 30. */
+function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {
+  const gateUtil = overrides.gateUtil ?? 20;
+  const warnUtil = overrides.warnUtil ?? gateUtil;
+  return {
+    ok: true,
+    stale: false,
+    gateUtil,
+    warnUtil,
+    fiveHour: { util: gateUtil, resetEpoch: NOW + 3600 },
+    weekly: { util: warnUtil, resetEpoch: NOW + 500_000 },
+    remaining: 100 - gateUtil,
+    rateLimitedUntil: 0,
+    fetchedAt: NOW,
+    parsedVia: "id-match",
+    ...overrides,
+  };
+}
+
+function state(claude: AgentUsage | null, codex: AgentUsage | null, now = NOW): BudgetState {
+  return computeBudgetState(claude, codex, CONFIG, now);
+}
+
+/** Per-side signals, all satisfied by default. Override one to drop a predicate. */
+function signals(overrides: Partial<ResumeSignals> = {}): ResumeSignals {
+  return {
+    tuiReady: { codex: true, claude: true },
+    pendingExists: { codex: true, claude: true },
+    checkpointExists: true,
+    ...overrides,
+  };
+}
+
+const over = usage({ gateUtil: 95, warnUtil: 95, remaining: 5 });
+const healthy = usage();
+
+/**
+ * Drive ONE realistic poll through the production reducer and return the sides
+ * the coordinator would evaluate this poll plus the resulting candidate. This
+ * exercises `classifyPoll` → `resumeCandidateSides` → `computeResumeCandidate`
+ * exactly as the coordinator does, with NO hand-forged fpState.
+ */
+function pollCandidate(
+  prev: ReturnType<typeof classifyPoll>["next"] | typeof INITIAL_FINGERPRINT_STATE,
+  claude: AgentUsage | null,
+  codex: AgentUsage | null,
+  sig: ResumeSignals,
+): { sides: AgentName[]; candidate: ResumeCandidate; next: ReturnType<typeof classifyPoll>["next"] } {
+  const { next, effect } = classifyPoll(prev, state(claude, codex), CONFIG);
+  const sides = resumeCandidateSides(effect);
+  const candidate = computeResumeCandidate(sides, state(claude, codex), CONFIG, sig);
+  return { sides, candidate, next };
+}
+
+/** Enter a pause on `side`, returning the post-pause fpState (premise for exit). */
+function enterPause(side: "claude" | "codex" | "both"): ReturnType<typeof classifyPoll>["next"] {
+  const claude = side === "codex" ? healthy : over;
+  const codex = side === "claude" ? healthy : over;
+  const { next, effect } = classifyPoll(INITIAL_FINGERPRINT_STATE, state(claude, codex), CONFIG);
+  expect(next.side).toBe(side);
+  expect(effect.kind).toBe("enter");
+  return next;
+}
+
+describe("computeResumeCandidate — single side exits a pause (refresh poll)", () => {
+  test("codex paused, then window refreshes → exit poll reports codex ready=true", () => {
+    const paused = enterPause("codex");
+    const { sides, candidate } = pollCandidate(paused, healthy, healthy, signals());
+    expect(sides).toEqual(["codex"]);
+    expect(candidate.codex).toBe(true);
+    // Only the recovered side gets a per-side entry.
+    expect(candidate.claude).toBeUndefined();
+    expect(candidate.detail?.codex?.ready).toBe(true);
+  });
+
+  test("claude paused (handoff), then refreshes → exit poll reports claude ready=true", () => {
+    const paused = enterPause("claude");
+    const { sides, candidate } = pollCandidate(paused, healthy, healthy, signals());
+    expect(sides).toEqual(["claude"]);
+    expect(candidate.claude).toBe(true);
+    expect(candidate.codex).toBeUndefined();
+  });
+});
+
+describe("computeResumeCandidate — still paused (no refresh) → not a candidate", () => {
+  test("codex paused and still over threshold → enter/hold poll, codex ready=false", () => {
+    const paused = enterPause("codex");
+    // Codex still over pauseAt → hysteresis keeps it paused (no exit this poll).
+    const { sides, candidate } = pollCandidate(paused, healthy, over, signals());
+    expect(sides).toEqual(["codex"]);
+    expect(candidate.codex).toBe(false);
+  });
+});
+
+describe("computeResumeCandidate — missing any one predicate → false (direct, exit side)", () => {
+  test("pendingExists[codex]=false → false", () => {
+    const candidate = computeResumeCandidate(
+      ["codex"],
+      state(healthy, healthy),
+      CONFIG,
+      signals({ pendingExists: { codex: false, claude: true } }),
+    );
+    expect(candidate.codex).toBe(false);
+  });
+
+  test("usage still >= resumeBelow (window NOT refreshed) → false", () => {
+    // Codex at gateUtil 40 >= resumeBelow 30 → canAgentResume false.
+    const notRefreshed = state(healthy, usage({ gateUtil: 40, warnUtil: 40, remaining: 60 }));
+    const candidate = computeResumeCandidate(["codex"], notRefreshed, CONFIG, signals());
+    expect(candidate.codex).toBe(false);
+  });
+
+  test("tuiReady[codex]=false → false", () => {
+    const candidate = computeResumeCandidate(
+      ["codex"],
+      state(healthy, healthy),
+      CONFIG,
+      signals({ tuiReady: { codex: false, claude: true } }),
+    );
+    expect(candidate.codex).toBe(false);
+  });
+
+  test("checkpointExists=false → false", () => {
+    const candidate = computeResumeCandidate(
+      ["codex"],
+      state(healthy, healthy),
+      CONFIG,
+      signals({ checkpointExists: false }),
+    );
+    expect(candidate.codex).toBe(false);
+  });
+
+  test("non-decision-grade usage (stale, every window already reset) → false", () => {
+    const degraded = state(
+      healthy,
+      usage({
+        gateUtil: 20,
+        warnUtil: 20,
+        fiveHour: { util: 20, resetEpoch: NOW - 5400 },
+        weekly: { util: 20, resetEpoch: NOW - 100 },
+        fetchedAt: NOW - 7200,
+      }),
+    );
+    const candidate = computeResumeCandidate(["codex"], degraded, CONFIG, signals());
+    expect(candidate.codex).toBe(false);
+  });
+});
+
+describe("computeResumeCandidate — per-side independence (both sides evaluated)", () => {
+  test("both refreshed + all signals → both ready=true", () => {
+    // exit from `both` recovers both sides; pass both explicitly.
+    const candidate = computeResumeCandidate(
+      ["claude", "codex"],
+      state(healthy, healthy),
+      CONFIG,
+      signals(),
+    );
+    expect(candidate.codex).toBe(true);
+    expect(candidate.claude).toBe(true);
+  });
+
+  test("only codex refreshed (claude over threshold) → codex true, claude false", () => {
+    const mixed = state(usage({ gateUtil: 40, warnUtil: 40, remaining: 60 }), healthy);
+    const candidate = computeResumeCandidate(["claude", "codex"], mixed, CONFIG, signals());
+    expect(candidate.codex).toBe(true);
+    expect(candidate.claude).toBe(false);
+  });
+
+  test("per-side signal isolation: codex pending false → only codex blocked", () => {
+    const candidate = computeResumeCandidate(
+      ["claude", "codex"],
+      state(healthy, healthy),
+      CONFIG,
+      signals({ pendingExists: { codex: false, claude: true } }),
+    );
+    expect(candidate.codex).toBe(false);
+    expect(candidate.claude).toBe(true);
+  });
+
+  test("shared checkpoint missing → both false", () => {
+    const candidate = computeResumeCandidate(
+      ["claude", "codex"],
+      state(healthy, healthy),
+      CONFIG,
+      signals({ checkpointExists: false }),
+    );
+    expect(candidate.codex).toBe(false);
+    expect(candidate.claude).toBe(false);
+  });
+});
+
+describe("resumeCandidateSides — effect-driven side selection", () => {
+  test("exit effect → previousSide", () => {
+    const paused = enterPause("codex");
+    const { effect } = classifyPoll(paused, state(healthy, healthy), CONFIG);
+    expect(effect.kind).toBe("exit");
+    expect(resumeCandidateSides(effect)).toEqual(["codex"]);
+  });
+
+  test("enter effect → still-paused side", () => {
+    const { effect } = classifyPoll(INITIAL_FINGERPRINT_STATE, state(healthy, over), CONFIG);
+    expect(effect.kind).toBe("enter");
+    expect(resumeCandidateSides(effect)).toEqual(["codex"]);
+  });
+
+  test("none effect (idle, nothing to advise) → []", () => {
+    const { effect } = classifyPoll(INITIAL_FINGERPRINT_STATE, state(healthy, healthy), CONFIG);
+    expect(effect.kind).toBe("none");
+    expect(resumeCandidateSides(effect)).toEqual([]);
+  });
+});
+
+describe("computeResumeCandidate — empty sides & purity", () => {
+  test("empty sides → empty candidate (no detail)", () => {
+    const candidate = computeResumeCandidate([], state(healthy, healthy), CONFIG, signals());
+    expect(candidate.codex).toBeUndefined();
+    expect(candidate.claude).toBeUndefined();
+    expect(candidate.detail).toBeUndefined();
+  });
+
+  test("identical inputs yield identical output (referential determinism)", () => {
+    const s = state(healthy, healthy);
+    const sig = signals();
+    const a = computeResumeCandidate(["codex"], s, CONFIG, sig);
+    const b = computeResumeCandidate(["codex"], s, CONFIG, sig);
+    expect(a).toEqual(b);
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary
budget-auto-resume 的 **PR2**:bridge 读 \`~/.budget-guard/pending\` 作续接源头 + 续接候选状态机。**仅检测,不注入**(注入是 PR3/PR4)。

Detection-only foundation for TUI auto-resume: reads guard pending files + computes per-side resume candidates. No injection yet (that's PR3 Codex queue / PR4 Claude channel).

## 改动 / Changes
- \`src/budget/pending-reader.ts\`(新):双 writer schema 解析(\`(.reset_epoch??.reset)\`/\`(.warn_util??.util)\`)+ glob \`pending/<agent>_*.json\` + legacy 去重 + \`cwdMatches\` realpath 匹配(symlink 安全 + cross-repo 排除)+ agent/status/cwd 过滤;全程 log-and-skip,绝不抛。
- \`src/budget/budget-fingerprint.ts\`:\`computeResumeCandidate\` 按 **exit 转移的 previousSide** 做 per-side 评估;\`ResumeSignals\` per-side(tuiReady/pendingExists/checkpointExists)。
- \`src/budget/budget-coordinator.ts\`:\`getResumeCandidate()\` 只读(深拷贝内层 detail 防 PR3 就地改污染);零副作用,不 emit/onPauseChange/inject;classifyPoll 未改。
- \`src/daemon.ts\`:\`readResumeSignals\` per-side 注入,每信号 fault-isolated 降级。
- \`src/budget/quota-source.ts\`:export asRecord/asFiniteNumber/numberOr/clamp(单一真源)。

## Cross-review
Codex cross-engine + 4 轮 adversarial subagent 复审,逮出并修复:
- **CRITICAL**:候选挂在退出后 \`next.side\`(被 hysteresis 同轮清空)→ 生产恒空、核心非功能,且被手工配对测试假绿掩盖(1339 pass 却功能死)。
- **HIGH**:全局 OR signals 错侧/跨项目误判;假绿测试。
- **MEDIUM**:cwd realpath 匹配(symlink 假阴性);getResumeCandidate 浅拷贝 state-corruption 陷阱;测试 BUDGET_STATE_DIR 隔离。
连续两路独立确认 0 真实 issue(Codex clean + subagent 收口 pass=true)。

## Test plan
- \`bun run typecheck\` 干净。
- \`bun test src\` **1355 pass / 0 fail**(新增 pending-reader + resume-candidate + e2e pollOnce 集成 + cwd symlink/env-override 用例)。
- \`bun run build:plugin\` + \`verify:plugin-sync\` in sync。
- E2E:detection-only,无运行时行为变更(getResumeCandidate 暂无消费者);PR3/PR4 落地后走 PR5 端到端实测。

## Backlog(LOW RECOMMEND,非阻塞)
- cwdMatches step-3(realpath-throw)测试缺口(代码已实证正确)。
- clamp over-export。
- bash/node pending schema 为跨仓契约,PR3/PR4 联调时对照外部 guard 复核。