### PR TITLE
fix(budget): resume 状态 GC + enqueue 测试 + probe --help + 文档 (backlog PR-A) [skip release]

### DIFF
--- a/docs/design/budget-auto-resume.md
+++ b/docs/design/budget-auto-resume.md
@@ -104,3 +104,15 @@ budget 协调器（`budget-coordinator.ts` + `daemon.ts`）：
 - **bash↔TS 一致性**：`src/integration-test/health-check-resume-sentinel.test.ts` spawn 真实 `health-check.sh` + 真实 `writeResumeAckDegradedSentinel`，端到端钉死「TS 写 → bash 读」（resumeId 提取、charset guard、TTL 门、消费一次）。非 bash 平台（Windows）自动 skip。
 - **`ack_resume` 不做 token 闸门 = 有意为之**：`daemon.ts` 控制开关里 `ack_resume` 与 `status`/`probe_incumbent` 同级、均不过 `validateClaudeClientIdentity`；只有消息注入路径 `claude_to_codex` 是特权。边界 = localhost + Origin/CSWSH 守卫；`ack_resume` 是纯控制面信号、非注入，符合既有信任模型。最坏情形仅「本地进程在 ack 窗口内猜中低熵 resumeId、压掉一次自动续接」，可手动续，影响有界。
 - **Codex 注入 confirm 时序（PR3）**：`ResumeInjectionQueue.onBridgeTurnStarted` 在确认后调 `tryInjectNext()`——此刻 Codex 刚开新 turn，可能与之竞争（codex-rs 不保证 turn/start 响应早于 turn/started 通知）。**保留为自纠正**而非改 drain-only：单飞门挡并发、busy→null→retry 不丢续接、且恢复流每侧至多 1 个 pending。Option B（仅 onTurnDrained 注入）更紧但未采纳——`turnAborted` 目前不 drain，drain-only 会在起的 turn 中止时卡住下一个 pending。待 PR5 probe 实测 codex-rs 时序后再定（采 Option B 需同时给 turnAborted 补 drain）。
+
+## 9. 续接幂等契约 + 状态生命周期（backlog 清理，2026-06-14）
+
+**幂等身份（R6 atomic claim）**：续接注入的去重身份 = `sha256(agent \0 sessionId \0 realpath(cwd) \0 contentHash)`（`tryClaimPendingResume`）。`contentHash` 取自 guard pending 文件内容——guard 每次降级用新内容重写 pending → 新 contentHash → 新身份。
+
+**落盘位置（重要）**：`claims/` 与 `consumed/` 写在 **guard 共享状态目录** `budgetGuardStateDir()` = `$BUDGET_STATE_DIR ?? ~/.budget-guard`（`daemon.ts` 调 `tryClaimPendingResume({ stateDir: budgetGuardStateDir() })`），**全机所有 pair 共享同一目录**——隔离靠**文件名 = identity sha256**（不是 per-pair 子目录）。唯一 per-pair 的是降级 sentinel `resume-ack-degraded.json`（写在 AgentBridge per-pair state dir）。
+- `~/.budget-guard/claims/<identity>.json`：**在途锁**（`claimed_at`，秒）。`writeJsonWx`（`O_EXCL`）保证跨进程/跨重启同一身份只有一个在途注入；`consume()` 成功即删，`release()` 在 abandon/dedup/stop 删。超过 `claimTtlSec`（默认 300s）的为 stale 可回收（进程死了没 release 的孤儿）。
+- `~/.budget-guard/consumed/<identity>.json`：**幂等墓碑**（`consumed_at`，秒）。确认续接后写，挡住同一 pending 再次注入。**必须跨重启/跨 kill 存活**——否则 `abg kill` + 重开会把升级/重启前已消费的续接重新注入。
+
+**状态 GC / 清理**：
+- `tryClaimPendingResume` 每次（仅预算恢复时触发，频率极低）顺手 prune：`consumed/` 超 `DEFAULT_CONSUMED_TTL_SEC`（默认 **7 天**，远超任何 pending 相关期；daemon 不传 `consumedTtlSec` 故用此默认）+ `claims/` 超 `claimTtlSec` 的孤儿 → 长寿 daemon 不会无限增长。注意 daemon 传的 `claimTtlSec = resumeClaimTtlSec()`（默认时序下 ≈ **320s** = ⌈(60000×5 + 5000×4)/1000⌉，**非** `DEFAULT_STALE_CLAIM_TTL_SEC=300` 默认），与同身份 stale-claim reclaim 用同一 TTL，故 ≤320s 的在途 claim 永不被误扫，只回收真孤儿。损坏 / 无时间戳 / 非 `.json` 文件一律不动（不激进删——绝不误删幂等墓碑）。
+- **`abg kill` 有意 NOT 清 `claims/`/`consumed/`**：① 它们在**共享** `~/.budget-guard`，per-pair kill 盲删会误伤其它在跑 pair 的墓碑；② `consumed/` 是**幂等墓碑，本就该跨 kill 存活**（删了会重注入已消费续接）；③ `claims/` 孤儿由上面的 TTL prune 自动回收。故无界增长问题已被 TTL prune 解决，kill 不需也不应动它们。降级 sentinel 是 per-pair 且有 24h TTL（见 §8），kill 也不删——保留跨会话续接连续性，陈旧由 TTL 兜底。

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14574,10 +14574,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("de7098c", "source"),
+  commit: defineString("69d8dc1", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("1289c3349277", "source")
+  codeHash: defineString("091c4809fd1c", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("de7098c", "source"),
+  commit: defineString("69d8dc1", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("1289c3349277", "source")
+  codeHash: defineString("091c4809fd1c", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -4975,7 +4975,7 @@ function readGuardPending(opts) {
 
 // src/budget/resume-injection-queue.ts
 import { createHash as createHash2 } from "crypto";
-import { closeSync as closeSync3, existsSync as existsSync6, mkdirSync as mkdirSync5, openSync as openSync3, readFileSync as readFileSync5, realpathSync, unlinkSync as unlinkSync4, writeFileSync as writeFileSync3 } from "fs";
+import { closeSync as closeSync3, existsSync as existsSync6, mkdirSync as mkdirSync5, openSync as openSync3, readdirSync, readFileSync as readFileSync5, realpathSync, unlinkSync as unlinkSync4, writeFileSync as writeFileSync3 } from "fs";
 import { join as join7 } from "path";
 
 // src/budget/resume-prompt.ts
@@ -4989,6 +4989,7 @@ var DEFAULT_RETRY_MS = 5000;
 var DEFAULT_CONFIRM_TIMEOUT_MS = 60000;
 var DEFAULT_MAX_ATTEMPTS = 5;
 var DEFAULT_STALE_CLAIM_TTL_SEC = 300;
+var DEFAULT_CONSUMED_TTL_SEC = 7 * 24 * 3600;
 function finitePositive(value, fallback) {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
 }
@@ -5232,9 +5233,32 @@ function readClaimedAt(path) {
     return null;
   }
 }
+function pruneStaleResumeArtifacts(dir, tsField, ttlSec, nowSec, log) {
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json"))
+      continue;
+    const p = join7(dir, name);
+    try {
+      const parsed = JSON.parse(readFileSync5(p, "utf-8"));
+      const ts = parsed?.[tsField];
+      if (typeof ts === "number" && Number.isFinite(ts) && nowSec - ts > ttlSec) {
+        unlinkIfExists(p);
+      }
+    } catch (error) {
+      log?.(`resume artifact prune skipped ${p}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}
 function tryClaimPendingResume(opts) {
   const now = opts.now ?? (() => Math.floor(Date.now() / 1000));
   const claimTtlSec = finitePositive(opts.claimTtlSec, DEFAULT_STALE_CLAIM_TTL_SEC);
+  const consumedTtlSec = finitePositive(opts.consumedTtlSec, DEFAULT_CONSUMED_TTL_SEC);
   const cwd = realpathOrRaw(opts.pending.cwd);
   const sourcePath = opts.pending.sourcePath ?? "";
   const contentHash = opts.pending.contentHash ?? "";
@@ -5250,9 +5274,11 @@ function tryClaimPendingResume(opts) {
   const consumedPath = join7(consumedDir, `${identity}.json`);
   mkdirSync5(claimsDir, { recursive: true });
   mkdirSync5(consumedDir, { recursive: true });
+  const nowSec = now();
+  pruneStaleResumeArtifacts(consumedDir, "consumed_at", consumedTtlSec, nowSec, opts.log);
+  pruneStaleResumeArtifacts(claimsDir, "claimed_at", claimTtlSec, nowSec, opts.log);
   if (existsSync6(consumedPath))
     return { ok: false, reason: "consumed" };
-  const nowSec = now();
   if (existsSync6(claimPath)) {
     const claimedAt = readClaimedAt(claimPath);
     if (claimedAt !== null && nowSec - claimedAt > claimTtlSec) {
@@ -5592,7 +5618,7 @@ class ReplyRequiredTracker {
 // src/thread-state.ts
 import {
   existsSync as existsSync7,
-  readdirSync,
+  readdirSync as readdirSync2,
   readFileSync as readFileSync7
 } from "fs";
 import { homedir as homedir3 } from "os";
@@ -5627,7 +5653,7 @@ function findCodexRolloutFile(threadId, env = process.env, maxEntries = 20000) {
     const dir = stack.pop();
     let entries;
     try {
-      entries = readdirSync(dir, { withFileTypes: true });
+      entries = readdirSync2(dir, { withFileTypes: true });
     } catch {
       continue;
     }

--- a/scripts/pr5-codex-idle-injection-probe.mjs
+++ b/scripts/pr5-codex-idle-injection-probe.mjs
@@ -117,6 +117,12 @@ function parseArgs(argv) {
     }
   }
 
+  // --help short-circuits the post-loop VALIDATION (scenario/control-port/timeout)
+  // so `--help --control-port abc` prints usage instead of erroring on the value.
+  // (The arg loop above still runs, so an unknown flag or a value-flag missing its
+  // operand still errors during parsing — --help only bypasses the checks below.)
+  if (opts.help) return opts;
+
   if (!SCENARIOS.has(opts.scenario)) {
     throw new Error(`Invalid --scenario ${opts.scenario}; expected one of ${[...SCENARIOS].join(", ")}`);
   }

--- a/src/budget/resume-injection-queue.ts
+++ b/src/budget/resume-injection-queue.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { PendingEntry } from "./pending-reader";
 import type { AgentName } from "./types";
@@ -55,6 +55,12 @@ const DEFAULT_RETRY_MS = 5_000;
 const DEFAULT_CONFIRM_TIMEOUT_MS = 60_000;
 const DEFAULT_MAX_ATTEMPTS = 5;
 const DEFAULT_STALE_CLAIM_TTL_SEC = 300;
+// consumed/ markers are idempotency tombstones: they keep the SAME pending
+// (identity = agent+session+cwd+contentHash) from being re-injected after a
+// confirmed resume. A new degrade rewrites the guard pending with a fresh
+// contentHash, so a marker is moot once superseded — 7 days is far beyond any
+// plausible pending lifetime yet bounds unbounded growth.
+const DEFAULT_CONSUMED_TTL_SEC = 7 * 24 * 3600;
 
 function finitePositive(value: number | undefined, fallback: number): number {
   return Number.isFinite(value) && value! > 0 ? Math.floor(value!) : fallback;
@@ -327,17 +333,56 @@ function readClaimedAt(path: string): number | null {
   }
 }
 
+/**
+ * Best-effort GC of stale resume idempotency artifacts: removes `<dir>/*.json`
+ * whose `tsField` timestamp (epoch seconds) is older than `ttlSec`. Unreadable /
+ * corrupt / timestamp-less files are LEFT untouched (never aggressively delete
+ * what we can't reason about). Called opportunistically on each claim attempt —
+ * claims happen only on budget recovery, so this keeps `consumed/` and orphaned
+ * `claims/` from growing without bound on a long-lived daemon, with no extra
+ * timer or startup wiring.
+ */
+function pruneStaleResumeArtifacts(
+  dir: string,
+  tsField: string,
+  ttlSec: number,
+  nowSec: number,
+  log?: (message: string) => void,
+): void {
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return; // dir absent yet — nothing to prune
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const p = join(dir, name);
+    try {
+      const parsed = JSON.parse(readFileSync(p, "utf-8"));
+      const ts = parsed?.[tsField];
+      if (typeof ts === "number" && Number.isFinite(ts) && nowSec - ts > ttlSec) {
+        unlinkIfExists(p);
+      }
+    } catch (error) {
+      log?.(`resume artifact prune skipped ${p}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}
+
 export function tryClaimPendingResume(opts: {
   stateDir: string;
   agent: AgentName;
   pending: PendingEntry;
   checkpointPath: string;
   claimTtlSec?: number;
+  consumedTtlSec?: number;
   now?: () => number;
   log?: (message: string) => void;
 }): ResumeClaimResult {
   const now = opts.now ?? (() => Math.floor(Date.now() / 1000));
   const claimTtlSec = finitePositive(opts.claimTtlSec, DEFAULT_STALE_CLAIM_TTL_SEC);
+  const consumedTtlSec = finitePositive(opts.consumedTtlSec, DEFAULT_CONSUMED_TTL_SEC);
   const cwd = realpathOrRaw(opts.pending.cwd);
   const sourcePath = opts.pending.sourcePath ?? "";
   const contentHash = opts.pending.contentHash ?? "";
@@ -354,8 +399,14 @@ export function tryClaimPendingResume(opts: {
   mkdirSync(claimsDir, { recursive: true });
   mkdirSync(consumedDir, { recursive: true });
 
-  if (existsSync(consumedPath)) return { ok: false, reason: "consumed" };
   const nowSec = now();
+  // GC stale idempotency artifacts first so a long-lived daemon's consumed/ and
+  // orphaned claims/ stay bounded. Uses the same claimTtlSec the per-identity
+  // stale-claim reclaim below already trusts, so the risk profile is unchanged.
+  pruneStaleResumeArtifacts(consumedDir, "consumed_at", consumedTtlSec, nowSec, opts.log);
+  pruneStaleResumeArtifacts(claimsDir, "claimed_at", claimTtlSec, nowSec, opts.log);
+
+  if (existsSync(consumedPath)) return { ok: false, reason: "consumed" };
 
   if (existsSync(claimPath)) {
     const claimedAt = readClaimedAt(claimPath);

--- a/src/unit-test/resume-injection-queue.test.ts
+++ b/src/unit-test/resume-injection-queue.test.ts
@@ -116,6 +116,38 @@ describe("ResumeInjectionQueue", () => {
     expect(released).toEqual(["claim-dedup"]);
   });
 
+  test("dedup still drops the duplicate (and does not throw) when its claim.release throws", () => {
+    const logs: string[] = [];
+    const queue = new ResumeInjectionQueue({
+      inject: () => null,
+      scheduler: new FakeScheduler(),
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 2,
+      log: (m) => logs.push(m),
+    });
+
+    queue.enqueue({ resumeId: "rid-dup", prompt: "first" });
+    expect(() =>
+      queue.enqueue({
+        resumeId: "rid-dup",
+        prompt: "second",
+        claim: {
+          identity: "boom",
+          claimPath: "/tmp/boom.json",
+          consumedPath: "/tmp/boom-consumed.json",
+          consume: () => {},
+          release: () => {
+            throw new Error("release boom");
+          },
+        },
+      }),
+    ).not.toThrow();
+
+    expect(queue.size).toBe(1); // duplicate never added
+    expect(logs.some((m) => m.includes("release failed") && m.includes("dedup"))).toBe(true);
+  });
+
   test("bridgeTurnStarted confirms the matching injection once and consumes the claim", () => {
     const scheduler = new FakeScheduler();
     const consumed: string[] = [];
@@ -575,6 +607,134 @@ describe("tryClaimPendingResume", () => {
       if (!second.ok) throw new Error("expected stale claim recovery");
       expect(second.claim.identity).toBe(first.claim.identity);
       expect(readFileSync(second.claim.claimPath, "utf-8")).toContain("1700000011");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("prunes a consumed tombstone older than consumedTtlSec so the same pending can resume again", () => {
+    const root = mkdtempSync(join(tmpdir(), "abg-resume-consumed-prune-"));
+    const project = join(root, "project");
+    mkdirSync(project, { recursive: true });
+    try {
+      const pending = entry({ cwd: project, sessionId: "sess-cprune", contentHash: "hash-cprune" });
+      const checkpointPath = join(project, ".agent", "checkpoint.md");
+      // Claim + consume at t0 → writes a consumed tombstone (consumed_at = 1_700_000_000).
+      const first = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath,
+        now: () => 1_700_000_000,
+      });
+      expect(first.ok).toBe(true);
+      if (!first.ok) throw new Error("expected claim");
+      first.claim.consume();
+      expect(existsSync(first.claim.consumedPath)).toBe(true);
+
+      // Within consumedTtlSec the tombstone still blocks re-claim.
+      const blocked = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath,
+        consumedTtlSec: 3600,
+        now: () => 1_700_000_100,
+      });
+      expect(blocked.ok).toBe(false);
+      if (blocked.ok) throw new Error("expected consumed block");
+      expect(blocked.reason).toBe("consumed");
+      expect(existsSync(first.claim.consumedPath)).toBe(true);
+
+      // Exactly AT the TTL boundary (age === consumedTtlSec) the strict `>` keeps it.
+      const boundary = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath,
+        consumedTtlSec: 3600,
+        now: () => 1_700_000_000 + 3600,
+      });
+      expect(boundary.ok).toBe(false);
+      if (boundary.ok) throw new Error("expected consumed block at exact TTL boundary");
+      expect(boundary.reason).toBe("consumed");
+      expect(existsSync(first.claim.consumedPath)).toBe(true);
+
+      // Past consumedTtlSec the tombstone is pruned → the same pending can resume.
+      const reclaim = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath,
+        consumedTtlSec: 3600,
+        now: () => 1_700_000_000 + 3601,
+      });
+      expect(reclaim.ok).toBe(true);
+      if (!reclaim.ok) throw new Error("expected reclaim after consumed prune");
+      expect(reclaim.claim.identity).toBe(first.claim.identity);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("prunes orphaned claims from OTHER identities on the next claim attempt", () => {
+    const root = mkdtempSync(join(tmpdir(), "abg-resume-orphan-prune-"));
+    const project = join(root, "project");
+    const claimsDir = join(root, "claims");
+    mkdirSync(project, { recursive: true });
+    mkdirSync(claimsDir, { recursive: true });
+    // An orphaned claim from a crashed claimant of a DIFFERENT identity, stale.
+    const orphan = join(claimsDir, "deadbeefdeadbeef.json");
+    writeFileSync(orphan, JSON.stringify({ identity: "deadbeefdeadbeef", claimed_at: 1_700_000_000 }), "utf-8");
+    try {
+      const pending = entry({ cwd: project, sessionId: "sess-oprune", contentHash: "hash-oprune" });
+      const res = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath: join(project, ".agent", "checkpoint.md"),
+        claimTtlSec: 10,
+        now: () => 1_700_000_100, // 100s later → orphan (>10s) pruned
+      });
+      expect(res.ok).toBe(true);
+      if (!res.ok) throw new Error("expected claim");
+      // The unrelated stale orphan was swept, not just our own identity.
+      expect(existsSync(orphan)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("prune leaves corrupt / timestamp-less / non-json artifacts untouched (never aggressively delete)", () => {
+    const root = mkdtempSync(join(tmpdir(), "abg-resume-corrupt-keep-"));
+    const project = join(root, "project");
+    const consumedDir = join(root, "consumed");
+    mkdirSync(project, { recursive: true });
+    mkdirSync(consumedDir, { recursive: true });
+    const corruptJson = join(consumedDir, "corrupt.json");
+    const noTs = join(consumedDir, "no-ts.json");
+    const nonJson = join(consumedDir, "keep.txt");
+    writeFileSync(corruptJson, "not json at all", "utf-8");
+    writeFileSync(noTs, JSON.stringify({ identity: "no-ts" }), "utf-8"); // no consumed_at
+    writeFileSync(nonJson, "whatever", "utf-8");
+    try {
+      const pending = entry({ cwd: project, sessionId: "sess-corrupt", contentHash: "hash-corrupt" });
+      // Tiny TTL + far-future now: a parseable+timestamped tombstone WOULD be pruned
+      // here, so survival proves each file is kept by its own guard (corrupt JSON →
+      // catch; missing consumed_at → non-number; non-.json → skipped).
+      const res = tryClaimPendingResume({
+        stateDir: root,
+        agent: "codex",
+        pending,
+        checkpointPath: join(project, ".agent", "checkpoint.md"),
+        consumedTtlSec: 1,
+        now: () => 9_999_999_999,
+      });
+      expect(res.ok).toBe(true);
+      // §9 safety contract: never aggressively delete what we can't reason about.
+      expect(existsSync(corruptJson)).toBe(true);
+      expect(existsSync(noTs)).toBe(true);
+      expect(existsSync(nonJson)).toBe(true);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 摘要 / Summary

Backlog 清理 **PR-A**：第 ①③④⑦ 条。第 ② 条（`abg kill` 清 resume 状态）经 cross-review 判定为**有意不实现**，理由见下 + 设计稿 §9。

## 改动

- **① 状态 GC**（`resume-injection-queue.ts`）：`pruneStaleResumeArtifacts` 在 `tryClaimPendingResume` 内顺手清 `~/.budget-guard/consumed/`（超 7 天）+ `claims/`（超 `claimTtlSec`≈320s 的孤儿）。按秒比较；损坏/无时间戳/非 `.json` 文件一律保留（不激进删）。长寿 daemon 不再无限增长。
- **③ 测试**：enqueue dedup 时 `claim.release` 抛错不崩；consumed 超期可重领；TTL 边界（== ttl 仍阻塞）；孤儿 claim 清理；损坏/无 ts/非 json 文件保留。
- **④ 文档**（设计稿 §9）：续接幂等契约 + 落盘位置（**共享** `~/.budget-guard`，文件名 identity 隔离）+ 为何 `consumed` 必须跨 kill 存活 + 为何 kill 不清这些。
- **⑦** probe `--help` 短路 post-loop 校验。

## ② 为何不实现 `abg kill` 清 resume 状态

cross-review **两轮独立**判定我的初版为 **HIGH bug**：
1. `claims/`/`consumed/` 实际写在**全机共享** `~/.budget-guard`（daemon 传 `budgetGuardStateDir()`），不是 per-pair AgentBridge state dir——原实现删错目录（静默 no-op，单测因 fixture 同样写错目录而假绿）。
2. 即便删对目录，per-pair `abg kill` 盲删**共享** `consumed/` 会误伤其它在跑 pair；且 `consumed` 是**跨重启幂等墓碑、本就该存活**（删了会重注入已消费续接）。

→ 无界增长问题已被 ① 的 TTL prune 解决，故 kill **不需也不应**清这些。整体回退（`kill.ts` == master），改为文档化。Codex 跨引擎复核已认可该结论。

## Tests
- [x] `bun test src`：**1441 pass / 0 fail**
- [x] `bun run typecheck` / `bun run verify:plugin-sync`

## Cross-review
6 轮 / 12 reviewer 对，连续 2 轮干净（#5/#6，0 confirmed REAL）。期间挖出 HIGH（kill 清错目录 + 破幂等）→ 整体回退 + 文档化。Codex 跨引擎复核中。