### PR TITLE
feat(budget): Codex-side resume injection queue + turn/start auto-resume (PR3)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14512,10 +14512,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("95223ff", "source"),
+  commit: defineString("2c8dc86", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("1680b1c1e99c", "source")
+  codeHash: defineString("907116a9cd8c", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -3,9 +3,9 @@
 var __require = import.meta.require;
 
 // src/daemon.ts
-import { existsSync as existsSync7, realpathSync, rmSync as rmSync2 } from "fs";
+import { existsSync as existsSync8, realpathSync as realpathSync2, rmSync as rmSync2 } from "fs";
 import { homedir as homedir4 } from "os";
-import { join as join8 } from "path";
+import { join as join9 } from "path";
 import { randomUUID as randomUUID4 } from "crypto";
 
 // src/contract-version.ts
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("95223ff", "source"),
+  commit: defineString("2c8dc86", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("1680b1c1e99c", "source")
+  codeHash: defineString("907116a9cd8c", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -4074,7 +4074,12 @@ function computeResumeCandidate(sides, state, cfg, signals) {
     const windowRefreshed = canAgentResume(state.perAgent[agent], cfg, state.now);
     const ready = windowRefreshed && signals.pendingExists[agent] && signals.tuiReady[agent] && signals.checkpointExists;
     candidate[agent] = ready;
-    detail[agent] = { ready };
+    const pending = signals.pending?.[agent];
+    detail[agent] = {
+      ready,
+      ...pending ? { pending } : {},
+      ...signals.checkpointPath ? { checkpointPath: signals.checkpointPath } : {}
+    };
   }
   if (sides.length > 0)
     candidate.detail = detail;
@@ -4270,7 +4275,13 @@ class BudgetCoordinator {
     const { detail, ...rest } = this.resumeCandidate;
     return detail ? {
       ...rest,
-      detail: Object.fromEntries(Object.entries(detail).map(([side, value]) => [side, { ...value }]))
+      detail: Object.fromEntries(Object.entries(detail).map(([side, value]) => [
+        side,
+        {
+          ...value,
+          ...value.pending ? { pending: { ...value.pending } } : {}
+        }
+      ]))
     } : { ...rest };
   }
   getCodexTurnOverrides() {
@@ -4859,6 +4870,7 @@ function createQuotaSource(options) {
 }
 
 // src/budget/pending-reader.ts
+import { createHash } from "crypto";
 import { join as join6 } from "path";
 function nodeFs() {
   return __require("fs");
@@ -4891,7 +4903,10 @@ function parsePendingPayload(value) {
   const agent = record.agent === "claude" || record.agent === "codex" ? record.agent : null;
   if (agent === null)
     return null;
-  return { status, agent, sessionId, cwd, resetEpoch, util, warnUtil, at };
+  return { status, agent, sessionId, cwd, resetEpoch, util, warnUtil, at, sourcePath: "", contentHash: "" };
+}
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
 }
 function resolveStateDir(homeDir) {
   const override = process.env.BUDGET_STATE_DIR;
@@ -4917,7 +4932,10 @@ function readPendingFile(path, log) {
     log(`pending reader: skip malformed JSON ${path}`);
     return null;
   }
-  return parsePendingPayload(parsed);
+  const entry = parsePendingPayload(parsed);
+  if (!entry)
+    return null;
+  return { ...entry, sourcePath: path, contentHash: sha256(text) };
 }
 function listScopeFiles(stateDir, agent, log) {
   const pendingDir = join6(stateDir, "pending");
@@ -4955,9 +4973,336 @@ function readGuardPending(opts) {
   return [...bySession.values()];
 }
 
+// src/budget/resume-injection-queue.ts
+import { createHash as createHash2 } from "crypto";
+import { closeSync as closeSync3, existsSync as existsSync6, mkdirSync as mkdirSync5, openSync as openSync3, readFileSync as readFileSync5, realpathSync, unlinkSync as unlinkSync4, writeFileSync as writeFileSync3 } from "fs";
+import { join as join7 } from "path";
+
+// src/budget/resume-prompt.ts
+var RESUME_PROMPT = "\u989D\u5EA6\u7A97\u53E3\u5DF2\u5237\u65B0\uFF0C\u7EE7\u7EED\u4E0A\u6B21\u672A\u5B8C\u6210\u7684\u4EFB\u52A1\uFF1A\u4ECE .agent/checkpoint.md \u7684\u300C\u4E0B\u4E00\u6B65\u300D\u63A5\u7740\u505A\uFF1B\u5B8C\u6210\u540E\u505C\u4E0B\u5E76\u6807 DONE\u3002";
+
+// src/budget/resume-injection-queue.ts
+var DEFAULT_RETRY_MS = 5000;
+var DEFAULT_CONFIRM_TIMEOUT_MS = 60000;
+var DEFAULT_MAX_ATTEMPTS = 5;
+var DEFAULT_STALE_CLAIM_TTL_SEC = 300;
+function finitePositive(value, fallback) {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+class ResumeInjectionQueue {
+  inject;
+  scheduler;
+  retryMs;
+  confirmTimeoutMs;
+  maxAttempts;
+  log;
+  onInjectionAccepted;
+  onInjectionSuperseded;
+  onConfirmed;
+  onAbandoned;
+  entries = new Map;
+  constructor(options) {
+    this.inject = options.inject;
+    this.scheduler = options.scheduler ?? globalThis;
+    this.retryMs = finitePositive(options.retryMs, DEFAULT_RETRY_MS);
+    this.confirmTimeoutMs = finitePositive(options.confirmTimeoutMs, DEFAULT_CONFIRM_TIMEOUT_MS);
+    this.maxAttempts = finitePositive(options.maxAttempts, DEFAULT_MAX_ATTEMPTS);
+    this.log = options.log ?? (() => {});
+    this.onInjectionAccepted = options.onInjectionAccepted ?? (() => {});
+    this.onInjectionSuperseded = options.onInjectionSuperseded ?? (() => {});
+    this.onConfirmed = options.onConfirmed ?? (() => {});
+    this.onAbandoned = options.onAbandoned ?? (() => {});
+  }
+  get size() {
+    return this.entries.size;
+  }
+  get(resumeId) {
+    const entry = this.entries.get(resumeId);
+    if (!entry)
+      return;
+    const { retryTimer: _retryTimer, confirmTimer: _confirmTimer, claim: _claim, ...publicEntry } = entry;
+    return { ...publicEntry };
+  }
+  enqueue(input) {
+    if (this.entries.has(input.resumeId)) {
+      this.log(`resume injection deduped: ${input.resumeId}`);
+      try {
+        input.claim?.release();
+      } catch (error) {
+        this.log(`resume claim release failed (${input.resumeId} dedup): ${error instanceof Error ? error.message : String(error)}`);
+      }
+      return;
+    }
+    this.entries.set(input.resumeId, {
+      resumeId: input.resumeId,
+      prompt: input.prompt ?? RESUME_PROMPT,
+      state: "pending",
+      attempts: 0,
+      ...input.claim ? { claim: input.claim } : {}
+    });
+    this.tryInjectNext();
+  }
+  onTurnDrained() {
+    this.tryInjectNext();
+  }
+  stop() {
+    for (const entry of this.entries.values()) {
+      const requestId = entry.injectionId;
+      this.clearRetryTimer(entry);
+      this.clearConfirmTimer(entry);
+      if (requestId !== undefined) {
+        this.onInjectionSuperseded({ resumeId: entry.resumeId, requestId, reason: "stop" });
+      }
+      try {
+        entry.claim?.release();
+      } catch (error) {
+        this.log(`resume claim release failed (${entry.resumeId}): ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    this.entries.clear();
+  }
+  onTurnTrackingReset() {
+    for (const entry of [...this.entries.values()]) {
+      if (entry.state === "awaiting_confirm") {
+        this.supersedeAwaiting(entry, "turn_tracking_reset");
+      } else if (entry.state === "pending") {
+        this.clearRetryTimer(entry);
+      } else {
+        continue;
+      }
+      this.countRealAttemptOrAbandon(entry, "turn tracking reset before turn/start confirmation");
+    }
+  }
+  onBridgeTurnStarted(event) {
+    const entry = this.entries.get(event.resumeId);
+    if (!entry || entry.state !== "awaiting_confirm" || entry.injectionId !== event.requestId)
+      return;
+    this.clearConfirmTimer(entry);
+    try {
+      entry.claim?.consume();
+    } catch (error) {
+      this.log(`resume claim consume failed (${event.resumeId}): ${error instanceof Error ? error.message : String(error)}`);
+    }
+    this.entries.delete(event.resumeId);
+    this.onConfirmed({ resumeId: event.resumeId, requestId: event.requestId, turnId: event.turnId });
+    this.tryInjectNext();
+  }
+  onBridgeTurnRejected(event) {
+    const entry = this.entries.get(event.resumeId);
+    if (!entry || entry.state !== "awaiting_confirm" || entry.injectionId !== event.requestId)
+      return;
+    this.supersedeAwaiting(entry, "bridge_rejected");
+    this.countRealAttemptOrAbandon(entry, event.error);
+  }
+  tryInjectNext() {
+    for (const entry of this.entries.values()) {
+      if (entry.state === "awaiting_confirm")
+        return;
+    }
+    for (const entry of this.entries.values()) {
+      if (entry.state !== "pending")
+        continue;
+      this.clearRetryTimer(entry);
+      let requestId;
+      try {
+        requestId = this.inject(entry.prompt);
+      } catch (error) {
+        this.countRealAttemptOrAbandon(entry, error instanceof Error ? error.message : String(error));
+        return;
+      }
+      if (requestId === null) {
+        this.scheduleRetry(entry);
+        return;
+      }
+      entry.state = "awaiting_confirm";
+      entry.injectionId = requestId;
+      this.onInjectionAccepted({ resumeId: entry.resumeId, requestId });
+      this.scheduleConfirmTimeout(entry);
+      return;
+    }
+  }
+  countRealAttemptOrAbandon(entry, reason) {
+    entry.attempts += 1;
+    if (entry.attempts >= this.maxAttempts) {
+      this.abandon(entry, reason);
+      return;
+    }
+    this.scheduleRetry(entry);
+  }
+  abandon(entry, reason) {
+    this.clearRetryTimer(entry);
+    this.clearConfirmTimer(entry);
+    this.entries.delete(entry.resumeId);
+    try {
+      entry.claim?.release();
+    } catch (error) {
+      this.log(`resume claim release failed (${entry.resumeId}): ${error instanceof Error ? error.message : String(error)}`);
+    }
+    this.onAbandoned({ resumeId: entry.resumeId, reason });
+    this.tryInjectNext();
+  }
+  supersedeAwaiting(entry, reason) {
+    this.clearConfirmTimer(entry);
+    const requestId = entry.injectionId;
+    delete entry.injectionId;
+    entry.state = "pending";
+    if (requestId !== undefined) {
+      this.onInjectionSuperseded({ resumeId: entry.resumeId, requestId, reason });
+    }
+  }
+  scheduleRetry(entry) {
+    if (!this.entries.has(entry.resumeId))
+      return;
+    this.clearRetryTimer(entry);
+    entry.retryTimer = this.scheduler.setTimeout(() => {
+      delete entry.retryTimer;
+      this.tryInjectNext();
+    }, this.retryMs);
+    entry.retryTimer?.unref?.();
+  }
+  scheduleConfirmTimeout(entry) {
+    this.clearConfirmTimer(entry);
+    entry.confirmTimer = this.scheduler.setTimeout(() => {
+      delete entry.confirmTimer;
+      if (entry.state !== "awaiting_confirm")
+        return;
+      this.supersedeAwaiting(entry, "confirm_timeout");
+      this.countRealAttemptOrAbandon(entry, "turn/start confirmation timed out");
+    }, this.confirmTimeoutMs);
+    entry.confirmTimer?.unref?.();
+  }
+  clearRetryTimer(entry) {
+    if (entry.retryTimer === undefined)
+      return;
+    this.scheduler.clearTimeout(entry.retryTimer);
+    delete entry.retryTimer;
+  }
+  clearConfirmTimer(entry) {
+    if (entry.confirmTimer === undefined)
+      return;
+    this.scheduler.clearTimeout(entry.confirmTimer);
+    delete entry.confirmTimer;
+  }
+}
+function realpathOrRaw(path) {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+function sha2562(value) {
+  return createHash2("sha256").update(value).digest("hex");
+}
+function writeJsonWx(path, value) {
+  let fd;
+  try {
+    fd = openSync3(path, "wx", 384);
+  } catch (error) {
+    if (error?.code === "EEXIST")
+      return false;
+    throw error;
+  }
+  try {
+    writeFileSync3(fd, JSON.stringify(value, null, 2));
+  } finally {
+    closeSync3(fd);
+  }
+  return true;
+}
+function unlinkIfExists(path) {
+  try {
+    unlinkSync4(path);
+  } catch (error) {
+    if (error?.code === "ENOENT")
+      return;
+    throw error;
+  }
+}
+function readClaimedAt(path) {
+  try {
+    const parsed = JSON.parse(readFileSync5(path, "utf-8"));
+    const claimedAt = parsed?.claimed_at;
+    return typeof claimedAt === "number" && Number.isFinite(claimedAt) ? claimedAt : null;
+  } catch {
+    return null;
+  }
+}
+function tryClaimPendingResume(opts) {
+  const now = opts.now ?? (() => Math.floor(Date.now() / 1000));
+  const claimTtlSec = finitePositive(opts.claimTtlSec, DEFAULT_STALE_CLAIM_TTL_SEC);
+  const cwd = realpathOrRaw(opts.pending.cwd);
+  const sourcePath = opts.pending.sourcePath ?? "";
+  const contentHash = opts.pending.contentHash ?? "";
+  const identity = sha2562([
+    opts.agent,
+    opts.pending.sessionId,
+    cwd,
+    contentHash
+  ].join("\x00"));
+  const claimsDir = join7(opts.stateDir, "claims");
+  const consumedDir = join7(opts.stateDir, "consumed");
+  const claimPath = join7(claimsDir, `${identity}.json`);
+  const consumedPath = join7(consumedDir, `${identity}.json`);
+  mkdirSync5(claimsDir, { recursive: true });
+  mkdirSync5(consumedDir, { recursive: true });
+  if (existsSync6(consumedPath))
+    return { ok: false, reason: "consumed" };
+  const nowSec = now();
+  if (existsSync6(claimPath)) {
+    const claimedAt = readClaimedAt(claimPath);
+    if (claimedAt !== null && nowSec - claimedAt > claimTtlSec) {
+      try {
+        unlinkIfExists(claimPath);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        opts.log?.(`stale resume claim cleanup failed: ${message}`);
+        return { ok: false, reason: "error", error: message };
+      }
+    } else {
+      return { ok: false, reason: "claimed" };
+    }
+  }
+  const payload = {
+    identity,
+    agent: opts.agent,
+    session_id: opts.pending.sessionId,
+    cwd,
+    pending_path: sourcePath,
+    pending_hash: contentHash,
+    checkpoint_path: opts.checkpointPath,
+    claimed_at: nowSec
+  };
+  try {
+    if (!writeJsonWx(claimPath, payload))
+      return { ok: false, reason: "claimed" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    opts.log?.(`resume claim failed: ${message}`);
+    return { ok: false, reason: "error", error: message };
+  }
+  return {
+    ok: true,
+    claim: {
+      identity,
+      claimPath,
+      consumedPath,
+      consume: () => {
+        mkdirSync5(consumedDir, { recursive: true });
+        writeFileSync3(consumedPath, JSON.stringify({ ...payload, consumed_at: now() }, null, 2));
+        unlinkIfExists(claimPath);
+      },
+      release: () => {
+        unlinkIfExists(claimPath);
+      }
+    }
+  };
+}
+
 // src/daemon-identity-ownership.ts
-import { readFileSync as readFileSync5 } from "fs";
-var defaultRead2 = (path) => readFileSync5(path, "utf-8");
+import { readFileSync as readFileSync6 } from "fs";
+var defaultRead2 = (path) => readFileSync6(path, "utf-8");
 function pidFileOwnedByUs(pidFilePath, ourPid, read = defaultRead2) {
   let raw;
   try {
@@ -5125,12 +5470,12 @@ class ReplyRequiredTracker {
 
 // src/thread-state.ts
 import {
-  existsSync as existsSync6,
+  existsSync as existsSync7,
   readdirSync,
-  readFileSync as readFileSync6
+  readFileSync as readFileSync7
 } from "fs";
 import { homedir as homedir3 } from "os";
-import { basename as basename2, join as join7 } from "path";
+import { basename as basename2, join as join8 } from "path";
 function nowIso() {
   return new Date().toISOString();
 }
@@ -5139,11 +5484,11 @@ function threadTag(identity) {
   return `abg:${name}:${identity.cwd}`;
 }
 function codexHome(env = process.env) {
-  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join7(homedir3(), ".codex");
+  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join8(homedir3(), ".codex");
 }
 function readRawCurrentThread(stateDir) {
   try {
-    const parsed = JSON.parse(readFileSync6(stateDir.currentThreadFile, "utf-8"));
+    const parsed = JSON.parse(readFileSync7(stateDir.currentThreadFile, "utf-8"));
     if (parsed?.version === 1 && typeof parsed.threadId === "string" && parsed.threadId.length > 0 && (parsed.status === "pending" || parsed.status === "current") && typeof parsed.cwd === "string") {
       return parsed;
     }
@@ -5151,8 +5496,8 @@ function readRawCurrentThread(stateDir) {
   return null;
 }
 function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
-  const sessionsDir = join7(codexHome(env), "sessions");
-  if (!threadId || !existsSync6(sessionsDir))
+  const sessionsDir = join8(codexHome(env), "sessions");
+  if (!threadId || !existsSync7(sessionsDir))
     return null;
   const exactName = `rollout-${threadId}.jsonl`;
   const stack = [sessionsDir];
@@ -5167,7 +5512,7 @@ function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
     }
     for (const entry of entries) {
       visited++;
-      const path = join7(dir, entry.name);
+      const path = join8(dir, entry.name);
       if (entry.isDirectory()) {
         stack.push(path);
         continue;
@@ -5356,6 +5701,9 @@ var BOOTSTRAP_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_BOOTSTRAP_TIMEOUT_MS
 var CODEX_BOOT_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_CODEX_BOOT_RETRIES", 2);
 var ALLOW_IDENTITYLESS_CLIENT = process.env.AGENTBRIDGE_COMPAT_IDENTITYLESS === "1";
 var BUDGET_CONFIG = applyBudgetEnvOverrides(config.budget);
+var RESUME_INJECT_RETRY_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_INJECT_RETRY_MS", 5000, log);
+var RESUME_CONFIRM_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_CONFIRM_TIMEOUT_MS", 60000, log);
+var RESUME_INJECT_MAX_ATTEMPTS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_INJECT_MAX_ATTEMPTS", 5, log);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var DAEMON_NONCE = randomUUID4();
 var DAEMON_STARTED_AT = Date.now();
@@ -5373,6 +5721,28 @@ var inAttentionWindow = false;
 var replyTracker = new ReplyRequiredTracker;
 var idempotencyTracker = new IdempotencyTracker;
 var pendingTurnStarts = new Map;
+var pendingResumeTurnStarts = new Map;
+var resumeInjectionQueue = new ResumeInjectionQueue({
+  inject: (prompt) => codex.injectMessage(prompt),
+  retryMs: RESUME_INJECT_RETRY_MS,
+  confirmTimeoutMs: RESUME_CONFIRM_TIMEOUT_MS,
+  maxAttempts: RESUME_INJECT_MAX_ATTEMPTS,
+  log,
+  onInjectionAccepted: ({ resumeId, requestId }) => {
+    pendingResumeTurnStarts.set(requestId, { resumeId });
+    log(`Budget resume injection accepted: ${resumeId} \u2192 request ${requestId}`);
+  },
+  onInjectionSuperseded: ({ resumeId, requestId, reason }) => {
+    pendingResumeTurnStarts.delete(requestId);
+    log(`Budget resume injection superseded: ${resumeId} request ${requestId} (${reason})`);
+  },
+  onConfirmed: ({ resumeId, requestId, turnId }) => {
+    log(`Budget resume injection confirmed: ${resumeId} request ${requestId} \u2192 turn ${turnId}`);
+  },
+  onAbandoned: ({ resumeId, reason }) => {
+    log(`Budget resume injection abandoned: ${resumeId}: ${reason}`);
+  }
+});
 var pendingSteerDispatches = new Map;
 var BUSY_RETRY_ADVISORY_MS = 15000;
 var shuttingDown = false;
@@ -5401,10 +5771,20 @@ var budgetCoordinator = null;
 function pairCwd() {
   const raw = process.cwd();
   try {
-    return realpathSync(raw);
+    return realpathSync2(raw);
   } catch {
     return raw;
   }
+}
+function budgetGuardStateDir() {
+  const override = process.env.BUDGET_STATE_DIR;
+  if (override && override.trim() !== "")
+    return override.trim();
+  return join9(homedir4(), ".budget-guard");
+}
+function resumeClaimTtlSec() {
+  const totalMs = RESUME_CONFIRM_TIMEOUT_MS * RESUME_INJECT_MAX_ATTEMPTS + RESUME_INJECT_RETRY_MS * Math.max(0, RESUME_INJECT_MAX_ATTEMPTS - 1);
+  return Math.max(1, Math.ceil(totalMs / 1000));
 }
 function readResumeSignals() {
   let tuiReadyCodex = false;
@@ -5421,25 +5801,66 @@ function readResumeSignals() {
   }
   let pendingCodex = false;
   let pendingClaude = false;
+  let pendingCodexEntry;
+  let pendingClaudeEntry;
   try {
     const home = homedir4();
     const cwd = pairCwd();
-    pendingCodex = readGuardPending({ homeDir: home, agent: "codex", cwd, log }).length > 0;
-    pendingClaude = readGuardPending({ homeDir: home, agent: "claude", cwd, log }).length > 0;
+    pendingCodexEntry = readGuardPending({ homeDir: home, agent: "codex", cwd, log })[0];
+    pendingClaudeEntry = readGuardPending({ homeDir: home, agent: "claude", cwd, log })[0];
+    pendingCodex = pendingCodexEntry !== undefined;
+    pendingClaude = pendingClaudeEntry !== undefined;
   } catch (error) {
     log(`resume signal: pending read failed: ${error instanceof Error ? error.message : String(error)}`);
   }
   let checkpointExists = false;
+  let checkpointPath;
   try {
-    checkpointExists = existsSync7(join8(pairCwd(), ".agent", "checkpoint.md"));
+    checkpointPath = join9(pairCwd(), ".agent", "checkpoint.md");
+    checkpointExists = existsSync8(checkpointPath);
   } catch (error) {
     log(`resume signal: checkpoint stat failed: ${error instanceof Error ? error.message : String(error)}`);
+    checkpointPath = undefined;
   }
   return {
     tuiReady: { codex: tuiReadyCodex, claude: tuiReadyClaude },
     pendingExists: { codex: pendingCodex, claude: pendingClaude },
-    checkpointExists
+    pending: {
+      ...pendingCodexEntry ? { codex: pendingCodexEntry } : {},
+      ...pendingClaudeEntry ? { claude: pendingClaudeEntry } : {}
+    },
+    checkpointExists,
+    ...checkpointPath ? { checkpointPath } : {}
   };
+}
+function enqueueCodexBudgetResume(resumeId) {
+  const candidate = budgetCoordinator?.getResumeCandidate();
+  const detail = candidate?.detail?.codex;
+  if (candidate?.codex !== true || detail?.ready !== true) {
+    log(`Budget resume ${resumeId} ignored: Codex resume candidate is not ready`);
+    return;
+  }
+  if (!detail.pending) {
+    log(`Budget resume ${resumeId} ignored: missing Codex guard pending entry`);
+    return;
+  }
+  if (!detail.checkpointPath) {
+    log(`Budget resume ${resumeId} ignored: missing checkpoint path`);
+    return;
+  }
+  const claim = tryClaimPendingResume({
+    stateDir: budgetGuardStateDir(),
+    agent: "codex",
+    pending: detail.pending,
+    checkpointPath: detail.checkpointPath,
+    claimTtlSec: resumeClaimTtlSec(),
+    log
+  });
+  if (!claim.ok) {
+    log(`Budget resume ${resumeId} not enqueued: pending claim ${claim.reason}${claim.error ? ` (${claim.error})` : ""}`);
+    return;
+  }
+  resumeInjectionQueue.enqueue({ resumeId, prompt: RESUME_PROMPT, claim: claim.claim });
 }
 function ensureBudgetCoordinatorStarted() {
   if (!BUDGET_CONFIG.enabled)
@@ -5457,6 +5878,13 @@ function ensureBudgetCoordinatorStarted() {
       },
       onSnapshot: () => broadcastStatus(),
       log,
+      onResume: (side, _directive, resumeId) => {
+        if (side === "codex") {
+          enqueueCodexBudgetResume(resumeId);
+          return;
+        }
+        log(`Budget resume ${resumeId} for Claude side deferred to PR4`);
+      },
       resumeSignals: readResumeSignals
     });
   }
@@ -5516,6 +5944,12 @@ codex.on("steerAccepted", ({ requestId }) => {
   }
 });
 codex.on("bridgeTurnStarted", ({ requestId, turnId }) => {
+  const pendingResume = pendingResumeTurnStarts.get(requestId);
+  if (pendingResume) {
+    pendingResumeTurnStarts.delete(requestId);
+    resumeInjectionQueue.onBridgeTurnStarted({ resumeId: pendingResume.resumeId, requestId, turnId });
+    return;
+  }
   const pending = pendingTurnStarts.get(requestId);
   if (!pending) {
     log(`bridgeTurnStarted for unknown injection ${requestId} (turn ${turnId}) \u2014 correlation dropped`);
@@ -5537,6 +5971,12 @@ codex.on("bridgeTurnStarted", ({ requestId, turnId }) => {
   }
 });
 codex.on("bridgeTurnRejected", ({ requestId, error }) => {
+  const pendingResume = pendingResumeTurnStarts.get(requestId);
+  if (pendingResume) {
+    pendingResumeTurnStarts.delete(requestId);
+    resumeInjectionQueue.onBridgeTurnRejected({ resumeId: pendingResume.resumeId, requestId, error });
+    return;
+  }
   const pending = pendingTurnStarts.get(requestId);
   if (!pending)
     return;
@@ -5554,11 +5994,16 @@ codex.on("turnTrackingReset", (reason) => {
   if (pendingTurnStarts.size > 0) {
     log(`Cleared ${pendingTurnStarts.size} pending turn-start correlation(s) on turn tracking reset (${reason})`);
   }
+  if (pendingResumeTurnStarts.size > 0) {
+    log(`Cleared ${pendingResumeTurnStarts.size} pending resume turn-start correlation(s) on turn tracking reset (${reason})`);
+  }
   if (pendingSteerDispatches.size > 0) {
     log(`Cleared ${pendingSteerDispatches.size} pending steer dispatch(es) on turn tracking reset (${reason})`);
   }
   pendingTurnStarts.clear();
+  pendingResumeTurnStarts.clear();
   pendingSteerDispatches.clear();
+  resumeInjectionQueue.onTurnTrackingReset();
 });
 codex.on("turnStarted", () => {
   log("Codex turn started");
@@ -5603,6 +6048,7 @@ codex.on("turnCompleted", () => {
   }
   emitToClaude(systemMessage("system_turn_completed", "\u2705 Codex finished the current turn. You can reply now if needed."));
   startAttentionWindow();
+  resumeInjectionQueue.onTurnDrained();
 });
 codex.on("turnAborted", (reason) => {
   log(`Codex turn aborted (${reason}) \u2014 clearing reply-required state`);
@@ -5662,7 +6108,9 @@ codex.on("exit", (code) => {
   replyTracker.reset();
   idempotencyTracker.terminateAll("aborted");
   pendingTurnStarts.clear();
+  pendingResumeTurnStarts.clear();
   pendingSteerDispatches.clear();
+  resumeInjectionQueue.onTurnTrackingReset();
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
@@ -6425,6 +6873,7 @@ function shutdown(reason, exitCode = 0) {
   shuttingDown = true;
   log(`Shutting down daemon (${reason})...`);
   clearBootDeadline();
+  resumeInjectionQueue.stop();
   stopBudgetCoordinator();
   idempotencyTracker.dispose();
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -236,7 +236,13 @@ export class BudgetCoordinator {
       ? {
           ...rest,
           detail: Object.fromEntries(
-            Object.entries(detail).map(([side, value]) => [side, { ...value }]),
+            Object.entries(detail).map(([side, value]) => [
+              side,
+              {
+                ...value,
+                ...(value.pending ? { pending: { ...value.pending } } : {}),
+              },
+            ]),
           ) as ResumeCandidate["detail"],
         }
       : { ...rest };

--- a/src/budget/budget-fingerprint.ts
+++ b/src/budget/budget-fingerprint.ts
@@ -27,6 +27,7 @@
  */
 import { resumeBlockingEpoch } from "./budget-gate";
 import { isDecisionGrade } from "./budget-state";
+import type { PendingEntry } from "./pending-reader";
 import type { AgentName, AgentUsage, BudgetConfig, BudgetState } from "./types";
 
 /** Active side, identical to the old pauseSide() bijection over activeSides. */
@@ -133,8 +134,12 @@ export interface ResumeSignals {
   tuiReady: Record<AgentName, boolean>;
   /** Per-side: a guard-pending record for THIS agent, scoped to the current pair cwd, exists. */
   pendingExists: Record<AgentName, boolean>;
+  /** Per-side matched pending entry for claim/injection; present when pendingExists is true. */
+  pending?: Partial<Record<AgentName, PendingEntry>>;
   /** fs.existsSync(<pair cwd>/.agent/checkpoint.md) — shared across sides. */
   checkpointExists: boolean;
+  /** Absolute checkpoint path when checkpointExists is true. */
+  checkpointPath?: string;
 }
 
 /**
@@ -146,6 +151,10 @@ export interface ResumeSignals {
 export interface ResumeCandidateDetail {
   /** All four predicates held: window refreshed AND per-side signals AND checkpoint. */
   ready: boolean;
+  /** Matched guard pending entry for the evaluated side, carried for PR3 atomic claim. */
+  pending?: PendingEntry;
+  /** Shared checkpoint path carried so PR3 does not re-resolve it. */
+  checkpointPath?: string;
 }
 
 /**
@@ -454,7 +463,12 @@ export function computeResumeCandidate(
       signals.tuiReady[agent] &&
       signals.checkpointExists;
     candidate[agent] = ready;
-    detail[agent] = { ready };
+    const pending = signals.pending?.[agent];
+    detail[agent] = {
+      ready,
+      ...(pending ? { pending } : {}),
+      ...(signals.checkpointPath ? { checkpointPath: signals.checkpointPath } : {}),
+    };
   }
   if (sides.length > 0) candidate.detail = detail;
   return candidate;

--- a/src/budget/pending-reader.ts
+++ b/src/budget/pending-reader.ts
@@ -34,6 +34,7 @@
  * throwaway temp dir without touching the real HOME — the same injection seam
  * QuotaSource uses.
  */
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { asFiniteNumber, asRecord, numberOr } from "./quota-source";
 import type { AgentName } from "./types";
@@ -102,6 +103,10 @@ export interface PendingEntry {
   warnUtil: number;
   /** Epoch seconds (.at) the pause was written. */
   at: number;
+  /** Absolute path of the pending file this entry came from; empty for pure parser output. */
+  sourcePath: string;
+  /** sha256 of the trimmed pending file content; empty for pure parser output. */
+  contentHash: string;
 }
 
 /**
@@ -134,7 +139,11 @@ export function parsePendingPayload(value: unknown): PendingEntry | null {
     : null;
   if (agent === null) return null;
 
-  return { status, agent, sessionId, cwd, resetEpoch, util, warnUtil, at };
+  return { status, agent, sessionId, cwd, resetEpoch, util, warnUtil, at, sourcePath: "", contentHash: "" };
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 /** Resolve the guard state dir: BUDGET_STATE_DIR env override, else ~/.budget-guard. */
@@ -174,7 +183,9 @@ function readPendingFile(path: string, log: (msg: string) => void): PendingEntry
     return null;
   }
 
-  return parsePendingPayload(parsed);
+  const entry = parsePendingPayload(parsed);
+  if (!entry) return null;
+  return { ...entry, sourcePath: path, contentHash: sha256(text) };
 }
 
 /** List per-scope pending files for the agent: pending/<agent>_*.json. */

--- a/src/budget/resume-injection-queue.ts
+++ b/src/budget/resume-injection-queue.ts
@@ -1,0 +1,394 @@
+import { createHash } from "node:crypto";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { PendingEntry } from "./pending-reader";
+import type { AgentName } from "./types";
+import { RESUME_PROMPT } from "./resume-prompt";
+
+export type ResumeInjectionState = "pending" | "awaiting_confirm";
+
+export interface ResumeClaim {
+  identity: string;
+  claimPath: string;
+  consumedPath: string;
+  consume: () => void;
+  release: () => void;
+}
+
+export type ResumeClaimResult =
+  | { ok: true; claim: ResumeClaim }
+  | { ok: false; reason: "claimed" | "consumed" | "error"; error?: string };
+
+export interface ResumeInjectionEntry {
+  resumeId: string;
+  prompt: string;
+  state: ResumeInjectionState;
+  attempts: number;
+  injectionId?: number;
+  claim?: ResumeClaim;
+}
+
+export interface ResumeInjectionQueueOptions {
+  inject: (prompt: string) => number | null;
+  scheduler?: ResumeScheduler;
+  retryMs?: number;
+  confirmTimeoutMs?: number;
+  maxAttempts?: number;
+  log?: (message: string) => void;
+  onInjectionAccepted?: (event: { resumeId: string; requestId: number }) => void;
+  onInjectionSuperseded?: (event: { resumeId: string; requestId: number; reason: string }) => void;
+  onConfirmed?: (event: { resumeId: string; requestId: number; turnId: string }) => void;
+  onAbandoned?: (event: { resumeId: string; reason: string }) => void;
+}
+
+export interface ResumeScheduler {
+  setTimeout(callback: () => void, delayMs: number): unknown;
+  clearTimeout(timer: unknown): void;
+}
+
+interface InternalEntry extends ResumeInjectionEntry {
+  retryTimer?: unknown;
+  confirmTimer?: unknown;
+}
+
+const DEFAULT_RETRY_MS = 5_000;
+const DEFAULT_CONFIRM_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_STALE_CLAIM_TTL_SEC = 300;
+
+function finitePositive(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && value! > 0 ? Math.floor(value!) : fallback;
+}
+
+export class ResumeInjectionQueue {
+  private readonly inject: ResumeInjectionQueueOptions["inject"];
+  private readonly scheduler: ResumeScheduler;
+  private readonly retryMs: number;
+  private readonly confirmTimeoutMs: number;
+  private readonly maxAttempts: number;
+  private readonly log: (message: string) => void;
+  private readonly onInjectionAccepted: NonNullable<ResumeInjectionQueueOptions["onInjectionAccepted"]>;
+  private readonly onInjectionSuperseded: NonNullable<ResumeInjectionQueueOptions["onInjectionSuperseded"]>;
+  private readonly onConfirmed: NonNullable<ResumeInjectionQueueOptions["onConfirmed"]>;
+  private readonly onAbandoned: NonNullable<ResumeInjectionQueueOptions["onAbandoned"]>;
+  private readonly entries = new Map<string, InternalEntry>();
+
+  constructor(options: ResumeInjectionQueueOptions) {
+    this.inject = options.inject;
+    this.scheduler = options.scheduler ?? globalThis;
+    this.retryMs = finitePositive(options.retryMs, DEFAULT_RETRY_MS);
+    this.confirmTimeoutMs = finitePositive(options.confirmTimeoutMs, DEFAULT_CONFIRM_TIMEOUT_MS);
+    this.maxAttempts = finitePositive(options.maxAttempts, DEFAULT_MAX_ATTEMPTS);
+    this.log = options.log ?? (() => {});
+    this.onInjectionAccepted = options.onInjectionAccepted ?? (() => {});
+    this.onInjectionSuperseded = options.onInjectionSuperseded ?? (() => {});
+    this.onConfirmed = options.onConfirmed ?? (() => {});
+    this.onAbandoned = options.onAbandoned ?? (() => {});
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  get(resumeId: string): ResumeInjectionEntry | undefined {
+    const entry = this.entries.get(resumeId);
+    if (!entry) return undefined;
+    const { retryTimer: _retryTimer, confirmTimer: _confirmTimer, claim: _claim, ...publicEntry } = entry;
+    return { ...publicEntry };
+  }
+
+  enqueue(input: { resumeId: string; prompt?: string; claim?: ResumeClaim }): void {
+    if (this.entries.has(input.resumeId)) {
+      this.log(`resume injection deduped: ${input.resumeId}`);
+      try {
+        input.claim?.release();
+      } catch (error) {
+        this.log(`resume claim release failed (${input.resumeId} dedup): ${error instanceof Error ? error.message : String(error)}`);
+      }
+      return;
+    }
+    this.entries.set(input.resumeId, {
+      resumeId: input.resumeId,
+      prompt: input.prompt ?? RESUME_PROMPT,
+      state: "pending",
+      attempts: 0,
+      ...(input.claim ? { claim: input.claim } : {}),
+    });
+    this.tryInjectNext();
+  }
+
+  onTurnDrained(): void {
+    this.tryInjectNext();
+  }
+
+  stop(): void {
+    for (const entry of this.entries.values()) {
+      const requestId = entry.injectionId;
+      this.clearRetryTimer(entry);
+      this.clearConfirmTimer(entry);
+      if (requestId !== undefined) {
+        this.onInjectionSuperseded({ resumeId: entry.resumeId, requestId, reason: "stop" });
+      }
+      try {
+        entry.claim?.release();
+      } catch (error) {
+        this.log(`resume claim release failed (${entry.resumeId}): ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    this.entries.clear();
+  }
+
+  onTurnTrackingReset(): void {
+    for (const entry of [...this.entries.values()]) {
+      if (entry.state === "awaiting_confirm") {
+        this.supersedeAwaiting(entry, "turn_tracking_reset");
+      } else if (entry.state === "pending") {
+        this.clearRetryTimer(entry);
+      } else {
+        continue;
+      }
+      this.countRealAttemptOrAbandon(entry, "turn tracking reset before turn/start confirmation");
+    }
+  }
+
+  onBridgeTurnStarted(event: { resumeId: string; requestId: number; turnId: string }): void {
+    const entry = this.entries.get(event.resumeId);
+    if (!entry || entry.state !== "awaiting_confirm" || entry.injectionId !== event.requestId) return;
+    this.clearConfirmTimer(entry);
+    try {
+      entry.claim?.consume();
+    } catch (error) {
+      this.log(`resume claim consume failed (${event.resumeId}): ${error instanceof Error ? error.message : String(error)}`);
+    }
+    this.entries.delete(event.resumeId);
+    this.onConfirmed({ resumeId: event.resumeId, requestId: event.requestId, turnId: event.turnId });
+    this.tryInjectNext();
+  }
+
+  onBridgeTurnRejected(event: { resumeId: string; requestId: number; error: string }): void {
+    const entry = this.entries.get(event.resumeId);
+    if (!entry || entry.state !== "awaiting_confirm" || entry.injectionId !== event.requestId) return;
+    this.supersedeAwaiting(entry, "bridge_rejected");
+    this.countRealAttemptOrAbandon(entry, event.error);
+  }
+
+  private tryInjectNext(): void {
+    for (const entry of this.entries.values()) {
+      if (entry.state === "awaiting_confirm") return;
+    }
+    for (const entry of this.entries.values()) {
+      if (entry.state !== "pending") continue;
+      this.clearRetryTimer(entry);
+      let requestId: number | null;
+      try {
+        requestId = this.inject(entry.prompt);
+      } catch (error) {
+        this.countRealAttemptOrAbandon(entry, error instanceof Error ? error.message : String(error));
+        return;
+      }
+      if (requestId === null) {
+        this.scheduleRetry(entry);
+        return;
+      }
+      entry.state = "awaiting_confirm";
+      entry.injectionId = requestId;
+      this.onInjectionAccepted({ resumeId: entry.resumeId, requestId });
+      this.scheduleConfirmTimeout(entry);
+      return;
+    }
+  }
+
+  private countRealAttemptOrAbandon(entry: InternalEntry, reason: string): void {
+    entry.attempts += 1;
+    if (entry.attempts >= this.maxAttempts) {
+      this.abandon(entry, reason);
+      return;
+    }
+    this.scheduleRetry(entry);
+  }
+
+  private abandon(entry: InternalEntry, reason: string): void {
+    this.clearRetryTimer(entry);
+    this.clearConfirmTimer(entry);
+    this.entries.delete(entry.resumeId);
+    try {
+      entry.claim?.release();
+    } catch (error) {
+      this.log(`resume claim release failed (${entry.resumeId}): ${error instanceof Error ? error.message : String(error)}`);
+    }
+    this.onAbandoned({ resumeId: entry.resumeId, reason });
+    this.tryInjectNext();
+  }
+
+  private supersedeAwaiting(entry: InternalEntry, reason: string): void {
+    this.clearConfirmTimer(entry);
+    const requestId = entry.injectionId;
+    delete entry.injectionId;
+    entry.state = "pending";
+    if (requestId !== undefined) {
+      this.onInjectionSuperseded({ resumeId: entry.resumeId, requestId, reason });
+    }
+  }
+
+  private scheduleRetry(entry: InternalEntry): void {
+    if (!this.entries.has(entry.resumeId)) return;
+    this.clearRetryTimer(entry);
+    entry.retryTimer = this.scheduler.setTimeout(() => {
+      delete entry.retryTimer;
+      this.tryInjectNext();
+    }, this.retryMs);
+    (entry.retryTimer as { unref?: () => void } | undefined)?.unref?.();
+  }
+
+  private scheduleConfirmTimeout(entry: InternalEntry): void {
+    this.clearConfirmTimer(entry);
+    entry.confirmTimer = this.scheduler.setTimeout(() => {
+      delete entry.confirmTimer;
+      if (entry.state !== "awaiting_confirm") return;
+      this.supersedeAwaiting(entry, "confirm_timeout");
+      this.countRealAttemptOrAbandon(entry, "turn/start confirmation timed out");
+    }, this.confirmTimeoutMs);
+    (entry.confirmTimer as { unref?: () => void } | undefined)?.unref?.();
+  }
+
+  private clearRetryTimer(entry: InternalEntry): void {
+    if (entry.retryTimer === undefined) return;
+    this.scheduler.clearTimeout(entry.retryTimer);
+    delete entry.retryTimer;
+  }
+
+  private clearConfirmTimer(entry: InternalEntry): void {
+    if (entry.confirmTimer === undefined) return;
+    this.scheduler.clearTimeout(entry.confirmTimer);
+    delete entry.confirmTimer;
+  }
+}
+
+function realpathOrRaw(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function writeJsonWx(path: string, value: unknown): boolean {
+  let fd: number;
+  try {
+    fd = openSync(path, "wx", 0o600);
+  } catch (error: any) {
+    if (error?.code === "EEXIST") return false;
+    throw error;
+  }
+  try {
+    writeFileSync(fd, JSON.stringify(value, null, 2));
+  } finally {
+    closeSync(fd);
+  }
+  return true;
+}
+
+function unlinkIfExists(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+}
+
+function readClaimedAt(path: string): number | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    const claimedAt = parsed?.claimed_at;
+    return typeof claimedAt === "number" && Number.isFinite(claimedAt) ? claimedAt : null;
+  } catch {
+    return null;
+  }
+}
+
+export function tryClaimPendingResume(opts: {
+  stateDir: string;
+  agent: AgentName;
+  pending: PendingEntry;
+  checkpointPath: string;
+  claimTtlSec?: number;
+  now?: () => number;
+  log?: (message: string) => void;
+}): ResumeClaimResult {
+  const now = opts.now ?? (() => Math.floor(Date.now() / 1000));
+  const claimTtlSec = finitePositive(opts.claimTtlSec, DEFAULT_STALE_CLAIM_TTL_SEC);
+  const cwd = realpathOrRaw(opts.pending.cwd);
+  const sourcePath = opts.pending.sourcePath ?? "";
+  const contentHash = opts.pending.contentHash ?? "";
+  const identity = sha256([
+    opts.agent,
+    opts.pending.sessionId,
+    cwd,
+    contentHash,
+  ].join("\0"));
+  const claimsDir = join(opts.stateDir, "claims");
+  const consumedDir = join(opts.stateDir, "consumed");
+  const claimPath = join(claimsDir, `${identity}.json`);
+  const consumedPath = join(consumedDir, `${identity}.json`);
+  mkdirSync(claimsDir, { recursive: true });
+  mkdirSync(consumedDir, { recursive: true });
+
+  if (existsSync(consumedPath)) return { ok: false, reason: "consumed" };
+  const nowSec = now();
+
+  if (existsSync(claimPath)) {
+    const claimedAt = readClaimedAt(claimPath);
+    if (claimedAt !== null && nowSec - claimedAt > claimTtlSec) {
+      try {
+        unlinkIfExists(claimPath);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        opts.log?.(`stale resume claim cleanup failed: ${message}`);
+        return { ok: false, reason: "error", error: message };
+      }
+    } else {
+      return { ok: false, reason: "claimed" };
+    }
+  }
+
+  const payload = {
+    identity,
+    agent: opts.agent,
+    session_id: opts.pending.sessionId,
+    cwd,
+    pending_path: sourcePath,
+    pending_hash: contentHash,
+    checkpoint_path: opts.checkpointPath,
+    claimed_at: nowSec,
+  };
+
+  try {
+    if (!writeJsonWx(claimPath, payload)) return { ok: false, reason: "claimed" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    opts.log?.(`resume claim failed: ${message}`);
+    return { ok: false, reason: "error", error: message };
+  }
+
+  return {
+    ok: true,
+    claim: {
+      identity,
+      claimPath,
+      consumedPath,
+      consume: () => {
+        mkdirSync(consumedDir, { recursive: true });
+        writeFileSync(consumedPath, JSON.stringify({ ...payload, consumed_at: now() }, null, 2));
+        unlinkIfExists(claimPath);
+      },
+      release: () => {
+        unlinkIfExists(claimPath);
+      },
+    },
+  };
+}

--- a/src/budget/resume-prompt.ts
+++ b/src/budget/resume-prompt.ts
@@ -1,0 +1,2 @@
+export const RESUME_PROMPT =
+  "额度窗口已刷新，继续上次未完成的任务：从 .agent/checkpoint.md 的「下一步」接着做；完成后停下并标 DONE。";

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -23,6 +23,8 @@ import { BudgetCoordinator } from "./budget/budget-coordinator";
 import { createQuotaSource } from "./budget/quota-source";
 import { readGuardPending } from "./budget/pending-reader";
 import type { ResumeSignals } from "./budget/budget-fingerprint";
+import { ResumeInjectionQueue, tryClaimPendingResume } from "./budget/resume-injection-queue";
+import { RESUME_PROMPT } from "./budget/resume-prompt";
 import {
   CLOSE_CODE_REPLACED,
   CLOSE_CODE_EVICTED_STALE,
@@ -123,6 +125,9 @@ const CODEX_BOOT_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_CODEX_BOOT_RETRIES",
 const ALLOW_IDENTITYLESS_CLIENT = process.env.AGENTBRIDGE_COMPAT_IDENTITYLESS === "1";
 // Budget coordination config: file config normalized + AGENTBRIDGE_BUDGET_* env overlay.
 const BUDGET_CONFIG = applyBudgetEnvOverrides(config.budget);
+const RESUME_INJECT_RETRY_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_INJECT_RETRY_MS", 5000, log);
+const RESUME_CONFIRM_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_CONFIRM_TIMEOUT_MS", 60000, log);
+const RESUME_INJECT_MAX_ATTEMPTS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_INJECT_MAX_ATTEMPTS", 5, log);
 
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 
@@ -164,6 +169,28 @@ const pendingTurnStarts = new Map<
   number,
   { requestId: string; idempotencyKey?: string; threadId: string }
 >();
+const pendingResumeTurnStarts = new Map<number, { resumeId: string }>();
+const resumeInjectionQueue = new ResumeInjectionQueue({
+  inject: (prompt) => codex.injectMessage(prompt),
+  retryMs: RESUME_INJECT_RETRY_MS,
+  confirmTimeoutMs: RESUME_CONFIRM_TIMEOUT_MS,
+  maxAttempts: RESUME_INJECT_MAX_ATTEMPTS,
+  log,
+  onInjectionAccepted: ({ resumeId, requestId }) => {
+    pendingResumeTurnStarts.set(requestId, { resumeId });
+    log(`Budget resume injection accepted: ${resumeId} → request ${requestId}`);
+  },
+  onInjectionSuperseded: ({ resumeId, requestId, reason }) => {
+    pendingResumeTurnStarts.delete(requestId);
+    log(`Budget resume injection superseded: ${resumeId} request ${requestId} (${reason})`);
+  },
+  onConfirmed: ({ resumeId, requestId, turnId }) => {
+    log(`Budget resume injection confirmed: ${resumeId} request ${requestId} → turn ${turnId}`);
+  },
+  onAbandoned: ({ resumeId, reason }) => {
+    log(`Budget resume injection abandoned: ${resumeId}: ${reason}`);
+  },
+});
 // Transport-accepted steers awaiting their JSON-RPC verdict, keyed by the
 // bridge request id the adapter assigned (steerAccepted/steerFailed echo that
 // id). Keying by id — instead of a FIFO that assumes responses arrive in send
@@ -245,6 +272,19 @@ function pairCwd(): string {
   }
 }
 
+function budgetGuardStateDir(): string {
+  const override = process.env.BUDGET_STATE_DIR;
+  if (override && override.trim() !== "") return override.trim();
+  return join(homedir(), ".budget-guard");
+}
+
+function resumeClaimTtlSec(): number {
+  const totalMs =
+    RESUME_CONFIRM_TIMEOUT_MS * RESUME_INJECT_MAX_ATTEMPTS +
+    RESUME_INJECT_RETRY_MS * Math.max(0, RESUME_INJECT_MAX_ATTEMPTS - 1);
+  return Math.max(1, Math.ceil(totalMs / 1000));
+}
+
 /**
  * PR2 (detection only): gather the resume-readiness signals the coordinator's
  * pure reducer needs. ALL IO lives here so the reducer stays pure. Called once
@@ -279,28 +319,72 @@ function readResumeSignals(): ResumeSignals {
   // throws, but the cwd resolution and the call are still fault-isolated.
   let pendingCodex = false;
   let pendingClaude = false;
+  let pendingCodexEntry: ReturnType<typeof readGuardPending>[number] | undefined;
+  let pendingClaudeEntry: ReturnType<typeof readGuardPending>[number] | undefined;
   try {
     const home = homedir();
     const cwd = pairCwd();
-    pendingCodex = readGuardPending({ homeDir: home, agent: "codex", cwd, log }).length > 0;
-    pendingClaude = readGuardPending({ homeDir: home, agent: "claude", cwd, log }).length > 0;
+    pendingCodexEntry = readGuardPending({ homeDir: home, agent: "codex", cwd, log })[0];
+    pendingClaudeEntry = readGuardPending({ homeDir: home, agent: "claude", cwd, log })[0];
+    pendingCodex = pendingCodexEntry !== undefined;
+    pendingClaude = pendingClaudeEntry !== undefined;
   } catch (error) {
     log(`resume signal: pending read failed: ${error instanceof Error ? error.message : String(error)}`);
   }
 
   // checkpointExists: the handoff checkpoint under the pair's project dir.
   let checkpointExists = false;
+  let checkpointPath: string | undefined;
   try {
-    checkpointExists = existsSync(join(pairCwd(), ".agent", "checkpoint.md"));
+    checkpointPath = join(pairCwd(), ".agent", "checkpoint.md");
+    checkpointExists = existsSync(checkpointPath);
   } catch (error) {
     log(`resume signal: checkpoint stat failed: ${error instanceof Error ? error.message : String(error)}`);
+    checkpointPath = undefined;
   }
 
   return {
     tuiReady: { codex: tuiReadyCodex, claude: tuiReadyClaude },
     pendingExists: { codex: pendingCodex, claude: pendingClaude },
+    pending: {
+      ...(pendingCodexEntry ? { codex: pendingCodexEntry } : {}),
+      ...(pendingClaudeEntry ? { claude: pendingClaudeEntry } : {}),
+    },
     checkpointExists,
+    ...(checkpointPath ? { checkpointPath } : {}),
   };
+}
+
+function enqueueCodexBudgetResume(resumeId: string): void {
+  const candidate = budgetCoordinator?.getResumeCandidate();
+  const detail = candidate?.detail?.codex;
+  if (candidate?.codex !== true || detail?.ready !== true) {
+    log(`Budget resume ${resumeId} ignored: Codex resume candidate is not ready`);
+    return;
+  }
+  if (!detail.pending) {
+    log(`Budget resume ${resumeId} ignored: missing Codex guard pending entry`);
+    return;
+  }
+  if (!detail.checkpointPath) {
+    log(`Budget resume ${resumeId} ignored: missing checkpoint path`);
+    return;
+  }
+
+  const claim = tryClaimPendingResume({
+    stateDir: budgetGuardStateDir(),
+    agent: "codex",
+    pending: detail.pending,
+    checkpointPath: detail.checkpointPath,
+    claimTtlSec: resumeClaimTtlSec(),
+    log,
+  });
+  if (!claim.ok) {
+    log(`Budget resume ${resumeId} not enqueued: pending claim ${claim.reason}${claim.error ? ` (${claim.error})` : ""}`);
+    return;
+  }
+
+  resumeInjectionQueue.enqueue({ resumeId, prompt: RESUME_PROMPT, claim: claim.claim });
 }
 
 function ensureBudgetCoordinatorStarted() {
@@ -337,6 +421,14 @@ function ensureBudgetCoordinatorStarted() {
       },
       onSnapshot: () => broadcastStatus(),
       log,
+      onResume: (side, _directive, resumeId) => {
+        if (side === "codex") {
+          enqueueCodexBudgetResume(resumeId);
+          return;
+        }
+        // PR4 wires Claude channel resume + ack_resume. PR3 only owns Codex turn/start.
+        log(`Budget resume ${resumeId} for Claude side deferred to PR4`);
+      },
       // PR2 (detection only): daemon-side readiness signals for the resume
       // candidate. Pure-reducer purity is preserved by gathering all IO here —
       // the coordinator only reads the returned ResumeSignals. The closure
@@ -480,6 +572,13 @@ codex.on("steerAccepted", ({ requestId }: { requestId: number }) => {
 // --- Protocol v2 PR B: turn_started ACK + idempotency terminal wiring ---
 
 codex.on("bridgeTurnStarted", ({ requestId, turnId }: { requestId: number; turnId: string }) => {
+  const pendingResume = pendingResumeTurnStarts.get(requestId);
+  if (pendingResume) {
+    pendingResumeTurnStarts.delete(requestId);
+    resumeInjectionQueue.onBridgeTurnStarted({ resumeId: pendingResume.resumeId, requestId, turnId });
+    return;
+  }
+
   const pending = pendingTurnStarts.get(requestId);
   if (!pending) {
     // Possible after a turnTrackingReset cleared the map while the response
@@ -504,6 +603,13 @@ codex.on("bridgeTurnStarted", ({ requestId, turnId }: { requestId: number; turnI
 });
 
 codex.on("bridgeTurnRejected", ({ requestId, error }: { requestId: number; error: string }) => {
+  const pendingResume = pendingResumeTurnStarts.get(requestId);
+  if (pendingResume) {
+    pendingResumeTurnStarts.delete(requestId);
+    resumeInjectionQueue.onBridgeTurnRejected({ resumeId: pendingResume.resumeId, requestId, error });
+    return;
+  }
+
   const pending = pendingTurnStarts.get(requestId);
   if (!pending) return;
   pendingTurnStarts.delete(requestId);
@@ -536,11 +642,16 @@ codex.on("turnTrackingReset", (reason: string) => {
   if (pendingTurnStarts.size > 0) {
     log(`Cleared ${pendingTurnStarts.size} pending turn-start correlation(s) on turn tracking reset (${reason})`);
   }
+  if (pendingResumeTurnStarts.size > 0) {
+    log(`Cleared ${pendingResumeTurnStarts.size} pending resume turn-start correlation(s) on turn tracking reset (${reason})`);
+  }
   if (pendingSteerDispatches.size > 0) {
     log(`Cleared ${pendingSteerDispatches.size} pending steer dispatch(es) on turn tracking reset (${reason})`);
   }
   pendingTurnStarts.clear();
+  pendingResumeTurnStarts.clear();
   pendingSteerDispatches.clear();
+  resumeInjectionQueue.onTurnTrackingReset();
 });
 
 codex.on("turnStarted", () => {
@@ -610,6 +721,7 @@ codex.on("turnCompleted", () => {
     ),
   );
   startAttentionWindow();
+  resumeInjectionQueue.onTurnDrained();
 });
 
 codex.on("turnAborted", (reason: string) => {
@@ -713,7 +825,9 @@ codex.on("exit", (code: number | null) => {
   // and per-injection correlation can never resolve (PR B).
   idempotencyTracker.terminateAll("aborted");
   pendingTurnStarts.clear();
+  pendingResumeTurnStarts.clear();
   pendingSteerDispatches.clear();
+  resumeInjectionQueue.onTurnTrackingReset();
   statusBuffer.flush("codex exited");
   tuiConnectionState.handleCodexExit();
   clearPendingClaudeDisconnect("Codex process exited");
@@ -1933,6 +2047,7 @@ function shutdown(reason: string, exitCode = 0) {
   shuttingDown = true;
   log(`Shutting down daemon (${reason})...`);
   clearBootDeadline();
+  resumeInjectionQueue.stop();
   stopBudgetCoordinator();
   idempotencyTracker.dispose();
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);

--- a/src/integration-test/daemon-wiring.test.ts
+++ b/src/integration-test/daemon-wiring.test.ts
@@ -5,6 +5,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -19,6 +20,7 @@ import { portsForSlot, type PairPorts } from "../pair-registry";
 import { readControlToken, resolveControlTokenPath } from "../control-token";
 import { CONTRACT_VERSION } from "../contract-version";
 import { installFakeCodex } from "./fixtures/fake-codex-install";
+import { RESUME_PROMPT } from "../budget/resume-prompt";
 
 const DAEMON_PATH = join(process.cwd(), "src", "daemon.ts");
 const DEFAULT_TEST_SLOT_START = 2500 + (process.pid % 500);
@@ -372,6 +374,99 @@ describe("daemon wiring", () => {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
   }, 45000);
+
+  test("budget resume with guard pending and checkpoint injects a Codex resume turn", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-budget-resume-fixture-"));
+    const probePath = join(fixtureRoot, "probe.sh");
+    const turnStartLog = join(fixtureRoot, "turn-starts.jsonl");
+    const guardStateDir = join(fixtureRoot, "budget-guard");
+    const readTurnStarts = (): Array<Record<string, any>> =>
+      existsSync(turnStartLog)
+        ? readFileSync(turnStartLog, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+        : [];
+    const writeUsage = (agent: "claude" | "codex", gateUtil: number) => {
+      writeFileSync(
+        join(fixtureRoot, `usage-${agent}.json`),
+        JSON.stringify({
+          ok: true,
+          util: gateUtil,
+          warn_util: gateUtil,
+          fetched_at: Math.floor(Date.now() / 1000),
+          buckets: [
+            { id: "five_hour", util: gateUtil, reset_epoch: Math.floor(Date.now() / 1000) + 600 },
+          ],
+        }),
+      );
+    };
+    writeUsage("claude", 10);
+    writeUsage("codex", 95);
+    writeFileSync(probePath, `#!/bin/sh\ncat "${fixtureRoot}/usage-$2.json"\n`, "utf-8");
+    chmodSync(probePath, 0o755);
+
+    try {
+      const harness = await startHarness({
+        pairId: "main-resumeabc",
+        pairName: "main",
+        extraEnv: {
+          AGENTBRIDGE_BUDGET_ENABLED: "1",
+          AGENTBRIDGE_QUOTA_PROBE: probePath,
+          AGENTBRIDGE_BUDGET_POLL_SECONDS: "5",
+          BUDGET_STATE_DIR: guardStateDir,
+          FAKE_APP_TURNSTART_LOG: turnStartLog,
+        },
+      });
+
+      mkdirSync(join(harness.cwd, ".agent"), { recursive: true });
+      writeFileSync(join(harness.cwd, ".agent", "checkpoint.md"), "# Checkpoint\n## 下一步\n1. continue\n", "utf-8");
+      mkdirSync(join(guardStateDir, "pending"), { recursive: true });
+      writeFileSync(
+        join(guardStateDir, "pending", "codex_scope.json"),
+        JSON.stringify({
+          status: "paused",
+          agent: "codex",
+          session_id: "sess-resume",
+          cwd: harness.cwd,
+          reset_epoch: Math.floor(Date.now() / 1000) + 600,
+          util: 95,
+          warn_util: 95,
+          at: Math.floor(Date.now() / 1000),
+        }),
+        "utf-8",
+      );
+
+      await harness.attachClaude();
+      await harness.connectTui();
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_budget_pause_"),
+        "system_budget_pause before resume injection",
+      );
+
+      writeUsage("codex", 5);
+      await waitFor(
+        () => readTurnStarts().length >= 1,
+        "resume turn/start after budget recovery",
+        400,
+        50,
+      );
+
+      const injected = readTurnStarts()[0]!;
+      expect(injected.threadId).toBe("thread-fake-1");
+      expect(injected.input[0].text).toContain(RESUME_PROMPT);
+      expect(injected.model).toBeUndefined();
+      expect(injected.effort).toBeUndefined();
+      expect(harness.statusMessages.some((m) => m.type === "turn_started")).toBe(false);
+
+      await waitFor(
+        () => existsSync(join(guardStateDir, "consumed")) && readdirSync(join(guardStateDir, "consumed")).length === 1,
+        "resume consumed marker",
+        80,
+        50,
+      );
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 60000);
 
   test("budget pause is visible without an attached Claude; STOP is buffered until attach", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-budget-buffer-fixture-"));

--- a/src/unit-test/pending-reader.test.ts
+++ b/src/unit-test/pending-reader.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -183,6 +184,18 @@ describe("readGuardPending — per-scope glob", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0].sessionId).toBe("sess-js-1");
     expect(entries[0].resetEpoch).toBe(1_900_000_000);
+  });
+
+  test("carries source path and content hash for atomic resume claims", () => {
+    const home = tempHome();
+    const payload = jsPending();
+    const path = writeScopePending(home, "claude", "abc123def4567890", payload);
+
+    const entries = readGuardPending({ homeDir: home, agent: "claude" });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].sourcePath).toBe(path);
+    expect(entries[0].contentHash).toBe(createHash("sha256").update(JSON.stringify(payload)).digest("hex"));
   });
 
   test("globs pending/<agent>_*.json for the requested agent only", () => {

--- a/src/unit-test/resume-candidate.test.ts
+++ b/src/unit-test/resume-candidate.test.ts
@@ -61,6 +61,19 @@ function signals(overrides: Partial<ResumeSignals> = {}): ResumeSignals {
   };
 }
 
+const codexPending = {
+  status: "paused",
+  agent: "codex" as const,
+  sessionId: "sess-codex",
+  cwd: "/repo/project",
+  resetEpoch: NOW + 3600,
+  util: 92,
+  warnUtil: 92,
+  at: NOW - 10,
+  sourcePath: "/tmp/budget/pending/codex_scope.json",
+  contentHash: "pending-hash",
+};
+
 const over = usage({ gateUtil: 95, warnUtil: 95, remaining: 5 });
 const healthy = usage();
 
@@ -101,6 +114,23 @@ describe("computeResumeCandidate — single side exits a pause (refresh poll)", 
     // Only the recovered side gets a per-side entry.
     expect(candidate.claude).toBeUndefined();
     expect(candidate.detail?.codex?.ready).toBe(true);
+  });
+
+  test("ready detail carries matched pending entry and checkpoint path for PR3 claim", () => {
+    const paused = enterPause("codex");
+    const { candidate } = pollCandidate(
+      paused,
+      healthy,
+      healthy,
+      signals({
+        pending: { codex: codexPending },
+        checkpointPath: "/repo/project/.agent/checkpoint.md",
+      }),
+    );
+
+    expect(candidate.codex).toBe(true);
+    expect(candidate.detail?.codex?.pending).toEqual(codexPending);
+    expect(candidate.detail?.codex?.checkpointPath).toBe("/repo/project/.agent/checkpoint.md");
   });
 
   test("claude paused (handoff), then refreshes → exit poll reports claude ready=true", () => {

--- a/src/unit-test/resume-injection-queue.test.ts
+++ b/src/unit-test/resume-injection-queue.test.ts
@@ -1,0 +1,582 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ResumeInjectionQueue,
+  tryClaimPendingResume,
+  type ResumeClaim,
+} from "../budget/resume-injection-queue";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PendingEntry } from "../budget/pending-reader";
+
+class FakeScheduler {
+  private nextId = 1;
+  timers = new Map<number, { callback: () => void; active: boolean; delayMs: number }>();
+
+  setTimeout(callback: () => void, delayMs: number): number {
+    const id = this.nextId++;
+    this.timers.set(id, { callback, active: true, delayMs });
+    return id;
+  }
+
+  clearTimeout(id: number): void {
+    const timer = this.timers.get(id);
+    if (timer) timer.active = false;
+  }
+
+  runNext(): void {
+    const next = [...this.timers.entries()].find(([, timer]) => timer.active);
+    if (!next) throw new Error("no active timer");
+    const [id, timer] = next;
+    timer.active = false;
+    this.timers.delete(id);
+    timer.callback();
+  }
+
+  activeCount(): number {
+    return [...this.timers.values()].filter((timer) => timer.active).length;
+  }
+}
+
+function entry(overrides: Partial<PendingEntry> = {}): PendingEntry {
+  return {
+    status: "paused",
+    agent: "codex",
+    sessionId: "sess-1",
+    cwd: "/repo/project",
+    resetEpoch: 1_700_010_000,
+    util: 92,
+    warnUtil: 92,
+    at: 1_700_000_000,
+    sourcePath: "/tmp/pending/codex_one.json",
+    contentHash: "hash-one",
+    ...overrides,
+  };
+}
+
+describe("ResumeInjectionQueue", () => {
+  test("soft inject null defers without counting attempts; turn drain retries once", () => {
+    const scheduler = new FakeScheduler();
+    const injected: string[] = [];
+    const accepted: Array<{ resumeId: string; requestId: number }> = [];
+    const queue = new ResumeInjectionQueue({
+      inject: (prompt) => {
+        injected.push(prompt);
+        return injected.length === 1 ? null : -10;
+      },
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+      onInjectionAccepted: (event) => accepted.push(event),
+    });
+
+    queue.enqueue({ resumeId: "system_budget_resume_1", prompt: "resume now" });
+    expect(injected).toEqual(["resume now"]);
+    expect(queue.get("system_budget_resume_1")?.attempts).toBe(0);
+    expect(accepted).toEqual([]);
+
+    queue.onTurnDrained();
+
+    expect(injected).toEqual(["resume now", "resume now"]);
+    expect(accepted).toEqual([{ resumeId: "system_budget_resume_1", requestId: -10 }]);
+    expect(queue.get("system_budget_resume_1")?.state).toBe("awaiting_confirm");
+  });
+
+  test("dedups by resumeId while preserving the first prompt", () => {
+    const prompts: string[] = [];
+    const released: string[] = [];
+    const queue = new ResumeInjectionQueue({
+      inject: (prompt) => {
+        prompts.push(prompt);
+        return null;
+      },
+      scheduler: new FakeScheduler(),
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+    });
+
+    queue.enqueue({ resumeId: "rid-1", prompt: "first" });
+    queue.enqueue({
+      resumeId: "rid-1",
+      prompt: "second",
+      claim: {
+        identity: "claim-dedup",
+        claimPath: "/tmp/claim-dedup.json",
+        consumedPath: "/tmp/consumed-dedup.json",
+        consume: () => {},
+        release: () => released.push("claim-dedup"),
+      },
+    });
+    queue.onTurnDrained();
+
+    expect(prompts).toEqual(["first", "first"]);
+    expect(queue.size).toBe(1);
+    expect(released).toEqual(["claim-dedup"]);
+  });
+
+  test("bridgeTurnStarted confirms the matching injection once and consumes the claim", () => {
+    const scheduler = new FakeScheduler();
+    const consumed: string[] = [];
+    const confirmed: string[] = [];
+    const claim: ResumeClaim = {
+      identity: "claim-1",
+      claimPath: "/tmp/claim.json",
+      consumedPath: "/tmp/consumed.json",
+      consume: () => consumed.push("claim-1"),
+      release: () => {},
+    };
+    const queue = new ResumeInjectionQueue({
+      inject: () => -11,
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+      onConfirmed: (event) => confirmed.push(`${event.resumeId}:${event.turnId}`),
+    });
+
+    queue.enqueue({ resumeId: "rid-2", prompt: "resume", claim });
+    queue.onBridgeTurnStarted({ resumeId: "rid-2", requestId: -11, turnId: "turn-1" });
+    queue.onBridgeTurnStarted({ resumeId: "rid-2", requestId: -11, turnId: "turn-1" });
+
+    expect(confirmed).toEqual(["rid-2:turn-1"]);
+    expect(consumed).toEqual(["claim-1"]);
+    expect(queue.get("rid-2")).toBeUndefined();
+  });
+
+  test("bridgeTurnRejected counts as a real attempt and retries with a fresh request id", () => {
+    const scheduler = new FakeScheduler();
+    const accepted: Array<{ resumeId: string; requestId: number }> = [];
+    const ids = [-21, -22];
+    const queue = new ResumeInjectionQueue({
+      inject: () => ids.shift() ?? -99,
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+      onInjectionAccepted: (event) => accepted.push(event),
+    });
+
+    queue.enqueue({ resumeId: "rid-3", prompt: "resume" });
+    queue.onBridgeTurnRejected({ resumeId: "rid-3", requestId: -21, error: "turn/start rejected" });
+    scheduler.runNext();
+
+    expect(accepted).toEqual([
+      { resumeId: "rid-3", requestId: -21 },
+      { resumeId: "rid-3", requestId: -22 },
+    ]);
+    expect(queue.get("rid-3")?.attempts).toBe(1);
+    expect(queue.get("rid-3")?.state).toBe("awaiting_confirm");
+  });
+
+  test("stale bridge events and turn tracking reset do not cross-confirm a newer injection", () => {
+    const scheduler = new FakeScheduler();
+    const confirmed: string[] = [];
+    const superseded: Array<{ resumeId: string; requestId: number; reason: string }> = [];
+    const queue = new ResumeInjectionQueue({
+      inject: () => -31,
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+      onConfirmed: (event) => confirmed.push(event.resumeId),
+      onInjectionSuperseded: (event) => superseded.push(event),
+    });
+
+    queue.enqueue({ resumeId: "rid-4", prompt: "resume" });
+    queue.onBridgeTurnStarted({ resumeId: "rid-4", requestId: -99, turnId: "stale" });
+    expect(confirmed).toEqual([]);
+
+    queue.onTurnTrackingReset();
+    expect(queue.get("rid-4")?.state).toBe("pending");
+    expect(queue.get("rid-4")?.attempts).toBe(1);
+    expect(superseded).toEqual([{ resumeId: "rid-4", requestId: -31, reason: "turn_tracking_reset" }]);
+
+    queue.onBridgeTurnStarted({ resumeId: "rid-4", requestId: -31, turnId: "stale-after-reset" });
+    expect(confirmed).toEqual([]);
+  });
+
+  test("confirm timeout counts attempts, supersedes stale request ids, and abandons at maxAttempts", () => {
+    const scheduler = new FakeScheduler();
+    const injected: number[] = [];
+    const superseded: Array<{ resumeId: string; requestId: number; reason: string }> = [];
+    const abandoned: string[] = [];
+    const queue = new ResumeInjectionQueue({
+      inject: () => {
+        const requestId = -50 - injected.length;
+        injected.push(requestId);
+        return requestId;
+      },
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+      onInjectionSuperseded: (event) => superseded.push(event),
+      onAbandoned: (event) => abandoned.push(event.resumeId),
+    });
+
+    queue.enqueue({ resumeId: "rid-timeout", prompt: "resume" });
+    scheduler.runNext(); // confirm timeout for -50
+    scheduler.runNext(); // retry → inject -51
+    scheduler.runNext(); // confirm timeout for -51 → maxAttempts abandon
+
+    expect(injected).toEqual([-50, -51]);
+    expect(superseded).toEqual([
+      { resumeId: "rid-timeout", requestId: -50, reason: "confirm_timeout" },
+      { resumeId: "rid-timeout", requestId: -51, reason: "confirm_timeout" },
+    ]);
+    expect(abandoned).toEqual(["rid-timeout"]);
+    expect(queue.get("rid-timeout")).toBeUndefined();
+
+    expect(() => scheduler.runNext()).toThrow("no active timer");
+  });
+
+  test("turn tracking reset is bounded by maxAttempts", () => {
+    const scheduler = new FakeScheduler();
+    const abandoned: string[] = [];
+    const queue = new ResumeInjectionQueue({
+      inject: () => -61,
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 1,
+      onAbandoned: (event) => abandoned.push(event.resumeId),
+    });
+
+    queue.enqueue({ resumeId: "rid-reset", prompt: "resume" });
+    queue.onTurnTrackingReset();
+
+    expect(abandoned).toEqual(["rid-reset"]);
+    expect(queue.get("rid-reset")).toBeUndefined();
+  });
+
+  test("turn tracking reset bounds pending retry entries and releases their claim", () => {
+    const scheduler = new FakeScheduler();
+    const released: string[] = [];
+    const abandoned: string[] = [];
+    let injectCalls = 0;
+    const queue = new ResumeInjectionQueue({
+      inject: () => {
+        injectCalls += 1;
+        return null;
+      },
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 1,
+      onAbandoned: (event) => abandoned.push(event.resumeId),
+    });
+
+    queue.enqueue({
+      resumeId: "rid-pending-reset",
+      prompt: "resume",
+      claim: {
+        identity: "claim-pending-reset",
+        claimPath: "/tmp/claim-pending-reset.json",
+        consumedPath: "/tmp/consumed-pending-reset.json",
+        consume: () => {},
+        release: () => released.push("claim-pending-reset"),
+      },
+    });
+    expect(queue.get("rid-pending-reset")?.state).toBe("pending");
+    expect(scheduler.activeCount()).toBe(1);
+
+    queue.onTurnTrackingReset();
+
+    expect(abandoned).toEqual(["rid-pending-reset"]);
+    expect(released).toEqual(["claim-pending-reset"]);
+    expect(queue.get("rid-pending-reset")).toBeUndefined();
+    expect(scheduler.activeCount()).toBe(0);
+    expect(injectCalls).toBe(1);
+  });
+
+  test("serializes different resumeIds; second waits until first is confirmed", () => {
+    const scheduler = new FakeScheduler();
+    const injected: string[] = [];
+    const accepted: Array<{ resumeId: string; requestId: number }> = [];
+    const queue = new ResumeInjectionQueue({
+      inject: (prompt) => {
+        injected.push(prompt);
+        return -90 - injected.length;
+      },
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+      onInjectionAccepted: (event) => accepted.push(event),
+    });
+
+    queue.enqueue({ resumeId: "rid-serial-1", prompt: "first" });
+    queue.enqueue({ resumeId: "rid-serial-2", prompt: "second" });
+
+    expect(injected).toEqual(["first"]);
+    expect(accepted).toEqual([{ resumeId: "rid-serial-1", requestId: -91 }]);
+    expect(queue.get("rid-serial-1")?.state).toBe("awaiting_confirm");
+    expect(queue.get("rid-serial-2")?.state).toBe("pending");
+
+    queue.onBridgeTurnStarted({ resumeId: "rid-serial-1", requestId: -91, turnId: "turn-1" });
+
+    expect(injected).toEqual(["first", "second"]);
+    expect(accepted).toEqual([
+      { resumeId: "rid-serial-1", requestId: -91 },
+      { resumeId: "rid-serial-2", requestId: -92 },
+    ]);
+    expect(queue.get("rid-serial-1")).toBeUndefined();
+    expect(queue.get("rid-serial-2")?.state).toBe("awaiting_confirm");
+  });
+
+  test("maxAttempts abandons after real transport rejections", () => {
+    const scheduler = new FakeScheduler();
+    const abandoned: string[] = [];
+    const queue = new ResumeInjectionQueue({
+      inject: () => -41,
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 1,
+      onAbandoned: (event) => abandoned.push(event.resumeId),
+    });
+
+    queue.enqueue({ resumeId: "rid-5", prompt: "resume" });
+    queue.onBridgeTurnRejected({ resumeId: "rid-5", requestId: -41, error: "turn/start rejected" });
+
+    expect(abandoned).toEqual(["rid-5"]);
+    expect(queue.get("rid-5")).toBeUndefined();
+  });
+
+  test("abandon releases the claim so the same pending identity can be retried later", () => {
+    const scheduler = new FakeScheduler();
+    const released: string[] = [];
+    const claim: ResumeClaim = {
+      identity: "claim-release",
+      claimPath: "/tmp/claim-release.json",
+      consumedPath: "/tmp/consumed-release.json",
+      consume: () => {},
+      release: () => released.push("claim-release"),
+    };
+    const queue = new ResumeInjectionQueue({
+      inject: () => -71,
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 1,
+    });
+
+    queue.enqueue({ resumeId: "rid-release", prompt: "resume", claim });
+    queue.onBridgeTurnRejected({ resumeId: "rid-release", requestId: -71, error: "turn/start rejected" });
+
+    expect(released).toEqual(["claim-release"]);
+  });
+
+  test("get does not expose the live claim object", () => {
+    const scheduler = new FakeScheduler();
+    const released: string[] = [];
+    const claim: ResumeClaim = {
+      identity: "claim-private",
+      claimPath: "/tmp/claim-private.json",
+      consumedPath: "/tmp/consumed-private.json",
+      consume: () => {},
+      release: () => released.push("claim-private"),
+    };
+    const queue = new ResumeInjectionQueue({
+      inject: () => null,
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+    });
+
+    queue.enqueue({ resumeId: "rid-private", prompt: "resume", claim });
+
+    expect(queue.get("rid-private")?.claim).toBeUndefined();
+    expect(released).toEqual([]);
+  });
+
+  test("stop clears retry and confirm timers and releases in-flight claims", () => {
+    const scheduler = new FakeScheduler();
+    const released: string[] = [];
+    const superseded: Array<{ resumeId: string; requestId: number; reason: string }> = [];
+    const retryQueue = new ResumeInjectionQueue({
+      inject: () => null,
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+    });
+    retryQueue.enqueue({
+      resumeId: "rid-retry-stop",
+      prompt: "resume",
+      claim: {
+        identity: "claim-retry-stop",
+        claimPath: "/tmp/claim-retry-stop.json",
+        consumedPath: "/tmp/consumed-retry-stop.json",
+        consume: () => {},
+        release: () => released.push("claim-retry-stop"),
+      },
+    });
+    expect(scheduler.activeCount()).toBe(1);
+
+    retryQueue.stop();
+
+    expect(scheduler.activeCount()).toBe(0);
+    expect(retryQueue.size).toBe(0);
+    expect(released).toEqual(["claim-retry-stop"]);
+
+    const confirmQueue = new ResumeInjectionQueue({
+      inject: () => -81,
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+      onInjectionSuperseded: (event) => superseded.push(event),
+    });
+    confirmQueue.enqueue({
+      resumeId: "rid-confirm-stop",
+      prompt: "resume",
+      claim: {
+        identity: "claim-confirm-stop",
+        claimPath: "/tmp/claim-confirm-stop.json",
+        consumedPath: "/tmp/consumed-confirm-stop.json",
+        consume: () => {},
+        release: () => released.push("claim-confirm-stop"),
+      },
+    });
+    expect(scheduler.activeCount()).toBe(1);
+
+    confirmQueue.stop();
+
+    expect(scheduler.activeCount()).toBe(0);
+    expect(confirmQueue.size).toBe(0);
+    expect(superseded).toContainEqual({ resumeId: "rid-confirm-stop", requestId: -81, reason: "stop" });
+    expect(released).toEqual(["claim-retry-stop", "claim-confirm-stop"]);
+  });
+});
+
+describe("tryClaimPendingResume", () => {
+  test("atomically claims one pending identity and writes consumed marker on confirmation", () => {
+    const root = mkdtempSync(join(tmpdir(), "abg-resume-claim-"));
+    const project = join(root, "project");
+    const pendingPath = join(root, "pending-codex.json");
+    mkdirSync(project, { recursive: true });
+    writeFileSync(pendingPath, JSON.stringify({ session_id: "sess-claim" }), "utf-8");
+    try {
+      const pending = entry({
+        sessionId: "sess-claim",
+        cwd: project,
+        sourcePath: pendingPath,
+        contentHash: "hash-claim",
+      });
+
+      const first = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath: join(project, ".agent", "checkpoint.md"),
+        now: () => 1_700_000_000,
+      });
+      expect(first.ok).toBe(true);
+      if (!first.ok) throw new Error("expected claim");
+      expect(readFileSync(first.claim.claimPath, "utf-8")).toContain("sess-claim");
+
+      const second = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath: join(project, ".agent", "checkpoint.md"),
+        now: () => 1_700_000_001,
+      });
+      expect(second.ok).toBe(false);
+      if (second.ok) throw new Error("expected duplicate claim rejection");
+      expect(second.reason).toBe("claimed");
+
+      first.claim.consume();
+      const consumed = JSON.parse(readFileSync(first.claim.consumedPath, "utf-8"));
+      expect(consumed.identity).toBe(first.claim.identity);
+      expect(consumed.agent).toBe("codex");
+      expect(existsSync(first.claim.claimPath)).toBe(false);
+
+      const third = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath: join(project, ".agent", "checkpoint.md"),
+        now: () => 1_700_000_002,
+      });
+      expect(third.ok).toBe(false);
+      if (third.ok) throw new Error("expected consumed rejection");
+      expect(third.reason).toBe("consumed");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("release removes an abandoned claim so the same pending can be claimed again", () => {
+    const root = mkdtempSync(join(tmpdir(), "abg-resume-claim-release-"));
+    const project = join(root, "project");
+    mkdirSync(project, { recursive: true });
+    try {
+      const pending = entry({ cwd: project, sessionId: "sess-release", contentHash: "hash-release" });
+      const checkpointPath = join(project, ".agent", "checkpoint.md");
+      const first = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath,
+        now: () => 1_700_000_000,
+      });
+      expect(first.ok).toBe(true);
+      if (!first.ok) throw new Error("expected claim");
+      first.claim.release();
+      expect(existsSync(first.claim.claimPath)).toBe(false);
+
+      const second = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath,
+        now: () => 1_700_000_001,
+      });
+      expect(second.ok).toBe(true);
+      if (!second.ok) throw new Error("expected second claim");
+      expect(second.claim.identity).toBe(first.claim.identity);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("stale claim TTL self-heals a crashed claimant", () => {
+    const root = mkdtempSync(join(tmpdir(), "abg-resume-claim-stale-"));
+    const project = join(root, "project");
+    mkdirSync(project, { recursive: true });
+    try {
+      const pending = entry({ cwd: project, sessionId: "sess-stale", contentHash: "hash-stale" });
+      const checkpointPath = join(project, ".agent", "checkpoint.md");
+      const first = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath,
+        claimTtlSec: 10,
+        now: () => 1_700_000_000,
+      });
+      expect(first.ok).toBe(true);
+      if (!first.ok) throw new Error("expected claim");
+
+      const second = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath,
+        claimTtlSec: 10,
+        now: () => 1_700_000_011,
+      });
+      expect(second.ok).toBe(true);
+      if (!second.ok) throw new Error("expected stale claim recovery");
+      expect(second.claim.identity).toBe(first.claim.identity);
+      expect(readFileSync(second.claim.claimPath, "utf-8")).toContain("1700000011");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/unit-test/resume-prompt.test.ts
+++ b/src/unit-test/resume-prompt.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { RESUME_PROMPT } from "../budget/resume-prompt";
+
+describe("RESUME_PROMPT", () => {
+  test("points Codex at checkpoint next steps and DONE stop marker", () => {
+    expect(RESUME_PROMPT).toContain("额度窗口已刷新");
+    expect(RESUME_PROMPT).toContain(".agent/checkpoint.md");
+    expect(RESUME_PROMPT).toContain("下一步");
+    expect(RESUME_PROMPT).toContain("DONE");
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary
budget-auto-resume 的 **PR3**(建在 PR2/PR2.5 上):Codex 侧自动续接。`onResume(codex)` 触发 → `getResumeCandidate` gate(ready+pending+checkpoint)→ R6 atomic claim → `ResumeInjectionQueue` → `turn/start` 注入 → `bridgeTurnStarted` 确认。**仅 Codex 侧**(Claude 侧 ack_resume/channel = PR4)。

Codex-side auto-resume: queued, gated, atomically-claimed turn/start injection with bounded retry + full lifecycle cleanup.

## 改动 / Changes
- `resume-prompt.ts`(新,shared):`RESUME_PROMPT`(从 checkpoint 下一步继续)。
- `resume-injection-queue.ts`(新):pending/awaiting_confirm/confirmed 状态机;**single-flight 守卫**;null=soft-defer 不计 attempts;confirm-timeout/reject/throw 计 attempts→maxAttempts 优雅 abandon+release claim;`onTurnTrackingReset` 处理 pending+awaiting;`stop()` 清全 timer(daemon shutdown 调)+ unref;`onInjectionSuperseded` 清 map。
- R6 atomic claim:`claims/<identity>.json` open(wx)(identity=agent+session+realpath(cwd)+contentHash)+ stale-claim TTL + consume 删 claim 留 consumed marker。
- `daemon.ts`:onResume(codex/both)→gate+claim+enqueue(claude 分支 TODO=PR4);pendingResumeTurnStarts source 分流(不污染 pendingTurnStarts/idempotencyTracker/replyTracker)。
- `pending-reader.ts`:sourcePath/contentHash + candidate detail 富集(matched pending + checkpointPath)。

## Cross-review(最高风险 PR:部署后真往活的 Codex 注入)
**3 fix-cycle + 2 clean rounds**。逮出并修复:
- **CRITICAL**:confirm-timeout 无限重注入活的 Codex。
- **HIGH**:孤儿 claim 永久死锁;onTurnTrackingReset 跳 pending → codex 退出时 busy-loop/claim-leak;timer-leak open-handle hang(bun test 挂 5min)。
- **MEDIUM**:并发注入(缺 single-flight 守卫)。
连续两轮 0 confirmed REAL。

## Test plan
- `bun run typecheck` 干净;`/usr/bin/time -p bun test src`:**1392 pass / 0 fail,exit 0,~73s 无 hang、无残留进程**。
- `bun run build:plugin` + `verify:plugin-sync` in sync。

## Backlog(LOW,非阻塞)
- confirm-time tryInjectNext collision(turn/start response-vs-notification 顺序无文档保证;窄+经 onTurnDrained 自恢复;Option B=只在 onTurnDrained 注入;PR5 probe 实测 codex-rs 顺序定性)。
- onTurnTrackingReset 重入 latent fragility(今天无害:appServerWs reset 前 null)。
- consumed/ marker GC;enqueue-guard 分支测试覆盖。