### PR TITLE
feat(budget): per-side committed recovery effect (PR2.5)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14512,10 +14512,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("1dc5e4f", "source"),
+  commit: defineString("95223ff", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("899ddecd2cf2", "source")
+  codeHash: defineString("1680b1c1e99c", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("1dc5e4f", "source"),
+  commit: defineString("95223ff", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("899ddecd2cf2", "source")
+  codeHash: defineString("1680b1c1e99c", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -3953,6 +3953,10 @@ function nextActiveSide(prevSide, state, cfg) {
   }
   return agentsToSide(active);
 }
+function removedAgents(prevSide, currentSide) {
+  const current = new Set(sideToAgents(currentSide));
+  return sideToAgents(prevSide).filter((agent) => !current.has(agent));
+}
 function activeSideReason(agent, usage, cfg, now) {
   if (!usage)
     return `${AGENT_LABEL2[agent]} \u63A2\u6D4B\u6682\u65F6\u4E0D\u53EF\u7528\uFF0C\u4FDD\u6301\u4E0A\u4E00\u8F6E\u9884\u7B97\u5E72\u9884`;
@@ -4002,6 +4006,7 @@ function directiveFingerprint(state, activeSide) {
 function classifyPoll(prev, state, cfg) {
   const previousSide = prev.side;
   const currentSide = nextActiveSide(previousSide, state, cfg);
+  const recoveredSides = removedAgents(previousSide, currentSide);
   if (currentSide) {
     const reason = interventionReason(currentSide, state, cfg);
     const nextResumeRaw = resumeAfterEpoch2(currentSide, state, cfg);
@@ -4018,35 +4023,39 @@ function classifyPoll(prev, state, cfg) {
         reason,
         resumeEpoch,
         emit,
-        pauseChanged
+        pauseChanged,
+        recoveredSides
       }
     };
   }
   if (previousSide) {
     return {
       next: { side: null, fingerprint: null, resumeEpoch: null, reason: null },
-      effect: { kind: "exit", previousSide }
+      effect: { kind: "exit", previousSide, recoveredSides }
     };
   }
   if (!isDecisionGrade(state.perAgent.claude, state.now) || !isDecisionGrade(state.perAgent.codex, state.now)) {
-    return { next: prev, effect: { kind: "none" } };
+    return { next: prev, effect: { kind: "none", recoveredSides: [] } };
   }
   if (!state.directiveToClaude) {
     return {
       next: { side: null, fingerprint: null, resumeEpoch: null, reason: null },
-      effect: { kind: "none" }
+      effect: { kind: "none", recoveredSides: [] }
     };
   }
   const fingerprint = directiveFingerprint(state);
   if (fingerprint !== prev.fingerprint) {
     return {
       next: { side: null, fingerprint, resumeEpoch: null, reason: null },
-      effect: { kind: "advise", phase: state.phase }
+      effect: { kind: "advise", phase: state.phase, recoveredSides: [] }
     };
   }
-  return { next: prev, effect: { kind: "none" } };
+  return { next: prev, effect: { kind: "none", recoveredSides: [] } };
 }
 function resumeCandidateSides(effect) {
+  if (effect.recoveredSides.length > 0) {
+    return effect.recoveredSides;
+  }
   switch (effect.kind) {
     case "exit":
       return sideToAgents(effect.previousSide);
@@ -4209,6 +4218,7 @@ class BudgetCoordinator {
   now;
   scheduler;
   log;
+  onResume;
   resumeSignals;
   timer = null;
   running = false;
@@ -4229,6 +4239,7 @@ class BudgetCoordinator {
     this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
     this.scheduler = options.scheduler ?? REAL_BUDGET_POLL_SCHEDULER;
     this.log = options.log ?? (() => {});
+    this.onResume = options.onResume ?? (() => {});
     this.resumeSignals = options.resumeSignals ?? null;
   }
   async start() {
@@ -4330,6 +4341,10 @@ class BudgetCoordinator {
     const { next, effect } = classifyPoll(this.fpState, state, this.config);
     this.fpState = next;
     this.resumeCandidate = this.resumeSignals ? computeResumeCandidate(resumeCandidateSides(effect), state, this.config, this.resumeSignals()) : {};
+    for (const side of effect.recoveredSides) {
+      const { id, directive } = this.emitRecovery(side, state);
+      this.onResume(side, directive, id);
+    }
     switch (effect.kind) {
       case "enter":
       case "hold-uncertain": {
@@ -4342,7 +4357,6 @@ class BudgetCoordinator {
       }
       case "exit": {
         this.onPauseChange(false);
-        this.emitDirective(this.recoveryPrefix(effect.previousSide), this.recoveryDirective(state, effect.previousSide));
         return;
       }
       case "advise": {
@@ -4388,19 +4402,26 @@ class BudgetCoordinator {
     this.pendingOverrides = { ...overrides };
   }
   emitDirective(prefix, content) {
-    this.emit(`${prefix}_${this.sequence++}`, content);
+    const id = `${prefix}_${this.sequence++}`;
+    this.emit(id, content);
+    return id;
   }
   interventionPrefix(side) {
     return side === "claude" ? "system_budget_handoff" : "system_budget_pause";
   }
-  recoveryPrefix(previousSide) {
-    return previousSide === "claude" ? "system_budget_claude_recovered" : "system_budget_resume";
+  recoveryPrefix(side) {
+    return side === "claude" ? "system_budget_claude_recovered" : "system_budget_resume";
+  }
+  emitRecovery(side, state) {
+    const directive = this.recoveryDirective(state, side);
+    const id = this.emitDirective(this.recoveryPrefix(side), directive);
+    return { id, directive };
   }
   interventionDirective(state, side, reason, resumeEpoch) {
     return renderBudgetInterventionDirective(state.perAgent.claude, state.perAgent.codex, side, reason || "\u9884\u7B97\u63A5\u8FD1\u8017\u5C3D", resumeEpoch, this.config);
   }
-  recoveryDirective(state, previousSide) {
-    if (previousSide === "claude") {
+  recoveryDirective(state, side) {
+    if (side === "claude") {
       return [
         "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Claude \u4FA7\u9884\u7B97\u5DF2\u6062\u590D\u3002",
         `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
@@ -4409,19 +4430,10 @@ class BudgetCoordinator {
       ].join(`
 `);
     }
-    if (previousSide === "codex") {
-      return [
-        "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Codex \u4FA7\u9884\u7B97\u95F8\u95E8\u89E3\u9664\u3002",
-        `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
-        `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1ACodex gateUtil \u4F4E\u4E8E ${pct3(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
-        "\u5EFA\u8BAE Claude \u7528 reply \u5E26\u4E0A\u5F53\u524D\u76EE\u6807\u3001checkpoint \u548C\u4E0B\u4E00\u6B65\uFF0C\u5524\u9192 Codex \u63A5\u7EED\u6267\u884C\u3002"
-      ].join(`
-`);
-    }
     return [
-      "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011\u8054\u5408\u6682\u505C\u89E3\u9664\u3002",
+      "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Codex \u4FA7\u9884\u7B97\u95F8\u95E8\u89E3\u9664\u3002",
       `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
-      `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1A\u53CC\u65B9 gateUtil \u5747\u4F4E\u4E8E ${pct3(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
+      `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1ACodex gateUtil \u4F4E\u4E8E ${pct3(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
       "\u5EFA\u8BAE Claude \u7528 reply \u5E26\u4E0A\u5F53\u524D\u76EE\u6807\u3001checkpoint \u548C\u4E0B\u4E00\u6B65\uFF0C\u5524\u9192 Codex \u63A5\u7EED\u6267\u884C\u3002"
     ].join(`
 `);

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -65,6 +65,7 @@ export interface BudgetCoordinatorOptions {
   now?: () => number;
   scheduler?: BudgetPollScheduler;
   log?: (message: string) => void;
+  onResume?: (side: AgentName, directive: string, resumeId: string) => void;
   /**
    * PR2 (detection only): daemon-injected readiness signals for the resume
    * candidate. Pulled once per poll after classifyPoll; the result is exposed
@@ -158,6 +159,7 @@ export class BudgetCoordinator {
   private readonly now: () => number;
   private readonly scheduler: BudgetPollScheduler;
   private readonly log: (message: string) => void;
+  private readonly onResume: (side: AgentName, directive: string, resumeId: string) => void;
   private readonly resumeSignals: (() => ResumeSignals) | null;
 
   private timer: BudgetPollTimer | null = null;
@@ -185,6 +187,7 @@ export class BudgetCoordinator {
     this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
     this.scheduler = options.scheduler ?? REAL_BUDGET_POLL_SCHEDULER;
     this.log = options.log ?? (() => {});
+    this.onResume = options.onResume ?? (() => {});
     this.resumeSignals = options.resumeSignals ?? null;
   }
 
@@ -337,12 +340,15 @@ export class BudgetCoordinator {
     // the still-paused side off enter/hold), so the candidate lands on the right
     // side. When no signal provider is wired the candidate stays empty — nothing
     // can be a candidate without the readiness signals. This populates state
-    // only; the switch below is untouched, so the 50+ classifyPoll regression
-    // baseline (branch order / outcome shapes) is unaffected. NO emit /
-    // onPauseChange / inject here — that is PR3/PR4.
+    // only; committed recovered sides emit below, but injection remains PR3/PR4.
     this.resumeCandidate = this.resumeSignals
       ? computeResumeCandidate(resumeCandidateSides(effect), state, this.config, this.resumeSignals())
       : {};
+
+    for (const side of effect.recoveredSides) {
+      const { id, directive } = this.emitRecovery(side, state);
+      this.onResume(side, directive, id);
+    }
 
     switch (effect.kind) {
       case "enter":
@@ -358,7 +364,6 @@ export class BudgetCoordinator {
       }
       case "exit": {
         this.onPauseChange(false);
-        this.emitDirective(this.recoveryPrefix(effect.previousSide), this.recoveryDirective(state, effect.previousSide));
         return;
       }
       case "advise": {
@@ -408,16 +413,24 @@ export class BudgetCoordinator {
     this.pendingOverrides = { ...overrides };
   }
 
-  private emitDirective(prefix: string, content: string): void {
-    this.emit(`${prefix}_${this.sequence++}`, content);
+  private emitDirective(prefix: string, content: string): string {
+    const id = `${prefix}_${this.sequence++}`;
+    this.emit(id, content);
+    return id;
   }
 
   private interventionPrefix(side: Exclude<PauseSide, null>): string {
     return side === "claude" ? "system_budget_handoff" : "system_budget_pause";
   }
 
-  private recoveryPrefix(previousSide: Exclude<PauseSide, null>): string {
-    return previousSide === "claude" ? "system_budget_claude_recovered" : "system_budget_resume";
+  private recoveryPrefix(side: AgentName): string {
+    return side === "claude" ? "system_budget_claude_recovered" : "system_budget_resume";
+  }
+
+  private emitRecovery(side: AgentName, state: BudgetState): { id: string; directive: string } {
+    const directive = this.recoveryDirective(state, side);
+    const id = this.emitDirective(this.recoveryPrefix(side), directive);
+    return { id, directive };
   }
 
   private interventionDirective(
@@ -441,8 +454,8 @@ export class BudgetCoordinator {
     );
   }
 
-  private recoveryDirective(state: BudgetState, previousSide: Exclude<PauseSide, null>): string {
-    if (previousSide === "claude") {
+  private recoveryDirective(state: BudgetState, side: AgentName): string {
+    if (side === "claude") {
       return [
         "【预算协调 · 账号级】Claude 侧预算已恢复。",
         `${usageLine("claude", state.perAgent.claude)}；${usageLine("codex", state.perAgent.codex)}。`,
@@ -451,19 +464,10 @@ export class BudgetCoordinator {
       ].join("\n");
     }
 
-    if (previousSide === "codex") {
-      return [
-        "【预算协调 · 账号级】Codex 侧预算闸门解除。",
-        `${usageLine("claude", state.perAgent.claude)}；${usageLine("codex", state.perAgent.codex)}。`,
-        `闸门已放开：Codex gateUtil 低于 ${pct(this.config.resumeBelow)}，且没有有效 rate_limit。`,
-        "建议 Claude 用 reply 带上当前目标、checkpoint 和下一步，唤醒 Codex 接续执行。",
-      ].join("\n");
-    }
-
     return [
-      "【预算协调 · 账号级】联合暂停解除。",
+      "【预算协调 · 账号级】Codex 侧预算闸门解除。",
       `${usageLine("claude", state.perAgent.claude)}；${usageLine("codex", state.perAgent.codex)}。`,
-      `闸门已放开：双方 gateUtil 均低于 ${pct(this.config.resumeBelow)}，且没有有效 rate_limit。`,
+      `闸门已放开：Codex gateUtil 低于 ${pct(this.config.resumeBelow)}，且没有有效 rate_limit。`,
       "建议 Claude 用 reply 带上当前目标、checkpoint 和下一步，唤醒 Codex 接续执行。",
     ].join("\n");
   }

--- a/src/budget/budget-fingerprint.ts
+++ b/src/budget/budget-fingerprint.ts
@@ -86,21 +86,29 @@ export type CoordinatorEffect =
       emit: boolean;
       /** True only on the first poll that enters a pause (drives onPauseChange(true)). */
       pauseChanged: boolean;
+      /** Agents removed from the active pause set on this committed transition. */
+      recoveredSides: AgentName[];
     }
   | {
       /** Leaving an intervention back to idle. */
       kind: "exit";
       previousSide: ActivePauseSide;
+      /** Agents removed from the active pause set on this committed transition. */
+      recoveredSides: AgentName[];
     }
   | {
       /** Drift/parallel advisory emitted (gate stays open). */
       kind: "advise";
       phase: BudgetState["phase"];
+      /** Agents removed from the active pause set on this committed transition. */
+      recoveredSides: AgentName[];
     }
   | {
       /** No directive to emit; covers phantom holds, dedup no-ops, and the
        * null-directive fingerprint reset. */
       kind: "none";
+      /** Agents removed from the active pause set on this committed transition. */
+      recoveredSides: AgentName[];
     };
 
 export interface ClassifyResult {
@@ -202,6 +210,11 @@ function nextActiveSide(prevSide: PauseSide, state: BudgetState, cfg: BudgetConf
   return agentsToSide(active);
 }
 
+function removedAgents(prevSide: PauseSide, currentSide: PauseSide): AgentName[] {
+  const current = new Set<AgentName>(sideToAgents(currentSide));
+  return sideToAgents(prevSide).filter((agent) => !current.has(agent));
+}
+
 function activeSideReason(agent: AgentName, usage: AgentUsage | null, cfg: BudgetConfig, now: number): string {
   if (!usage) return `${AGENT_LABEL[agent]} 探测暂时不可用，保持上一轮预算干预`;
   if (usage.rateLimitedUntil > now) {
@@ -301,6 +314,7 @@ export function directiveFingerprint(state: BudgetState, activeSide?: ActivePaus
 export function classifyPoll(prev: FingerprintState, state: BudgetState, cfg: BudgetConfig): ClassifyResult {
   const previousSide = prev.side;
   const currentSide = nextActiveSide(previousSide, state, cfg);
+  const recoveredSides = removedAgents(previousSide, currentSide);
 
   // --- Paused branch (intervention active) ---
   if (currentSide) {
@@ -324,6 +338,7 @@ export function classifyPoll(prev: FingerprintState, state: BudgetState, cfg: Bu
         resumeEpoch,
         emit,
         pauseChanged,
+        recoveredSides,
       },
     };
   }
@@ -332,7 +347,7 @@ export function classifyPoll(prev: FingerprintState, state: BudgetState, cfg: Bu
   if (previousSide) {
     return {
       next: { side: null, fingerprint: null, resumeEpoch: null, reason: null },
-      effect: { kind: "exit", previousSide },
+      effect: { kind: "exit", previousSide, recoveredSides },
     };
   }
 
@@ -343,14 +358,14 @@ export function classifyPoll(prev: FingerprintState, state: BudgetState, cfg: Bu
     !isDecisionGrade(state.perAgent.claude, state.now) ||
     !isDecisionGrade(state.perAgent.codex, state.now)
   ) {
-    return { next: prev, effect: { kind: "none" } };
+    return { next: prev, effect: { kind: "none", recoveredSides: [] } };
   }
 
   // --- Null-directive reset: decision-grade but nothing to advise. ---
   if (!state.directiveToClaude) {
     return {
       next: { side: null, fingerprint: null, resumeEpoch: null, reason: null },
-      effect: { kind: "none" },
+      effect: { kind: "none", recoveredSides: [] },
     };
   }
 
@@ -359,10 +374,10 @@ export function classifyPoll(prev: FingerprintState, state: BudgetState, cfg: Bu
   if (fingerprint !== prev.fingerprint) {
     return {
       next: { side: null, fingerprint, resumeEpoch: null, reason: null },
-      effect: { kind: "advise", phase: state.phase },
+      effect: { kind: "advise", phase: state.phase, recoveredSides: [] },
     };
   }
-  return { next: prev, effect: { kind: "none" } };
+  return { next: prev, effect: { kind: "none", recoveredSides: [] } };
 }
 
 /**
@@ -387,6 +402,9 @@ export function classifyPoll(prev: FingerprintState, state: BudgetState, cfg: Bu
  * branch internals.
  */
 export function resumeCandidateSides(effect: CoordinatorEffect): AgentName[] {
+  if (effect.recoveredSides.length > 0) {
+    return effect.recoveredSides;
+  }
   switch (effect.kind) {
     case "exit":
       return sideToAgents(effect.previousSide);

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { BudgetCoordinator, nextBudgetPollDelayMs } from "../budget/budget-coordinator";
+import type { ResumeSignals } from "../budget/budget-fingerprint";
 import type { AgentUsage, BudgetConfig } from "../budget/types";
 
 const NOW = 1_700_000_000;
@@ -95,6 +96,15 @@ function makeCoordinator(source: FakeSource, config: BudgetConfig = CONFIG) {
   });
 
   return { coordinator, emitted, pauseChanges, logs };
+}
+
+function readySignals(overrides: Partial<ResumeSignals> = {}): ResumeSignals {
+  return {
+    tuiReady: { codex: true, claude: true },
+    pendingExists: { codex: true, claude: true },
+    checkpointExists: true,
+    ...overrides,
+  };
 }
 
 function longPollConfig(overrides: Partial<BudgetConfig> = {}): BudgetConfig {
@@ -711,6 +721,7 @@ describe("BudgetCoordinator", () => {
     expect(emitted.map((event) => event.id.replace(/_\d+$/, ""))).toEqual([
       "system_budget_handoff",
       "system_budget_pause",
+      "system_budget_claude_recovered",
       "system_budget_pause",
     ]);
     expect(coordinator.getSnapshot()).toMatchObject({ paused: true, gateClosed: true, pauseSide: "codex" });
@@ -732,9 +743,141 @@ describe("BudgetCoordinator", () => {
 
     expect(emitted.map((event) => event.id.replace(/_\d+$/, ""))).toEqual([
       "system_budget_pause",
+      "system_budget_resume",
       "system_budget_handoff",
     ]);
     expect(coordinator.getSnapshot()).toMatchObject({ paused: true, gateClosed: false, pauseSide: "claude" });
+  });
+
+  test("partial recovery emits Codex resume, calls onResume once, and leaves Claude handoff active", async () => {
+    const source = new FakeSource([
+      {
+        claude: usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }),
+        codex: usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+      },
+      { claude: usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }), codex: usage() },
+      { claude: usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }), codex: usage() },
+    ]);
+    const emitted: Array<{ id: string; content: string }> = [];
+    const resumes: Array<{ side: "claude" | "codex"; directive: string; resumeId: string; gateClosed: boolean; paused: boolean }> = [];
+    let coordinator: BudgetCoordinator;
+    coordinator = new BudgetCoordinator({
+      source,
+      config: longPollConfig(),
+      emit: (id, content) => emitted.push({ id, content }),
+      onPauseChange: () => {},
+      onResume: (side, directive, resumeId) => {
+        resumes.push({ side, directive, resumeId, gateClosed: coordinator.isGateClosed(), paused: coordinator.isPaused() });
+      },
+      now: () => NOW,
+      resumeSignals: () => readySignals(),
+    });
+
+    await coordinator.start();
+    await (coordinator as unknown as { pollOnce: () => Promise<void> }).pollOnce();
+
+    expect(coordinator.isPaused()).toBe(true);
+    expect(coordinator.isGateClosed()).toBe(false);
+    expect(coordinator.getSnapshot()).toMatchObject({ paused: true, gateClosed: false, pauseSide: "claude" });
+    expect(coordinator.getResumeCandidate().codex).toBe(true);
+    expect(coordinator.getResumeCandidate().claude).toBeUndefined();
+    expect(emitted.map((event) => event.id.replace(/_\d+$/, ""))).toEqual([
+      "system_budget_pause",
+      "system_budget_resume",
+      "system_budget_handoff",
+    ]);
+    expect(resumes).toHaveLength(1);
+    expect(resumes[0]).toMatchObject({ side: "codex" });
+    expect(resumes[0].resumeId).toBe(emitted[1].id);
+    expect(resumes[0].directive).toBe(emitted[1].content);
+    expect(resumes[0].gateClosed).toBe(false);
+    expect(resumes[0].paused).toBe(true);
+
+    await (coordinator as unknown as { pollOnce: () => Promise<void> }).pollOnce();
+    coordinator.stop();
+
+    expect(resumes).toHaveLength(1);
+    expect(emitted.map((event) => event.id.replace(/_\d+$/, ""))).toEqual([
+      "system_budget_pause",
+      "system_budget_resume",
+      "system_budget_handoff",
+    ]);
+  });
+
+  test("final recovery after a partial recovery emits the remaining side only", async () => {
+    const source = new FakeSource([
+      {
+        claude: usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }),
+        codex: usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+      },
+      { claude: usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }), codex: usage() },
+      { claude: usage(), codex: usage() },
+    ]);
+    const emitted: Array<{ id: string; content: string }> = [];
+    const resumes: Array<{ side: "claude" | "codex"; directive: string; resumeId: string }> = [];
+    const coordinator = new BudgetCoordinator({
+      source,
+      config: longPollConfig(),
+      emit: (id, content) => emitted.push({ id, content }),
+      onPauseChange: () => {},
+      onResume: (side, directive, resumeId) => resumes.push({ side, directive, resumeId }),
+      now: () => NOW,
+      resumeSignals: () => readySignals(),
+    });
+
+    await coordinator.start();
+    await (coordinator as unknown as { pollOnce: () => Promise<void> }).pollOnce();
+    await (coordinator as unknown as { pollOnce: () => Promise<void> }).pollOnce();
+    coordinator.stop();
+
+    expect(coordinator.isPaused()).toBe(false);
+    expect(coordinator.isGateClosed()).toBe(false);
+    expect(emitted.map((event) => event.id.replace(/_\d+$/, ""))).toEqual([
+      "system_budget_pause",
+      "system_budget_resume",
+      "system_budget_handoff",
+      "system_budget_claude_recovered",
+    ]);
+    expect(resumes.map((resume) => resume.side)).toEqual(["codex", "claude"]);
+    expect(resumes[0].resumeId).toBe(emitted[1].id);
+    expect(resumes[1].resumeId).toBe(emitted[3].id);
+  });
+
+  test("full recovery from joint pause emits both per-side recovery directives", async () => {
+    const source = new FakeSource([
+      {
+        claude: usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }),
+        codex: usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+      },
+      { claude: usage(), codex: usage() },
+    ]);
+    const emitted: Array<{ id: string; content: string }> = [];
+    const resumes: Array<{ side: "claude" | "codex"; directive: string; resumeId: string }> = [];
+    const coordinator = new BudgetCoordinator({
+      source,
+      config: longPollConfig(),
+      emit: (id, content) => emitted.push({ id, content }),
+      onPauseChange: () => {},
+      onResume: (side, directive, resumeId) => resumes.push({ side, directive, resumeId }),
+      now: () => NOW,
+      resumeSignals: () => readySignals(),
+    });
+
+    await coordinator.start();
+    await (coordinator as unknown as { pollOnce: () => Promise<void> }).pollOnce();
+    coordinator.stop();
+
+    expect(emitted.map((event) => event.id.replace(/_\d+$/, ""))).toEqual([
+      "system_budget_pause",
+      "system_budget_claude_recovered",
+      "system_budget_resume",
+    ]);
+    expect(resumes.map(({ side }) => ({ side }))).toEqual([{ side: "claude" }, { side: "codex" }]);
+    expect(resumes[0].resumeId).toBe(emitted[1].id);
+    expect(resumes[1].resumeId).toBe(emitted[2].id);
+    expect(resumes[0].directive).toBe(emitted[1].content);
+    expect(resumes[1].directive).toBe(emitted[2].content);
+    expect(coordinator.getSnapshot()).toMatchObject({ paused: false, gateClosed: false, pauseSide: null });
   });
 
   test("emits distinct recovery events for Codex pause and Claude handoff", async () => {

--- a/src/unit-test/budget-fingerprint.test.ts
+++ b/src/unit-test/budget-fingerprint.test.ts
@@ -4,6 +4,7 @@ import {
   classifyPoll,
   directiveFingerprint,
   INITIAL_FINGERPRINT_STATE,
+  resumeCandidateSides,
   type FingerprintState,
 } from "../budget/budget-fingerprint";
 import type { AgentUsage, BudgetConfig, BudgetState } from "../budget/types";
@@ -69,7 +70,7 @@ function runPolls(
 describe("classifyPoll reducer — event coverage", () => {
   test("none: both sides healthy, no directive, from idle", () => {
     const { final, effects } = runPolls([state(usage(), usage({ gateUtil: 21, warnUtil: 21 }))]);
-    expect(effects[0]).toEqual({ kind: "none" });
+    expect(effects[0]).toEqual({ kind: "none", recoveredSides: [] });
     expect(final.side).toBeNull();
     expect(final.fingerprint).toBeNull();
   });
@@ -134,7 +135,7 @@ describe("classifyPoll reducer — event coverage", () => {
     const recovered = state(usage(), usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }));
     const { effects, final } = runPolls([paused, recovered]);
     expect(effects[0].kind).toBe("enter");
-    expect(effects[1]).toEqual({ kind: "exit", previousSide: "codex" });
+    expect(effects[1]).toEqual({ kind: "exit", previousSide: "codex", recoveredSides: ["codex"] });
     expect(final.side).toBeNull();
     expect(final.fingerprint).toBeNull();
     expect(final.resumeEpoch).toBeNull();
@@ -145,7 +146,7 @@ describe("classifyPoll reducer — event coverage", () => {
     const drifted = state(usage({ gateUtil: 35, warnUtil: 45 }), usage({ gateUtil: 20, warnUtil: 20 }));
     expect(drifted.phase).toBe("balance");
     const { effects, final } = runPolls([drifted]);
-    expect(effects[0]).toEqual({ kind: "advise", phase: "balance" });
+    expect(effects[0]).toEqual({ kind: "advise", phase: "balance", recoveredSides: [] });
     expect(final.side).toBeNull();
     expect(final.fingerprint).not.toBeNull();
   });
@@ -153,8 +154,8 @@ describe("classifyPoll reducer — event coverage", () => {
   test("advise dedup: identical drift on the next poll → none (no re-emit)", () => {
     const drifted = state(usage({ gateUtil: 35, warnUtil: 45 }), usage({ gateUtil: 20, warnUtil: 20 }));
     const { effects } = runPolls([drifted, drifted]);
-    expect(effects[0]).toEqual({ kind: "advise", phase: "balance" });
-    expect(effects[1]).toEqual({ kind: "none" });
+    expect(effects[0]).toEqual({ kind: "advise", phase: "balance", recoveredSides: [] });
+    expect(effects[1]).toEqual({ kind: "none", recoveredSides: [] });
   });
 
   test("advise: parallel phase emits with phase=parallel", () => {
@@ -164,7 +165,7 @@ describe("classifyPoll reducer — event coverage", () => {
     );
     expect(parallel.phase).toBe("parallel");
     const { effects } = runPolls([parallel]);
-    expect(effects[0]).toEqual({ kind: "advise", phase: "parallel" });
+    expect(effects[0]).toEqual({ kind: "advise", phase: "parallel", recoveredSides: [] });
   });
 
   test("reset: advising → directive disappears (decision-grade) clears fingerprint", () => {
@@ -174,7 +175,7 @@ describe("classifyPoll reducer — event coverage", () => {
     const { effects, final } = runPolls([drifted, calm]);
     expect(effects[0].kind).toBe("advise");
     // null-directive on decision-grade data → effect none, but fingerprint reset.
-    expect(effects[1]).toEqual({ kind: "none" });
+    expect(effects[1]).toEqual({ kind: "none", recoveredSides: [] });
     expect(final.fingerprint).toBeNull();
     expect(final.side).toBeNull();
   });
@@ -195,12 +196,12 @@ describe("classifyPoll reducer — branch-order sensitivity", () => {
 
     const afterPhantom = classifyPoll(afterDrift.next, phantom, CONFIG);
     // Phantom branch runs first → none effect, fingerprint held (NOT reset).
-    expect(afterPhantom.effect).toEqual({ kind: "none" });
+    expect(afterPhantom.effect).toEqual({ kind: "none", recoveredSides: [] });
     expect(afterPhantom.next.fingerprint).toBe(afterDrift.next.fingerprint);
 
     // Recovery to the same real drift must re-emit NOTHING (fingerprint match).
     const afterRecovery = classifyPoll(afterPhantom.next, drifted, CONFIG);
-    expect(afterRecovery.effect).toEqual({ kind: "none" });
+    expect(afterRecovery.effect).toEqual({ kind: "none", recoveredSides: [] });
   });
 
   test("phantom that inflates the heavier side still holds (no spurious re-emit)", () => {
@@ -251,7 +252,7 @@ describe("classifyPoll reducer — branch-order sensitivity", () => {
       }),
     );
     const { effects, final } = runPolls([stale]);
-    expect(effects[0]).toEqual({ kind: "none" });
+    expect(effects[0]).toEqual({ kind: "none", recoveredSides: [] });
     expect(final.side).toBeNull();
   });
 
@@ -295,6 +296,55 @@ describe("classifyPoll reducer — hysteresis side transitions", () => {
     const { effects, final } = runPolls([s1, s2]);
     expect(effects.map((e) => (e.kind === "enter" ? e.side : e.kind))).toEqual(["both", "claude"]);
     expect(final.side).toBe("claude");
+  });
+
+  test("joint pause downgrades to claude handoff and marks codex recovered", () => {
+    const s1 = state(
+      usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }),
+      usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+    );
+    const s2 = state(usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }), usage());
+    const { effects } = runPolls([s1, s2]);
+
+    expect(effects[1]).toMatchObject({
+      kind: "enter",
+      side: "claude",
+      recoveredSides: ["codex"],
+    });
+    expect(resumeCandidateSides(effects[1])).toEqual(["codex"]);
+  });
+
+  test("joint pause downgrades to codex pause and marks claude recovered", () => {
+    const s1 = state(
+      usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }),
+      usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+    );
+    const s2 = state(usage(), usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }));
+    const { effects } = runPolls([s1, s2]);
+
+    expect(effects[1]).toMatchObject({
+      kind: "enter",
+      side: "codex",
+      recoveredSides: ["claude"],
+    });
+    expect(resumeCandidateSides(effects[1])).toEqual(["claude"]);
+  });
+
+  test("joint pause full exit marks both sides recovered", () => {
+    const s1 = state(
+      usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }),
+      usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }),
+    );
+    const s2 = state(usage(), usage());
+    const { effects, final } = runPolls([s1, s2]);
+
+    expect(effects[1]).toEqual({
+      kind: "exit",
+      previousSide: "both",
+      recoveredSides: ["claude", "codex"],
+    });
+    expect(resumeCandidateSides(effects[1])).toEqual(["claude", "codex"]);
+    expect(final.side).toBeNull();
   });
 
   test("resumeEpoch is sticky on same side, reset on side change", () => {

--- a/src/unit-test/doctor.test.ts
+++ b/src/unit-test/doctor.test.ts
@@ -40,6 +40,7 @@ beforeEach(() => {
 
 afterEach(() => {
   process.chdir(previousCwd);
+  process.exitCode = 0;
   for (const key of ENV_KEYS) {
     const value = savedEnv.get(key);
     if (value === undefined) delete process.env[key];

--- a/src/unit-test/resume-candidate.test.ts
+++ b/src/unit-test/resume-candidate.test.ts
@@ -112,6 +112,22 @@ describe("computeResumeCandidate — single side exits a pause (refresh poll)", 
   });
 });
 
+describe("computeResumeCandidate — partial recovery from joint pause", () => {
+  test("both paused, then codex refreshes first → only codex is evaluated as recovered", () => {
+    const paused = enterPause("both");
+    // Claude remains above pauseAt, Codex has refreshed below resumeBelow. The
+    // reducer stays paused on Claude, but Codex is a committed recovered side and
+    // must become the sole resume-candidate source for this poll.
+    const { sides, candidate, next } = pollCandidate(paused, over, healthy, signals());
+
+    expect(next.side).toBe("claude");
+    expect(sides).toEqual(["codex"]);
+    expect(candidate.codex).toBe(true);
+    expect(candidate.claude).toBeUndefined();
+    expect(candidate.detail?.codex?.ready).toBe(true);
+  });
+});
+
 describe("computeResumeCandidate — still paused (no refresh) → not a candidate", () => {
   test("codex paused and still over threshold → enter/hold poll, codex ready=false", () => {
     const paused = enterPause("codex");


### PR DESCRIPTION
## 摘要 / Summary
budget-auto-resume 的 **PR2.5**(建在 PR2 上):reducer per-side committed recovery effect + coordinator onResume 触发回调。让续接覆盖**错峰恢复**(模型 B)——both-paused 时先刷新的一侧立即唤醒,不等另一侧。**仅触发,不注入**(注入是 PR3/PR4)。

Per-side committed recovery in the reducer + onResume trigger callback. Staggered both-paused recovery wakes the recovered side without waiting.

## 改动 / Changes
- **budget-fingerprint.ts**:CoordinatorEffect 所有 committed transition 带 `recoveredSides`(both→claude=`['codex']`、both→codex=`['claude']`、both→null=`['claude','codex']`、单侧→null=该侧、非恢复=`[]`)。`resumeCandidateSides` 用 recoveredSides 做 partial recovery 候选,保留 PR2 的 exit fallback。**classifyPoll 分支序/四 outcome 形态不变**(只追加字段)。
- **budget-coordinator.ts**:加 optional `onResume(side,directive,resumeId)`(no-op default;PR3/PR4 接 handler);`emitDirective` 返实际 id;`emitRecovery`(claude→`system_budget_claude_recovered` / codex→`system_budget_resume`);`applyState` 在 `fpState=next` 提交后 loop recoveredSides 调 emitRecovery+onResume 并算候选。
- **doctor.test.ts**:afterEach 重置 `process.exitCode`(预存 harness 泄漏:`runDoctor()` 按 CLI 语义留 exitCode=1,17/17 过但 Bun 非零退出)。

## Cross-review
2 轮 adversarial subagent 复审,**都 pass=true / 0 confirmed REAL**。两轮独立点出 both→null 全恢复行为变更(单条「联合暂停解除」→ 两条 per-side),**已加 coordinator 回归测试锁死**(emitted 顺序 + onResume×2 + resumeId 对应;突变证判别力:旧单条行为下 RED)。无 PR2 回归、classifyPoll branch-order intact。

## Test plan
- `bun run typecheck` 干净。
- `bun test src`:**1362 pass / 0 fail**。
- `bun run build:plugin`(主 checkout 真 node_modules)+ `verify:plugin-sync` in sync。

## Note
both→null 全退出**有意发两条 per-side recovery directive**(无单条合并消息)——PR3/PR4 需 per-side resumeId 做 per-side 注入。