### PR TITLE
chore(budget): PR5 idle-injection probe + 设计稿/测试计划 + gitignore [skip release]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ codex-plugin-cc/
 agentbridge-context.md
 .agentbridge/
 V1_PROGRESS.md
+.agent/
 # Added by code-review-graph
 .code-review-graph/
 

--- a/docs/design/budget-auto-resume.md
+++ b/docs/design/budget-auto-resume.md
@@ -1,0 +1,97 @@
+# 设计稿：额度减速线 + 原 TUI 自动续接（跨 guard + bridge 两仓）
+
+> 状态：实施细化稿 v0.1，待 Codex 对抗审。基于 2026-06-14 用户决策 + Claude/Codex 命门验证。
+> 作者：Claude；评审：Codex（命门判断已记 §3，对抗审待补）。
+
+## 1. 宗旨与目标
+
+用户最高宗旨（原话）：**「既要把周窗口额度尽可能用满，又不让任务被中途打断」** + **「停了要能在原本的 Claude/Codex TUI 里全自动续接，不要后台无头进程，不要手动」**。
+
+拆解成可实现目标：
+1. 额度高位时**执行工具调用中途绝不拦**（不被"中途"打断）。
+2. **一轮自然结束（轮末）到硬线时停在干净点** + 写 checkpoint（这个"停"是 watchdog/续接的前提）。
+3. **窗口刷新后自动续接**，在**原本的交互式 TUI** 里继续（不要 headless `claude -p` / tmux 后台）。
+
+## 2. 用户决策汇总（2026-06-14）
+
+| # | 决策 |
+|---|---|
+| D1 | 减速线 = remind 形态 B（中途不拦 + 轮末干净点停 + 自动续），不是纯不停 |
+| D2 | 自动续接要全自动、不要手动（手动 skip 退居逃生门） |
+| D3 | 在原 TUI 续接，不要后台无头进程 |
+| D4 | 用 AgentBridge channel/turn 注入续接（不用 guard watchdog tmux/headless） |
+| D5 | Claude 侧接受 best-effort channel + 本机实测定级（Codex 侧全自动） |
+
+## 3. 命门验证结论（Claude 实证 + Codex 查证，2026-06-14）
+
+**Codex 侧自动续接：✅ 完全可行。** `codex-adapter.ts:503 injectMessage()` 写 `turn/start`（请求型）能主动开新 turn 驱动原 Codex TUI；`turn/started`/`turn/completed` 跟踪生命周期 + `bridgeTurnStarted`/reject 确认。
+
+**Claude 侧自动续接：⚠️ best-effort（有官方不可靠性）。**
+- 活跃 loop 下 channel push 能触发 Claude 行动——**本场协作已实证**（Codex 发消息 Claude 即行动）。
+- 但 idle（`❯` 提示符）时不保证唤醒：官方 issue [#44380](https://github.com/anthropics/claude-code/issues/44380) 实锤——idle 时 channel 消息只显示、Claude 不自动处理、要手动敲；issue [#61797](https://github.com/anthropics/claude-code/issues/61797) 报告 idle notification 变量性丢失。
+- `server.notification()` 无执行 ACK——只代表写入 transport，不代表 Claude 已处理。
+
+**三档能力结论（2026-06-14 本机实测更新）：**
+| 路径 | 能力 | 代价 |
+|---|---|---|
+| Codex turn/start | fully automatic | 无 |
+| **Claude channel** | **fully automatic（本机实测推翻 best-effort 判断，见下）** | 偶发丢失风险（#61797），保留 ACK+少量重试兜底 |
+| Claude SessionStart | 可靠 fallback（仅 channel 偶发失败时兜底） | 要重启/恢复 TUI |
+
+**🎯 本机实测结论（2026-06-14，决定性数据，推翻官方 issue 悲观判断）：**
+- 测法：Claude 真 idle（非 require_reply 武装态）时，Codex 经 bridge channel push 一条普通消息，观测 Claude 是否自动响应（用户全程不碰 Claude 键盘）。
+- **测试 1**：消息一到 Claude 立即自动打字、不停留输入框、用户未碰键盘 → ✅ 唤醒。
+- **测试 2（排除隐性等待）**：Claude 明确收尾「不等任何东西」+ 纯空闲约 3 分钟后，Codex 再发 → ✅ 依然自动响应。
+- **结论**：本机 Claude Code + AgentBridge channel 实现，**纯 idle 能可靠唤醒**，比官方 issue #44380 描述强（疑似该版已修，或 bridge channel 投递方式恰好能唤醒 loop）。Claude 侧续接 = **fully automatic**，不需 SessionStart 作主路径。
+- **残留风险**：issue #61797 报过 idle notification 变量性丢失。故设计仍保留 ACK + 少量重试兜底（不是因为唤不醒，是防偶发丢消息），channel 连续失败 N 次才降级 SessionStart。
+
+## 3.5 设计共识（Claude + Codex，2026-06-14 实测后达成）
+
+- **能力定级**：本机 Claude Code + AgentBridge channel 下，Claude 与 Codex **都走自动续接主路径**（fully automatic in supported local environment, with ACK/retry for reliability）。官方 #44380/#61797 保留为版本/环境风险注记，非当前能力结论。
+- **两侧差异**：Claude = channel push + `ack_resume` MCP tool；Codex = queued `turn/start` + `bridgeTurnStarted` 确认。
+- **ACK 角色**：确认 + 幂等（不再承担"证明能否唤醒"）。`ack_resume` 仍 P1——notification 无执行 ACK，bridge 需知 resume_id 是否被接收并开始处理。
+- **SessionStart**：纯兜底逃生门（channel 连续未 ACK / frontend 离线 / 能力探测失败时），不进正常路径。
+- **guard pending = 续接源头**；**ResumeInjectionQueue = Codex 侧必补的可靠性层**。
+
+## 4. 设计与分工
+
+### 4.1 guard 侧（agent-quota-guard）—— 减速线，不 deny
+`lib/guard/hook.mjs` + `claude-budget-guard/budget_guard.sh` + `codex-budget-guard/budget_guard.sh`：
+- **phasePre（中途）**：去掉硬线 deny（hook.mjs:347-366）→ 改强提醒 `additionalContext`/`systemMessage`，**绝不 deny**。
+- **收尾保护线**：probe runway 字段可用且 confident 时，`runway_seconds < FINISHING_HORIZON_SEC`（默认 1800s，可配）→ 强提醒写 checkpoint（比静态 92% 更准）。runway 不可用 → 退静态线提醒。
+- **phaseStop（轮末）**：到硬线**停在干净点** + 写 checkpoint + 写 pending（供 bridge 检测）。**保留这个"停"**（是续接前提）。
+- probe / 数据源：不动。
+
+### 4.2 bridge 侧（agent_bridge）—— 检测刷新 + 注入续接（新功能，核心）
+budget 协调器（`budget-coordinator.ts` + `daemon.ts`）：
+- **检测"曾暂停的 agent 窗口刷新了"**：复用现有 `system_budget_resume`/`claude_recovered` 状态机（budget-coordinator.ts:360-364）。
+- **续接注入**：
+  - **Codex**：新增 coordinator/system → Codex 的受控 `turn/start` 注入入口（现在只有 Claude reply 触发 injectMessage，daemon.ts:1154），注入 resume turn（"从 checkpoint 下一步继续"）。
+  - **Claude**：channel push 一条带 `resume_id` 的 resume 指令。
+- **ACK + 幂等 + 重传**（Claude 侧关键）：
+  - resume 消息带 `resume_id`。bridge 只有看到 Claude **真 ACK**（调用 MCP tool 确认 / 用 reply 交接 / 有后续活动）才标记 resumed。
+  - 没 ACK → 超时重传 N 次 → 仍无 → **降级到 SessionStart fallback**（提示/触发重启恢复）或留待用户手动。
+  - 幂等：同 resume_id 不重复注入（防刷屏/重复续接）。
+
+### 4.3 续接指令内容
+复用 guard watchdog 的 RESUME_PROMPT 风格：「继续上次未完成的任务，从 .agent/checkpoint.md 的「下一步」接着做；完成后停下并标 DONE」。
+
+## 5. 实测计划（best-effort 定级，D5）
+在用户本机目标 Claude Code 版本上实测：
+1. Claude TUI idle（`❯`）时，bridge channel push 一条消息 → Claude 会不会自动开始处理？
+2. 若会 → Claude 侧定级 fully automatic；若不会 → 定级 best-effort（配 SessionStart fallback）。
+3. Codex idle 时 turn/start 注入 → 确认开新 turn。
+
+## 6. 影响面 + 测试要点
+- guard：hook 三阶段改 + 收尾保护线 + bash/node 双实现一致；测试 deny→remind、runway 触发、watchdog/pending 保留。
+- bridge：续接状态机 + Codex turn/start system 入口 + Claude channel resume + ACK/重传/幂等/降级；测试刷新检测、注入、ACK 观测、超时降级、幂等。
+
+## 7. 风险
+| # | 风险 | 护栏 |
+|---|---|---|
+| R1 | Claude idle 唤不醒（官方 #44380） | best-effort + ACK 超时降级 SessionStart；实测定级 |
+| R2 | 腰斩（中途不停撞限流） | 收尾保护线提前提醒 + checkpoint 纪律 |
+| R3 | 重复续接刷屏 | resume_id 幂等 |
+| R4 | bridge 误判已续接（notification 无 ACK） | 必须看到 Claude 真 ACK 才标 resumed |
+| R5 | guard bash/node 双实现漂移 | 两套都改 + 对照测试 |
+| R6 | watchdog 续接 vs bridge 续接重复 | 二选一：bridge 续接为主，guard watchdog 不装（避免两套都唤醒）|

--- a/docs/test-plans/pr5-codex-idle-injection.md
+++ b/docs/test-plans/pr5-codex-idle-injection.md
@@ -1,0 +1,292 @@
+# PR5 Codex Idle Injection Capability Test Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to run this plan step-by-step. This plan intentionally does not run from the current Codex collaboration turn.
+
+**Goal:** Determine whether an idle Codex TUI can be fully automatically awakened by AgentBridge's existing `turn/start` injection path.
+
+**Architecture:** The probe uses the public daemon control WebSocket as a temporary Claude-side client. It drives the real path `claude_to_codex -> codex.injectMessage() -> turn/start`, then waits for both the control `turn_started` ACK and the `system_turn_started` bridge message emitted from Codex's real `turn/started` notification.
+
+**Tech Stack:** Bun/Node WebSocket, AgentBridge control protocol, existing daemon `/healthz`, existing Codex adapter injection path.
+
+---
+
+## Scope
+
+This is a live capability test for current AgentBridge/Codex behavior. It does not depend on PR3 `ResumeInjectionQueue` and must not import daemon internals.
+
+Code anchors being exercised:
+
+- `src/codex-adapter.ts:503` `injectMessage()` sends app-server `turn/start`.
+- `src/codex-adapter.ts:2013` handles app-server `turn/started`.
+- `src/codex-adapter.ts:1874` emits `bridgeTurnStarted` from a bridge-originated `turn/start` response.
+- `src/daemon.ts:616` (`codex.on("bridgeTurnStarted")`) converts `bridgeTurnStarted` into control `turn_started` (sent at `:638`).
+- `src/daemon.ts:699` (`codex.on("turnStarted")`) emits `system_turn_started` (at `:703`) after the raw Codex turn lifecycle starts.
+- `src/daemon.ts:1040` (`case "claude_to_codex"`) routes control `claude_to_codex` into `handleClaudeToCodex` (`:1134`), which calls `codex.injectMessage()` at `:1407`.
+
+> Line numbers track `master` (PR4 / `21fd937`); prefer the named symbols if they drift on a later refactor.
+
+## Files
+
+- Script: `scripts/pr5-codex-idle-injection-probe.mjs`
+- Plan: `docs/test-plans/pr5-codex-idle-injection.md`
+
+## Safety Rules
+
+Do not run this against the active collaboration pair. The current Codex session executing this work is not idle, and injecting into it would pollute this thread.
+
+Use a disposable pair and cwd:
+
+```bash
+export PR5_CWD="/tmp/agentbridge-pr5-idle"
+export PR5_PAIR="pr5-idle-probe"
+mkdir -p "$PR5_CWD"
+```
+
+Run the probe script from this repo while targeting the disposable cwd, so the script's default `status.cwd === process.cwd()` refusal protects the current repo:
+
+```bash
+cd /Users/raysonmeng/repo/agent_bridge
+```
+
+The script also refuses to contest a live attached Claude frontend unless `--replace-incumbent` is supplied. Do not use `--replace-incumbent` for this test; the script itself should be the only temporary Claude-side control client for the disposable pair.
+
+## Observable Signals
+
+The success scenario must observe all of these:
+
+1. Precondition status shows true idle target:
+   - `bridgeReady: true`
+   - `tuiConnected: true`
+   - `threadId` is a non-empty string
+   - `turnPhase: "idle"`
+
+2. The probe sends one `claude_to_codex` message with `onBusy: "reject"`.
+
+3. The daemon returns:
+   - `claude_to_codex_result.success === true`
+
+4. The daemon emits:
+   - `turn_started` with the same `requestId`
+   - a `turnId`
+   - the same live `threadId`
+
+5. The daemon forwards a `codex_to_claude` message whose id starts with `system_turn_started_`. This is the evidence that Codex's real `turn/started` notification fired, not only that the `turn/start` request was accepted.
+
+If all five hold without manual input in Codex after the probe send, classify the capability as:
+
+```text
+fully_automatic_idle_wakeup
+```
+
+## Non-Success Classifications
+
+Use these labels in the PR5 report:
+
+- `not_ready_no_thread`: status lacks a live `threadId` or `bridgeReady`; daemon returns `no_thread`.
+- `not_ready_ws_down`: status shows `tuiConnected:false` or `bridgeReady:false`; daemon returns `no_thread`.
+- `busy_reject_only`: status shows `turnPhase:running|stalled`; daemon returns `busy_reject` and no `turn_started`.
+- `transport_rejected`: `claude_to_codex_result.success:false` with an app-server rejection, or `turn_started` never arrives after result success.
+- `not_fully_automatic`: `turn_started` arrives only after manual Codex input, or no `system_turn_started_` message arrives.
+
+## Step 1: Start Disposable Codex Pair
+
+In Terminal A:
+
+```bash
+cd "$PR5_CWD"
+abg kill --pair "$PR5_PAIR" || true
+abg codex --pair "$PR5_PAIR" --new
+```
+
+Create or verify a live thread in that Codex TUI, then wait until the turn is complete and Codex is idle. A simple manual warm-up prompt is acceptable inside the disposable TUI:
+
+```text
+Reply exactly READY and stop.
+```
+
+Leave the disposable Codex TUI open and idle.
+
+Get the control port in Terminal B:
+
+```bash
+export CONTROL_PORT=$(abg pairs --json | jq -r --arg pair "$PR5_PAIR" '.[] | select(.name == $pair or .pairId == $pair) | .ports.controlPort')
+echo "CONTROL_PORT=$CONTROL_PORT"
+[ -n "$CONTROL_PORT" ] && [ "$CONTROL_PORT" != "null" ] || echo "WARN: control port not resolved — check 'abg pairs' (is the daemon up and the pair named '$PR5_PAIR'?)"
+```
+
+If the JSON shape differs, use the pair row's control port shown by `abg pairs`.
+
+## Step 2: Observe Without Injecting
+
+From `/Users/raysonmeng/repo/agent_bridge`:
+
+```bash
+bun scripts/pr5-codex-idle-injection-probe.mjs \
+  --scenario observe \
+  --control-port "$CONTROL_PORT" \
+  --expected-cwd "$PR5_CWD"
+```
+
+Expected:
+
+- If no Claude frontend is attached to the disposable pair, the script attaches and prints status.
+- If a live Claude frontend is attached, the script reports observe-only and does not contest it.
+- No `claude_to_codex` injection is sent.
+
+Required status before Step 3:
+
+```json
+{
+  "bridgeReady": true,
+  "tuiConnected": true,
+  "threadId": "non-empty",
+  "turnPhase": "idle"
+}
+```
+
+## Step 3: Success Scenario
+
+From `/Users/raysonmeng/repo/agent_bridge`:
+
+```bash
+bun scripts/pr5-codex-idle-injection-probe.mjs \
+  --scenario success \
+  --control-port "$CONTROL_PORT" \
+  --expected-cwd "$PR5_CWD" \
+  --confirm-inject
+```
+
+Expected pass line:
+
+```text
+[PASS] fully_automatic_idle_wakeup
+```
+
+The JSON form is useful for PR artifacts:
+
+```bash
+bun scripts/pr5-codex-idle-injection-probe.mjs \
+  --scenario success \
+  --control-port "$CONTROL_PORT" \
+  --expected-cwd "$PR5_CWD" \
+  --confirm-inject \
+  --json | tee /tmp/pr5-codex-idle-success.json
+```
+
+The resulting JSON must include:
+
+- `classification: "fully_automatic_idle_wakeup"`
+- `result.success: true`
+- `turnStartedAck.turnId`
+- `rawTurnStartedMessageId` starting with `system_turn_started_`
+- `before.turnPhase: "idle"`
+
+## Step 4: Busy Failure Mode
+
+In the disposable Codex TUI, start a long-running turn. For example:
+
+```text
+Run a shell command that sleeps for 60 seconds, then reply DONE.
+```
+
+While it is running, execute:
+
+```bash
+bun scripts/pr5-codex-idle-injection-probe.mjs \
+  --scenario busy \
+  --control-port "$CONTROL_PORT" \
+  --expected-cwd "$PR5_CWD" \
+  --confirm-inject
+```
+
+Expected:
+
+```text
+[PASS] busy produced busy_reject without turn_started
+```
+
+This proves the probe is not silently steering or queueing while Codex is busy; the PR3 queue must defer until a later idle boundary.
+
+## Step 5: No-Thread Failure Mode
+
+Use a disposable daemon state where no Codex thread has been established yet, or start the pair and probe before the Codex TUI creates a thread.
+
+Run:
+
+```bash
+bun scripts/pr5-codex-idle-injection-probe.mjs \
+  --scenario no-thread \
+  --control-port "$CONTROL_PORT" \
+  --expected-cwd "$PR5_CWD" \
+  --confirm-inject
+```
+
+Expected:
+
+```text
+[PASS] no-thread produced no_thread without turn_started
+```
+
+This confirms PR3 cannot rely on bridge injection unless PR2/PR3 has a live candidate thread/checkpoint.
+
+## Step 6: WS-Down Failure Mode
+
+Close the disposable Codex TUI while keeping the daemon alive. If needed, launch the pair with a long idle shutdown setting so the daemon remains reachable long enough to test:
+
+```bash
+AGENTBRIDGE_IDLE_SHUTDOWN_MS=300000 abg codex --pair "$PR5_PAIR"
+```
+
+After the TUI disconnects and status shows `tuiConnected:false` or `bridgeReady:false`, run:
+
+```bash
+bun scripts/pr5-codex-idle-injection-probe.mjs \
+  --scenario ws-down \
+  --control-port "$CONTROL_PORT" \
+  --expected-cwd "$PR5_CWD" \
+  --confirm-inject
+```
+
+Expected:
+
+```text
+[PASS] ws-down produced no_thread without turn_started
+```
+
+Current daemon behavior collapses no live thread and no app-server/TUI readiness into `code:"no_thread"`. The report should include the pre-status fields to distinguish the two cases.
+
+## PR5 Report Template
+
+Use this shape in the PR5 result:
+
+```markdown
+## Codex Idle Injection Capability
+
+Result: fully_automatic_idle_wakeup | not_fully_automatic | transport_rejected | not_ready_no_thread | not_ready_ws_down | busy_reject_only
+
+Environment:
+- AgentBridge commit/build:
+- Codex version:
+- Pair:
+- Cwd:
+- Control port:
+
+Success evidence:
+- before.bridgeReady:
+- before.tuiConnected:
+- before.threadId:
+- before.turnPhase:
+- claude_to_codex_result:
+- turn_started ACK:
+- system_turn_started message id:
+- after.turnPhase:
+
+Failure-mode checks:
+- busy:
+- no-thread:
+- ws-down:
+
+Conclusion for PR3:
+- ResumeInjectionQueue may inject immediately when candidate side is idle and status has live thread+WS.
+- ResumeInjectionQueue must soft-defer on busy/no-thread/ws-down and retry from turnCompleted/status/watchdog triggers.
+```

--- a/scripts/pr5-codex-idle-injection-probe.mjs
+++ b/scripts/pr5-codex-idle-injection-probe.mjs
@@ -1,0 +1,518 @@
+#!/usr/bin/env bun
+/**
+ * PR5 Codex idle injection probe.
+ *
+ * This script intentionally drives the existing AgentBridge control protocol:
+ * control WS -> claude_connect -> claude_to_codex -> CodexAdapter.injectMessage
+ * -> app-server turn/start. It does not import private daemon internals.
+ *
+ * Default mode is observe-only. Any scenario that sends claude_to_codex requires
+ * --confirm-inject and refuses to target the current cwd unless
+ * --allow-current-cwd is provided.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_CONTROL_PORT = Number.parseInt(process.env.AGENTBRIDGE_CONTROL_PORT || "4502", 10);
+const SCENARIOS = new Set(["observe", "success", "busy", "no-thread", "ws-down"]);
+
+function usage() {
+  return `Usage:
+  bun scripts/pr5-codex-idle-injection-probe.mjs --scenario observe [--control-port 4502]
+  bun scripts/pr5-codex-idle-injection-probe.mjs --scenario success --control-port 45xx --confirm-inject [--expected-cwd /tmp/pr5]
+
+Scenarios:
+  observe    Attach/read status only. No claude_to_codex injection.
+  success    Require true idle: bridgeReady+tuiConnected+threadId+turnPhase=idle, then inject and wait for:
+             claude_to_codex_result(success), turn_started ACK, and system_turn_started message.
+  busy       Require running/stalled turn; inject with onBusy=reject and expect busy_reject, no turn_started.
+  no-thread  Require no usable thread/readiness; expect no_thread, no turn_started.
+  ws-down    Require TUI/bridge not ready; expect no_thread, no turn_started.
+
+Safety:
+  Non-observe scenarios require --confirm-inject.
+  The script refuses status.cwd === process.cwd() unless --allow-current-cwd is set.
+  It refuses to replace a live attached Claude frontend unless --replace-incumbent is set.
+
+Options:
+  --control-port <port>       Daemon control port. Default: AGENTBRIDGE_CONTROL_PORT or 4502.
+  --state-dir <path>          Pair state dir. Default: /healthz status.stateDir.
+  --expected-cwd <path>       Refuse if daemon status.cwd differs.
+  --message <text>            Probe message for success scenario.
+  --timeout-ms <ms>           Overall wait timeout per awaited event. Default: ${DEFAULT_TIMEOUT_MS}.
+  --idempotency-key <key>     Optional idempotency key. Default: pr5-<scenario>-<timestamp>.
+  --confirm-inject            Required for success/busy/no-thread/ws-down.
+  --allow-current-cwd         Allow targeting the process cwd.
+  --replace-incumbent         Allow attaching when probe_incumbent reports a live Claude frontend.
+  --json                      Print machine-readable JSON summary.
+  --help                      Show this help.
+`;
+}
+
+function parseArgs(argv) {
+  const opts = {
+    scenario: "observe",
+    controlPort: DEFAULT_CONTROL_PORT,
+    stateDir: null,
+    expectedCwd: null,
+    message: null,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    idempotencyKey: null,
+    confirmInject: false,
+    allowCurrentCwd: false,
+    replaceIncumbent: false,
+    json: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => {
+      if (i + 1 >= argv.length) throw new Error(`Missing value for ${arg}`);
+      return argv[++i];
+    };
+
+    switch (arg) {
+      case "--scenario":
+        opts.scenario = next();
+        break;
+      case "--control-port":
+        opts.controlPort = Number.parseInt(next(), 10);
+        break;
+      case "--state-dir":
+        opts.stateDir = next();
+        break;
+      case "--expected-cwd":
+        opts.expectedCwd = next();
+        break;
+      case "--message":
+        opts.message = next();
+        break;
+      case "--timeout-ms":
+        opts.timeoutMs = Number.parseInt(next(), 10);
+        break;
+      case "--idempotency-key":
+        opts.idempotencyKey = next();
+        break;
+      case "--confirm-inject":
+        opts.confirmInject = true;
+        break;
+      case "--allow-current-cwd":
+        opts.allowCurrentCwd = true;
+        break;
+      case "--replace-incumbent":
+        opts.replaceIncumbent = true;
+        break;
+      case "--json":
+        opts.json = true;
+        break;
+      case "--help":
+      case "-h":
+        opts.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!SCENARIOS.has(opts.scenario)) {
+    throw new Error(`Invalid --scenario ${opts.scenario}; expected one of ${[...SCENARIOS].join(", ")}`);
+  }
+  if (!Number.isInteger(opts.controlPort) || opts.controlPort <= 0) {
+    throw new Error(`Invalid --control-port ${opts.controlPort}`);
+  }
+  if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs <= 0) {
+    throw new Error(`Invalid --timeout-ms ${opts.timeoutMs}`);
+  }
+  return opts;
+}
+
+function samePath(a, b) {
+  return resolve(a) === resolve(b);
+}
+
+function readToken(stateDir) {
+  const path = join(stateDir, "control-token");
+  if (!existsSync(path)) return null;
+  const token = readFileSync(path, "utf-8").trim();
+  return token.length > 0 ? token : null;
+}
+
+async function fetchStatus(controlPort, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`http://127.0.0.1:${controlPort}/healthz`, { signal: controller.signal });
+    if (!response.ok) throw new Error(`/healthz returned ${response.status}`);
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+class ControlProbe {
+  constructor(url, timeoutMs) {
+    this.url = url;
+    this.timeoutMs = timeoutMs;
+    this.ws = null;
+    this.messages = [];
+    this.waiters = [];
+    this.closed = null;
+  }
+
+  async connect() {
+    if (typeof WebSocket !== "function") {
+      throw new Error("Global WebSocket is unavailable; run with Bun or a Node version that provides WebSocket.");
+    }
+    await new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.url);
+      const timer = setTimeout(() => {
+        try { ws.close(); } catch {}
+        reject(new Error(`Timed out connecting to ${this.url}`));
+      }, this.timeoutMs);
+
+      ws.onopen = () => {
+        clearTimeout(timer);
+        this.ws = ws;
+        resolve();
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        reject(new Error(`WebSocket error connecting to ${this.url}`));
+      };
+      ws.onclose = (event) => {
+        clearTimeout(timer);
+        this.closed = { code: event.code, reason: event.reason };
+        this.rejectAll(new Error(`WebSocket closed (${event.code} ${event.reason || "no reason"})`));
+      };
+      ws.onmessage = (event) => this.onMessage(event.data);
+    });
+  }
+
+  onMessage(raw) {
+    let parsed;
+    try {
+      parsed = JSON.parse(String(raw));
+    } catch {
+      parsed = { type: "unparseable", raw: String(raw) };
+    }
+    this.messages.push(parsed);
+    for (const waiter of [...this.waiters]) {
+      if (!waiter.predicate(parsed)) continue;
+      waiter.resolve(parsed);
+      this.removeWaiter(waiter);
+    }
+  }
+
+  send(message) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Control WebSocket is not OPEN");
+    }
+    this.ws.send(JSON.stringify(message));
+  }
+
+  waitFor(predicate, label, timeoutMs = this.timeoutMs) {
+    const existing = this.messages.find(predicate);
+    if (existing) return Promise.resolve(existing);
+    if (this.closed) {
+      return Promise.reject(new Error(`Cannot wait for ${label}; socket already closed (${this.closed.code})`));
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        predicate,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this.removeWaiter(waiter);
+          reject(new Error(`Timed out waiting for ${label}`));
+        }, timeoutMs),
+      };
+      this.waiters.push(waiter);
+    });
+  }
+
+  async maybeWaitFor(predicate, timeoutMs) {
+    try {
+      return await this.waitFor(predicate, "optional event", timeoutMs);
+    } catch {
+      return null;
+    }
+  }
+
+  removeWaiter(waiter) {
+    clearTimeout(waiter.timer);
+    const idx = this.waiters.indexOf(waiter);
+    if (idx >= 0) this.waiters.splice(idx, 1);
+  }
+
+  rejectAll(error) {
+    for (const waiter of [...this.waiters]) {
+      waiter.reject(error);
+      this.removeWaiter(waiter);
+    }
+  }
+
+  close() {
+    try { this.ws?.close(); } catch {}
+  }
+}
+
+function buildIdentity(status, stateDir) {
+  const token = readToken(stateDir);
+  const identity = {
+    pairId: status.pairId ?? null,
+    pairName: null,
+    cwd: status.cwd ?? undefined,
+    stateDir,
+    clientPid: process.pid,
+    contractVersion: status.build?.contractVersion,
+  };
+  if (token) identity.controlToken = token;
+  return identity;
+}
+
+function assertPreconditions(opts, status) {
+  const phase = status.turnPhase || (status.turnInProgress ? "running" : "idle");
+  const hasThread = typeof status.threadId === "string" && status.threadId.length > 0;
+  const ready = status.bridgeReady === true;
+  const tuiConnected = status.tuiConnected === true;
+
+  if (opts.scenario === "success") {
+    if (!ready || !tuiConnected || !hasThread || phase !== "idle") {
+      throw new Error(
+        `success scenario requires bridgeReady=true, tuiConnected=true, threadId present, turnPhase=idle; got ` +
+          `bridgeReady=${ready} tuiConnected=${tuiConnected} threadId=${status.threadId ?? "null"} turnPhase=${phase}`,
+      );
+    }
+    return;
+  }
+
+  if (opts.scenario === "busy") {
+    if (!(phase === "running" || phase === "stalled" || status.turnInProgress === true)) {
+      throw new Error(`busy scenario requires an active turn; got turnPhase=${phase}`);
+    }
+    return;
+  }
+
+  if (opts.scenario === "no-thread") {
+    if (ready && hasThread) {
+      throw new Error("no-thread scenario requires missing threadId or bridgeReady=false");
+    }
+    return;
+  }
+
+  if (opts.scenario === "ws-down") {
+    if (ready && tuiConnected) {
+      throw new Error("ws-down scenario requires bridgeReady=false or tuiConnected=false");
+    }
+  }
+}
+
+function makeProbeMessage(opts) {
+  return opts.message ||
+    "[PR5 idle injection probe] This is an isolated AgentBridge wakeup test. Reply exactly: PR5_IDLE_WAKEUP_OK";
+}
+
+function summarizeStatus(status) {
+  return {
+    bridgeReady: status.bridgeReady,
+    tuiConnected: status.tuiConnected,
+    threadId: status.threadId ?? null,
+    turnPhase: status.turnPhase ?? null,
+    turnInProgress: status.turnInProgress ?? null,
+    cwd: status.cwd ?? null,
+    pairId: status.pairId ?? null,
+    stateDir: status.stateDir ?? null,
+    controlContractVersion: status.build?.contractVersion ?? null,
+  };
+}
+
+function print(opts, message, data = undefined) {
+  if (opts.json) return;
+  if (data === undefined) {
+    console.log(message);
+  } else {
+    console.log(`${message} ${JSON.stringify(data)}`);
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    console.log(usage());
+    return;
+  }
+
+  if (opts.scenario !== "observe" && !opts.confirmInject) {
+    throw new Error(`--scenario ${opts.scenario} sends claude_to_codex; pass --confirm-inject to proceed`);
+  }
+
+  const initialStatus = await fetchStatus(opts.controlPort, Math.min(opts.timeoutMs, 5000));
+  const stateDir = opts.stateDir || initialStatus.stateDir;
+  if (!stateDir) throw new Error("No state dir available; pass --state-dir or use a daemon that reports status.stateDir");
+
+  if (opts.expectedCwd && (!initialStatus.cwd || !samePath(initialStatus.cwd, opts.expectedCwd))) {
+    throw new Error(`Daemon cwd mismatch: expected ${resolve(opts.expectedCwd)}, got ${initialStatus.cwd ?? "<none>"}`);
+  }
+
+  if (!opts.allowCurrentCwd && initialStatus.cwd && samePath(initialStatus.cwd, process.cwd())) {
+    throw new Error(
+      `Refusing to target current cwd (${initialStatus.cwd}). Run from a different directory or pass --allow-current-cwd for an isolated probe pair.`,
+    );
+  }
+
+  const probe = new ControlProbe(`ws://127.0.0.1:${opts.controlPort}/ws`, opts.timeoutMs);
+  await probe.connect();
+
+  try {
+    probe.send({ type: "probe_incumbent" });
+    const incumbent = await probe.waitFor((m) => m.type === "incumbent_status", "incumbent_status", 5000);
+    if (incumbent.connected && incumbent.alive && !opts.replaceIncumbent) {
+      if (opts.scenario === "observe") {
+        const summary = {
+          ok: true,
+          scenario: "observe",
+          injected: false,
+          attached: false,
+          reason: "live Claude frontend already attached; observe mode did not contest it",
+          incumbent,
+          status: summarizeStatus(initialStatus),
+        };
+        if (opts.json) console.log(JSON.stringify(summary, null, 2));
+        else print(opts, "[PR5] observe-only: live incumbent present; not attaching", summary);
+        return;
+      }
+      throw new Error("A live Claude frontend is already attached; refusing to contest it without --replace-incumbent");
+    }
+
+    const identity = buildIdentity(initialStatus, stateDir);
+    probe.send({ type: "claude_connect", identity });
+    const attachedStatus = await probe.waitFor((m) => m.type === "status", "attach status", opts.timeoutMs);
+    const status = attachedStatus.status;
+    print(opts, "[PR5] attached status:", summarizeStatus(status));
+
+    if (opts.scenario === "observe") {
+      const summary = {
+        ok: true,
+        scenario: "observe",
+        injected: false,
+        incumbent,
+        status: summarizeStatus(status),
+      };
+      if (opts.json) console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    assertPreconditions(opts, status);
+
+    const requestId = `pr5-${opts.scenario}-${Date.now()}`;
+    const idempotencyKey = opts.idempotencyKey || `pr5-${opts.scenario}-${Date.now()}`;
+    const sentAt = Date.now();
+    const resultP = probe.waitFor(
+      (m) => m.type === "claude_to_codex_result" && m.requestId === requestId,
+      "claude_to_codex_result",
+      opts.timeoutMs,
+    );
+
+    probe.send({
+      type: "claude_to_codex",
+      requestId,
+      message: {
+        id: `pr5_msg_${Date.now()}`,
+        source: "claude",
+        content: makeProbeMessage(opts),
+        timestamp: sentAt,
+      },
+      requireReply: false,
+      onBusy: "reject",
+      idempotencyKey,
+    });
+
+    const result = await resultP;
+
+    if (opts.scenario === "success") {
+      if (!result.success) {
+        throw new Error(`Expected success but daemon returned ${JSON.stringify(result)}`);
+      }
+      const turnStartedAckP = probe.waitFor(
+        (m) => m.type === "turn_started" && m.requestId === requestId,
+        "turn_started ACK",
+        opts.timeoutMs,
+      );
+      const rawTurnStartedP = probe.waitFor(
+        (m) =>
+          m.type === "codex_to_claude" &&
+          typeof m.message?.id === "string" &&
+          m.message.id.startsWith("system_turn_started_") &&
+          (typeof m.message.timestamp !== "number" || m.message.timestamp >= sentAt - 1000),
+        "system_turn_started bridge message",
+        opts.timeoutMs,
+      );
+      const [turnStartedAck, rawTurnStarted] = await Promise.all([turnStartedAckP, rawTurnStartedP]);
+      probe.send({ type: "status" });
+      const after = await probe.waitFor(
+        (m) => m.type === "status" && m !== attachedStatus,
+        "post-injection status",
+        opts.timeoutMs,
+      );
+      const summary = {
+        ok: true,
+        scenario: opts.scenario,
+        classification: "fully_automatic_idle_wakeup",
+        requestId,
+        idempotencyKey,
+        result,
+        turnStartedAck,
+        rawTurnStartedMessageId: rawTurnStarted.message?.id ?? null,
+        before: summarizeStatus(status),
+        after: summarizeStatus(after.status),
+      };
+      if (opts.json) console.log(JSON.stringify(summary, null, 2));
+      else {
+        print(opts, "[PASS] fully_automatic_idle_wakeup", {
+          requestId,
+          turnId: turnStartedAck.turnId,
+          rawTurnStartedMessageId: rawTurnStarted.message?.id ?? null,
+          after: summarizeStatus(after.status),
+        });
+      }
+      return;
+    }
+
+    const expectedCode = opts.scenario === "busy" ? "busy_reject" : "no_thread";
+    if (result.success || result.code !== expectedCode) {
+      throw new Error(`Expected failure code ${expectedCode}, got ${JSON.stringify(result)}`);
+    }
+
+    const unexpectedAck = await probe.maybeWaitFor((m) => m.type === "turn_started" && m.requestId === requestId, 1500);
+    if (unexpectedAck) {
+      throw new Error(`Failure scenario unexpectedly produced turn_started: ${JSON.stringify(unexpectedAck)}`);
+    }
+
+    const summary = {
+      ok: true,
+      scenario: opts.scenario,
+      classification: `expected_${expectedCode}`,
+      requestId,
+      idempotencyKey,
+      result,
+      before: summarizeStatus(status),
+    };
+    if (opts.json) console.log(JSON.stringify(summary, null, 2));
+    else print(opts, `[PASS] ${opts.scenario} produced ${expectedCode} without turn_started`, { requestId });
+  } finally {
+    probe.close();
+  }
+}
+
+main().catch((err) => {
+  const payload = { ok: false, error: err?.message ?? String(err) };
+  if (process.argv.includes("--json")) {
+    console.error(JSON.stringify(payload, null, 2));
+  } else {
+    console.error(`[FAIL] ${payload.error}`);
+  }
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 摘要 / Summary

预算自动续接系列（PR1–PR4 已合）的**收尾 PR**：诊断 probe + 设计稿 + 测试计划 + gitignore。**无运行时代码改动**（probe 是 standalone `.mjs`，`tsconfig include=["src"]` 故不进 typecheck/test/plugin-sync）。

Final PR of the budget auto-resume series — diagnostic probe + docs + gitignore. **No runtime code changes.**

## 内容 / Contents

- **`scripts/pr5-codex-idle-injection-probe.mjs`** — 独立诊断脚本，经**公共**控制协议（control WS → `claude_connect` → `claude_to_codex` → `CodexAdapter.injectMessage` → `turn/start`）验证空闲 Codex TUI 能否被全自动唤醒。**安全优先**：`observe` 默认只读；注入场景需 `--confirm-inject`；拒绝 `status.cwd === process.cwd()`（除非 `--allow-current-cwd`）；拒绝抢占在线 Claude 前端（除非 `--replace-incumbent`）。不 import daemon 内部。
- **`docs/test-plans/pr5-codex-idle-injection.md`** — 6 步实测计划 + 分类标签（`fully_automatic_idle_wakeup` / `busy_reject_only` / `not_ready_*` / `transport_rejected` / `not_fully_automatic`）。
- **`docs/design/budget-auto-resume.md`** — 端到端续接设计稿。
- **`.gitignore`** — 忽略本地 `.agent/` 交接目录。

## Cross-review

4 轮 / 8 reviewer + 对抗式 verify，**连续 2 轮干净**（#3/#4，0 confirmed REAL）。前 2 轮报的 2 个 REAL 均为 test-plan 文档缺陷，已修并实证：
- `abg pairs --json` 输出顶层数组 → jq `.pairs[]` 改 `.[]`，删除不存在的 `.pairName` 子句，结果赋值给 `CONTROL_PORT`（实跑验证输出真实端口）。
- `daemon.ts` 代码锚点 393/457/1155 漂移（PR3/PR4 后）→ 更正为 616/699/1040(+1134/1407)，grep 核对，并加「行号跟随 master，漂移时认符号名」提示。

probe 代码本身 4 轮 0 REAL。

## 实测说明 / Running the probe

实际跑 probe 需一个干净 idle 的 Codex disposable pair（不可对在线协作 pair 跑），按 test-plan 由操作者执行。

## Test plan

- [x] probe 不进 CI 检查范围（`tsconfig include=["src"]`），CI 仅验证既有 src 未受影响
- [x] 4 轮 cross-review（probe 代码 + 文档命令实证）
- [ ] 操作者按 `docs/test-plans/pr5-codex-idle-injection.md` 实跑（需 idle Codex）