### PR TITLE
feat(budget): Claude 侧额度自动续接 ack/重试/降级 / Claude-side budget auto-resume [skip release]

### DIFF
--- a/plugins/agentbridge/scripts/health-check.sh
+++ b/plugins/agentbridge/scripts/health-check.sh
@@ -19,6 +19,52 @@ if printf '%s' "$pair_id" | grep -Eq '^[A-Za-z0-9._-]+$'; then
   pair_arg=" --pair ${pair_id}"
 fi
 
+# ── PR4 §6: resume-ack degraded escape hatch ─────────────────────────────────
+# When the daemon's Claude-side ResumeAckTracker exhausts retries with no ack, it
+# drops a sentinel in the state dir. Surface it here BEFORE the cooldown gate so
+# a fresh session within the cooldown window still sees it (else it'd be eaten),
+# then CONSUME (delete) the sentinel so the notice shows exactly once.
+resolve_state_dir() {
+  if [ -n "${AGENTBRIDGE_STATE_DIR:-}" ]; then
+    printf '%s' "${AGENTBRIDGE_STATE_DIR}"
+    return
+  fi
+  case "$(uname -s 2>/dev/null)" in
+    Darwin)
+      printf '%s' "${HOME}/Library/Application Support/AgentBridge"
+      ;;
+    *)
+      local xdg="${XDG_STATE_HOME:-}"
+      if [ -n "$xdg" ]; then
+        printf '%s' "${xdg}/agentbridge"
+      else
+        printf '%s' "${HOME}/.local/state/agentbridge"
+      fi
+      ;;
+  esac
+}
+
+state_dir="$(resolve_state_dir)"
+resume_sentinel="${state_dir}/resume-ack-degraded.json"
+if [ -f "$resume_sentinel" ]; then
+  resume_id="$(grep -o '"resumeId"[[:space:]]*:[[:space:]]*"[^"]*"' "$resume_sentinel" 2>/dev/null | head -n1 | sed 's/.*"resumeId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+  rm -f "$resume_sentinel" 2>/dev/null || true
+  # Defense-in-depth (resume_id is daemon-controlled, but harden anyway): only
+  # interpolate it into the JSON heredoc if it matches the known-safe id charset
+  # (system_budget_claude_recovered_<seq> — a plain monotonic sequence, no salt;
+  # the salt lives in BridgeMessage.id, not in the resumeId the sentinel stores).
+  # Anything else (a corrupted or
+  # tampered sentinel carrying " or \) collapses to "unknown" so the emitted hook
+  # JSON can never be broken by the value — mirrors the pair_id guard above.
+  if ! printf '%s' "$resume_id" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+    resume_id="unknown"
+  fi
+  cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge: 上次额度刷新后的续接通知未被确认（resume_id=${resume_id:-unknown}），可能上一个会话已空闲或退出。请从 .agent/checkpoint.md 的「下一步」继续未完成的任务。"}}
+EOF
+  exit 0
+fi
+
 if ! command -v curl >/dev/null 2>&1; then
   exit 0
 fi

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14118,6 +14118,7 @@ class ClaudeAdapter extends EventEmitter {
   notificationIdPrefix;
   instanceId;
   replySender = null;
+  resumeAckHandler = null;
   logFile;
   logger;
   pendingMessages = [];
@@ -14168,6 +14169,9 @@ class ClaudeAdapter extends EventEmitter {
   setReplySender(sender) {
     this.replySender = sender;
   }
+  setResumeAckHandler(handler) {
+    this.resumeAckHandler = handler;
+  }
   getPendingMessageCount() {
     return this.pendingMessages.length;
   }
@@ -14195,7 +14199,8 @@ class ClaudeAdapter extends EventEmitter {
             user: "Codex",
             user_id: "codex",
             ts,
-            source_type: "codex"
+            source_type: "codex",
+            ...message.resumeId ? { resume_id: message.resumeId } : {}
           }
         }
       });
@@ -14368,6 +14373,25 @@ chat_id: ${this.sessionId}`);
             properties: {},
             required: []
           }
+        },
+        {
+          name: "ack_resume",
+          description: "ONLY for acknowledging a system_budget_resume directive (the budget window refreshed). NOT a general channel to Codex (use reply for that). This is an acknowledgement that you RECEIVED the resume directive \u2014 call it as soon as you see the notice, then continue the work; do NOT wait until the task is finished.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              resume_id: {
+                type: "string",
+                description: "The resume_id from the system_budget_resume notice (meta.resume_id)."
+              },
+              status: {
+                type: "string",
+                enum: ["resumed", "declined", "already_running"],
+                description: 'Acknowledgement outcome, recorded for observability only \u2014 all three values stop the resume re-push identically (the bridge takes no different downstream action for "declined"). "resumed" (default): you are resuming the task. "declined": you are not resuming. "already_running": you were already working and need no resume.'
+              }
+            },
+            required: ["resume_id"]
+          }
         }
       ]
     }));
@@ -14382,11 +14406,49 @@ chat_id: ${this.sessionId}`);
       if (name === "get_budget") {
         return this.handleGetBudget();
       }
+      if (name === "ack_resume") {
+        return this.handleAckResume(args);
+      }
       return {
         content: [{ type: "text", text: `Unknown tool: ${name}` }],
         isError: true
       };
     });
+  }
+  async handleAckResume(args) {
+    const resumeIdRaw = args?.resume_id;
+    if (typeof resumeIdRaw !== "string" || resumeIdRaw.length === 0) {
+      return {
+        content: [{ type: "text", text: "Error: missing required parameter 'resume_id'" }],
+        isError: true
+      };
+    }
+    if (resumeIdRaw.length > 128) {
+      return {
+        content: [{ type: "text", text: `Error: resume_id is too long (${resumeIdRaw.length} chars, max 128).` }],
+        isError: true
+      };
+    }
+    const statusRaw = args?.status;
+    if (statusRaw !== undefined && statusRaw !== "resumed" && statusRaw !== "declined" && statusRaw !== "already_running") {
+      return {
+        content: [{ type: "text", text: `Error: invalid status value ${JSON.stringify(statusRaw)} \u2014 use "resumed", "declined" or "already_running".` }],
+        isError: true
+      };
+    }
+    const status = typeof statusRaw === "string" ? statusRaw : "resumed";
+    if (!this.resumeAckHandler) {
+      this.log("No resume ack handler registered");
+      return {
+        content: [{ type: "text", text: "Error: bridge not initialized, cannot acknowledge resume." }],
+        isError: true
+      };
+    }
+    this.log(`ack_resume received (resume_id=${resumeIdRaw}, status=${status}, instance=${this.instanceId})`);
+    this.resumeAckHandler(resumeIdRaw, status);
+    return {
+      content: [{ type: "text", text: `Resume acknowledged (resume_id=${resumeIdRaw}, status=${status}).` }]
+    };
   }
   handleGetBudget() {
     this.log(`get_budget called (instance=${this.instanceId}, hasSnapshot=${this.budgetSnapshot !== null})`);
@@ -14512,10 +14574,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("2c8dc86", "source"),
+  commit: defineString("305fb62", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("907116a9cd8c", "source")
+  codeHash: defineString("6e6ae2f59324", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)
@@ -14780,6 +14842,9 @@ class DaemonClient extends EventEmitter2 {
       ...idempotencyKey ? { idempotencyKey } : {}
     });
     return pending;
+  }
+  sendAckResume(resumeId, status) {
+    this.send({ type: "ack_resume", resumeId, status });
   }
   attachSocketHandlers(ws, socketId) {
     ws.onmessage = (event) => {
@@ -16208,6 +16273,17 @@ claude.setReplySender(async (msg, requireReply, onBusy, idempotencyKey) => {
     };
   }
   return daemonClient.sendReply(msg, requireReply, onBusy, idempotencyKey);
+});
+claude.setResumeAckHandler((resumeId, status) => {
+  if (daemonDisabled) {
+    log(`Resume ack ${resumeId} (${status}) dropped \u2014 daemon disabled (${daemonDisabledReason ?? "killed"})`);
+    return;
+  }
+  try {
+    daemonClient.sendAckResume(resumeId, status);
+  } catch (err) {
+    log(`Resume ack ${resumeId} (${status}) send failed: ${err?.message ?? err}`);
+  }
 });
 daemonClient.on("turnStarted", ({ requestId, idempotencyKey, threadId, turnId }) => {
   log(`Codex turn started for reply ${requestId} (turn=${turnId}, thread=${threadId}` + `${idempotencyKey ? `, idempotencyKey=${idempotencyKey}` : ""})`);

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -5,7 +5,7 @@ var __require = import.meta.require;
 // src/daemon.ts
 import { existsSync as existsSync8, realpathSync as realpathSync2, rmSync as rmSync2 } from "fs";
 import { homedir as homedir4 } from "os";
-import { join as join9 } from "path";
+import { join as join10 } from "path";
 import { randomUUID as randomUUID4 } from "crypto";
 
 // src/contract-version.ts
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("2c8dc86", "source"),
+  commit: defineString("305fb62", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("907116a9cd8c", "source")
+  codeHash: defineString("6e6ae2f59324", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -4980,6 +4980,9 @@ import { join as join7 } from "path";
 
 // src/budget/resume-prompt.ts
 var RESUME_PROMPT = "\u989D\u5EA6\u7A97\u53E3\u5DF2\u5237\u65B0\uFF0C\u7EE7\u7EED\u4E0A\u6B21\u672A\u5B8C\u6210\u7684\u4EFB\u52A1\uFF1A\u4ECE .agent/checkpoint.md \u7684\u300C\u4E0B\u4E00\u6B65\u300D\u63A5\u7740\u505A\uFF1B\u5B8C\u6210\u540E\u505C\u4E0B\u5E76\u6807 DONE\u3002";
+function claudeResumePrompt(resumeId) {
+  return "\u989D\u5EA6\u7A97\u53E3\u5DF2\u5237\u65B0\u3002" + `\u8BF7\u5148\u8C03\u7528 ack_resume(resume_id="${resumeId}", status="resumed") \u786E\u8BA4\u5DF2\u6536\u5230\u672C\u901A\u77E5\uFF08ACK = \u5DF2\u63A5\u6536\uFF0C\u4E0D\u662F\u5B8C\u6210\uFF0C\u8BF7\u7ACB\u5373\u8C03\u7528\uFF0C\u4E0D\u8981\u7B49\u4EFB\u52A1\u505A\u5B8C\uFF09\uFF0C` + "\u518D\u4ECE .agent/checkpoint.md \u7684\u300C\u4E0B\u4E00\u6B65\u300D\u63A5\u7740\u505A\uFF1B\u5B8C\u6210\u540E\u505C\u4E0B\u5E76\u6807 DONE\u3002";
+}
 
 // src/budget/resume-injection-queue.ts
 var DEFAULT_RETRY_MS = 5000;
@@ -5300,6 +5303,124 @@ function tryClaimPendingResume(opts) {
   };
 }
 
+// src/budget/resume-ack-tracker.ts
+function finitePositive2(value, fallback) {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+class ResumeAckTracker {
+  push;
+  scheduler;
+  timeoutMs;
+  retries;
+  onDegraded;
+  entries = new Map;
+  deliverySeq = 0;
+  constructor(options) {
+    this.push = options.push;
+    this.scheduler = options.scheduler;
+    this.timeoutMs = finitePositive2(options.timeoutMs, 60000);
+    this.retries = finitePositive2(options.retries, 3);
+    this.onDegraded = options.onDegraded ?? (() => {});
+  }
+  get size() {
+    return this.entries.size;
+  }
+  get(resumeId) {
+    const entry = this.entries.get(resumeId);
+    if (!entry)
+      return;
+    const { timer: _timer, ...publicEntry } = entry;
+    return { ...publicEntry };
+  }
+  start(resumeId) {
+    if (this.entries.has(resumeId))
+      return;
+    const entry = { resumeId, attempts: 0, state: "awaiting_ack" };
+    this.entries.set(resumeId, entry);
+    this.pushAttempt(entry);
+    this.armTimer(entry);
+  }
+  ack(resumeId) {
+    const entry = this.entries.get(resumeId);
+    if (!entry)
+      return;
+    this.clearTimer(entry);
+    entry.state = "resumed";
+    this.entries.delete(resumeId);
+  }
+  stop() {
+    for (const entry of this.entries.values()) {
+      this.clearTimer(entry);
+    }
+    this.entries.clear();
+  }
+  pushAttempt(entry) {
+    const deliveryId = `${entry.resumeId}_retry${entry.attempts}_${++this.deliverySeq}`;
+    this.push({ resumeId: entry.resumeId, deliveryId, attempt: entry.attempts });
+  }
+  armTimer(entry) {
+    this.clearTimer(entry);
+    entry.timer = this.scheduler.setTimeout(() => {
+      delete entry.timer;
+      this.onTimeout(entry);
+    }, this.timeoutMs);
+    entry.timer?.unref?.();
+  }
+  onTimeout(entry) {
+    if (entry.state !== "awaiting_ack" || !this.entries.has(entry.resumeId))
+      return;
+    entry.attempts += 1;
+    if (entry.attempts >= this.retries) {
+      entry.state = "degraded";
+      this.entries.delete(entry.resumeId);
+      this.onDegraded(entry.resumeId);
+      return;
+    }
+    this.pushAttempt(entry);
+    this.armTimer(entry);
+  }
+  clearTimer(entry) {
+    if (entry.timer === undefined)
+      return;
+    this.scheduler.clearTimeout(entry.timer);
+    delete entry.timer;
+  }
+}
+
+// src/budget/route-resume.ts
+function routeResume(side, resumeId, deps) {
+  if (side === "codex") {
+    deps.enqueueCodex(resumeId);
+    return;
+  }
+  deps.claudeTracker.start(resumeId);
+}
+
+// src/budget/resume-ack-sentinel.ts
+import { renameSync as renameSync3, writeFileSync as writeFileSync4 } from "fs";
+import { join as join8 } from "path";
+var RESUME_ACK_DEGRADED_SENTINEL = "resume-ack-degraded.json";
+function resumeAckSentinelPath(stateDir) {
+  return join8(stateDir, RESUME_ACK_DEGRADED_SENTINEL);
+}
+function writeResumeAckDegradedSentinel(opts) {
+  const now = opts.now ?? (() => Date.now());
+  const payload = {
+    resumeId: opts.resumeId,
+    degradedAt: now()
+  };
+  const target = resumeAckSentinelPath(opts.stateDir);
+  const tmp = `${target}.${process.pid}.tmp`;
+  try {
+    writeFileSync4(tmp, JSON.stringify(payload, null, 2), { mode: 384 });
+    renameSync3(tmp, target);
+    opts.log?.(`Resume-ack degraded sentinel written: ${opts.resumeId}`);
+  } catch (err) {
+    opts.log?.(`Resume-ack degraded sentinel write failed (${opts.resumeId}): ${err?.message ?? err}`);
+  }
+}
+
 // src/daemon-identity-ownership.ts
 import { readFileSync as readFileSync6 } from "fs";
 var defaultRead2 = (path) => readFileSync6(path, "utf-8");
@@ -5475,7 +5596,7 @@ import {
   readFileSync as readFileSync7
 } from "fs";
 import { homedir as homedir3 } from "os";
-import { basename as basename2, join as join8 } from "path";
+import { basename as basename2, join as join9 } from "path";
 function nowIso() {
   return new Date().toISOString();
 }
@@ -5484,7 +5605,7 @@ function threadTag(identity) {
   return `abg:${name}:${identity.cwd}`;
 }
 function codexHome(env = process.env) {
-  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join8(homedir3(), ".codex");
+  return env.CODEX_HOME && env.CODEX_HOME.length > 0 ? env.CODEX_HOME : join9(homedir3(), ".codex");
 }
 function readRawCurrentThread(stateDir) {
   try {
@@ -5496,7 +5617,7 @@ function readRawCurrentThread(stateDir) {
   return null;
 }
 function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
-  const sessionsDir = join8(codexHome(env), "sessions");
+  const sessionsDir = join9(codexHome(env), "sessions");
   if (!threadId || !existsSync7(sessionsDir))
     return null;
   const exactName = `rollout-${threadId}.jsonl`;
@@ -5512,7 +5633,7 @@ function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
     }
     for (const entry of entries) {
       visited++;
-      const path = join8(dir, entry.name);
+      const path = join9(dir, entry.name);
       if (entry.isDirectory()) {
         stack.push(path);
         continue;
@@ -5704,6 +5825,8 @@ var BUDGET_CONFIG = applyBudgetEnvOverrides(config.budget);
 var RESUME_INJECT_RETRY_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_INJECT_RETRY_MS", 5000, log);
 var RESUME_CONFIRM_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_CONFIRM_TIMEOUT_MS", 60000, log);
 var RESUME_INJECT_MAX_ATTEMPTS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_INJECT_MAX_ATTEMPTS", 5, log);
+var RESUME_ACK_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_ACK_TIMEOUT_MS", 60000, log);
+var RESUME_ACK_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_RESUME_ACK_RETRIES", 3, log);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var DAEMON_NONCE = randomUUID4();
 var DAEMON_STARTED_AT = Date.now();
@@ -5743,6 +5866,30 @@ var resumeInjectionQueue = new ResumeInjectionQueue({
     log(`Budget resume injection abandoned: ${resumeId}: ${reason}`);
   }
 });
+var claudeResumeTracker = new ResumeAckTracker({
+  push: ({ resumeId, deliveryId, attempt }) => {
+    const message = {
+      id: `system_budget_resume_${SYSTEM_MSG_SALT}_${deliveryId}`,
+      source: "codex",
+      content: claudeResumePrompt(resumeId),
+      timestamp: Date.now(),
+      resumeId
+    };
+    log(`Budget resume push to Claude: ${resumeId} (attempt ${attempt}, delivery ${deliveryId})`);
+    emitToClaude(message);
+  },
+  scheduler: globalThis,
+  timeoutMs: RESUME_ACK_TIMEOUT_MS,
+  retries: RESUME_ACK_RETRIES,
+  onDegraded: (resumeId) => {
+    log(`Budget resume ${resumeId} degraded: no ack from Claude after ${RESUME_ACK_RETRIES} attempts`);
+    try {
+      writeResumeAckDegradedSentinel({ stateDir: stateDir.dir, resumeId, log });
+    } catch (err) {
+      log(`Resume degraded sentinel write failed (${resumeId}): ${err?.message ?? err}`);
+    }
+  }
+});
 var pendingSteerDispatches = new Map;
 var BUSY_RETRY_ADVISORY_MS = 15000;
 var shuttingDown = false;
@@ -5780,7 +5927,7 @@ function budgetGuardStateDir() {
   const override = process.env.BUDGET_STATE_DIR;
   if (override && override.trim() !== "")
     return override.trim();
-  return join9(homedir4(), ".budget-guard");
+  return join10(homedir4(), ".budget-guard");
 }
 function resumeClaimTtlSec() {
   const totalMs = RESUME_CONFIRM_TIMEOUT_MS * RESUME_INJECT_MAX_ATTEMPTS + RESUME_INJECT_RETRY_MS * Math.max(0, RESUME_INJECT_MAX_ATTEMPTS - 1);
@@ -5816,7 +5963,7 @@ function readResumeSignals() {
   let checkpointExists = false;
   let checkpointPath;
   try {
-    checkpointPath = join9(pairCwd(), ".agent", "checkpoint.md");
+    checkpointPath = join10(pairCwd(), ".agent", "checkpoint.md");
     checkpointExists = existsSync8(checkpointPath);
   } catch (error) {
     log(`resume signal: checkpoint stat failed: ${error instanceof Error ? error.message : String(error)}`);
@@ -5879,11 +6026,13 @@ function ensureBudgetCoordinatorStarted() {
       onSnapshot: () => broadcastStatus(),
       log,
       onResume: (side, _directive, resumeId) => {
-        if (side === "codex") {
-          enqueueCodexBudgetResume(resumeId);
-          return;
+        if (side === "claude") {
+          log(`Budget resume ${resumeId} for Claude side \u2192 arming ack tracker`);
         }
-        log(`Budget resume ${resumeId} for Claude side deferred to PR4`);
+        routeResume(side, resumeId, {
+          claudeTracker: claudeResumeTracker,
+          enqueueCodex: enqueueCodexBudgetResume
+        });
       },
       resumeSignals: readResumeSignals
     });
@@ -6219,6 +6368,10 @@ function handleControlMessage(ws, raw) {
       return;
     case "status":
       sendStatus(ws);
+      return;
+    case "ack_resume":
+      log(`Received ack_resume from Claude #${ws.data.clientId}: ${message.resumeId} (${message.status})`);
+      claudeResumeTracker.ack(message.resumeId);
       return;
     case "probe_incumbent":
       handleProbeIncumbent(ws).catch((err) => {
@@ -6874,6 +7027,7 @@ function shutdown(reason, exitCode = 0) {
   log(`Shutting down daemon (${reason})...`);
   clearBootDeadline();
   resumeInjectionQueue.stop();
+  claudeResumeTracker.stop();
   stopBudgetCoordinator();
   idempotencyTracker.dispose();
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -119,6 +119,24 @@ claude.setReplySender(async (
   return daemonClient.sendReply(msg, requireReply, onBusy, idempotencyKey);
 });
 
+// PR4: forward Claude's budget-resume ack to the daemon's ResumeAckTracker.
+// DELIBERATELY separate from setReplySender — an ack is a Claude→bridge
+// control-plane signal, NOT a Claude→Codex message. It must never travel
+// sendReply (no pause gate, no idempotency machine, no Codex turn injection).
+claude.setResumeAckHandler((resumeId: string, status: string) => {
+  if (daemonDisabled) {
+    log(`Resume ack ${resumeId} (${status}) dropped — daemon disabled (${daemonDisabledReason ?? "killed"})`);
+    return;
+  }
+  try {
+    daemonClient.sendAckResume(resumeId, status);
+  } catch (err: any) {
+    // Best-effort: a lost ack just means the daemon keeps re-pushing until it
+    // times out into degraded — no crash, no double-injection.
+    log(`Resume ack ${resumeId} (${status}) send failed: ${err?.message ?? err}`);
+  }
+});
+
 // turn_started ACK (protocol v2 PR B): logged for correlation forensics. The
 // reply tool's synchronous result already told the model its message was
 // accepted; the ACK confirms the turn actually started (the "Claude saw a

--- a/src/budget/resume-ack-sentinel.ts
+++ b/src/budget/resume-ack-sentinel.ts
@@ -1,0 +1,51 @@
+/**
+ * Resume-ack degraded sentinel (PR4 §6 — SessionStart escape hatch).
+ *
+ * When the Claude-side ResumeAckTracker exhausts its retries with no ack, the
+ * resume directive never reached an active Claude session (idle/dead session, or
+ * a session that ignored the channel push). The daemon drops a sentinel file in
+ * the state dir; the next SessionStart hook reads it and surfaces a recovery
+ * hint — BEFORE the health-check cooldown gate, so a fresh session within the
+ * cooldown window still sees it (otherwise the notice would be swallowed).
+ *
+ * The hook CONSUMES (deletes) the sentinel after surfacing it, so the notice is
+ * shown exactly once per degrade event. Writing is best-effort and atomic-ish
+ * (write to a temp path then rename) so a concurrent read never sees a partial
+ * file.
+ */
+
+import { renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const RESUME_ACK_DEGRADED_SENTINEL = "resume-ack-degraded.json";
+
+export interface ResumeAckDegradedSentinel {
+  resumeId: string;
+  degradedAt: number;
+}
+
+export function resumeAckSentinelPath(stateDir: string): string {
+  return join(stateDir, RESUME_ACK_DEGRADED_SENTINEL);
+}
+
+export function writeResumeAckDegradedSentinel(opts: {
+  stateDir: string;
+  resumeId: string;
+  now?: () => number;
+  log?: (message: string) => void;
+}): void {
+  const now = opts.now ?? (() => Date.now());
+  const payload: ResumeAckDegradedSentinel = {
+    resumeId: opts.resumeId,
+    degradedAt: now(),
+  };
+  const target = resumeAckSentinelPath(opts.stateDir);
+  const tmp = `${target}.${process.pid}.tmp`;
+  try {
+    writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 });
+    renameSync(tmp, target);
+    opts.log?.(`Resume-ack degraded sentinel written: ${opts.resumeId}`);
+  } catch (err: any) {
+    opts.log?.(`Resume-ack degraded sentinel write failed (${opts.resumeId}): ${err?.message ?? err}`);
+  }
+}

--- a/src/budget/resume-ack-tracker.ts
+++ b/src/budget/resume-ack-tracker.ts
@@ -1,0 +1,175 @@
+/**
+ * ResumeAckTracker — Claude-side auto-resume ack/retry state machine (PR4).
+ *
+ * Daemon-owned single source of truth for the "did Claude acknowledge the
+ * budget resume directive?" lifecycle. Unlike PR3's Codex ResumeInjectionQueue
+ * (which injects a turn into the Codex app-server), the Claude side is push-only:
+ * the daemon pushes a `system_budget_resume` channel notification carrying a
+ * stable `resumeId`, and waits for Claude to echo it back via the `ack_resume`
+ * MCP tool. If no ack arrives within `timeoutMs`, it re-pushes (a fresh
+ * deliveryId each time so the adapter's LRU dedup never drops the retry, while
+ * the resumeId stays stable so Claude's echo still correlates). After `retries`
+ * timeouts with no ack, the entry transitions to a terminal `degraded` state.
+ *
+ * Timer hygiene (PR3 timer-leak lesson): every timer is tracked and clearable;
+ * `stop()` clears all timers and empties the tracker (called on daemon
+ * shutdown); the production scheduler unrefs its timers so a pending ack window
+ * never keeps the process alive. Unit tests inject a fake scheduler — no real
+ * setTimeout is ever armed, so `bun test src` exits 0 with no open handles.
+ *
+ * Map hygiene: a terminal entry (acked → resumed, or retries-exhausted →
+ * degraded) is DELETED from the map immediately. The Map can therefore only ever
+ * hold entries that are actively awaiting an ack, so a long-lived daemon never
+ * accumulates dead entries. Idempotency is preserved by the unknown-id no-op
+ * path: a repeated/late ack for an already-removed resumeId hits `!entry` and is
+ * a silent no-op (exactly as it was when the entry was kept in a terminal state).
+ */
+
+import type { ResumeScheduler } from "./resume-injection-queue";
+
+export type ResumeAckState = "awaiting_ack" | "resumed" | "degraded";
+
+/** Payload handed to the push callback for one delivery attempt. */
+export interface ResumeAckPushEvent {
+  /** Stable correlation id — same across retries so Claude's echo matches. */
+  resumeId: string;
+  /** Per-attempt delivery id — UNIQUE per push so LRU dedup never drops it. */
+  deliveryId: string;
+  /** 0 on the first push; incremented on each timeout-driven re-push. */
+  attempt: number;
+}
+
+export interface ResumeAckEntry {
+  resumeId: string;
+  attempts: number;
+  state: ResumeAckState;
+}
+
+interface InternalEntry extends ResumeAckEntry {
+  timer?: unknown;
+}
+
+export interface ResumeAckTrackerOptions {
+  /** Push one delivery attempt of the resume directive to Claude. */
+  push: (event: ResumeAckPushEvent) => void;
+  /** Timer DI — shared with ResumeInjectionQueue ({ setTimeout, clearTimeout }). */
+  scheduler: ResumeScheduler;
+  /** Per-attempt ack window before a re-push fires. */
+  timeoutMs: number;
+  /** Number of timeouts tolerated before the entry degrades (terminal). */
+  retries: number;
+  /** Invoked once when an entry reaches the terminal degraded state. */
+  onDegraded?: (resumeId: string) => void;
+}
+
+function finitePositive(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+export class ResumeAckTracker {
+  private readonly push: ResumeAckTrackerOptions["push"];
+  private readonly scheduler: ResumeScheduler;
+  private readonly timeoutMs: number;
+  private readonly retries: number;
+  private readonly onDegraded: (resumeId: string) => void;
+  private readonly entries = new Map<string, InternalEntry>();
+  // Monotonic counter for unique delivery ids (independent of attempt number so
+  // even a same-attempt re-push — which never happens today — stays unique).
+  private deliverySeq = 0;
+
+  constructor(options: ResumeAckTrackerOptions) {
+    this.push = options.push;
+    this.scheduler = options.scheduler;
+    this.timeoutMs = finitePositive(options.timeoutMs, 60_000);
+    this.retries = finitePositive(options.retries, 3);
+    this.onDegraded = options.onDegraded ?? (() => {});
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Public, timer-free view of an entry (for diagnostics + tests). */
+  get(resumeId: string): ResumeAckEntry | undefined {
+    const entry = this.entries.get(resumeId);
+    if (!entry) return undefined;
+    const { timer: _timer, ...publicEntry } = entry;
+    return { ...publicEntry };
+  }
+
+  /**
+   * Register a resume directive and push attempt 0. Idempotent: a duplicate
+   * start for a resumeId already tracked (in any state) is a no-op — it does NOT
+   * re-push or re-arm a timer.
+   */
+  start(resumeId: string): void {
+    if (this.entries.has(resumeId)) return;
+    const entry: InternalEntry = { resumeId, attempts: 0, state: "awaiting_ack" };
+    this.entries.set(resumeId, entry);
+    this.pushAttempt(entry);
+    this.armTimer(entry);
+  }
+
+  /**
+   * Record Claude's ack. Clears the entry's timer and DELETES it from the map
+   * (terminal `resumed`). No-op for an unknown resumeId, a repeated/late ack
+   * (the entry is already gone), or an ack arriving after degrade (also gone) —
+   * all collapse to the same `!entry` unknown-id no-op, preserving idempotency.
+   */
+  ack(resumeId: string): void {
+    const entry = this.entries.get(resumeId);
+    if (!entry) return;
+    this.clearTimer(entry);
+    // Terminal: drop the entry so the map never grows with dead state. The
+    // state flip is bookkeeping for any synchronous observer before deletion.
+    entry.state = "resumed";
+    this.entries.delete(resumeId);
+  }
+
+  /** Clear all timers and empty the tracker (daemon shutdown). */
+  stop(): void {
+    for (const entry of this.entries.values()) {
+      this.clearTimer(entry);
+    }
+    this.entries.clear();
+  }
+
+  private pushAttempt(entry: InternalEntry): void {
+    const deliveryId = `${entry.resumeId}_retry${entry.attempts}_${++this.deliverySeq}`;
+    this.push({ resumeId: entry.resumeId, deliveryId, attempt: entry.attempts });
+  }
+
+  private armTimer(entry: InternalEntry): void {
+    this.clearTimer(entry);
+    entry.timer = this.scheduler.setTimeout(() => {
+      delete entry.timer;
+      this.onTimeout(entry);
+    }, this.timeoutMs);
+    (entry.timer as { unref?: () => void } | undefined)?.unref?.();
+  }
+
+  private onTimeout(entry: InternalEntry): void {
+    // Defensive: a cleared/terminal entry should never reach here (its timer was
+    // cleared and the entry deleted on ack/degrade), but guard anyway so a
+    // fired-then-acked race is inert.
+    if (entry.state !== "awaiting_ack" || !this.entries.has(entry.resumeId)) return;
+    entry.attempts += 1;
+    if (entry.attempts >= this.retries) {
+      // Terminal degrade: flip the state for any synchronous observer, fire the
+      // degrade hook, then DELETE the entry so the map never retains dead state.
+      // A late ack afterwards hits the unknown-id no-op path (idempotent).
+      entry.state = "degraded";
+      this.entries.delete(entry.resumeId);
+      this.onDegraded(entry.resumeId);
+      return;
+    }
+    this.pushAttempt(entry);
+    this.armTimer(entry);
+  }
+
+  private clearTimer(entry: InternalEntry): void {
+    if (entry.timer === undefined) return;
+    this.scheduler.clearTimeout(entry.timer);
+    delete entry.timer;
+  }
+}

--- a/src/budget/resume-prompt.ts
+++ b/src/budget/resume-prompt.ts
@@ -1,2 +1,18 @@
 export const RESUME_PROMPT =
   "额度窗口已刷新，继续上次未完成的任务：从 .agent/checkpoint.md 的「下一步」接着做；完成后停下并标 DONE。";
+
+/**
+ * Claude-side resume directive (PR4 channel push). Unlike the Codex variant
+ * (injected as a turn), this is delivered as a channel notification carrying a
+ * stable `resumeId`. The daemon re-pushes it until Claude acks via the
+ * `ack_resume` MCP tool, so the wording MUST make clear the ack means RECEIVED
+ * (call it immediately), NOT FINISHED — a long task (>60s) would otherwise keep
+ * triggering re-pushes if Claude waited until completion to ack.
+ */
+export function claudeResumePrompt(resumeId: string): string {
+  return (
+    "额度窗口已刷新。" +
+    `请先调用 ack_resume(resume_id="${resumeId}", status="resumed") 确认已收到本通知（ACK = 已接收，不是完成，请立即调用，不要等任务做完），` +
+    "再从 .agent/checkpoint.md 的「下一步」接着做；完成后停下并标 DONE。"
+  );
+}

--- a/src/budget/route-resume.ts
+++ b/src/budget/route-resume.ts
@@ -1,0 +1,45 @@
+/**
+ * routeResume — pure side-aware dispatch for a committed budget recovery (PR4).
+ *
+ * The daemon's BudgetCoordinator calls `onResume(side, directive, resumeId)`
+ * once PER recovered side (the coordinator iterates `effect.recoveredSides`,
+ * which is an `AgentName[]` — it NEVER passes the synthetic "both"; a joint
+ * recovery surfaces as two independent calls, one per concrete side). This
+ * function is the single source of truth for that routing rule:
+ *
+ *   - side === "codex"  → PR3's Codex resume-injection queue (enqueueCodex). The
+ *     Claude ack tracker is DELIBERATELY untouched here.
+ *   - side === "claude" → arm the Claude-side ResumeAckTracker (claudeTracker.start),
+ *     which pushes the resume directive over the channel and retries until acked.
+ *
+ * Extracting this into a pure, exported function means the daemon's onResume
+ * closure and the wiring unit test import the SAME implementation — eliminating
+ * the prior "re-implemented closure" drift where the test pinned a hand-copied
+ * routing rule that could silently diverge from the real daemon.
+ */
+
+import type { AgentName } from "./types";
+
+/** The two collaborators routeResume dispatches into (daemon-owned). */
+export interface ResumeRouterDeps {
+  /** Arm the Claude-side ack/retry tracker for a Claude recovery. */
+  claudeTracker: { start: (resumeId: string) => void };
+  /** Hand a Codex recovery to PR3's injection queue path. */
+  enqueueCodex: (resumeId: string) => void;
+}
+
+/**
+ * Route a single committed recovery to the correct side.
+ *
+ * @param side     the concrete recovered side (AgentName — never "both").
+ * @param resumeId stable correlation id for this recovery.
+ * @param deps     the daemon-owned collaborators (Claude tracker + Codex enqueue).
+ */
+export function routeResume(side: AgentName, resumeId: string, deps: ResumeRouterDeps): void {
+  if (side === "codex") {
+    deps.enqueueCodex(resumeId);
+    return;
+  }
+  // side === "claude": arm the ack tracker (push + retry until acked).
+  deps.claudeTracker.start(resumeId);
+}

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -92,6 +92,12 @@ export class ClaudeAdapter extends EventEmitter {
   private readonly notificationIdPrefix: string;
   private readonly instanceId: string;
   private replySender: ReplySender | null = null;
+  // PR4: budget-resume ack callback, DELIBERATELY isolated from replySender.
+  // ack_resume is a Claude→bridge control-plane signal (acknowledging a
+  // system_budget_resume directive), NOT a Claude→Codex message — it must never
+  // route through the reply path (no idempotency/replyTracker pollution, no
+  // budget pause gate, no turn injection into Codex).
+  private resumeAckHandler: ((resumeId: string, status: string) => void) | null = null;
   private readonly logFile: string;
   private readonly logger: ProcessLogger;
 
@@ -170,6 +176,16 @@ export class ClaudeAdapter extends EventEmitter {
     this.replySender = sender;
   }
 
+  /**
+   * Register the budget-resume ack callback (PR4). Wired by bridge.ts to forward
+   * an `ack_resume` control message to the daemon's ResumeAckTracker. Kept fully
+   * separate from the reply sender so ack_resume can never be confused with a
+   * Claude→Codex message.
+   */
+  setResumeAckHandler(handler: (resumeId: string, status: string) => void) {
+    this.resumeAckHandler = handler;
+  }
+
   /** Returns the number of messages waiting in the fallback queue. */
   getPendingMessageCount(): number {
     return this.pendingMessages.length;
@@ -205,6 +221,10 @@ export class ClaudeAdapter extends EventEmitter {
             user_id: "codex",
             ts,
             source_type: "codex",
+            // PR4: budget-resume correlation id. Only present on resume pushes;
+            // omitted entirely for normal Codex messages so the meta shape is
+            // unchanged for the common path.
+            ...(message.resumeId ? { resume_id: message.resumeId } : {}),
           },
         },
       });
@@ -421,6 +441,27 @@ export class ClaudeAdapter extends EventEmitter {
             required: [],
           },
         },
+        {
+          name: "ack_resume",
+          description:
+            "ONLY for acknowledging a system_budget_resume directive (the budget window refreshed). NOT a general channel to Codex (use reply for that). This is an acknowledgement that you RECEIVED the resume directive — call it as soon as you see the notice, then continue the work; do NOT wait until the task is finished.",
+          inputSchema: {
+            type: "object" as const,
+            properties: {
+              resume_id: {
+                type: "string",
+                description: "The resume_id from the system_budget_resume notice (meta.resume_id).",
+              },
+              status: {
+                type: "string",
+                enum: ["resumed", "declined", "already_running"],
+                description:
+                  "Acknowledgement outcome, recorded for observability only — all three values stop the resume re-push identically (the bridge takes no different downstream action for \"declined\"). \"resumed\" (default): you are resuming the task. \"declined\": you are not resuming. \"already_running\": you were already working and need no resume.",
+              },
+            },
+            required: ["resume_id"],
+          },
+        },
       ],
     }));
 
@@ -439,11 +480,66 @@ export class ClaudeAdapter extends EventEmitter {
         return this.handleGetBudget();
       }
 
+      if (name === "ack_resume") {
+        return this.handleAckResume(args as Record<string, unknown>);
+      }
+
       return {
         content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
         isError: true,
       };
     });
+  }
+
+  /**
+   * Handle ack_resume (PR4): Claude acknowledging a system_budget_resume
+   * directive. Mirrors handleReply's boundary checks, but routes through the
+   * dedicated resumeAckHandler — NEVER the replySender. Validation failures
+   * never invoke the handler.
+   */
+  private async handleAckResume(args: Record<string, unknown>) {
+    const resumeIdRaw = args?.resume_id;
+    if (typeof resumeIdRaw !== "string" || resumeIdRaw.length === 0) {
+      return {
+        content: [{ type: "text" as const, text: "Error: missing required parameter 'resume_id'" }],
+        isError: true,
+      };
+    }
+    if (resumeIdRaw.length > 128) {
+      return {
+        content: [{ type: "text" as const, text: `Error: resume_id is too long (${resumeIdRaw.length} chars, max 128).` }],
+        isError: true,
+      };
+    }
+
+    const statusRaw = args?.status;
+    if (
+      statusRaw !== undefined &&
+      statusRaw !== "resumed" &&
+      statusRaw !== "declined" &&
+      statusRaw !== "already_running"
+    ) {
+      return {
+        content: [{ type: "text" as const, text: `Error: invalid status value ${JSON.stringify(statusRaw)} — use "resumed", "declined" or "already_running".` }],
+        isError: true,
+      };
+    }
+    const status: string = typeof statusRaw === "string" ? statusRaw : "resumed";
+
+    if (!this.resumeAckHandler) {
+      this.log("No resume ack handler registered");
+      return {
+        content: [{ type: "text" as const, text: "Error: bridge not initialized, cannot acknowledge resume." }],
+        isError: true,
+      };
+    }
+
+    this.log(`ack_resume received (resume_id=${resumeIdRaw}, status=${status}, instance=${this.instanceId})`);
+    this.resumeAckHandler(resumeIdRaw, status);
+
+    return {
+      content: [{ type: "text" as const, text: `Resume acknowledged (resume_id=${resumeIdRaw}, status=${status}).` }],
+    };
   }
 
   private handleGetBudget() {

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -100,6 +100,16 @@ export type ControlClientMessage =
       idempotencyKey?: string;
     }
   | { type: "status" }
+  /**
+   * Claude acknowledged a budget-resume directive (PR4). A Claude→bridge
+   * control-plane signal forwarded from the `ack_resume` MCP tool: it resolves
+   * the daemon's ResumeAckTracker entry for `resumeId` (stopping the re-push
+   * retry loop). DELIBERATELY distinct from claude_to_codex — an ack must never
+   * be injected into the Codex thread as a turn (see ResumeAckTracker docs).
+   * `status` mirrors the MCP tool's enum ("resumed" | "declined" |
+   * "already_running").
+   */
+  | { type: "ack_resume"; resumeId: string; status: string }
   // Non-attaching probe: ask the daemon whether it already has a LIVE Claude
   // frontend attached, WITHOUT contesting/attaching this socket. Used by the
   // `abg claude` CLI conflict guard so a second session in the same pair errors

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -303,6 +303,17 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     return pending;
   }
 
+  /**
+   * Forward Claude's budget-resume acknowledgement to the daemon (PR4). A
+   * fire-and-forget control-plane message (the daemon does not reply): it
+   * resolves the daemon's ResumeAckTracker entry, stopping the re-push loop.
+   * DELIBERATELY separate from sendReply — an ack is NOT a Claude→Codex message
+   * and must never travel the claude_to_codex path.
+   */
+  sendAckResume(resumeId: string, status: string): void {
+    this.send({ type: "ack_resume", resumeId, status });
+  }
+
   private attachSocketHandlers(ws: WebSocket, socketId: number) {
     ws.onmessage = (event) => {
       const raw = typeof event.data === "string" ? event.data : event.data.toString();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -24,7 +24,10 @@ import { createQuotaSource } from "./budget/quota-source";
 import { readGuardPending } from "./budget/pending-reader";
 import type { ResumeSignals } from "./budget/budget-fingerprint";
 import { ResumeInjectionQueue, tryClaimPendingResume } from "./budget/resume-injection-queue";
-import { RESUME_PROMPT } from "./budget/resume-prompt";
+import { ResumeAckTracker } from "./budget/resume-ack-tracker";
+import { routeResume } from "./budget/route-resume";
+import { RESUME_PROMPT, claudeResumePrompt } from "./budget/resume-prompt";
+import { writeResumeAckDegradedSentinel } from "./budget/resume-ack-sentinel";
 import {
   CLOSE_CODE_REPLACED,
   CLOSE_CODE_EVICTED_STALE,
@@ -128,6 +131,9 @@ const BUDGET_CONFIG = applyBudgetEnvOverrides(config.budget);
 const RESUME_INJECT_RETRY_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_INJECT_RETRY_MS", 5000, log);
 const RESUME_CONFIRM_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_CONFIRM_TIMEOUT_MS", 60000, log);
 const RESUME_INJECT_MAX_ATTEMPTS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_INJECT_MAX_ATTEMPTS", 5, log);
+// PR4 Claude-side ack/retry window (spec S4: resumeAckTimeoutMs=60_000, resumeAckRetries=3).
+const RESUME_ACK_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_RESUME_ACK_TIMEOUT_MS", 60000, log);
+const RESUME_ACK_RETRIES = parsePositiveIntEnv("AGENTBRIDGE_RESUME_ACK_RETRIES", 3, log);
 
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 
@@ -189,6 +195,36 @@ const resumeInjectionQueue = new ResumeInjectionQueue({
   },
   onAbandoned: ({ resumeId, reason }) => {
     log(`Budget resume injection abandoned: ${resumeId}: ${reason}`);
+  },
+});
+// PR4 Claude-side resume ack/retry tracker (daemon-owned single source of truth).
+// Push delivers a system_budget_resume channel notification carrying the stable
+// resumeId; the per-attempt `deliveryId` becomes the BridgeMessage.id so the
+// adapter's LRU dedup never drops a re-push, while resumeId stays stable so
+// Claude's ack_resume echo still correlates. After RESUME_ACK_RETRIES timeouts
+// with no ack it degrades and drops a SessionStart escape-hatch sentinel.
+const claudeResumeTracker = new ResumeAckTracker({
+  push: ({ resumeId, deliveryId, attempt }) => {
+    const message: BridgeMessage = {
+      id: `system_budget_resume_${SYSTEM_MSG_SALT}_${deliveryId}`,
+      source: "codex",
+      content: claudeResumePrompt(resumeId),
+      timestamp: Date.now(),
+      resumeId,
+    };
+    log(`Budget resume push to Claude: ${resumeId} (attempt ${attempt}, delivery ${deliveryId})`);
+    emitToClaude(message);
+  },
+  scheduler: globalThis,
+  timeoutMs: RESUME_ACK_TIMEOUT_MS,
+  retries: RESUME_ACK_RETRIES,
+  onDegraded: (resumeId) => {
+    log(`Budget resume ${resumeId} degraded: no ack from Claude after ${RESUME_ACK_RETRIES} attempts`);
+    try {
+      writeResumeAckDegradedSentinel({ stateDir: stateDir.dir, resumeId, log });
+    } catch (err: any) {
+      log(`Resume degraded sentinel write failed (${resumeId}): ${err?.message ?? err}`);
+    }
   },
 });
 // Transport-accepted steers awaiting their JSON-RPC verdict, keyed by the
@@ -422,12 +458,18 @@ function ensureBudgetCoordinatorStarted() {
       onSnapshot: () => broadcastStatus(),
       log,
       onResume: (side, _directive, resumeId) => {
-        if (side === "codex") {
-          enqueueCodexBudgetResume(resumeId);
-          return;
+        // Side-aware routing lives in the pure, exported routeResume so the
+        // daemon and its wiring test share ONE implementation (no re-impl drift).
+        // `side` is an AgentName — the coordinator iterates recoveredSides and
+        // calls this once per concrete side, so "both" is NEVER passed (a joint
+        // recovery arrives as two calls: codex → PR3 queue, claude → ack tracker).
+        if (side === "claude") {
+          log(`Budget resume ${resumeId} for Claude side → arming ack tracker`);
         }
-        // PR4 wires Claude channel resume + ack_resume. PR3 only owns Codex turn/start.
-        log(`Budget resume ${resumeId} for Claude side deferred to PR4`);
+        routeResume(side, resumeId, {
+          claudeTracker: claudeResumeTracker,
+          enqueueCodex: enqueueCodexBudgetResume,
+        });
       },
       // PR2 (detection only): daemon-side readiness signals for the resume
       // candidate. Pure-reducer purity is preserved by gathering all IO here —
@@ -982,6 +1024,13 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
       return;
     case "status":
       sendStatus(ws);
+      return;
+    case "ack_resume":
+      // PR4: Claude acked a budget-resume directive. Resolve the tracker entry
+      // (stops the re-push loop). DELIBERATELY does NOT touch the Codex queue,
+      // idempotency machine, or reply path — it is a pure control-plane ack.
+      log(`Received ack_resume from Claude #${ws.data.clientId}: ${message.resumeId} (${message.status})`);
+      claudeResumeTracker.ack(message.resumeId);
       return;
     case "probe_incumbent":
       handleProbeIncumbent(ws).catch((err) => {
@@ -2048,6 +2097,7 @@ function shutdown(reason: string, exitCode = 0) {
   log(`Shutting down daemon (${reason})...`);
   clearBootDeadline();
   resumeInjectionQueue.stop();
+  claudeResumeTracker.stop();
   stopBudgetCoordinator();
   idempotencyTracker.dispose();
   tuiConnectionState.dispose(`daemon shutdown (${reason})`);

--- a/src/integration-test/daemon-wiring.test.ts
+++ b/src/integration-test/daemon-wiring.test.ts
@@ -20,7 +20,7 @@ import { portsForSlot, type PairPorts } from "../pair-registry";
 import { readControlToken, resolveControlTokenPath } from "../control-token";
 import { CONTRACT_VERSION } from "../contract-version";
 import { installFakeCodex } from "./fixtures/fake-codex-install";
-import { RESUME_PROMPT } from "../budget/resume-prompt";
+import { RESUME_PROMPT, claudeResumePrompt } from "../budget/resume-prompt";
 
 const DAEMON_PATH = join(process.cwd(), "src", "daemon.ts");
 const DEFAULT_TEST_SLOT_START = 2500 + (process.pid % 500);
@@ -51,6 +51,8 @@ interface Harness {
     text: string,
     opts?: { onBusy?: "reject" | "steer" | "interrupt"; requireReply?: boolean; idempotencyKey?: string },
   ) => void;
+  /** Send an ack_resume control message over the attached control socket (PR4). */
+  sendAckResume: (resumeId: string, status: string) => void;
 }
 
 const harnesses: Harness[] = [];
@@ -463,6 +465,109 @@ describe("daemon wiring", () => {
         80,
         50,
       );
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  // --- PR4: Claude-side auto-resume via a REAL daemon (mirrors the Codex E2E) ---
+  //
+  // Drives an end-to-end Claude recovery through the real daemon process: the
+  // budget probe pauses the CLAUDE side (handoff), then refreshes it → the
+  // coordinator's onResume("claude", …) calls the SHARED routeResume →
+  // claudeResumeTracker.start → a `system_budget_resume_*` channel push carrying
+  // the stable resumeId. The test then sends an `ack_resume` control message and
+  // asserts the tracker resolved (no further re-push beyond the single delivery).
+  test("Claude-side recovery pushes system_budget_resume with resumeId; ack_resume stops the re-push", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-claude-resume-fixture-"));
+    const probePath = join(fixtureRoot, "probe.sh");
+    const writeUsage = (agent: "claude" | "codex", gateUtil: number) => {
+      writeFileSync(
+        join(fixtureRoot, `usage-${agent}.json`),
+        JSON.stringify({
+          ok: true,
+          util: gateUtil,
+          warn_util: gateUtil,
+          fetched_at: Math.floor(Date.now() / 1000),
+          buckets: [
+            { id: "five_hour", util: gateUtil, reset_epoch: Math.floor(Date.now() / 1000) + 600 },
+          ],
+        }),
+      );
+    };
+    writeUsage("claude", 95); // Claude-only trip → handoff (gate stays open)
+    writeUsage("codex", 10);
+    writeFileSync(probePath, `#!/bin/sh\ncat "${fixtureRoot}/usage-$2.json"\n`, "utf-8");
+    chmodSync(probePath, 0o755);
+
+    try {
+      const harness = await startHarness({
+        pairId: "main-clauderes",
+        pairName: "main",
+        extraEnv: {
+          AGENTBRIDGE_BUDGET_ENABLED: "1",
+          AGENTBRIDGE_QUOTA_PROBE: probePath,
+          AGENTBRIDGE_BUDGET_POLL_SECONDS: "5",
+          // A compressed (but not razor-thin) ack window: long enough that the
+          // ack control message round-trips before the first re-push timer could
+          // fire (so the count we capture at ack time is stable), yet short
+          // enough that a STILL-armed timer after the ack would fire inside the
+          // post-ack wait below — turning a broken ack into a visible re-push.
+          AGENTBRIDGE_RESUME_ACK_TIMEOUT_MS: "3000",
+          AGENTBRIDGE_RESUME_ACK_RETRIES: "3",
+        },
+      });
+
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      // Claude side trips first → a handoff directive (NOT a pause), gate open.
+      await waitForMessage(
+        harness.messages,
+        (message) => message.id.startsWith("system_budget_handoff_"),
+        "system_budget_handoff before Claude recovery",
+      );
+
+      // Refresh the Claude window → next poll (≤5s) recovers it. The recovery
+      // surfaces as BOTH the coordinator directive (system_budget_claude_recovered_*)
+      // and the ack-tracker channel push (system_budget_resume_*, carrying resumeId).
+      writeUsage("claude", 5);
+      const isResumePush = (m: BridgeMessage) =>
+        m.id.startsWith("system_budget_resume_") && typeof m.resumeId === "string";
+      // Recovery fires on the NEXT coordinator poll (≤5s), so wait well past one
+      // poll cycle — generous for slow CI (300 × 50ms = 15s).
+      await waitFor(
+        () => harness.messages.some(isResumePush),
+        "Claude-side system_budget_resume channel push with resumeId",
+        300,
+        50,
+      );
+      const push = harness.messages.find(isResumePush)!;
+
+      const resumeId = push.resumeId!;
+      expect(resumeId.startsWith("system_budget_claude_recovered_")).toBe(true);
+      // The push content carries the ack instruction (claudeResumePrompt), which
+      // embeds the stable resumeId so Claude's echo correlates.
+      expect(push.content).toBe(claudeResumePrompt(resumeId));
+      expect(push.content).toContain(`ack_resume(resume_id="${resumeId}"`);
+
+      // Record how many resume pushes (for THIS resumeId) we've seen so we can
+      // prove the ack stops the loop rather than a later poll incidentally quieting.
+      const pushesForResume = () =>
+        harness.messages.filter(
+          (m) => m.id.startsWith("system_budget_resume_") && m.resumeId === resumeId,
+        );
+      const countAtAck = pushesForResume().length;
+      expect(countAtAck).toBeGreaterThanOrEqual(1);
+
+      // Ack it via the control plane (exactly what the ack_resume MCP tool does).
+      harness.sendAckResume(resumeId, "resumed");
+
+      // After the ack, no further re-push for this resumeId may arrive — wait out
+      // more than one full ack window (3000ms) to give a (wrongly) still-armed
+      // timer time to fire.
+      await sleep(4000);
+      expect(pushesForResume().length).toBe(countAtAck);
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
@@ -1665,6 +1770,9 @@ async function startHarness(opts: {
         ...(sendOpts?.onBusy && sendOpts.onBusy !== "reject" ? { onBusy: sendOpts.onBusy } : {}),
         ...(sendOpts?.idempotencyKey ? { idempotencyKey: sendOpts.idempotencyKey } : {}),
       }));
+    },
+    sendAckResume: (resumeId: string, status: string) => {
+      harness.controlWs?.send(JSON.stringify({ type: "ack_resume", resumeId, status }));
     },
   };
   harnesses.push(harness);

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,14 @@ export interface BridgeMessage {
   source: MessageSource;
   content: string;
   timestamp: number;
+  /**
+   * Stable budget-resume correlation id (PR4, additive). Present ONLY on Claude
+   * channel resume pushes (system_budget_resume directives). When set, the
+   * Claude adapter surfaces it as `meta.resume_id` so Claude can echo it back
+   * via the `ack_resume` MCP tool. Does NOT affect the source-never-forwarded
+   * invariant — it is an opaque payload field, not a routing key.
+   */
+  resumeId?: string;
 }
 
 // ===== JSON-RPC 2.0 =====

--- a/src/unit-test/claude-adapter-resume.test.ts
+++ b/src/unit-test/claude-adapter-resume.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, test } from "bun:test";
+import { ClaudeAdapter } from "../claude-adapter";
+
+// The MCP Server stores wrapped request handlers in a Map keyed by JSON-RPC
+// method. Invoking them directly drives ListTools / CallTool without a transport.
+function listTools(adapter: any) {
+  const handler = adapter.server._requestHandlers.get("tools/list");
+  return handler({ method: "tools/list" }, {});
+}
+
+function callTool(adapter: any, name: string, args?: Record<string, unknown>) {
+  const handler = adapter.server._requestHandlers.get("tools/call");
+  return handler({ method: "tools/call", params: { name, arguments: args ?? {} } }, {});
+}
+
+function withMockedChannel(adapter: any, mode: "success" | "fail" = "success") {
+  const notifications: any[] = [];
+  adapter.server.notification = async (payload: any) => {
+    if (mode === "fail") throw new Error("channel unavailable");
+    notifications.push(payload);
+  };
+  return notifications;
+}
+
+function makeCodexMessage(content: string, extra: Record<string, unknown> = {}) {
+  return {
+    id: `m_${Math.random().toString(36).slice(2)}`,
+    source: "codex" as const,
+    content,
+    timestamp: Date.now(),
+    ...extra,
+  };
+}
+
+describe("ack_resume MCP tool — registration", () => {
+  test("ack_resume appears in ListTools as the fourth tool", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    const result = await listTools(adapter);
+    const names = result.tools.map((t: any) => t.name);
+
+    // Snapshot: reply, get_messages, get_budget were the prior three.
+    expect(names).toEqual(["reply", "get_messages", "get_budget", "ack_resume"]);
+    expect(result.tools).toHaveLength(4);
+  });
+
+  test("ack_resume schema requires resume_id and constrains status enum", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    const result = await listTools(adapter);
+    const ackTool = result.tools.find((t: any) => t.name === "ack_resume");
+
+    expect(ackTool).toBeDefined();
+    // Must NOT be advertised as a general send-to-Codex channel.
+    expect(ackTool.description.toLowerCase()).toContain("ack");
+    expect(ackTool.description).not.toContain("send a message back to Codex");
+    expect(ackTool.inputSchema.required).toContain("resume_id");
+    expect(ackTool.inputSchema.properties.resume_id.type).toBe("string");
+    expect(ackTool.inputSchema.properties.status.enum).toEqual([
+      "resumed",
+      "declined",
+      "already_running",
+    ]);
+  });
+});
+
+describe("ack_resume MCP tool — handleAckResume", () => {
+  test("invokes the registered resumeAckHandler with (resumeId, status)", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    const calls: Array<{ resumeId: string; status: string }> = [];
+    adapter.setResumeAckHandler((resumeId: string, status: string) => {
+      calls.push({ resumeId, status });
+    });
+
+    const res = await callTool(adapter, "ack_resume", {
+      resume_id: "system_budget_resume_7",
+      status: "resumed",
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ resumeId: "system_budget_resume_7", status: "resumed" });
+  });
+
+  test("status defaults to 'resumed' when omitted", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    const calls: Array<{ resumeId: string; status: string }> = [];
+    adapter.setResumeAckHandler((resumeId: string, status: string) => {
+      calls.push({ resumeId, status });
+    });
+
+    const res = await callTool(adapter, "ack_resume", { resume_id: "rid_default" });
+    expect(res.isError).toBeFalsy();
+    expect(calls[0].status).toBe("resumed");
+  });
+
+  test("empty resume_id is an error and never calls the handler", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    let called = false;
+    adapter.setResumeAckHandler(() => {
+      called = true;
+    });
+
+    const res = await callTool(adapter, "ack_resume", { resume_id: "" });
+    expect(res.isError).toBe(true);
+    expect(called).toBe(false);
+  });
+
+  test("over-long resume_id (>128 chars) is an error", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    let called = false;
+    adapter.setResumeAckHandler(() => {
+      called = true;
+    });
+
+    const res = await callTool(adapter, "ack_resume", { resume_id: "x".repeat(129) });
+    expect(res.isError).toBe(true);
+    expect(called).toBe(false);
+  });
+
+  test("illegal status enum value is an error", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    let called = false;
+    adapter.setResumeAckHandler(() => {
+      called = true;
+    });
+
+    const res = await callTool(adapter, "ack_resume", {
+      resume_id: "rid_bad_status",
+      status: "finished",
+    });
+    expect(res.isError).toBe(true);
+    expect(called).toBe(false);
+  });
+
+  // Non-string / non-enum inputs must be rejected at the boundary — never coerced
+  // and never forwarded to the handler (defense against a malformed MCP call).
+  test.each([123, null, { nested: true }])(
+    "non-string resume_id (%p) is an error and never calls the handler",
+    async (badResumeId) => {
+      const adapter = new ClaudeAdapter() as any;
+      let called = false;
+      adapter.setResumeAckHandler(() => {
+        called = true;
+      });
+
+      const res = await callTool(adapter, "ack_resume", { resume_id: badResumeId });
+      expect(res.isError).toBe(true);
+      expect(called).toBe(false);
+    },
+  );
+
+  test("non-string status (number) is an error and never calls the handler", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    let called = false;
+    adapter.setResumeAckHandler(() => {
+      called = true;
+    });
+
+    const res = await callTool(adapter, "ack_resume", { resume_id: "rid_num_status", status: 123 });
+    expect(res.isError).toBe(true);
+    expect(called).toBe(false);
+  });
+
+  test("no registered handler yields an error (not a silent success)", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    const res = await callTool(adapter, "ack_resume", { resume_id: "rid_no_handler" });
+    expect(res.isError).toBe(true);
+  });
+
+  test("ack_resume NEVER routes through the reply sender", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    let replySenderCalled = false;
+    adapter.setReplySender(async () => {
+      replySenderCalled = true;
+      return { success: true };
+    });
+    adapter.setResumeAckHandler(() => {});
+
+    await callTool(adapter, "ack_resume", { resume_id: "rid_isolated", status: "resumed" });
+    expect(replySenderCalled).toBe(false);
+  });
+});
+
+describe("ack_resume does not regress reply / get_messages / get_budget", () => {
+  test("reply still dispatches through the reply sender", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    let sent = false;
+    adapter.setReplySender(async () => {
+      sent = true;
+      return { success: true };
+    });
+
+    const res = await callTool(adapter, "reply", { chat_id: "c1", text: "hi codex" });
+    expect(res.isError).toBeFalsy();
+    expect(sent).toBe(true);
+  });
+
+  test("get_messages still drains the fallback queue", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    adapter.queueFallbackMessage(makeCodexMessage("queued msg"));
+    const res = await callTool(adapter, "get_messages", {});
+    expect(res.content[0].text).toContain("queued msg");
+  });
+
+  test("get_budget still responds (unavailable when no snapshot)", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    const res = await callTool(adapter, "get_budget", {});
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].type).toBe("text");
+  });
+});
+
+describe("channel resume push — meta.resume_id", () => {
+  test("pushViaChannel surfaces message.resumeId as meta.resume_id", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    const notifications = withMockedChannel(adapter);
+
+    await adapter.pushNotification(
+      makeCodexMessage("额度窗口已刷新", { resumeId: "system_budget_claude_recovered_3" }),
+    );
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].params.meta.resume_id).toBe("system_budget_claude_recovered_3");
+  });
+
+  test("a normal Codex message without resumeId carries no meta.resume_id", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    const notifications = withMockedChannel(adapter);
+
+    await adapter.pushNotification(makeCodexMessage("plain message"));
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].params.meta.resume_id).toBeUndefined();
+  });
+
+  test("a resume push that fails falls back to the in-memory queue", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    withMockedChannel(adapter, "fail");
+
+    await adapter.pushNotification(
+      makeCodexMessage("resume content", { resumeId: "rid_fallback" }),
+    );
+
+    expect(adapter.getPendingMessageCount()).toBe(1);
+  });
+
+  // PR4 core invariant (§4.5): a re-push carries the SAME stable resumeId but a
+  // DIFFERENT production-shaped message id (the per-attempt deliveryId). The
+  // adapter's LRU dedup is keyed on message.id, so BOTH attempts must reach the
+  // channel — if dedup keyed on resumeId (or shared an id), the retry would be
+  // silently dropped and an idle Claude session would never be re-woken.
+  test("two re-push attempts (same resumeId, distinct production-shaped ids) both reach the channel", async () => {
+    const adapter = new ClaudeAdapter() as any;
+    const notifications = withMockedChannel(adapter);
+
+    const salt = "abcd1234";
+    const rid = "system_budget_claude_recovered_xy_7";
+    const attempt0 = `system_budget_resume_${salt}_${rid}_retry0_1`;
+    const attempt1 = `system_budget_resume_${salt}_${rid}_retry1_2`;
+
+    await adapter.pushNotification({
+      id: attempt0,
+      source: "codex" as const,
+      content: "resume attempt 0",
+      timestamp: Date.now(),
+      resumeId: rid,
+    });
+    await adapter.pushNotification({
+      id: attempt1,
+      source: "codex" as const,
+      content: "resume attempt 1",
+      timestamp: Date.now(),
+      resumeId: rid,
+    });
+
+    // Neither was dropped by LRU dedup — both delivered.
+    expect(notifications).toHaveLength(2);
+    expect(notifications[0].params.meta.message_id).toBe(attempt0);
+    expect(notifications[1].params.meta.message_id).toBe(attempt1);
+    // Both carry the SAME stable resumeId so Claude's single ack correlates.
+    expect(notifications[0].params.meta.resume_id).toBe(rid);
+    expect(notifications[1].params.meta.resume_id).toBe(rid);
+  });
+});

--- a/src/unit-test/resume-ack-sentinel.test.ts
+++ b/src/unit-test/resume-ack-sentinel.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  RESUME_ACK_DEGRADED_SENTINEL,
+  resumeAckSentinelPath,
+  writeResumeAckDegradedSentinel,
+  type ResumeAckDegradedSentinel,
+} from "../budget/resume-ack-sentinel";
+import { ResumeAckTracker } from "../budget/resume-ack-tracker";
+import type { ResumeScheduler } from "../budget/resume-injection-queue";
+
+/**
+ * Covers PR4 §6 — the degrade→sentinel escape hatch. This is the SOLE recovery
+ * path when a Claude session is idle/dead and never acks a resume directive, so
+ * the payload shape, atomic temp+rename, 0o600 mode, and the full
+ * ResumeAckTracker → onDegraded → sentinel wiring all need automated pins (the
+ * bash consumer in health-check.sh parses exactly what this writer emits).
+ */
+
+const tmpDirs: string[] = [];
+
+function tempStateDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "abg-resume-sentinel-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("resumeAckSentinelPath", () => {
+  test("joins the state dir with the well-known sentinel filename", () => {
+    expect(resumeAckSentinelPath("/state")).toBe(`/state/${RESUME_ACK_DEGRADED_SENTINEL}`);
+    expect(RESUME_ACK_DEGRADED_SENTINEL).toBe("resume-ack-degraded.json");
+  });
+});
+
+describe("writeResumeAckDegradedSentinel", () => {
+  test("writes a parseable {resumeId, degradedAt} payload at the sentinel path", () => {
+    const stateDir = tempStateDir();
+    writeResumeAckDegradedSentinel({
+      stateDir,
+      resumeId: "system_budget_claude_recovered_7",
+      now: () => 1_700_000_000_000,
+    });
+
+    const target = resumeAckSentinelPath(stateDir);
+    expect(existsSync(target)).toBe(true);
+    const parsed = JSON.parse(readFileSync(target, "utf-8")) as ResumeAckDegradedSentinel;
+    expect(parsed.resumeId).toBe("system_budget_claude_recovered_7");
+    expect(parsed.degradedAt).toBe(1_700_000_000_000);
+    expect(typeof parsed.degradedAt).toBe("number");
+  });
+
+  test("the bash health-check regex extracts the same resumeId from what TS writes", () => {
+    // Pins bash↔TS parity: the hook reads resumeId via
+    //   grep -o '"resumeId"[[:space:]]*:[[:space:]]*"[^"]*"'  then sed.
+    // Reproduce that against the actual JSON.stringify(payload, null, 2) output so
+    // a future change to either side that breaks parsing fails here.
+    const stateDir = tempStateDir();
+    const resumeId = "system_budget_claude_recovered_42";
+    writeResumeAckDegradedSentinel({ stateDir, resumeId, now: () => 1 });
+    const raw = readFileSync(resumeAckSentinelPath(stateDir), "utf-8");
+    const m = raw.match(/"resumeId"\s*:\s*"([^"]*)"/);
+    expect(m?.[1]).toBe(resumeId);
+    // And the value passes the hook's charset guard (^[A-Za-z0-9._-]+$).
+    expect(/^[A-Za-z0-9._-]+$/.test(m![1])).toBe(true);
+  });
+
+  test("writes with 0o600 mode (owner-only)", () => {
+    const stateDir = tempStateDir();
+    writeResumeAckDegradedSentinel({ stateDir, resumeId: "rid_mode", now: () => 0 });
+    const mode = statSync(resumeAckSentinelPath(stateDir)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("leaves no temp file behind (atomic temp+rename)", () => {
+    const stateDir = tempStateDir();
+    writeResumeAckDegradedSentinel({ stateDir, resumeId: "rid_tmp", now: () => 0 });
+    const leftovers = readdirSync(stateDir).filter((name) => name.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
+    expect(readdirSync(stateDir)).toEqual([RESUME_ACK_DEGRADED_SENTINEL]);
+  });
+
+  test("best-effort: a write failure (missing state dir) is swallowed, never throws, and logs", () => {
+    const stateDir = join(tempStateDir(), "does", "not", "exist");
+    const logs: string[] = [];
+    expect(() =>
+      writeResumeAckDegradedSentinel({
+        stateDir,
+        resumeId: "rid_fail",
+        now: () => 0,
+        log: (m) => logs.push(m),
+      }),
+    ).not.toThrow();
+    expect(existsSync(resumeAckSentinelPath(stateDir))).toBe(false);
+    expect(logs.some((m) => m.includes("failed"))).toBe(true);
+  });
+});
+
+/**
+ * Deterministic fake scheduler (mirrors resume-ack-tracker.test.ts) so the
+ * end-to-end wiring test stays hermetic — no real setTimeout, exit 0.
+ */
+function createFakeScheduler() {
+  let nextId = 1;
+  const timers = new Map<number, () => void>();
+  const scheduler: ResumeScheduler = {
+    setTimeout(callback: () => void) {
+      const id = nextId++;
+      timers.set(id, callback);
+      return id;
+    },
+    clearTimeout(timer: unknown) {
+      if (typeof timer === "number") timers.delete(timer);
+    },
+  };
+  return {
+    scheduler,
+    flush() {
+      const next = timers.keys().next();
+      if (next.done) throw new Error("no pending timer to flush");
+      const id = next.value as number;
+      const cb = timers.get(id)!;
+      timers.delete(id);
+      cb();
+    },
+  };
+}
+
+describe("ResumeAckTracker → writeResumeAckDegradedSentinel (end-to-end §6 wiring)", () => {
+  test("retries-exhausted degrade lands a sentinel file carrying the pushed resumeId", () => {
+    const stateDir = tempStateDir();
+    const fake = createFakeScheduler();
+    const resumeId = "system_budget_claude_recovered_99";
+    const tracker = new ResumeAckTracker({
+      push: () => {},
+      scheduler: fake.scheduler,
+      timeoutMs: 60_000,
+      retries: 3,
+      // Wire the REAL sentinel writer (not an in-memory stub) so the whole
+      // degrade→sentinel chain is exercised.
+      onDegraded: (rid) => writeResumeAckDegradedSentinel({ stateDir, resumeId: rid, now: () => 5 }),
+    });
+
+    tracker.start(resumeId);
+    // No ack: drive past retries to the terminal degrade.
+    fake.flush();
+    fake.flush();
+    fake.flush();
+
+    const target = resumeAckSentinelPath(stateDir);
+    expect(existsSync(target)).toBe(true);
+    const parsed = JSON.parse(readFileSync(target, "utf-8")) as ResumeAckDegradedSentinel;
+    expect(parsed.resumeId).toBe(resumeId);
+    expect(parsed.degradedAt).toBe(5);
+  });
+
+  test("a timely ack means NO sentinel is ever written", () => {
+    const stateDir = tempStateDir();
+    const fake = createFakeScheduler();
+    const tracker = new ResumeAckTracker({
+      push: () => {},
+      scheduler: fake.scheduler,
+      timeoutMs: 60_000,
+      retries: 3,
+      onDegraded: (rid) => writeResumeAckDegradedSentinel({ stateDir, resumeId: rid }),
+    });
+
+    tracker.start("rid_acked");
+    tracker.ack("rid_acked"); // acked before any timeout → never degrades
+    expect(existsSync(resumeAckSentinelPath(stateDir))).toBe(false);
+  });
+});

--- a/src/unit-test/resume-ack-tracker.test.ts
+++ b/src/unit-test/resume-ack-tracker.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test";
+import { ResumeAckTracker } from "../budget/resume-ack-tracker";
+import type { ResumeScheduler } from "../budget/resume-injection-queue";
+
+/**
+ * Deterministic fake scheduler: never touches real setTimeout, so the suite is
+ * hermetic (no open handles, no hang, exit 0). Each scheduled callback gets a
+ * synthetic timer handle; `flush()` fires the next pending timer (FIFO), which
+ * is how we drive timeout/re-push transitions in tests.
+ */
+function createFakeScheduler() {
+  let nextId = 1;
+  const timers = new Map<number, { callback: () => void; delayMs: number }>();
+  const scheduler: ResumeScheduler = {
+    setTimeout(callback: () => void, delayMs: number) {
+      const id = nextId++;
+      timers.set(id, { callback, delayMs });
+      return id;
+    },
+    clearTimeout(timer: unknown) {
+      if (typeof timer === "number") timers.delete(timer);
+    },
+  };
+  return {
+    scheduler,
+    /** Number of timers still pending (i.e. not fired and not cleared). */
+    pending: () => timers.size,
+    /** Fire the oldest pending timer once (simulating its delay elapsing). */
+    flush() {
+      const next = timers.keys().next();
+      if (next.done) throw new Error("no pending timer to flush");
+      const id = next.value as number;
+      const entry = timers.get(id)!;
+      timers.delete(id);
+      entry.callback();
+    },
+  };
+}
+
+interface PushEvent {
+  resumeId: string;
+  deliveryId: string;
+  attempt: number;
+}
+
+function createTracker(overrides: Partial<{
+  timeoutMs: number;
+  retries: number;
+  onDegraded: (resumeId: string) => void;
+}> = {}) {
+  const fake = createFakeScheduler();
+  const pushes: PushEvent[] = [];
+  const degraded: string[] = [];
+  const tracker = new ResumeAckTracker({
+    push: (event: PushEvent) => pushes.push({ ...event }),
+    scheduler: fake.scheduler,
+    timeoutMs: overrides.timeoutMs ?? 60_000,
+    retries: overrides.retries ?? 3,
+    onDegraded: overrides.onDegraded ?? ((resumeId: string) => degraded.push(resumeId)),
+  });
+  return { tracker, fake, pushes, degraded };
+}
+
+describe("ResumeAckTracker — start", () => {
+  test("start pushes once and arms a single timer", () => {
+    const { tracker, fake, pushes } = createTracker();
+    tracker.start("system_budget_claude_recovered_1");
+
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0].resumeId).toBe("system_budget_claude_recovered_1");
+    expect(pushes[0].attempt).toBe(0);
+    expect(fake.pending()).toBe(1);
+
+    const entry = tracker.get("system_budget_claude_recovered_1");
+    expect(entry?.state).toBe("awaiting_ack");
+    expect(entry?.attempts).toBe(0);
+  });
+
+  test("duplicate start for same resumeId is a no-op (idempotent)", () => {
+    const { tracker, fake, pushes } = createTracker();
+    tracker.start("rid_dup");
+    tracker.start("rid_dup");
+
+    expect(pushes).toHaveLength(1); // not re-pushed
+    expect(fake.pending()).toBe(1); // not a second timer
+    expect(tracker.size).toBe(1);
+  });
+});
+
+describe("ResumeAckTracker — ack", () => {
+  test("ack clears the timer and DELETES the terminal entry (map hygiene)", () => {
+    const { tracker, fake } = createTracker();
+    tracker.start("rid_ack");
+    expect(fake.pending()).toBe(1);
+    expect(tracker.size).toBe(1);
+
+    tracker.ack("rid_ack");
+    // Terminal entry is removed: get() returns undefined and size drops to 0.
+    expect(tracker.get("rid_ack")).toBeUndefined();
+    expect(tracker.size).toBe(0);
+    expect(fake.pending()).toBe(0); // timer cleared on ack
+  });
+
+  test("repeated ack after resumed is a no-op (idempotent, no re-push, no throw)", () => {
+    const { tracker, pushes } = createTracker();
+    tracker.start("rid_ack2");
+    tracker.ack("rid_ack2");
+    const before = pushes.length;
+
+    // Late/duplicate ack hits the unknown-id no-op path (entry already deleted).
+    expect(() => tracker.ack("rid_ack2")).not.toThrow();
+    expect(pushes.length).toBe(before); // no re-push
+    expect(tracker.size).toBe(0);
+  });
+
+  test("ack for an unknown resumeId is a no-op (no throw)", () => {
+    const { tracker } = createTracker();
+    expect(() => tracker.ack("never_started")).not.toThrow();
+    expect(tracker.size).toBe(0);
+  });
+});
+
+describe("ResumeAckTracker — timeout / re-push", () => {
+  test("timeout re-pushes with a NEW delivery id but the SAME resumeId, attempts++", () => {
+    const { tracker, fake, pushes } = createTracker({ retries: 3 });
+    tracker.start("rid_retry");
+
+    const firstDelivery = pushes[0].deliveryId;
+    expect(pushes[0].attempt).toBe(0);
+
+    fake.flush(); // first timeout fires
+
+    expect(pushes).toHaveLength(2);
+    // resumeId is stable so Claude's echoed ack still correlates.
+    expect(pushes[1].resumeId).toBe("rid_retry");
+    // delivery id MUST differ so the LRU dedup in pushNotification does not drop it.
+    expect(pushes[1].deliveryId).not.toBe(firstDelivery);
+    expect(pushes[1].attempt).toBe(1);
+
+    const entry = tracker.get("rid_retry");
+    expect(entry?.attempts).toBe(1);
+    expect(entry?.state).toBe("awaiting_ack");
+    // A fresh timer is armed for the next retry window.
+    expect(fake.pending()).toBe(1);
+  });
+
+  test("consecutive timeouts past retries degrade (terminal), DELETE the entry, and stop re-pushing", () => {
+    const { tracker, fake, pushes, degraded } = createTracker({ retries: 3 });
+    tracker.start("rid_degrade"); // attempt 0 push
+
+    fake.flush(); // attempt 1
+    fake.flush(); // attempt 2
+    fake.flush(); // attempt 3 -> exhausts retries -> degraded
+
+    // Terminal entry deleted: get() undefined, size 0 (map hygiene). The degrade
+    // hook still fired with the resumeId.
+    expect(tracker.get("rid_degrade")).toBeUndefined();
+    expect(tracker.size).toBe(0);
+    expect(degraded).toContain("rid_degrade");
+    // No timer left running once degraded.
+    expect(fake.pending()).toBe(0);
+
+    // EXACTLY 3 pushes total (attempt 0 + 2 re-pushes; the 3rd timeout degrades
+    // WITHOUT a 4th push) — pins the anti-spam upper bound, not just a floor.
+    expect(pushes.length).toBe(3);
+    // Every delivery id is distinct so the adapter's LRU dedup never drops a
+    // re-push (the whole point of the per-attempt deliveryId).
+    const deliveryIds = pushes.map((p) => p.deliveryId);
+    expect(new Set(deliveryIds).size).toBe(3);
+  });
+
+  test("late ack after degraded is a no-op (entry gone, no re-push, no throw)", () => {
+    const { tracker, fake, pushes } = createTracker({ retries: 3 });
+    tracker.start("rid_late");
+    fake.flush();
+    fake.flush();
+    fake.flush();
+    expect(tracker.get("rid_late")).toBeUndefined(); // degraded → deleted
+    expect(tracker.size).toBe(0);
+
+    const before = pushes.length;
+    expect(() => tracker.ack("rid_late")).not.toThrow(); // late ack after degrade
+    expect(tracker.size).toBe(0);
+    expect(pushes.length).toBe(before);
+  });
+});
+
+describe("ResumeAckTracker — finitePositive option fallback", () => {
+  // Captures the delay each timer is armed with so we can assert the timeoutMs
+  // fallback, plus exposes flush() to drive the retries fallback.
+  function createDelayCapturingScheduler() {
+    let nextId = 1;
+    const timers = new Map<number, () => void>();
+    const delays: number[] = [];
+    const scheduler: ResumeScheduler = {
+      setTimeout(callback: () => void, delayMs: number) {
+        const id = nextId++;
+        timers.set(id, callback);
+        delays.push(delayMs);
+        return id;
+      },
+      clearTimeout(timer: unknown) {
+        if (typeof timer === "number") timers.delete(timer);
+      },
+    };
+    return {
+      scheduler,
+      delays,
+      flush() {
+        const next = timers.keys().next();
+        if (next.done) throw new Error("no pending timer to flush");
+        const id = next.value as number;
+        const cb = timers.get(id)!;
+        timers.delete(id);
+        cb();
+      },
+    };
+  }
+
+  test("illegal timeoutMs (0) falls back to the 60_000 default, not literal 0", () => {
+    const cap = createDelayCapturingScheduler();
+    const tracker = new ResumeAckTracker({
+      push: () => {},
+      scheduler: cap.scheduler,
+      timeoutMs: 0,
+      retries: 3,
+    });
+    tracker.start("rid_to0");
+    expect(cap.delays[0]).toBe(60_000);
+  });
+
+  test("illegal timeoutMs (NaN) falls back to the 60_000 default", () => {
+    const cap = createDelayCapturingScheduler();
+    const tracker = new ResumeAckTracker({
+      push: () => {},
+      scheduler: cap.scheduler,
+      timeoutMs: Number.NaN,
+      retries: 3,
+    });
+    tracker.start("rid_tonan");
+    expect(cap.delays[0]).toBe(60_000);
+  });
+
+  test("illegal retries (0) falls back to the 3 default — 3 flushes to degrade, not 1", () => {
+    const cap = createDelayCapturingScheduler();
+    const degraded: string[] = [];
+    const tracker = new ResumeAckTracker({
+      push: () => {},
+      scheduler: cap.scheduler,
+      timeoutMs: 60_000,
+      retries: 0, // literal 0 would degrade on the FIRST timeout; fallback 3 must not
+      onDegraded: (rid) => degraded.push(rid),
+    });
+    tracker.start("rid_re0");
+
+    cap.flush(); // attempt 1
+    cap.flush(); // attempt 2
+    expect(degraded).toHaveLength(0); // still awaiting → proves 0 fell back to 3
+    expect(tracker.get("rid_re0")?.state).toBe("awaiting_ack");
+
+    cap.flush(); // attempt 3 → exhausts the fallback-3 → degrade
+    expect(degraded).toContain("rid_re0");
+  });
+});
+
+describe("ResumeAckTracker — stop", () => {
+  test("stop clears all pending timers and empties the tracker (no open handles)", () => {
+    const { tracker, fake } = createTracker();
+    tracker.start("rid_a");
+    tracker.start("rid_b");
+    expect(fake.pending()).toBe(2);
+
+    tracker.stop();
+    expect(fake.pending()).toBe(0);
+    expect(tracker.size).toBe(0);
+  });
+});

--- a/src/unit-test/resume-ack-wiring.test.ts
+++ b/src/unit-test/resume-ack-wiring.test.ts
@@ -1,0 +1,197 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { DaemonClient } from "../daemon-client";
+import { ResumeAckTracker } from "../budget/resume-ack-tracker";
+import { routeResume } from "../budget/route-resume";
+import type { ResumeScheduler } from "../budget/resume-injection-queue";
+
+/**
+ * Wiring tests for PR4 Claude-side auto-resume:
+ *  - control-protocol ack_resume message round-trip (bridge -> daemon).
+ *  - the SHARED routeResume dispatch the daemon installs: claude ->
+ *    claudeResumeTracker.start, codex -> enqueueCodex (PR3 owns the Codex
+ *    queue, untouched here). Importing the real routeResume (not a re-impl)
+ *    means the test pins the daemon's actual routing, not a hand-copied rule.
+ *  - daemon shutdown -> claudeResumeTracker.stop().
+ */
+
+// ── Fake scheduler (no real timers; hermetic) ──────────────────
+function fakeScheduler(): ResumeScheduler {
+  let nextId = 1;
+  const timers = new Map<number, () => void>();
+  return {
+    setTimeout(cb: () => void) {
+      const id = nextId++;
+      timers.set(id, cb);
+      return id;
+    },
+    clearTimeout(timer: unknown) {
+      if (typeof timer === "number") timers.delete(timer);
+    },
+  };
+}
+
+// ── control-protocol ack_resume round-trip ─────────────────────
+let server: ReturnType<typeof Bun.serve> | null = null;
+let serverPort = 0;
+let client: DaemonClient;
+let serverSockets: Set<any>;
+let onServerMessage: (ws: any, raw: string | Buffer) => void = () => {};
+
+function startServer() {
+  serverSockets = new Set();
+  const srv = Bun.serve({
+    port: 0,
+    fetch(req, s) {
+      if (s.upgrade(req)) return undefined;
+      return new Response("ok");
+    },
+    websocket: {
+      open(ws: any) {
+        serverSockets.add(ws);
+      },
+      message(ws: any, raw: any) {
+        onServerMessage(ws, raw);
+      },
+      close(ws: any) {
+        serverSockets.delete(ws);
+      },
+    },
+  });
+  server = srv;
+  serverPort = srv.port as number;
+}
+
+function stopServer() {
+  if (server) {
+    server.stop(true);
+    server = null;
+  }
+}
+
+describe("control-protocol ack_resume round-trip (bridge -> daemon)", () => {
+  beforeEach(() => {
+    onServerMessage = () => {};
+    startServer();
+    client = new DaemonClient(`ws://127.0.0.1:${serverPort}/ws`);
+  });
+
+  afterEach(async () => {
+    await client.disconnect();
+    stopServer();
+  });
+
+  test("sendAckResume emits an ack_resume control message carrying resumeId + status", async () => {
+    await client.connect();
+
+    const received = new Promise<any>((resolve) => {
+      onServerMessage = (_ws, raw) => {
+        resolve(JSON.parse(typeof raw === "string" ? raw : raw.toString()));
+      };
+    });
+
+    client.sendAckResume("system_budget_resume_9", "resumed");
+
+    const msg = await received;
+    expect(msg.type).toBe("ack_resume");
+    expect(msg.resumeId).toBe("system_budget_resume_9");
+    expect(msg.status).toBe("resumed");
+  });
+});
+
+// ── routeResume dispatch contract (the SHARED daemon routing) ───
+//
+// These tests import the REAL routeResume the daemon installs, so the contract
+// they pin is the daemon's actual dispatch — not a re-implemented copy that
+// could drift. `side` is always a concrete AgentName (codex | claude); the
+// coordinator iterates recoveredSides, so "both" is never passed (a joint
+// recovery is two distinct calls — see the both-sides test below).
+describe("routeResume(side, resumeId, deps) — shared daemon dispatch", () => {
+  test("side=claude starts the Claude tracker and does NOT enqueue Codex", () => {
+    const codexEnqueued: string[] = [];
+    const pushes: string[] = [];
+    const tracker = new ResumeAckTracker({
+      push: (e: { resumeId: string }) => pushes.push(e.resumeId),
+      scheduler: fakeScheduler(),
+      timeoutMs: 60_000,
+      retries: 3,
+    });
+
+    routeResume("claude", "rid_claude", {
+      claudeTracker: tracker,
+      enqueueCodex: (rid) => codexEnqueued.push(rid),
+    });
+
+    expect(tracker.get("rid_claude")?.state).toBe("awaiting_ack");
+    expect(pushes).toContain("rid_claude");
+    expect(codexEnqueued).toHaveLength(0);
+    tracker.stop();
+  });
+
+  test("side=codex enqueues Codex and does NOT touch the Claude tracker (PR3 owns the queue)", () => {
+    const codexEnqueued: string[] = [];
+    const tracker = new ResumeAckTracker({
+      push: () => {},
+      scheduler: fakeScheduler(),
+      timeoutMs: 60_000,
+      retries: 3,
+    });
+
+    routeResume("codex", "rid_codex", {
+      claudeTracker: tracker,
+      enqueueCodex: (rid) => codexEnqueued.push(rid),
+    });
+
+    expect(tracker.size).toBe(0); // Claude tracker untouched
+    expect(codexEnqueued).toEqual(["rid_codex"]);
+    tracker.stop();
+  });
+
+  test("both-sides recovery = two independent routeResume calls (distinct resumeIds)", () => {
+    // The coordinator never passes "both": a joint recovery iterates
+    // recoveredSides = ["codex", "claude"] and calls routeResume once per side
+    // with its OWN resumeId. Codex enqueues exactly once; Claude starts exactly
+    // once — neither cross-contaminates the other.
+    const codexEnqueued: string[] = [];
+    const tracker = new ResumeAckTracker({
+      push: () => {},
+      scheduler: fakeScheduler(),
+      timeoutMs: 60_000,
+      retries: 3,
+    });
+    const deps = {
+      claudeTracker: tracker,
+      enqueueCodex: (rid: string) => codexEnqueued.push(rid),
+    };
+
+    routeResume("codex", "rid_codex_side", deps);
+    routeResume("claude", "rid_claude_side", deps);
+
+    expect(codexEnqueued).toEqual(["rid_codex_side"]); // Codex enqueued once
+    expect(tracker.size).toBe(1); // Claude tracker has exactly one entry
+    expect(tracker.get("rid_claude_side")?.state).toBe("awaiting_ack");
+    expect(tracker.get("rid_codex_side")).toBeUndefined(); // codex rid not in Claude tracker
+    tracker.stop();
+  });
+});
+
+describe("setResumeAckHandler wiring -> tracker.ack", () => {
+  test("the ack handler the daemon wires resolves the awaiting entry", () => {
+    const tracker = new ResumeAckTracker({
+      push: () => {},
+      scheduler: fakeScheduler(),
+      timeoutMs: 60_000,
+      retries: 3,
+    });
+    tracker.start("rid_wire");
+
+    // daemon wires setResumeAckHandler -> (resumeId) => tracker.ack(resumeId)
+    const ackHandler = (resumeId: string, _status: string) => tracker.ack(resumeId);
+    ackHandler("rid_wire", "resumed");
+
+    // ack resolves and DELETES the terminal entry (map hygiene): the re-push
+    // loop is stopped and the map is empty.
+    expect(tracker.get("rid_wire")).toBeUndefined();
+    expect(tracker.size).toBe(0);
+    tracker.stop();
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary

预算减速线 + 自动续接系列的 **PR4**。为 PR3 (#167) 的 Codex `ResumeInjectionQueue` 补上 **Claude 侧对偶**：一个 daemon 驱动的 push-only `ack/重试/降级` 状态机。额度窗口刷新后，daemon 推一条 `system_budget_resume` 通知给 Claude，等 Claude 通过新的 `ack_resume` MCP 工具回执；超时重推，重试耗尽则降级并落 sentinel，让下一个会话仍能续接。

PR4 of the budget slowdown-line + auto-resume series. Adds the **Claude-side counterpart** to PR3 (#167)'s Codex `ResumeInjectionQueue`: a daemon-owned, push-only `ack/retry/degrade` state machine.

## 改动 / Changes

- **`ResumeAckTracker`** (`src/budget/resume-ack-tracker.ts`) — 状态机 `awaiting_ack/resumed/degraded`。推送携带**稳定 resumeId** 的 `system_budget_resume` channel 通知；等 Claude 经 `ack_resume` 回执。超时重推用**全新 deliveryId**（绕过 LRU dedup）但 resumeId 不变（回执仍能对上）；`retries` 次超时后进入终态降级。计时器卫生：DI scheduler + unref + `stop()`，无悬挂句柄。
- **降级→sentinel 逃生通道** (`src/budget/resume-ack-sentinel.ts`) — 原子 temp+rename、0o600。SessionStart 钩子 (`health-check.sh`) 在 cooldown 闸门**之前**读取并一次性消费，空闲/已退出的会话也能拿到续接提示。
- **`ack_resume` MCP 工具** (`claude-adapter.ts`) + `control-protocol`/`daemon-client`/`bridge` 接线；`routeResume()` 纯函数路由（daemon 与测试共享）。
- **`types.ts`**：新增可选字段 `BridgeMessage.resumeId?`（additive，向后兼容）。

## 测试 / Tests

- 单测：`resume-ack-tracker` / `resume-ack-sentinel` / `claude-adapter-resume` / `resume-ack-wiring`
- 集成：`daemon-wiring` Claude 侧续接路径
- 全量：**1428 pass / 0 fail**，`tsc --noEmit` clean，`verify:plugin-sync` 通过（bundle 与源同步）

`resume-ack-sentinel.test.ts` 覆盖 §6 逃生通道端到端：payload `{resumeId,degradedAt}`、0o600、原子 temp+rename（无 .tmp 残留）、写失败 best-effort 不抛、bash↔TS resumeId 解析一致性，以及 `ResumeAckTracker → onDegraded → 真实 sentinel writer` 全链路。

## Cross-review

4 轮 / 8 个独立 reviewer + 对抗式 verify，**连续 2 轮干净**（#C/#D，0 confirmed REAL）。一个 SUSPECT（`ack_resume` 未做 token 闸门）由主 agent 亲自实证驳回：`daemon.ts:998-1053` 显示 `status`/`probe_incumbent` 同样不闸门，localhost + Origin/CSWSH 才是边界，`ack_resume` 是纯控制面信号、非消息注入路径——与既有信任模型一致。

## 已知 backlog（非阻塞 RECOMMEND）/ Known backlog (non-blocking)

- `degradedAt` 已写未读 —— 可加 TTL staleness gate 或移除该字段
- bash↔TS parity 目前由 TS 复刻 regex 钉住 —— 可加 spawn `health-check.sh` 的集成测试端到端兜住
- `ack_resume` 有意不闸门（与 `status`/`probe_incumbent` 一致）—— 文档化即可

## Test plan

- [x] `bun run typecheck`
- [x] `bun test src`（1428 pass / 0 fail）
- [x] `bun run verify:plugin-sync`
- [ ] 部署后人工验证：额度窗口刷新触发 Claude 侧自动续接（依赖真实额度边界，部署后由用户/后续观测验证）