### PR TITLE
fix(budget): 续接 sentinel 陈旧门 + bash↔TS 实测 + 注入时序文档 [skip release]

### DIFF
--- a/docs/design/budget-auto-resume.md
+++ b/docs/design/budget-auto-resume.md
@@ -95,3 +95,12 @@ budget 协调器（`budget-coordinator.ts` + `daemon.ts`）：
 | R4 | bridge 误判已续接（notification 无 ACK） | 必须看到 Claude 真 ACK 才标 resumed |
 | R5 | guard bash/node 双实现漂移 | 两套都改 + 对照测试 |
 | R6 | watchdog 续接 vs bridge 续接重复 | 二选一：bridge 续接为主，guard watchdog 不装（避免两套都唤醒）|
+
+## 8. 实施后补充说明（fast-follow，2026-06-14）
+
+落地后的几条非阻塞决策，记此备查（对应 PR4/PR5 cross-review 的 RECOMMEND/SUSPECT）：
+
+- **降级 sentinel 陈旧门（degradedAt TTL）**：`health-check.sh` 读 sentinel 的 `degradedAt`（epoch 毫秒），超过 `AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC`（默认 **86400s=24h**）即丢弃且仍消费（删除），不再弹「从 checkpoint 续接」误导。默认 24h 的取舍：**覆盖一夜离开的核心场景**（醒来通知还在），又压住多日陈旧。**fail-open**：`degradedAt` 缺失/非数字 → 当作新鲜照常弹（绝不静默吞掉可能真实的恢复）。
+- **bash↔TS 一致性**：`src/integration-test/health-check-resume-sentinel.test.ts` spawn 真实 `health-check.sh` + 真实 `writeResumeAckDegradedSentinel`，端到端钉死「TS 写 → bash 读」（resumeId 提取、charset guard、TTL 门、消费一次）。非 bash 平台（Windows）自动 skip。
+- **`ack_resume` 不做 token 闸门 = 有意为之**：`daemon.ts` 控制开关里 `ack_resume` 与 `status`/`probe_incumbent` 同级、均不过 `validateClaudeClientIdentity`；只有消息注入路径 `claude_to_codex` 是特权。边界 = localhost + Origin/CSWSH 守卫；`ack_resume` 是纯控制面信号、非注入，符合既有信任模型。最坏情形仅「本地进程在 ack 窗口内猜中低熵 resumeId、压掉一次自动续接」，可手动续，影响有界。
+- **Codex 注入 confirm 时序（PR3）**：`ResumeInjectionQueue.onBridgeTurnStarted` 在确认后调 `tryInjectNext()`——此刻 Codex 刚开新 turn，可能与之竞争（codex-rs 不保证 turn/start 响应早于 turn/started 通知）。**保留为自纠正**而非改 drain-only：单飞门挡并发、busy→null→retry 不丢续接、且恢复流每侧至多 1 个 pending。Option B（仅 onTurnDrained 注入）更紧但未采纳——`turnAborted` 目前不 drain，drain-only 会在起的 turn 中止时卡住下一个 pending。待 PR5 probe 实测 codex-rs 时序后再定（采 Option B 需同时给 turnAborted 补 drain）。

--- a/plugins/agentbridge/scripts/health-check.sh
+++ b/plugins/agentbridge/scripts/health-check.sh
@@ -48,21 +48,58 @@ state_dir="$(resolve_state_dir)"
 resume_sentinel="${state_dir}/resume-ack-degraded.json"
 if [ -f "$resume_sentinel" ]; then
   resume_id="$(grep -o '"resumeId"[[:space:]]*:[[:space:]]*"[^"]*"' "$resume_sentinel" 2>/dev/null | head -n1 | sed 's/.*"resumeId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
-  rm -f "$resume_sentinel" 2>/dev/null || true
-  # Defense-in-depth (resume_id is daemon-controlled, but harden anyway): only
-  # interpolate it into the JSON heredoc if it matches the known-safe id charset
-  # (system_budget_claude_recovered_<seq> — a plain monotonic sequence, no salt;
-  # the salt lives in BridgeMessage.id, not in the resumeId the sentinel stores).
-  # Anything else (a corrupted or
-  # tampered sentinel carrying " or \) collapses to "unknown" so the emitted hook
-  # JSON can never be broken by the value — mirrors the pair_id guard above.
-  if ! printf '%s' "$resume_id" | grep -Eq '^[A-Za-z0-9._-]+$'; then
-    resume_id="unknown"
+  # Staleness gate: the sentinel carries degradedAt (epoch MILLISECONDS, written by
+  # writeResumeAckDegradedSentinel). A degrade that happened long ago points at a
+  # checkpoint that is probably already handled, so surfacing "continue from
+  # checkpoint" would mislead. Drop (still consuming) a sentinel older than the TTL.
+  # Default 24h survives an overnight away-window (the core use case — wake up and
+  # the recovery notice is still there) yet suppresses multi-day-stale notices;
+  # configurable via AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC. Fail-open: a missing,
+  # non-numeric, or implausibly-long (>16-digit) degradedAt / TTL is treated as
+  # FRESH so a possibly-real recovery is never silently suppressed. (A parseable
+  # but genuinely old timestamp is still aged normally → stale.)
+  degraded_at_ms="$(grep -o '"degradedAt"[[:space:]]*:[[:space:]]*[0-9][0-9]*' "$resume_sentinel" 2>/dev/null | head -n1 | grep -o '[0-9][0-9]*$')"
+  resume_ttl_sec="${AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC:-86400}"
+  resume_stale=0
+  # Accept only a plausible 1–16 digit integer for BOTH operands: 16 digits keeps
+  # every value (epoch-ms ~13 digits, any sane TTL ≤ ~9.99e15) far under bash's
+  # signed 64-bit ceiling, so the subtraction below can never overflow; anything
+  # longer / non-numeric / missing is rejected here → FRESH (fail-open).
+  if printf '%s' "$degraded_at_ms" | grep -Eq '^[0-9]{1,16}$' && printf '%s' "$resume_ttl_sec" | grep -Eq '^[0-9]{1,16}$'; then
+    # Compare in SECONDS (degradedAt is epoch ms → integer-divide by 1000) and never
+    # multiply the user TTL by 1000, so the comparison can't overflow. `10#` forces
+    # base-10 so a leading-zero value (e.g. 0888…) parses decimally instead of as
+    # octal — an octal-invalid operand would otherwise make the $(( )) arithmetic
+    # fail, and in bash a failed arithmetic assignment terminates the enclosing
+    # if-block (regardless of set flags), skipping the consume (rm) below and leaking
+    # the sentinel. The ^[0-9]{1,16}$ guard above + `10#` together make this
+    # arithmetic TOTAL for every accepted input (no octal abort, no int64 overflow),
+    # so age_sec is always assigned and the unconditional rm below always runs
+    # (consume-once holds).
+    now_sec="$(date +%s 2>/dev/null)"
+    age_sec=$(( ${now_sec:-0} - 10#${degraded_at_ms} / 1000 ))
+    if [ "$age_sec" -gt "$resume_ttl_sec" ]; then
+      resume_stale=1
+    fi
   fi
-  cat <<EOF
+  rm -f "$resume_sentinel" 2>/dev/null || true  # consume once, whether surfaced or dropped-as-stale
+  if [ "$resume_stale" -eq 0 ]; then
+    # Defense-in-depth (resume_id is daemon-controlled, but harden anyway): only
+    # interpolate it into the JSON heredoc if it matches the known-safe id charset
+    # (system_budget_claude_recovered_<seq> — a plain monotonic sequence, no salt;
+    # the salt lives in BridgeMessage.id, not in the resumeId the sentinel stores).
+    # Anything else (a corrupted or
+    # tampered sentinel carrying " or \) collapses to "unknown" so the emitted hook
+    # JSON can never be broken by the value — mirrors the pair_id guard above.
+    if ! printf '%s' "$resume_id" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+      resume_id="unknown"
+    fi
+    cat <<EOF
 {"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AgentBridge: 上次额度刷新后的续接通知未被确认（resume_id=${resume_id:-unknown}），可能上一个会话已空闲或退出。请从 .agent/checkpoint.md 的「下一步」继续未完成的任务。"}}
 EOF
-  exit 0
+    exit 0
+  fi
+  # stale → sentinel consumed above; fall through to the normal health check below.
 fi
 
 if ! command -v curl >/dev/null 2>&1; then

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14574,10 +14574,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("305fb62", "source"),
+  commit: defineString("de7098c", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("6e6ae2f59324", "source")
+  codeHash: defineString("1289c3349277", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("305fb62", "source"),
+  commit: defineString("de7098c", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("6e6ae2f59324", "source")
+  codeHash: defineString("1289c3349277", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };

--- a/src/budget/resume-injection-queue.ts
+++ b/src/budget/resume-injection-queue.ts
@@ -162,6 +162,22 @@ export class ResumeInjectionQueue {
     }
     this.entries.delete(event.resumeId);
     this.onConfirmed({ resumeId: event.resumeId, requestId: event.requestId, turnId: event.turnId });
+    // Ordering note (PR3 fast-follow analysis): a turn just STARTED in Codex, so
+    // draining the next pending here can race the just-started turn — codex-rs does
+    // not guarantee the turn/start response orders before its turn/started
+    // notification. This is intentionally left self-correcting rather than gated on
+    // a drain-only model, because: (1) the single-flight guard at the top of
+    // tryInjectNext() prevents a second concurrent injection; (2) injecting into a
+    // still-busy Codex makes inject() return null → scheduleRetry (no lost resume,
+    // no double turn); (3) the budget-recovery flow enqueues at most ONE resume per
+    // side, so 2+ simultaneously-pending entries is not a real scenario today.
+    // "Option B" (inject ONLY from onTurnDrained, never at confirm-time) would be
+    // strictly tighter but is NOT adopted unverified: turnAborted does not currently
+    // call onTurnDrained (daemon.ts), so a drain-only model could stall the next
+    // pending if the started turn aborts. Revisit once the PR5 probe
+    // (docs/test-plans/pr5-codex-idle-injection.md) empirically characterizes
+    // codex-rs turn/start ordering; adopting Option B then also requires draining on
+    // turnAborted.
     this.tryInjectNext();
   }
 

--- a/src/integration-test/health-check-resume-sentinel.test.ts
+++ b/src/integration-test/health-check-resume-sentinel.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { resumeAckSentinelPath, writeResumeAckDegradedSentinel } from "../budget/resume-ack-sentinel";
+
+/**
+ * End-to-end bash↔TS parity for the PR4 §6 degrade→sentinel escape hatch: spawns
+ * the REAL plugins/agentbridge/scripts/health-check.sh against a temp state dir
+ * seeded by the REAL TS writer (writeResumeAckDegradedSentinel). This closes the
+ * drift gap that a hand-copied regex test could not — if either the JSON shape or
+ * the bash grep/sed/charset/TTL logic changes incompatibly, this fails. Also
+ * exercises the staleness TTL gate (fast-follow) and the corrupted-id guard.
+ */
+
+const HOOK = resolve(import.meta.dir, "../../plugins/agentbridge/scripts/health-check.sh");
+const RESUME_NOTICE = "续接通知未被确认";
+
+// Spawning bash; skip on platforms without it (Windows CI only runs port-cleanup).
+const bashAvailable =
+  process.platform !== "win32" && spawnSync("bash", ["-c", ":"], { encoding: "utf-8" }).status === 0;
+const describeOrSkip = bashAvailable ? describe : describe.skip;
+
+const tmpDirs: string[] = [];
+function tempStateDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "abg-hc-sentinel-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+function runHook(stateDir: string, extraEnv: Record<string, string> = {}) {
+  return spawnSync("bash", [HOOK], {
+    input: "",
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      AGENTBRIDGE_STATE_DIR: stateDir,
+      // Isolate the cooldown stamp so a fall-through case never reads a real one.
+      AGENTBRIDGE_HOOK_STATE_DIR: join(stateDir, "hook-state"),
+      // Point the health probe at a port nothing listens on so fall-through is
+      // deterministic ("not reachable"), never a real local daemon.
+      AGENTBRIDGE_CONTROL_PORT: "59",
+      // Pin the default TTL so default-TTL tests stay hermetic even if the ambient
+      // env happens to export AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC. Per-test
+      // overrides (below) still win.
+      AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC: "86400",
+      // Per-test overrides win.
+      ...extraEnv,
+    },
+  });
+}
+
+describeOrSkip("health-check.sh resume-ack sentinel (bash↔TS parity)", () => {
+  test("a fresh sentinel surfaces the resumeId in the SessionStart notice and is consumed", () => {
+    const stateDir = tempStateDir();
+    const resumeId = "system_budget_claude_recovered_7";
+    writeResumeAckDegradedSentinel({ stateDir, resumeId, now: () => Date.now() });
+
+    const res = runHook(stateDir);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('"hookEventName":"SessionStart"');
+    expect(res.stdout).toContain(`resume_id=${resumeId}`);
+    expect(res.stdout).toContain(RESUME_NOTICE);
+    // Consumed exactly once.
+    expect(existsSync(resumeAckSentinelPath(stateDir))).toBe(false);
+  });
+
+  test("a corrupted resumeId collapses to 'unknown' (charset guard)", () => {
+    const stateDir = tempStateDir();
+    // Space is outside ^[A-Za-z0-9._-]+$ → the hook must collapse it to "unknown".
+    writeResumeAckDegradedSentinel({ stateDir, resumeId: "bad id with spaces", now: () => Date.now() });
+
+    const res = runHook(stateDir);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("resume_id=unknown");
+    expect(res.stdout).not.toContain("bad id with spaces");
+    expect(existsSync(resumeAckSentinelPath(stateDir))).toBe(false);
+  });
+
+  test("a stale sentinel (older than TTL) is dropped without surfacing, but still consumed", () => {
+    const stateDir = tempStateDir();
+    writeResumeAckDegradedSentinel({
+      stateDir,
+      resumeId: "system_budget_claude_recovered_8",
+      now: () => Date.now() - 2 * 3600 * 1000, // 2h ago
+    });
+
+    // TTL = 1h → the 2h-old sentinel is stale.
+    const res = runHook(stateDir, { AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC: "3600" });
+    expect(res.stdout).not.toContain(RESUME_NOTICE);
+    expect(res.stdout).not.toContain("system_budget_claude_recovered_8");
+    expect(res.status).toBe(0);
+    // Consumed (deleted) so it cannot resurface on a later session — the strong
+    // invariant. (We intentionally do NOT assert the fall-through SessionStart
+    // notice here: that path is gated by `command -v curl`, and the large-TTL
+    // sibling test already proves the surface path works, so the gate is the only
+    // difference — keeping this assertion curl-independent.)
+    expect(existsSync(resumeAckSentinelPath(stateDir))).toBe(false);
+  });
+
+  test("a huge TTL surfaces a fresh sentinel — forward guard against a naive ms-multiply reintroduction", () => {
+    const stateDir = tempStateDir();
+    const resumeId = "system_budget_claude_recovered_11";
+    writeResumeAckDegradedSentinel({ stateDir, resumeId, now: () => Date.now() - 1000 }); // 1s old → fresh
+
+    // FORWARD-LOOKING guard (the committed gate already uses the seconds compare, so
+    // this does NOT red/green the current diff): if anyone reintroduces a naive
+    // `ttl_sec * 1000` ms-multiply, 9223372036854776 * 1000 overflows signed int64
+    // → wraps negative → this fresh sentinel would be spuriously SUPPRESSED. The
+    // seconds-based gate must keep SURFACING it.
+    const res = runHook(stateDir, { AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC: "9223372036854776" });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain(`resume_id=${resumeId}`);
+    expect(res.stdout).toContain(RESUME_NOTICE);
+    expect(existsSync(resumeAckSentinelPath(stateDir))).toBe(false);
+  });
+
+  test("a leading-zero (octal-invalid) degradedAt does not crash and the sentinel is still consumed", () => {
+    const stateDir = tempStateDir();
+    // JSON.parse rejects leading zeros, so write the raw bytes. `0888888888888`
+    // passes the bash ^[0-9]{1,16}$ guard but is octal-invalid. FORWARD-LOOKING
+    // guard: if the `10#` base-10 prefix is ever dropped, the arithmetic fails and
+    // bash terminates the enclosing if-block, skipping the rm (sentinel leaks /
+    // resurfaces forever); consume-once must hold.
+    writeFileSync(
+      resumeAckSentinelPath(stateDir),
+      '{\n  "resumeId": "system_budget_claude_recovered_12",\n  "degradedAt": 0888888888888\n}\n',
+    );
+
+    const res = runHook(stateDir);
+    expect(res.status).toBe(0);
+    // The strong invariant the fix protects: consume-once holds even for a
+    // corrupted numeric degradedAt (no leak, no infinite resurface).
+    expect(existsSync(resumeAckSentinelPath(stateDir))).toBe(false);
+  });
+
+  test("a FRESH leading-zero degradedAt still surfaces (10# decimal parse, surface branch)", () => {
+    const stateDir = tempStateDir();
+    // A fresh sentinel whose degradedAt is zero-padded: 10# must parse it as a
+    // recent decimal epoch-ms (not octal) so it ages as fresh and SURFACES, while
+    // still being consumed. Pairs with the octal-invalid STALE case above to cover
+    // both branches of the base-10 fix.
+    const ms = Date.now() - 1000;
+    writeFileSync(
+      resumeAckSentinelPath(stateDir),
+      `{\n  "resumeId": "system_budget_claude_recovered_14",\n  "degradedAt": 0${ms}\n}\n`,
+    );
+
+    const res = runHook(stateDir);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("resume_id=system_budget_claude_recovered_14");
+    expect(res.stdout).toContain(RESUME_NOTICE);
+    expect(existsSync(resumeAckSentinelPath(stateDir))).toBe(false);
+  });
+
+  test("TTL=0 suppresses an aged sentinel (and still consumes it)", () => {
+    const stateDir = tempStateDir();
+    writeResumeAckDegradedSentinel({
+      stateDir,
+      resumeId: "system_budget_claude_recovered_13",
+      now: () => Date.now() - 5000, // 5s old → age_sec ≥ 1 > 0
+    });
+    const res = runHook(stateDir, { AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC: "0" });
+    expect(res.status).toBe(0);
+    expect(res.stdout).not.toContain(RESUME_NOTICE);
+    expect(existsSync(resumeAckSentinelPath(stateDir))).toBe(false);
+  });
+
+  test("the same old sentinel surfaces under a large TTL (gate is the only difference)", () => {
+    const stateDir = tempStateDir();
+    writeResumeAckDegradedSentinel({
+      stateDir,
+      resumeId: "system_budget_claude_recovered_9",
+      now: () => Date.now() - 2 * 3600 * 1000, // 2h ago
+    });
+
+    // TTL = 24h (default) → a 2h-old sentinel is still fresh and surfaces.
+    const res = runHook(stateDir, { AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC: "86400" });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("resume_id=system_budget_claude_recovered_9");
+    expect(res.stdout).toContain(RESUME_NOTICE);
+  });
+
+  test("an unparseable degradedAt fails open (treated as fresh, surfaced)", () => {
+    const stateDir = tempStateDir();
+    // Write a sentinel whose degradedAt is non-numeric — fail-open must surface it.
+    const path = resumeAckSentinelPath(stateDir);
+    writeFileSync(path, JSON.stringify({ resumeId: "system_budget_claude_recovered_10", degradedAt: "oops" }, null, 2));
+
+    const res = runHook(stateDir);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("resume_id=system_budget_claude_recovered_10");
+    expect(res.stdout).toContain(RESUME_NOTICE);
+    expect(existsSync(path)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary

清理 PR4/PR5 cross-review 留下的 **3 条非阻塞 fast-follow backlog**，一并收口。
Clears the 3 non-blocking fast-follow items from the PR4/PR5 cross-review.

## 改动 / Changes

1. **降级 sentinel 陈旧门**（`plugins/agentbridge/scripts/health-check.sh`）
   - 读 sentinel 的 `degradedAt`（epoch ms），age 超过 `AGENTBRIDGE_RESUME_SENTINEL_TTL_SEC`（默认 **86400=24h**）即丢弃且**仍消费**，不再对多日陈旧的恢复弹「从 checkpoint 续接」误导。
   - 默认 24h 覆盖**一夜离开**（核心场景：醒来通知还在）又压住多日陈旧。
   - **按秒比较** + `^[0-9]{1,16}$` 位界 + `10#` 十进制：算术对任何取值都 total（无 octal 中止、无 int64 溢出），**consume-once 恒成立**；缺失/非数字/超 16 位 → fail-open 当作新鲜。

2. **bash↔TS 一致性测试**（新增 `src/integration-test/health-check-resume-sentinel.test.ts`）
   - spawn 真实 `health-check.sh` + 真实 `writeResumeAckDegradedSentinel`，端到端钉死「TS 写 → bash 读」。
   - 9 例：fresh / 损坏 id→unknown / 陈旧→suppress+consume / 大 TTL→surface / 非数字→fail-open / 巨 TTL 前瞻守护 / octal-invalid→consume / TTL=0→suppress / 前导零 fresh→surface。非 bash 平台自动 skip。

3. **Codex 注入 confirm 时序文档**（`resume-injection-queue.ts` 注释 + 设计稿 §8）
   - 说明 `onBridgeTurnStarted` 确认后的 `tryInjectNext` 为**自纠正**（单飞门 + busy→null→retry + 恢复流每侧 ≤1 pending）；Option B（仅 `onTurnDrained` 注入）待 PR5 probe 实测 codex-rs 时序后再定（且需给 `turnAborted` 补 drain）。

## Tests

- [x] `bun test src`：**1437 pass / 0 fail**
- [x] `bun run typecheck`
- [x] `bun run verify:plugin-sync`

## Cross-review

**10 轮 / 20 reviewer 对 + 对抗式 verify，连续 2 轮干净（#9/#10，0 confirmed REAL）**。期间挖出并修复 **3 个 REAL**：
- `degradedAt` 前导零（octal-invalid）致算术中止 → 跳过 `rm` → sentinel 永久泄漏（MEDIUM）
- naive `ms*1000` 巨 TTL 负溢出 → 误抑制新鲜 sentinel
- 回归测试 TDD 缺口（测试无法红/绿钉死修复）

外加多处注释精度更正（按秒比较的机制、`10#` 的作用、前瞻 vs 历史回归钉的措辞）。

> 纯诊断/防御加固，无运行时行为破坏；`health-check.sh` 是插件脚本（非 bundle），probe 时序结论待 PR5 实测。