### PR TITLE
feat(budget): v3 P2 时间感知暂停线 maximize 真正生效 / time-aware maximize pause line

### DIFF
--- a/docs/design/budget-strategy-v3.md
+++ b/docs/design/budget-strategy-v3.md
@@ -1,6 +1,6 @@
 # Budget 策略 v3 设计稿 — 窗口利用率最大化 + 任务完整性保护
 
-> 状态：**修订版 v3.1**（已吸收 Codex 对抗审 2026-06-11：4 REAL + 2 SUSPECT + 2 RECOMMEND 全采纳，Q1-Q10 共识落定）—— 待 Codex 复核确认后即为实施基线。基于 master dfc093b，纯设计，不含任何代码改动。
+> 状态：**v3.1 实施中**。Codex 对抗审 2026-06-11（4 REAL + 2 SUSPECT + 2 RECOMMEND 全采纳，Q1-Q10 共识）已落定为实施基线。**进度：P1（燃尽率展示 + Q7 doctor）已上线 master；P2（时间感知暂停线 / maximize）已实现并通过 cross-review（见 §6 P2 实现落点）；P3（三态闸门）/ P4（runway 分配判据）待实施。** 原稿基于 master dfc093b。
 > 作者：Claude；评审：Codex（对抗审记录见 §8，开放问题共识见 §7）。
 
 ---
@@ -386,16 +386,18 @@ interface BudgetConfig {
 - **测试要点**：样本对剔除（跨重置/util 回退/时间倒流）；EWMA 收敛与半衰期；ring 截断；corrupt 文件恢复；daemon 重启恢复 confident 状态；snapshot 字段 optional 兼容（旧消费者反序列化不破）；doctor warning 触发矩阵（strategy × guard 硬线组合）；guard 线展示与 runway 展示层 clamp（只影响渲染、不影响内部估计值）。
 - **风险**：低。决策路径零接触；最坏情况是展示一行错误的预估。
 
-### P2 — 时间感知暂停线（opt-in `strategy:"maximize"`）
+### P2 — 时间感知暂停线（opt-in `strategy:"maximize"`）— ✅ 已实现（2026-06-15，feat/budget-v3-p2-maximize-pause-line）
 
-- **改动文件**：`src/budget/budget-state.ts`（按窗口 `pauseTrigger` + `dynamicPauseAt`）；`src/budget/budget-fingerprint.ts`（`shouldEnter`/`canAgentResume` 策略化 + 对称出闸 + 指纹量化）；`src/config-service.ts`（strategy/maximize 键 + 关系约束 + env）；`src/budget/render.ts`（展示生效中的动态线）。
+> **实现落点（与原设计的差异）**：决策逻辑收敛到新模块 `src/budget/budget-decision.ts`（单一决策源：`dynamicPauseAt` / `agentShouldPause` / `agentCanResume` / `resumeBlockingEpochFor` / `effectiveDynamicLine` / `isDecisionGrade`），由 `budget-state.pauseTrigger` 与 `budget-fingerprint.shouldEnter/canAgentResume` 共同消费，杜绝两处分叉（cross-review 共识）。指纹量化采取更严格路线——动态线**完全不进**指纹（见 budget-fingerprint.ts directiveFingerprint 注释），比设计的「量化后进指纹」更稳，无新指纹轴。maximize 块 P2 只落 `targetUtil/reserveSlopePctPerHour/reserveMaxPct/finishingHorizonMinutes/resumeHysteresisPct` 五键，`admissionAt/wrapUpQuota` 留给 P3（不做 parse-only 空键）。
+
+- **改动文件**：`src/budget/budget-decision.ts`（新增，单一决策源）；`src/budget/budget-state.ts`（`pauseTrigger` 委派 + 恢复文案 strategy 化）；`src/budget/budget-fingerprint.ts`（`shouldEnter`/`canAgentResume`/`resumeAfterEpoch` 改调决策源）；`src/budget/budget-coordinator.ts`（snapshot 动态线 + recovery 文案 strategy 化）；`src/config-service.ts`（maximize 键 + 关系约束 + env + shape/doctor 一致性）；`src/budget/render.ts`（展示动态线）；`src/cli/doctor.ts`（Q7 读 config targetUtil）；`src/daemon.ts`（reply gate 错误文案 strategy 化）；`src/budget/types.ts`（MaximizeConfig + snapshot.dynamicPauseLine）。
 - **测试要点**：**今日活案例回归**（codex weekly 92 / tH 6.5h / rate 1.2 → 不暂停）；远期（tH 120h）行为 = conserve；最后 1h 95% 继续（走 (a) 烧不满路径）；降级矩阵全分支（resetEpoch=0 / stale / 非 confident / 双窗口未知）；出闸对称性与窗口重置秒级恢复；不变量 I1 的 property 测试（任意参数下 maximize 线 ≥ pauseAt）。
 - **验收追加（对抗审落定）**：
   - **REAL-1 修正后的标定表回归**：§3.1 标定表全部行逐行断言分支归属 —— (a) 烧不满 return 100（tH=1/util=92）、(b) 触线暂停（tH=1/util=96 → 95.6 线）、(b) 远期 clamp 到 pauseAt（tH=120）、hard cap → admission-closed（util ≥ 97 等 REAL-4 情形）。
   - **不变量 I2 phantom-hold 测试**：closed / admission-closed 后数据转 stale，状态必须维持，绝不开闸。
-  - **Q2 参数标定表**：用 P1 收集的 burn-history 真实样本回放标定 0.4/7 默认参数，标定表本身进验收材料。
-  - **Q10 出闸对称化牵连清单 checklist**（清单待代码核实，核完逐项打勾）：`resumeBlockingEpoch`、budget-gate 的 `canAgentResume`/`shouldBlock`、coordinator 的 STOP/RESUME 指令生成、snapshot 的 `paused`/`gateClosed`/`pauseReason`/`resumeAfterEpoch`、fingerprint 去重、budget CLI/`get_budget` 渲染、reply gate 错误文案、checkpoint/handoff 文案、测试中 gate reopen 断言。
-- **REAL-4 过渡说明**：P2 阶段尚无三态闸门，hard cap 的 `"admission-closed"` 信号暂映射为 closed（此时 util 必然已 ≥ pauseAt，不违反 I1）；P3 合入后切换为真 admission-closed。
+  - **Q2 参数标定表**：✅ 默认 0.4/7 用 2026-06-15 实拍燃尽率做了 sanity 校验（Claude 5h≈1.33%/h·周≈0.44%/h；Codex 5h≈0.37%/h·周≈5.16%/h），标定表四行（今日案例/最后1h (a)+(b)/远期）落 `budget-maximize.test.ts` 逐行断言。**遗留**：用 guard `hist_*.jsonl` 历史样本批量回放的完整参数扫描表延后到参数调优阶段（非阻塞 P2 功能正确性，已显式记此口）。
+  - **Q10 出闸对称化牵连清单 checklist**（✅ 已逐项核实并落代码）：`resumeBlockingEpochFor`（maximize 取阻塞窗口 reset 最小值）、`agentCanResume`（per-window 对称出闸）、coordinator 的 RESUME 指令生成（`recoveryDirective` strategy 化）、snapshot 的 `paused`/`gateClosed`/`pauseReason`/`resumeAfterEpoch`、fingerprint 去重（动态线不进指纹）、budget CLI/`get_budget` 渲染（`render.ts` 动态线行）、reply gate 错误文案（`daemon.ts budgetPauseGateError` strategy 化）、checkpoint/handoff 文案（`renderBudgetInterventionDirective` strategy 化）、测试中 gate reopen 断言（coordinator maximize recovery 测试）。
+- **REAL-4 过渡说明**：P2 阶段尚无三态闸门，hard cap 的 `"admission-closed"` 信号暂映射为 closed —— **但必须过 I1 floor**：`blocks = window.util >= cfg.pauseAt`。hard cap 子情形 1（`util ≥ targetUtil`）因 `targetUtil > pauseAt` 恒满足 floor；子情形 2（临近重置收尾余量带）可能 `util < pauseAt`（如 pauseAt90/target97/finishingHorizon30/rate20/tH0.25/util88 → admission-closed 但 88<90），此时 floor 后**退化为 open**（P2 不暂停），P3 三态闸门接管后才由 `dynamicPauseAt` 返回值直接驱动 admission-closed。代码见 `budget-decision.ts maximizeWindowEntry`。
 - **风险**：中。决策路径核心改动；靠默认 conserve + 全降级路径退 conserve 控制爆炸半径。
 
 ### P3 — 任务完整性 admission（三态闸门）

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13866,7 +13866,8 @@ class StateDirResolver {
 // src/budget/types.ts
 var STALE_MAX_AGE_SEC = 600;
 
-// src/budget/budget-state.ts
+// src/budget/budget-decision.ts
+var MAX_TIME_TO_RESET_HOURS = 7 * 24;
 function isDecisionGrade(usage, now) {
   if (!usage)
     return false;
@@ -13877,7 +13878,6 @@ function isDecisionGrade(usage, now) {
     return false;
   return true;
 }
-
 // src/budget/burn-view.ts
 function agentWeeklyFiveHourWindowsLeft(usage, now) {
   if (!usage || usage.stale || !usage.ok)
@@ -14007,6 +14007,25 @@ function formatFiveHourWindowsLeftLine(snapshot) {
   const byAgent = values.map(([name, value]) => `${name} ~${value.toFixed(1)}`).join(" / ");
   return `\u6309\u5F53\u524D\u8282\u594F\uFF0C\u5468\u989D\u5EA6\u8FD8\u591F ${byAgent} \u4E2A 5h \u7A97\u53E3`;
 }
+function formatDynamicLineLine(snapshot) {
+  const lines = snapshot.dynamicPauseLine;
+  if (!lines)
+    return null;
+  const parts = [];
+  const entries = [
+    ["Claude", lines.claude, snapshot.claude],
+    ["Codex", lines.codex, snapshot.codex]
+  ];
+  for (const [name, line, usage] of entries) {
+    if (line === null)
+      continue;
+    const headroom = usage ? `\uFF08util ${usage.gateUtil}%\uFF0C\u4F59\u91CF ${(line - usage.gateUtil).toFixed(1)}\uFF09` : "";
+    parts.push(`${name} ${line.toFixed(1)}%${headroom}`);
+  }
+  if (parts.length === 0)
+    return null;
+  return `\u52A8\u6001\u6682\u505C\u7EBF\uFF08maximize\uFF09\uFF1A${parts.join(" \xB7 ")}`;
+}
 var PHASE_LABELS = {
   normal: "normal\uFF08\u6B63\u5E38\uFF09",
   balance: "balance\uFF08\u9700\u5747\u8861\uFF09",
@@ -14030,6 +14049,9 @@ function renderBudgetSnapshot(snapshot, options = {}) {
   const fiveHourWindowsLeftLine = formatFiveHourWindowsLeftLine(snapshot);
   if (fiveHourWindowsLeftLine)
     lines.push(fiveHourWindowsLeftLine);
+  const dynamicLineLine = formatDynamicLineLine(snapshot);
+  if (dynamicLineLine)
+    lines.push(dynamicLineLine);
   if (snapshot.claude && snapshot.codex) {
     const abs = Math.abs(snapshot.driftPct);
     if (abs > 0) {
@@ -14574,10 +14596,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("d85c9c9", "source"),
+  commit: defineString("52a49ef", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("9d80360c2afc", "source")
+  codeHash: defineString("e124596f4642", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)
@@ -15612,7 +15634,14 @@ var DEFAULT_BUDGET_CONFIG = {
     balanced: { effort: "medium" },
     eco: { effort: "low" }
   },
-  strategy: "conserve"
+  strategy: "conserve",
+  maximize: {
+    targetUtil: 97,
+    reserveSlopePctPerHour: 0.4,
+    reserveMaxPct: 7,
+    finishingHorizonMinutes: 30,
+    resumeHysteresisPct: 5
+  }
 };
 var DEFAULT_CONFIG = {
   version: "1.0",
@@ -15665,6 +15694,23 @@ function findShapeViolation(raw) {
         }
       }
     }
+    if ("maximize" in budget) {
+      const maximize = budget.maximize;
+      if (!isRecord(maximize)) {
+        return "budget.maximize is present but not an object";
+      }
+      for (const key of [
+        "targetUtil",
+        "reserveSlopePctPerHour",
+        "reserveMaxPct",
+        "finishingHorizonMinutes",
+        "resumeHysteresisPct"
+      ]) {
+        if (key in maximize && !isCoercibleNumber(maximize[key])) {
+          return `budget.maximize.${key} is present but not a number`;
+        }
+      }
+    }
   }
   return null;
 }
@@ -15672,7 +15718,7 @@ function hasCustomDecisionValues(config2) {
   const d = DEFAULT_CONFIG;
   const b = config2.budget;
   const db = d.budget;
-  return config2.idleShutdownSeconds !== d.idleShutdownSeconds || config2.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config2.codex.appPort !== d.codex.appPort || config2.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl;
+  return config2.idleShutdownSeconds !== d.idleShutdownSeconds || config2.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config2.codex.appPort !== d.codex.appPort || config2.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.strategy !== db.strategy || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -15690,8 +15736,37 @@ function normalizeBoundedInteger(value, fallback, min, max) {
     return fallback;
   return parsed;
 }
+function normalizeBoundedNumber(value, fallback, min, max) {
+  let parsed;
+  if (typeof value === "number") {
+    parsed = value;
+  } else if (typeof value === "string" && value.trim() !== "") {
+    parsed = Number(value);
+  } else {
+    return fallback;
+  }
+  if (!Number.isFinite(parsed))
+    return fallback;
+  if (parsed < min || parsed > max)
+    return fallback;
+  return parsed;
+}
 function normalizeStrategy(value, fallback) {
   return value === "conserve" || value === "maximize" ? value : fallback;
+}
+function normalizeMaximizeConfig(raw, pauseAt, fallback = DEFAULT_BUDGET_CONFIG.maximize) {
+  const m = isRecord(raw) ? raw : {};
+  const normalized = {
+    targetUtil: normalizeBoundedInteger(m.targetUtil, fallback.targetUtil, 90, 99),
+    reserveSlopePctPerHour: normalizeBoundedNumber(m.reserveSlopePctPerHour, fallback.reserveSlopePctPerHour, 0, 5),
+    reserveMaxPct: normalizeBoundedInteger(m.reserveMaxPct, fallback.reserveMaxPct, 0, 30),
+    finishingHorizonMinutes: normalizeBoundedInteger(m.finishingHorizonMinutes, fallback.finishingHorizonMinutes, 5, 180),
+    resumeHysteresisPct: normalizeBoundedInteger(m.resumeHysteresisPct, fallback.resumeHysteresisPct, 1, 30)
+  };
+  if (normalized.targetUtil <= pauseAt) {
+    return { ...DEFAULT_BUDGET_CONFIG.maximize };
+  }
+  return normalized;
 }
 function normalizeBoolean(value, fallback) {
   if (typeof value === "boolean")
@@ -15742,7 +15817,8 @@ function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
     },
     codexTierControl: normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) && codexTiers.full !== null,
     codexTiers,
-    strategy: normalizeStrategy(budget.strategy, fallback.strategy)
+    strategy: normalizeStrategy(budget.strategy, fallback.strategy),
+    maximize: normalizeMaximizeConfig(budget.maximize, pauseAt, fallback.maximize)
   };
 }
 function normalizeConfig(raw) {

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("d85c9c9", "source"),
+  commit: defineString("52a49ef", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("9d80360c2afc", "source")
+  codeHash: defineString("e124596f4642", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -3405,7 +3405,14 @@ var DEFAULT_BUDGET_CONFIG = {
     balanced: { effort: "medium" },
     eco: { effort: "low" }
   },
-  strategy: "conserve"
+  strategy: "conserve",
+  maximize: {
+    targetUtil: 97,
+    reserveSlopePctPerHour: 0.4,
+    reserveMaxPct: 7,
+    finishingHorizonMinutes: 30,
+    resumeHysteresisPct: 5
+  }
 };
 var DEFAULT_CONFIG = {
   version: "1.0",
@@ -3458,6 +3465,23 @@ function findShapeViolation(raw) {
         }
       }
     }
+    if ("maximize" in budget) {
+      const maximize = budget.maximize;
+      if (!isRecord(maximize)) {
+        return "budget.maximize is present but not an object";
+      }
+      for (const key of [
+        "targetUtil",
+        "reserveSlopePctPerHour",
+        "reserveMaxPct",
+        "finishingHorizonMinutes",
+        "resumeHysteresisPct"
+      ]) {
+        if (key in maximize && !isCoercibleNumber(maximize[key])) {
+          return `budget.maximize.${key} is present but not a number`;
+        }
+      }
+    }
   }
   return null;
 }
@@ -3465,7 +3489,7 @@ function hasCustomDecisionValues(config) {
   const d = DEFAULT_CONFIG;
   const b = config.budget;
   const db = d.budget;
-  return config.idleShutdownSeconds !== d.idleShutdownSeconds || config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config.codex.appPort !== d.codex.appPort || config.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl;
+  return config.idleShutdownSeconds !== d.idleShutdownSeconds || config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config.codex.appPort !== d.codex.appPort || config.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.strategy !== db.strategy || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -3483,8 +3507,37 @@ function normalizeBoundedInteger(value, fallback, min, max) {
     return fallback;
   return parsed;
 }
+function normalizeBoundedNumber(value, fallback, min, max) {
+  let parsed;
+  if (typeof value === "number") {
+    parsed = value;
+  } else if (typeof value === "string" && value.trim() !== "") {
+    parsed = Number(value);
+  } else {
+    return fallback;
+  }
+  if (!Number.isFinite(parsed))
+    return fallback;
+  if (parsed < min || parsed > max)
+    return fallback;
+  return parsed;
+}
 function normalizeStrategy(value, fallback) {
   return value === "conserve" || value === "maximize" ? value : fallback;
+}
+function normalizeMaximizeConfig(raw, pauseAt, fallback = DEFAULT_BUDGET_CONFIG.maximize) {
+  const m = isRecord(raw) ? raw : {};
+  const normalized = {
+    targetUtil: normalizeBoundedInteger(m.targetUtil, fallback.targetUtil, 90, 99),
+    reserveSlopePctPerHour: normalizeBoundedNumber(m.reserveSlopePctPerHour, fallback.reserveSlopePctPerHour, 0, 5),
+    reserveMaxPct: normalizeBoundedInteger(m.reserveMaxPct, fallback.reserveMaxPct, 0, 30),
+    finishingHorizonMinutes: normalizeBoundedInteger(m.finishingHorizonMinutes, fallback.finishingHorizonMinutes, 5, 180),
+    resumeHysteresisPct: normalizeBoundedInteger(m.resumeHysteresisPct, fallback.resumeHysteresisPct, 1, 30)
+  };
+  if (normalized.targetUtil <= pauseAt) {
+    return { ...DEFAULT_BUDGET_CONFIG.maximize };
+  }
+  return normalized;
 }
 function normalizeBoolean(value, fallback) {
   if (typeof value === "boolean")
@@ -3535,7 +3588,8 @@ function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
     },
     codexTierControl: normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) && codexTiers.full !== null,
     codexTiers,
-    strategy: normalizeStrategy(budget.strategy, fallback.strategy)
+    strategy: normalizeStrategy(budget.strategy, fallback.strategy),
+    maximize: normalizeMaximizeConfig(budget.maximize, pauseAt, fallback.maximize)
   };
 }
 function applyBudgetEnvOverrides(budget, env = process.env) {
@@ -3551,7 +3605,14 @@ function applyBudgetEnvOverrides(budget, env = process.env) {
     },
     codexTierControl: env.AGENTBRIDGE_BUDGET_CODEX_TIER_CONTROL ?? budget.codexTierControl,
     codexTiers: budget.codexTiers,
-    strategy: env.AGENTBRIDGE_BUDGET_STRATEGY ?? budget.strategy
+    strategy: env.AGENTBRIDGE_BUDGET_STRATEGY ?? budget.strategy,
+    maximize: {
+      targetUtil: env.AGENTBRIDGE_BUDGET_TARGET_UTIL ?? budget.maximize.targetUtil,
+      reserveSlopePctPerHour: env.AGENTBRIDGE_BUDGET_RESERVE_SLOPE_PCT_PER_HOUR ?? budget.maximize.reserveSlopePctPerHour,
+      reserveMaxPct: env.AGENTBRIDGE_BUDGET_RESERVE_MAX_PCT ?? budget.maximize.reserveMaxPct,
+      finishingHorizonMinutes: env.AGENTBRIDGE_BUDGET_FINISHING_HORIZON_MINUTES ?? budget.maximize.finishingHorizonMinutes,
+      resumeHysteresisPct: env.AGENTBRIDGE_BUDGET_RESUME_HYSTERESIS_PCT ?? budget.maximize.resumeHysteresisPct
+    }
   };
   return normalizeBudgetConfig(overlay, budget);
 }
@@ -3688,35 +3749,25 @@ function resumeBlockingEpoch(usage, cfg, now) {
 // src/budget/types.ts
 var STALE_MAX_AGE_SEC = 600;
 
-// src/budget/budget-state.ts
+// src/budget/budget-decision.ts
 var AGENT_LABEL = {
   claude: "Claude",
   codex: "Codex"
 };
-var CODEX_BALANCED_WARN_UTIL = 60;
-var CODEX_ECO_WARN_UTIL = 80;
-var CLAUDE_ADVICE_WARN_UTIL = 80;
+var WINDOW_LABEL = {
+  fiveHour: "5h",
+  weekly: "\u5468"
+};
+var WINDOW_KEYS = ["fiveHour", "weekly"];
+var MAX_TIME_TO_RESET_HOURS = 7 * 24;
+var FINISHING_MARGIN_MIN_PCT = 1;
+var FINISHING_MARGIN_MAX_PCT = 10;
+var DYNAMIC_LINE_CEILING_PCT = 99;
 function pct(value) {
   return `${Math.round(value * 10) / 10}%`;
 }
-function formatEpoch(epoch) {
-  if (!epoch || epoch <= 0)
-    return "\u672A\u77E5";
-  return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
-}
-function usageSummary(name, usage) {
-  if (!usage)
-    return `${AGENT_LABEL[name]} \u672A\u77E5`;
-  return `${AGENT_LABEL[name]} gate=${pct(usage.gateUtil)} warn=${pct(usage.warnUtil)} 5h\u91CD\u7F6E=${formatEpoch(usage.fiveHour?.resetEpoch ?? 0)}`;
-}
-function resumeAfterEpoch(claude, codex, cfg, now) {
-  const epochs = [
-    resumeBlockingEpoch(claude, cfg, now),
-    resumeBlockingEpoch(codex, cfg, now)
-  ].filter((epoch) => epoch > 0);
-  if (epochs.length === 0)
-    return null;
-  return Math.max(...epochs);
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
 }
 function isDecisionGrade(usage, now) {
   if (!usage)
@@ -3728,18 +3779,204 @@ function isDecisionGrade(usage, now) {
     return false;
   return true;
 }
-function pauseTrigger(agent, usage, cfg, now) {
-  if (!usage)
-    return null;
-  if (!isDecisionGrade(usage, now))
-    return null;
-  if (usage.gateUtil >= cfg.pauseAt) {
-    return {
-      agent,
-      reason: `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} \u2265 pauseAt ${pct(cfg.pauseAt)}`
-    };
+function dynamicPauseAt(window, burnRatePctPerHour, cfg, now) {
+  const m = cfg.maximize;
+  const rawTimeToResetHours = (window.resetEpoch - now) / 3600;
+  if (rawTimeToResetHours <= 0)
+    return 100;
+  const tH = Math.min(rawTimeToResetHours, MAX_TIME_TO_RESET_HOURS);
+  const finishingMarginPct = clamp(burnRatePctPerHour * (m.finishingHorizonMinutes / 60), FINISHING_MARGIN_MIN_PCT, FINISHING_MARGIN_MAX_PCT);
+  const projectedAtReset = window.util + burnRatePctPerHour * tH;
+  if (projectedAtReset <= m.targetUtil) {
+    if (window.util >= m.targetUtil)
+      return "admission-closed";
+    if (tH < m.finishingHorizonMinutes / 60 && window.util >= m.targetUtil - finishingMarginPct) {
+      return "admission-closed";
+    }
+    return 100;
   }
-  return null;
+  const reservePct = Math.min(m.reserveMaxPct, m.reserveSlopePctPerHour * tH);
+  const line = m.targetUtil - finishingMarginPct - reservePct;
+  return clamp(line, cfg.pauseAt, Math.max(cfg.pauseAt, DYNAMIC_LINE_CEILING_PCT));
+}
+function confidentRate(window) {
+  if (window.burnConfident !== true)
+    return null;
+  if (typeof window.burnRate !== "number" || !Number.isFinite(window.burnRate) || window.burnRate < 0) {
+    return null;
+  }
+  return window.burnRate;
+}
+function maximizeWindowEntry(window, cfg, now) {
+  const rate = confidentRate(window);
+  if (rate === null) {
+    return { blocks: window.util >= cfg.pauseAt, line: null, admission: false };
+  }
+  const line = dynamicPauseAt(window, rate, cfg, now);
+  if (line === "admission-closed") {
+    return { blocks: window.util >= cfg.pauseAt, line: null, admission: true };
+  }
+  return { blocks: window.util >= line, line, admission: false };
+}
+function maximizeWindowBlocksResume(window, cfg, now) {
+  const rate = confidentRate(window);
+  if (rate === null) {
+    return window.util >= cfg.resumeBelow;
+  }
+  const line = dynamicPauseAt(window, rate, cfg, now);
+  const hyst = cfg.maximize.resumeHysteresisPct;
+  if (line === "admission-closed") {
+    return window.util >= cfg.pauseAt - hyst;
+  }
+  if (line === 100)
+    return false;
+  return window.util >= line - hyst;
+}
+function freshWindows(usage, now) {
+  const out = [];
+  for (const key of WINDOW_KEYS) {
+    const window = usage[key];
+    if (window && window.resetEpoch > now)
+      out.push({ key, window });
+  }
+  return out;
+}
+var NO_PAUSE = { pause: false, window: null, line: null, reason: "" };
+function conserveReason(agent, usage, cfg) {
+  return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} \u2265 pauseAt ${pct(cfg.pauseAt)}`;
+}
+function agentShouldPause(agent, usage, cfg, now) {
+  if (!usage)
+    return NO_PAUSE;
+  if (!isDecisionGrade(usage, now))
+    return NO_PAUSE;
+  if (cfg.strategy !== "maximize") {
+    if (usage.gateUtil >= cfg.pauseAt) {
+      return { pause: true, window: null, line: null, reason: conserveReason(agent, usage, cfg) };
+    }
+    return NO_PAUSE;
+  }
+  const windows = freshWindows(usage, now);
+  if (windows.length === 0) {
+    if (usage.gateUtil >= cfg.pauseAt) {
+      return { pause: true, window: null, line: null, reason: conserveReason(agent, usage, cfg) };
+    }
+    return NO_PAUSE;
+  }
+  for (const { key, window } of windows) {
+    const verdict = maximizeWindowEntry(window, cfg, now);
+    if (verdict.blocks) {
+      return {
+        pause: true,
+        window: key,
+        line: verdict.line,
+        reason: buildMaximizeReason(agent, key, window, verdict, cfg)
+      };
+    }
+  }
+  return NO_PAUSE;
+}
+function buildMaximizeReason(agent, key, window, verdict, cfg) {
+  const head = `${AGENT_LABEL[agent]} ${WINDOW_LABEL[key]}\u7A97\u53E3 util ${pct(window.util)}`;
+  if (verdict.line !== null) {
+    const rate = window.burnRate;
+    const rateText = typeof rate === "number" ? `\uFF0C\u71C3\u5C3D\u7387\u2248${pct(rate)}/h` : "";
+    return `${head} \u2265 \u52A8\u6001\u6682\u505C\u7EBF ${pct(verdict.line)}${rateText}`;
+  }
+  if (verdict.admission) {
+    return `${head} \u89E6\u53D1\u6536\u5C3E\u4FDD\u62A4\u786C\u7EBF\uFF08\u2265 pauseAt ${pct(cfg.pauseAt)}\uFF09`;
+  }
+  return `${head} \u2265 pauseAt ${pct(cfg.pauseAt)}\uFF08\u71C3\u5C3D\u7387\u91C7\u6837\u4E2D\uFF0C\u9000\u4FDD\u5B88\u5224\u636E\uFF09`;
+}
+function agentCanResume(usage, cfg, now) {
+  if (!isDecisionGrade(usage, now))
+    return false;
+  if (usage.rateLimitedUntil > now)
+    return false;
+  if (cfg.strategy !== "maximize") {
+    return usage.gateUtil < cfg.resumeBelow;
+  }
+  const windows = freshWindows(usage, now);
+  for (const { window } of windows) {
+    if (maximizeWindowBlocksResume(window, cfg, now))
+      return false;
+  }
+  return true;
+}
+function effectiveDynamicLine(usage, cfg, now) {
+  if (cfg.strategy !== "maximize")
+    return null;
+  if (!usage || !isDecisionGrade(usage, now))
+    return null;
+  let bestLine = null;
+  let bestHeadroom = Number.POSITIVE_INFINITY;
+  for (const { window } of freshWindows(usage, now)) {
+    const rate = confidentRate(window);
+    if (rate === null)
+      continue;
+    const line = dynamicPauseAt(window, rate, cfg, now);
+    if (line === "admission-closed" || line >= 100)
+      continue;
+    const headroom = line - window.util;
+    if (headroom < bestHeadroom) {
+      bestHeadroom = headroom;
+      bestLine = line;
+    }
+  }
+  return bestLine;
+}
+function resumeBlockingEpochFor(usage, cfg, now) {
+  if (!usage)
+    return 0;
+  if (cfg.strategy !== "maximize")
+    return resumeBlockingEpoch(usage, cfg, now);
+  if (usage.rateLimitedUntil > now)
+    return usage.rateLimitedUntil;
+  if (!isDecisionGrade(usage, now)) {
+    const reset = matchingGateReset(usage);
+    return reset > now ? reset : 0;
+  }
+  const blockingResets = freshWindows(usage, now).filter(({ window }) => maximizeWindowBlocksResume(window, cfg, now)).map(({ window }) => window.resetEpoch).filter((epoch) => epoch > 0);
+  if (blockingResets.length === 0)
+    return 0;
+  return Math.min(...blockingResets);
+}
+
+// src/budget/budget-state.ts
+var AGENT_LABEL2 = {
+  claude: "Claude",
+  codex: "Codex"
+};
+var CODEX_BALANCED_WARN_UTIL = 60;
+var CODEX_ECO_WARN_UTIL = 80;
+var CLAUDE_ADVICE_WARN_UTIL = 80;
+function pct2(value) {
+  return `${Math.round(value * 10) / 10}%`;
+}
+function formatEpoch(epoch) {
+  if (!epoch || epoch <= 0)
+    return "\u672A\u77E5";
+  return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+}
+function usageSummary(name, usage) {
+  if (!usage)
+    return `${AGENT_LABEL2[name]} \u672A\u77E5`;
+  return `${AGENT_LABEL2[name]} gate=${pct2(usage.gateUtil)} warn=${pct2(usage.warnUtil)} 5h\u91CD\u7F6E=${formatEpoch(usage.fiveHour?.resetEpoch ?? 0)}`;
+}
+function resumeAfterEpoch(claude, codex, cfg, now) {
+  const epochs = [
+    resumeBlockingEpochFor(claude, cfg, now),
+    resumeBlockingEpochFor(codex, cfg, now)
+  ].filter((epoch) => epoch > 0);
+  if (epochs.length === 0)
+    return null;
+  return Math.max(...epochs);
+}
+function pauseTrigger(agent, usage, cfg, now) {
+  const decision = agentShouldPause(agent, usage, cfg, now);
+  if (!decision.pause)
+    return null;
+  return { agent, reason: decision.reason };
 }
 function driftFor(claude, codex, cfg) {
   if (!claude || !codex)
@@ -3770,17 +4007,19 @@ function parallelState(claude, codex, cfg, now) {
   const minutes = Math.ceil(nearestResetSec / 60);
   return {
     recommended: true,
-    reason: `\u53CC\u65B9\u5269\u4F59\u989D\u5EA6\u5747\u9AD8\u4E8E ${pct(cfg.parallel.minRemainingPct)}\uFF0C\u6700\u8FD1 5h \u6876\u7EA6 ${minutes} \u5206\u949F\u540E\u91CD\u7F6E`
+    reason: `\u53CC\u65B9\u5269\u4F59\u989D\u5EA6\u5747\u9AD8\u4E8E ${pct2(cfg.parallel.minRemainingPct)}\uFF0C\u6700\u8FD1 5h \u6876\u7EA6 ${minutes} \u5206\u949F\u540E\u91CD\u7F6E`
   };
 }
 function renderBudgetInterventionDirective(claude, codex, side, reason, resumeEpoch, cfg) {
   const resumeText = `\u9884\u8BA1\u6062\u590D\u65F6\u95F4\uFF08\u4EE5\u5B9E\u6D4B\u4E3A\u51C6\uFF1B\u63D0\u524D\u5237\u65B0\u4F1A\u66F4\u65E9\u89E3\u9664\uFF09\uFF1A${formatEpoch(resumeEpoch)}\u3002`;
+  const resumeCondSingle = cfg.strategy === "maximize" ? `\u5404\u7A97\u53E3 util \u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${pct2(cfg.maximize.resumeHysteresisPct)} \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0` : `gateUtil \u4F4E\u4E8E ${pct2(cfg.resumeBelow)}`;
+  const resumeCondBoth = cfg.strategy === "maximize" ? `\u5404\u7A97\u53E3 util \u90FD\u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${pct2(cfg.maximize.resumeHysteresisPct)} \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0` : `gateUtil \u90FD\u4F4E\u4E8E ${pct2(cfg.resumeBelow)}`;
   if (side === "claude") {
     return [
       "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Claude \u4FA7\u989D\u5EA6\u7D27\u5F20\uFF0C\u8FDB\u5165\u63A5\u529B\u6A21\u5F0F\u3002",
       `\u89E6\u53D1\u65B9\uFF1AClaude\uFF1B\u539F\u56E0\uFF1A${reason}\u3002`,
       `${usageSummary("claude", claude)}\uFF1B${usageSummary("codex", codex)}\u3002`,
-      `\u6062\u590D\u53C2\u8003\uFF1AClaude gateUtil \u4F4E\u4E8E ${pct(cfg.resumeBelow)} \u4E14\u6CA1\u6709\u6709\u6548 rate_limit\uFF1B${resumeText}`,
+      `\u6062\u590D\u53C2\u8003\uFF1AClaude ${resumeCondSingle} \u4E14\u6CA1\u6709\u6709\u6548 rate_limit\uFF1B${resumeText}`,
       "\u8BF7\u7ACB\u5373\u4EA4\u63A5\uFF1A\u628A\u5269\u4F59\u4EFB\u52A1\u6E05\u5355\u3001\u5173\u952E\u4E0A\u4E0B\u6587\u3001\u4EA7\u51FA\u4F4D\u7F6E\u3001\u9A8C\u6536\u6807\u51C6\u6253\u5305\u6210\u4E00\u6761 reply \u53D1\u7ED9 Codex\u3002",
       "\u4EA4\u63A5\u540E Claude \u505C\u624B\uFF1B\u8981\u6C42 Codex \u5728\u5355 turn \u5185\u5C3D\u91CF\u5B8C\u6210\uFF0C\u5C3E\u5DF4\u5199 checkpoint\uFF0C\u6682\u505C\u671F\u4E0D\u8981\u671F\u5F85 Claude \u56DE\u590D\u3002"
     ].join(`
@@ -3791,7 +4030,7 @@ function renderBudgetInterventionDirective(claude, codex, side, reason, resumeEp
       "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Codex \u4FA7\u989D\u5EA6\u7D27\u5F20\uFF0C\u6682\u505C\u59D4\u6D3E\u3002",
       `\u89E6\u53D1\u65B9\uFF1ACodex\uFF1B\u539F\u56E0\uFF1A${reason}\u3002`,
       `${usageSummary("claude", claude)}\uFF1B${usageSummary("codex", codex)}\u3002`,
-      `\u6062\u590D\u53C2\u8003\uFF1ACodex gateUtil \u4F4E\u4E8E ${pct(cfg.resumeBelow)} \u4E14\u6CA1\u6709\u6709\u6548 rate_limit\uFF1B${resumeText}`,
+      `\u6062\u590D\u53C2\u8003\uFF1ACodex ${resumeCondSingle} \u4E14\u6CA1\u6709\u6709\u6548 rate_limit\uFF1B${resumeText}`,
       "\u8BF7 Claude \u5199 checkpoint\uFF0C\u5E76\u53EF solo \u63A8\u8FDB\u4E0D\u4F9D\u8D56 Codex \u7684\u72EC\u7ACB\u90E8\u5206\uFF1B\u4E0D\u8981\u7EE7\u7EED\u5411 Codex \u59D4\u6D3E\uFF0C\u6807\u6CE8\u6E05\u695A\u5206\u5DE5\u65AD\u70B9\u3002"
     ].join(`
 `);
@@ -3800,18 +4039,18 @@ function renderBudgetInterventionDirective(claude, codex, side, reason, resumeEp
     "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011\u8FDB\u5165\u8054\u5408\u6682\u505C\u3002",
     `\u89E6\u53D1\u65B9\uFF1A\u53CC\u65B9\uFF1B\u539F\u56E0\uFF1A${reason}\u3002`,
     `${usageSummary("claude", claude)}\uFF1B${usageSummary("codex", codex)}\u3002`,
-    `\u6062\u590D\u6761\u4EF6\uFF1AClaude \u4E0E Codex \u7684 gateUtil \u90FD\u4F4E\u4E8E ${pct(cfg.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\uFF1B${resumeText}`,
+    `\u6062\u590D\u6761\u4EF6\uFF1AClaude \u4E0E Codex \u7684 ${resumeCondBoth}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\uFF1B${resumeText}`,
     "\u8BF7\u6536\u5C3E\u5F53\u524D\u6B65\u3001\u5199 checkpoint\u3001\u505C\u6B62\u7EE7\u7EED\u59D4\u6D3E\uFF1Bpause \u671F\u95F4\u4E0D\u8981\u91CD\u8BD5\u5411 Codex \u53D1\u9001 reply\u3002"
   ].join(`
 `);
 }
 function balanceDirective(claude, codex, drift, parallel) {
-  const heavier = drift.heavier ? AGENT_LABEL[drift.heavier] : "\u672A\u77E5";
-  const lighter = drift.lighter ? AGENT_LABEL[drift.lighter] : "\u672A\u77E5";
+  const heavier = drift.heavier ? AGENT_LABEL2[drift.heavier] : "\u672A\u77E5";
+  const lighter = drift.lighter ? AGENT_LABEL2[drift.lighter] : "\u672A\u77E5";
   const lines = [
     "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011\u68C0\u6D4B\u5230\u53CC\u65B9\u7528\u91CF\u6BD4\u4F8B\u6F02\u79FB\u3002",
     `${usageSummary("claude", claude)}\uFF1B${usageSummary("codex", codex)}\u3002`,
-    `${heavier} \u6BD4 ${lighter} \u9AD8 ${pct(Math.abs(drift.pct))}\uFF0C\u8BF7\u4F18\u5148\u628A\u540E\u7EED\u53EF\u62C6\u5206\u4EFB\u52A1\u5206\u7ED9 ${lighter}\uFF0C\u76F4\u5230 warnUtil \u63A5\u8FD1\u3002`
+    `${heavier} \u6BD4 ${lighter} \u9AD8 ${pct2(Math.abs(drift.pct))}\uFF0C\u8BF7\u4F18\u5148\u628A\u540E\u7EED\u53EF\u62C6\u5206\u4EFB\u52A1\u5206\u7ED9 ${lighter}\uFF0C\u76F4\u5230 warnUtil \u63A5\u8FD1\u3002`
   ];
   if (parallel.recommended && parallel.reason) {
     lines.push(`${parallel.reason}\uFF1B\u53EF\u8BA9 ${lighter} \u627F\u62C5\u66F4\u591A\u5E76\u884C\u5B50\u4EFB\u52A1\uFF0C\u517C\u987E\u5747\u8861\u4E0E\u63D0\u901F\u3002`);
@@ -3841,7 +4080,7 @@ function claudeAdviceFor(claude, now) {
     return null;
   if (claude.warnUtil < CLAUDE_ADVICE_WARN_UTIL)
     return null;
-  return `Claude warnUtil ${pct(claude.warnUtil)} \u5DF2\u504F\u9AD8\uFF1B\u540E\u7EED\u53EF\u62C6\u5206 subagent \u5EFA\u8BAE\u964D\u6863\u5230 haiku/sonnet\uFF0C\u5E76\u4FDD\u7559\u9AD8\u96BE\u5EA6\u4E3B\u7EBF\u7ED9\u5F53\u524D\u4F1A\u8BDD\u3002`;
+  return `Claude warnUtil ${pct2(claude.warnUtil)} \u5DF2\u504F\u9AD8\uFF1B\u540E\u7EED\u53EF\u62C6\u5206 subagent \u5EFA\u8BAE\u964D\u6863\u5230 haiku/sonnet\uFF0C\u5E76\u4FDD\u7559\u9AD8\u96BE\u5EA6\u4E3B\u7EBF\u7ED9\u5F53\u524D\u4F1A\u8BDD\u3002`;
 }
 function computeBudgetState(claude, codex, cfg, now) {
   const triggers = [
@@ -3893,11 +4132,11 @@ function computeBudgetState(claude, codex, cfg, now) {
 
 // src/budget/budget-fingerprint.ts
 var RESET_FINGERPRINT_BUCKET_SEC = 600;
-var AGENT_LABEL2 = {
+var AGENT_LABEL3 = {
   claude: "Claude",
   codex: "Codex"
 };
-function pct2(value) {
+function pct3(value) {
   return `${Math.round(value * 10) / 10}%`;
 }
 function formatEpoch2(epoch) {
@@ -3929,25 +4168,13 @@ function agentsToSide(agents) {
     return "codex";
   return null;
 }
-function shouldEnter(usage, cfg, now) {
-  if (!isDecisionGrade(usage, now))
-    return false;
-  return usage.gateUtil >= cfg.pauseAt;
-}
-function canAgentResume(usage, cfg, now) {
-  if (!isDecisionGrade(usage, now))
-    return false;
-  if (usage.rateLimitedUntil > now)
-    return false;
-  return usage.gateUtil < cfg.resumeBelow;
-}
 function nextActiveSide(prevSide, state, cfg) {
   const active = new Set(sideToAgents(prevSide));
   for (const agent of ["claude", "codex"]) {
     const usage = state.perAgent[agent];
-    if (shouldEnter(usage, cfg, state.now)) {
+    if (agentShouldPause(agent, usage, cfg, state.now).pause) {
       active.add(agent);
-    } else if (active.has(agent) && canAgentResume(usage, cfg, state.now)) {
+    } else if (active.has(agent) && agentCanResume(usage, cfg, state.now)) {
       active.delete(agent);
     }
   }
@@ -3959,20 +4186,20 @@ function removedAgents(prevSide, currentSide) {
 }
 function activeSideReason(agent, usage, cfg, now) {
   if (!usage)
-    return `${AGENT_LABEL2[agent]} \u63A2\u6D4B\u6682\u65F6\u4E0D\u53EF\u7528\uFF0C\u4FDD\u6301\u4E0A\u4E00\u8F6E\u9884\u7B97\u5E72\u9884`;
+    return `${AGENT_LABEL3[agent]} \u63A2\u6D4B\u6682\u65F6\u4E0D\u53EF\u7528\uFF0C\u4FDD\u6301\u4E0A\u4E00\u8F6E\u9884\u7B97\u5E72\u9884`;
   if (usage.rateLimitedUntil > now) {
-    return `${AGENT_LABEL2[agent]} \u63A2\u9488\u88AB\u9650\u6D41\u81F3 ${formatEpoch2(usage.rateLimitedUntil)}`;
+    return `${AGENT_LABEL3[agent]} \u63A2\u9488\u88AB\u9650\u6D41\u81F3 ${formatEpoch2(usage.rateLimitedUntil)}`;
   }
-  if (usage.gateUtil >= cfg.pauseAt) {
-    return `${AGENT_LABEL2[agent]} gateUtil ${pct2(usage.gateUtil)} \u2265 pauseAt ${pct2(cfg.pauseAt)}`;
-  }
-  return `${AGENT_LABEL2[agent]} gateUtil ${pct2(usage.gateUtil)} \u5C1A\u672A\u4F4E\u4E8E resumeBelow ${pct2(cfg.resumeBelow)}`;
+  const decision = agentShouldPause(agent, usage, cfg, now);
+  if (decision.pause)
+    return decision.reason;
+  return `${AGENT_LABEL3[agent]} gateUtil ${pct3(usage.gateUtil)} \u5C1A\u672A\u6EE1\u8DB3\u51FA\u95F8\u6761\u4EF6`;
 }
 function interventionReason(side, state, cfg) {
   return sideToAgents(side).map((agent) => activeSideReason(agent, state.perAgent[agent], cfg, state.now)).join("\uFF1B");
 }
 function resumeAfterEpoch2(side, state, cfg) {
-  const epochs = sideToAgents(side).map((agent) => resumeBlockingEpoch(state.perAgent[agent], cfg, state.now)).filter((epoch) => epoch > 0);
+  const epochs = sideToAgents(side).map((agent) => resumeBlockingEpochFor(state.perAgent[agent], cfg, state.now)).filter((epoch) => epoch > 0);
   if (epochs.length === 0)
     return null;
   return Math.max(...epochs);
@@ -4071,7 +4298,7 @@ function computeResumeCandidate(sides, state, cfg, signals) {
   const candidate = {};
   const detail = {};
   for (const agent of sides) {
-    const windowRefreshed = canAgentResume(state.perAgent[agent], cfg, state.now);
+    const windowRefreshed = agentCanResume(state.perAgent[agent], cfg, state.now);
     const ready = windowRefreshed && signals.pendingExists[agent] && signals.tuiReady[agent] && signals.checkpointExists;
     candidate[agent] = ready;
     const pending = signals.pending?.[agent];
@@ -4152,17 +4379,17 @@ var REAL_BUDGET_POLL_SCHEDULER = {
     clearTimeout(timer);
   }
 };
-var AGENT_LABEL3 = {
+var AGENT_LABEL4 = {
   claude: "Claude",
   codex: "Codex"
 };
-function pct3(value) {
+function pct4(value) {
   return `${Math.round(value * 10) / 10}%`;
 }
 function usageLine(agent, usage) {
   if (!usage)
-    return `${AGENT_LABEL3[agent]} \u672A\u77E5`;
-  return `${AGENT_LABEL3[agent]} gate=${pct3(usage.gateUtil)} warn=${pct3(usage.warnUtil)}`;
+    return `${AGENT_LABEL4[agent]} \u672A\u77E5`;
+  return `${AGENT_LABEL4[agent]} gate=${pct4(usage.gateUtil)} warn=${pct4(usage.warnUtil)}`;
 }
 function maxPollDelayMs(config) {
   return Math.max(0, config.pollSeconds * 1000);
@@ -4432,19 +4659,22 @@ class BudgetCoordinator {
     return renderBudgetInterventionDirective(state.perAgent.claude, state.perAgent.codex, side, reason || "\u9884\u7B97\u63A5\u8FD1\u8017\u5C3D", resumeEpoch, this.config);
   }
   recoveryDirective(state, side) {
+    const maximizeRecoveredText = `\u5404\u7A97\u53E3 util \u5DF2\u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${pct4(this.config.maximize.resumeHysteresisPct)} \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5DF2\u5237\u65B0`;
     if (side === "claude") {
+      const condClaude = this.config.strategy === "maximize" ? maximizeRecoveredText : `gateUtil \u5DF2\u4F4E\u4E8E ${pct4(this.config.resumeBelow)}`;
       return [
         "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Claude \u4FA7\u9884\u7B97\u5DF2\u6062\u590D\u3002",
         `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
-        `Claude gateUtil \u5DF2\u4F4E\u4E8E ${pct3(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
+        `Claude ${condClaude}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
         "Claude \u53EF\u6062\u590D orchestrator \u89D2\u8272\uFF1B\u540E\u7EED\u5206\u914D\u524D\u8BF7\u91CD\u65B0\u67E5\u8BE2\u5B9E\u65F6\u989D\u5EA6\uFF0C\u4E0D\u8981\u4F9D\u8D56\u65E7\u6570\u5B57\u3002"
       ].join(`
 `);
     }
+    const condCodex = this.config.strategy === "maximize" ? maximizeRecoveredText : `gateUtil \u4F4E\u4E8E ${pct4(this.config.resumeBelow)}`;
     return [
       "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Codex \u4FA7\u9884\u7B97\u95F8\u95E8\u89E3\u9664\u3002",
       `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
-      `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1ACodex gateUtil \u4F4E\u4E8E ${pct3(this.config.resumeBelow)}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
+      `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1ACodex ${condCodex}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
       "\u5EFA\u8BAE Claude \u7528 reply \u5E26\u4E0A\u5F53\u524D\u76EE\u6807\u3001checkpoint \u548C\u4E0B\u4E00\u6B65\uFF0C\u5524\u9192 Codex \u63A5\u7EED\u6267\u884C\u3002"
     ].join(`
 `);
@@ -4465,7 +4695,18 @@ class BudgetCoordinator {
       parallelRecommended: paused ? false : state.parallel.recommended,
       codexTier: state.effort.codexTier,
       claudeAdvice: state.effort.claudeAdvice,
-      ...this.burnRateSnapshotFields(state)
+      ...this.burnRateSnapshotFields(state),
+      ...this.dynamicLineSnapshotFields(state)
+    };
+  }
+  dynamicLineSnapshotFields(state) {
+    if (this.config.strategy !== "maximize")
+      return {};
+    return {
+      dynamicPauseLine: {
+        claude: effectiveDynamicLine(state.perAgent.claude, this.config, state.now),
+        codex: effectiveDynamicLine(state.perAgent.codex, this.config, state.now)
+      }
     };
   }
   burnRateSnapshotFields(state) {
@@ -4577,7 +4818,7 @@ function asFiniteNumber(value) {
 function numberOr(value, fallback) {
   return asFiniteNumber(value) ?? fallback;
 }
-function clamp(value, min, max) {
+function clamp2(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 function asRecord(value) {
@@ -4598,7 +4839,7 @@ function normalizeBucket(value, fetchedAt) {
   }
   return {
     id,
-    util: clamp(util, 0, 100),
+    util: clamp2(util, 0, 100),
     resetEpoch: Math.max(0, resetEpoch),
     resetAfterSeconds: resetAfter === null ? null : Math.max(0, resetAfter),
     burn: parseBurnFields(bucket)
@@ -4612,7 +4853,7 @@ function normalizeTopLevelBucket(record, util, fetchedAt) {
   }
   return {
     id: "top_level",
-    util: clamp(util, 0, 100),
+    util: clamp2(util, 0, 100),
     resetEpoch: Math.max(0, resetEpoch),
     resetAfterSeconds: resetAfter === null ? null : Math.max(0, resetAfter),
     burn: parseBurnFields(record)
@@ -4679,8 +4920,8 @@ function identifyWindows(buckets) {
 function normalizeTolerantProbeRecord(record) {
   const fetchedAt = numberOr(record.fetched_at ?? record.fetchedAt ?? record.now_epoch ?? record.nowEpoch, 0);
   const hasFiniteUtil = asFiniteNumber(record.util ?? record.hard_util ?? record.hardUtil) !== null || asFiniteNumber(record.warn_util ?? record.warnUtil) !== null;
-  const gateUtil = clamp(numberOr(record.util ?? record.hard_util ?? record.hardUtil, 0), 0, 100);
-  const warnUtil = clamp(numberOr(record.warn_util ?? record.warnUtil, gateUtil), 0, 100);
+  const gateUtil = clamp2(numberOr(record.util ?? record.hard_util ?? record.hardUtil, 0), 0, 100);
+  const warnUtil = clamp2(numberOr(record.warn_util ?? record.warnUtil, gateUtil), 0, 100);
   const rawBuckets = Array.isArray(record.buckets) ? record.buckets : [];
   const buckets = rawBuckets.map((bucket) => normalizeBucket(bucket, fetchedAt)).filter((bucket) => bucket !== null);
   let parsedVia = "id-match";
@@ -4707,7 +4948,7 @@ function normalizeTolerantProbeRecord(record) {
     warnUtil,
     fiveHour,
     weekly,
-    remaining: clamp(100 - gateUtil, 0, 100),
+    remaining: clamp2(100 - gateUtil, 0, 100),
     rateLimitedUntil,
     fetchedAt,
     parsedVia
@@ -6080,7 +6321,8 @@ function budgetPauseGateError() {
   const reason = snapshot?.pauseReason ?? "Codex \u4FA7\u989D\u5EA6\u63A5\u8FD1\u8017\u5C3D";
   const resumeAt = snapshot?.resumeAfterEpoch ? new Date(snapshot.resumeAfterEpoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z") : null;
   const sideHint = snapshot?.pauseSide === "both" ? "\u53CC\u4FA7\u989D\u5EA6\u5747\u5DF2\u8017\u5C3D\uFF0C\u8BF7\u5199 checkpoint \u7B49\u5F85\u5237\u65B0" : "\u4F60\u53EF\u7EE7\u7EED solo \u63A8\u8FDB\u53EF\u72EC\u7ACB\u90E8\u5206\uFF0C\u5E76\u5199 checkpoint \u6807\u6CE8\u5206\u5DE5\u65AD\u70B9";
-  return `\u9884\u7B97\u6682\u505C\uFF08\u95F8\u95E8\u5173\u95ED\uFF09\uFF0C\u5DF2\u62D2\u7EDD\u8F6C\u53D1\uFF1A${reason}\u3002` + `Codex \u4FA7 gateUtil \u4F4E\u4E8E ${BUDGET_CONFIG.resumeBelow}% \u540E\u95F8\u95E8\u81EA\u52A8\u653E\u5F00` + (resumeAt ? `\uFF08\u9884\u8BA1\u6062\u590D ${resumeAt}\uFF0C\u4EE5\u5B9E\u6D4B\u4E3A\u51C6\uFF1B\u63D0\u524D\u5237\u65B0\u4F1A\u66F4\u65E9\u89E3\u9664\uFF09` : "") + `\u3002\u6536\u5230 RESUME \u901A\u77E5\u524D\u8BF7\u52FF\u91CD\u8BD5\u5411 Codex \u53D1\u9001 reply\uFF1B${sideHint}\u3002`;
+  const reopenText = BUDGET_CONFIG.strategy === "maximize" ? `Codex \u4FA7\u5404\u7A97\u53E3 util \u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${BUDGET_CONFIG.maximize.resumeHysteresisPct}% \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0\u540E\u95F8\u95E8\u81EA\u52A8\u653E\u5F00` : `Codex \u4FA7 gateUtil \u4F4E\u4E8E ${BUDGET_CONFIG.resumeBelow}% \u540E\u95F8\u95E8\u81EA\u52A8\u653E\u5F00`;
+  return `\u9884\u7B97\u6682\u505C\uFF08\u95F8\u95E8\u5173\u95ED\uFF09\uFF0C\u5DF2\u62D2\u7EDD\u8F6C\u53D1\uFF1A${reason}\u3002` + reopenText + (resumeAt ? `\uFF08\u9884\u8BA1\u6062\u590D ${resumeAt}\uFF0C\u4EE5\u5B9E\u6D4B\u4E3A\u51C6\uFF1B\u63D0\u524D\u5237\u65B0\u4F1A\u66F4\u65E9\u89E3\u9664\uFF09` : "") + `\u3002\u6536\u5230 RESUME \u901A\u77E5\u524D\u8BF7\u52FF\u91CD\u8BD5\u5411 Codex \u53D1\u9001 reply\uFF1B${sideHint}\u3002`;
 }
 var tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -1,4 +1,5 @@
 import { computeBudgetState, renderBudgetInterventionDirective } from "./budget-state";
+import { effectiveDynamicLine } from "./budget-decision";
 import {
   classifyPoll,
   computeResumeCandidate,
@@ -461,19 +462,31 @@ export class BudgetCoordinator {
   }
 
   private recoveryDirective(state: BudgetState, side: AgentName): string {
+    // Q10: the recovery-condition text must match the active strategy. maximize
+    // exits per-window (dynamic line − hysteresis, or window reset), not at
+    // resumeBelow — see renderBudgetInterventionDirective for the same fix.
+    const maximizeRecoveredText = `各窗口 util 已回落至动态暂停线 − ${pct(this.config.maximize.resumeHysteresisPct)} 以下或对应窗口已刷新`;
     if (side === "claude") {
+      const condClaude =
+        this.config.strategy === "maximize"
+          ? maximizeRecoveredText
+          : `gateUtil 已低于 ${pct(this.config.resumeBelow)}`;
       return [
         "【预算协调 · 账号级】Claude 侧预算已恢复。",
         `${usageLine("claude", state.perAgent.claude)}；${usageLine("codex", state.perAgent.codex)}。`,
-        `Claude gateUtil 已低于 ${pct(this.config.resumeBelow)}，且没有有效 rate_limit。`,
+        `Claude ${condClaude}，且没有有效 rate_limit。`,
         "Claude 可恢复 orchestrator 角色；后续分配前请重新查询实时额度，不要依赖旧数字。",
       ].join("\n");
     }
 
+    const condCodex =
+      this.config.strategy === "maximize"
+        ? maximizeRecoveredText
+        : `gateUtil 低于 ${pct(this.config.resumeBelow)}`;
     return [
       "【预算协调 · 账号级】Codex 侧预算闸门解除。",
       `${usageLine("claude", state.perAgent.claude)}；${usageLine("codex", state.perAgent.codex)}。`,
-      `闸门已放开：Codex gateUtil 低于 ${pct(this.config.resumeBelow)}，且没有有效 rate_limit。`,
+      `闸门已放开：Codex ${condCodex}，且没有有效 rate_limit。`,
       "建议 Claude 用 reply 带上当前目标、checkpoint 和下一步，唤醒 Codex 接续执行。",
     ].join("\n");
   }
@@ -495,6 +508,22 @@ export class BudgetCoordinator {
       codexTier: state.effort.codexTier,
       claudeAdvice: state.effort.claudeAdvice,
       ...this.burnRateSnapshotFields(state),
+      ...this.dynamicLineSnapshotFields(state),
+    };
+  }
+
+  /**
+   * v3 P2 (display-only): the binding maximize dynamic pause line per agent.
+   * Omitted entirely in conserve mode so the legacy snapshot shape is unchanged;
+   * mirrors the decision layer (effectiveDynamicLine) without ever feeding it.
+   */
+  private dynamicLineSnapshotFields(state: BudgetState): Pick<BudgetSnapshot, "dynamicPauseLine"> | Record<never, never> {
+    if (this.config.strategy !== "maximize") return {};
+    return {
+      dynamicPauseLine: {
+        claude: effectiveDynamicLine(state.perAgent.claude, this.config, state.now),
+        codex: effectiveDynamicLine(state.perAgent.codex, this.config, state.now),
+      },
     };
   }
 

--- a/src/budget/budget-decision.ts
+++ b/src/budget/budget-decision.ts
@@ -1,0 +1,377 @@
+/**
+ * Single source of truth for strategy-aware pause/resume decisions (v3 P2).
+ *
+ * Both the directive-content path (budget-state.ts `pauseTrigger`) and the
+ * coordinator's gating state machine (budget-fingerprint.ts `shouldEnter` /
+ * `canAgentResume`) must agree on whether an agent is paused, or the rendered
+ * state and the fingerprint state drift apart. This module centralizes that
+ * decision so the two callers can never fork.
+ *
+ * conserve mode is a byte-for-byte port of the previous gateUtil ≥ pauseAt /
+ * gateUtil < resumeBelow logic. maximize mode (opt-in `strategy:"maximize"`)
+ * replaces the single gateUtil scalar with a per-window time-aware pause line
+ * (design budget-strategy-v3.md §3.1). Every maximize degradation path falls
+ * back to conserve behavior (invariant I1: maximize never pauses earlier than
+ * conserve; invariant I2: missing/stale data never opens a gate).
+ *
+ * Keep this file dependency-light (only ./types + ./budget-gate); it is bundled
+ * into the plugin daemon.
+ */
+import { matchingGateReset, resumeBlockingEpoch as conserveResumeBlockingEpoch } from "./budget-gate";
+import { STALE_MAX_AGE_SEC } from "./types";
+import type {
+  AgentName,
+  AgentUsage,
+  BudgetConfig,
+  BudgetWindow,
+  BudgetWindowKey,
+} from "./types";
+
+const AGENT_LABEL: Record<AgentName, string> = {
+  claude: "Claude",
+  codex: "Codex",
+};
+
+const WINDOW_LABEL: Record<BudgetWindowKey, string> = {
+  fiveHour: "5h",
+  weekly: "周",
+};
+
+/** Iteration order is stable so the FIRST tripping window wins the reason. */
+const WINDOW_KEYS: readonly BudgetWindowKey[] = ["fiveHour", "weekly"];
+
+/** Clamp `tH` so a clock skew / bogus reset epoch cannot blow up the line. */
+const MAX_TIME_TO_RESET_HOURS = 7 * 24;
+
+/** finishing-margin floor/ceiling (design §3.1: clamp burnRate×horizon to [1,10]). */
+const FINISHING_MARGIN_MIN_PCT = 1;
+const FINISHING_MARGIN_MAX_PCT = 10;
+
+/** Dynamic-line ceiling (design §3.1: clamp(line, pauseAt, 99)). */
+const DYNAMIC_LINE_CEILING_PCT = 99;
+
+function pct(value: number): string {
+  return `${Math.round(value * 10) / 10}%`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Decision-grade data check (moved here from budget-state.ts so the decision
+ * module is self-contained; budget-state re-exports it for existing importers).
+ * A record whose every window has already reset, or that was fetched long ago
+ * (stale probe cache during an upstream outage), describes a PAST quota window —
+ * its utils must not trigger an intervention now, nor authorize a resume.
+ */
+export function isDecisionGrade(usage: AgentUsage | null, now: number): boolean {
+  if (!usage) return false;
+  const freshWindow =
+    (usage.fiveHour !== null && usage.fiveHour.resetEpoch > now) ||
+    (usage.weekly !== null && usage.weekly.resetEpoch > now);
+  if (!freshWindow) return false;
+  if (usage.fetchedAt > 0 && now - usage.fetchedAt > STALE_MAX_AGE_SEC) return false;
+  return true;
+}
+
+/**
+ * Per-window dynamic pause line (design §3.1). Returns:
+ *   - 100               — this window does not trigger a pause this poll (open);
+ *   - "admission-closed"— a hard cap fired (util at/over target, or near reset
+ *                         inside the finishing band) — P3's finishing gate; P2
+ *                         maps it to closed ONLY when util ≥ pauseAt (I1 floor);
+ *   - a number in [pauseAt, 99] — pause when util ≥ this line.
+ *
+ * `burnRatePctPerHour` is the guard's confident EWMA for this window (caller
+ * has already verified confidence; a non-confident window degrades to conserve
+ * before calling here). PRECONDITION: it must be a finite, non-negative number —
+ * every internal caller routes through `confidentRate()` which guarantees this;
+ * a direct caller passing NaN/Infinity would propagate it (the clamp does not
+ * defend against NaN).
+ */
+export function dynamicPauseAt(
+  window: BudgetWindow,
+  burnRatePctPerHour: number,
+  cfg: BudgetConfig,
+  now: number,
+): number | "admission-closed" {
+  const m = cfg.maximize;
+  const rawTimeToResetHours = (window.resetEpoch - now) / 3600;
+  // Past reset point: do not pause on a stale window — wait for fresh data.
+  if (rawTimeToResetHours <= 0) return 100;
+  const tH = Math.min(rawTimeToResetHours, MAX_TIME_TO_RESET_HOURS);
+
+  const finishingMarginPct = clamp(
+    burnRatePctPerHour * (m.finishingHorizonMinutes / 60),
+    FINISHING_MARGIN_MIN_PCT,
+    FINISHING_MARGIN_MAX_PCT,
+  );
+
+  const projectedAtReset = window.util + burnRatePctPerHour * tH;
+  if (projectedAtReset <= m.targetUtil) {
+    // (a) Will not fill before reset — but two hard caps first (REAL-4): metering
+    //     lag / a burst can still slam into the provider limit, so do not leave a
+    //     high-util window wide open.
+    if (window.util >= m.targetUtil) return "admission-closed";
+    if (
+      tH < m.finishingHorizonMinutes / 60 &&
+      window.util >= m.targetUtil - finishingMarginPct
+    ) {
+      return "admission-closed";
+    }
+    return 100; // truly will not fill: do not pause.
+  }
+
+  // (b) Will fill: line = target − finishing margin − time-buffer reserve.
+  const reservePct = Math.min(m.reserveMaxPct, m.reserveSlopePctPerHour * tH);
+  const line = m.targetUtil - finishingMarginPct - reservePct;
+  // Invariant I1: floor at conserve's pauseAt. The ceiling is normally 99, but
+  // the FLOOR must always win — a degenerate `pauseAt > 99` (e.g. pauseAt=100,
+  // a valid config meaning "effectively never pause") would otherwise let the 99
+  // ceiling clamp the line BELOW pauseAt, making maximize pause earlier than
+  // conserve (I1 violation). Raising the ceiling to max(pauseAt, 99) keeps the
+  // line ≥ pauseAt, so maximize degrades to conserve at such configs.
+  return clamp(line, cfg.pauseAt, Math.max(cfg.pauseAt, DYNAMIC_LINE_CEILING_PCT));
+}
+
+/** A maximize window's contribution to the entry decision. */
+interface WindowEntryVerdict {
+  /** This window triggers a full pause (after the I1 floor). */
+  blocks: boolean;
+  /** Effective numeric dynamic line for display/fingerprint; null when degraded/admission. */
+  line: number | null;
+  /** The hard-cap signal fired (carried for P3; in P2 only `blocks` matters). */
+  admission: boolean;
+}
+
+/** True when the guard supplied a confident burn rate for this window. */
+function confidentRate(window: BudgetWindow): number | null {
+  if (window.burnConfident !== true) return null;
+  if (typeof window.burnRate !== "number" || !Number.isFinite(window.burnRate) || window.burnRate < 0) {
+    return null;
+  }
+  return window.burnRate;
+}
+
+/**
+ * Evaluate one fresh window for the maximize ENTRY side. Degraded windows
+ * (no confident rate) fall back to conserve's per-window `util ≥ pauseAt`.
+ */
+function maximizeWindowEntry(window: BudgetWindow, cfg: BudgetConfig, now: number): WindowEntryVerdict {
+  const rate = confidentRate(window);
+  if (rate === null) {
+    // Degraded: conserve criterion on THIS window (per design §3.1 degrade path).
+    return { blocks: window.util >= cfg.pauseAt, line: null, admission: false };
+  }
+  const line = dynamicPauseAt(window, rate, cfg, now);
+  if (line === "admission-closed") {
+    // P2 has no three-state gate: map to closed ONLY when not stricter than
+    // conserve (I1 floor — see Codex's counterexample, util can be < pauseAt in
+    // the near-reset finishing band).
+    return { blocks: window.util >= cfg.pauseAt, line: null, admission: true };
+  }
+  return { blocks: window.util >= line, line, admission: false };
+}
+
+/**
+ * Evaluate one fresh window for the maximize RESUME side (symmetric to entry):
+ * the window still BLOCKS resume until its util recedes below the relaxed
+ * threshold. Degraded windows use conserve's `util ≥ resumeBelow` (asymmetric
+ * 90-in/30-out, no hysteresis — matches design "degrade to conserve").
+ */
+function maximizeWindowBlocksResume(window: BudgetWindow, cfg: BudgetConfig, now: number): boolean {
+  const rate = confidentRate(window);
+  if (rate === null) {
+    return window.util >= cfg.resumeBelow;
+  }
+  const line = dynamicPauseAt(window, rate, cfg, now);
+  const hyst = cfg.maximize.resumeHysteresisPct;
+  if (line === "admission-closed") {
+    // Symmetric to the I1-floored entry (effective line = pauseAt).
+    return window.util >= cfg.pauseAt - hyst;
+  }
+  // 100 is the "won't-fill" sentinel: this window NEVER triggers entry, so it
+  // must NEVER block resume either (symmetry). Without this, a window at e.g.
+  // util 95 that returns line 100 would block resume at `util >= 100 − hyst`
+  // even though it never caused the pause — delaying recovery up to a full
+  // window reset on the OTHER side's behalf.
+  if (line === 100) return false;
+  return window.util >= line - hyst;
+}
+
+/** Fresh, currently-active windows for an agent (resetEpoch in the future). */
+function freshWindows(usage: AgentUsage, now: number): Array<{ key: BudgetWindowKey; window: BudgetWindow }> {
+  const out: Array<{ key: BudgetWindowKey; window: BudgetWindow }> = [];
+  for (const key of WINDOW_KEYS) {
+    const window = usage[key];
+    if (window && window.resetEpoch > now) out.push({ key, window });
+  }
+  return out;
+}
+
+/** Structured pause-entry decision for one agent (single source of truth). */
+export interface AgentPauseDecision {
+  /** Should this agent enter a pause this poll. */
+  pause: boolean;
+  /** Window that tripped (entry), for reason + fingerprint; null when not paused. */
+  window: BudgetWindowKey | null;
+  /** Effective numeric dynamic line of the trigger window; null in conserve/degraded/admission. */
+  line: number | null;
+  /** Human-readable Chinese reason; empty string when not paused. */
+  reason: string;
+}
+
+const NO_PAUSE: AgentPauseDecision = { pause: false, window: null, line: null, reason: "" };
+
+function conserveReason(agent: AgentName, usage: AgentUsage, cfg: BudgetConfig): string {
+  return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} ≥ pauseAt ${pct(cfg.pauseAt)}`;
+}
+
+/**
+ * Decide whether an agent should enter a budget pause. conserve mode is a
+ * verbatim port of the old `pauseTrigger`/`shouldEnter`; maximize mode evaluates
+ * each fresh window via the dynamic line and trips on the FIRST blocking window.
+ */
+export function agentShouldPause(
+  agent: AgentName,
+  usage: AgentUsage | null,
+  cfg: BudgetConfig,
+  now: number,
+): AgentPauseDecision {
+  if (!usage) return NO_PAUSE;
+  if (!isDecisionGrade(usage, now)) return NO_PAUSE;
+
+  if (cfg.strategy !== "maximize") {
+    if (usage.gateUtil >= cfg.pauseAt) {
+      return { pause: true, window: null, line: null, reason: conserveReason(agent, usage, cfg) };
+    }
+    return NO_PAUSE;
+  }
+
+  // maximize: per-window evaluation.
+  const windows = freshWindows(usage, now);
+  if (windows.length === 0) {
+    // Defensive: isDecisionGrade guarantees ≥1 fresh window, so this is
+    // unreachable. Degrade to conserve on gateUtil if it ever is reached.
+    if (usage.gateUtil >= cfg.pauseAt) {
+      return { pause: true, window: null, line: null, reason: conserveReason(agent, usage, cfg) };
+    }
+    return NO_PAUSE;
+  }
+
+  for (const { key, window } of windows) {
+    const verdict = maximizeWindowEntry(window, cfg, now);
+    if (verdict.blocks) {
+      return {
+        pause: true,
+        window: key,
+        line: verdict.line,
+        reason: buildMaximizeReason(agent, key, window, verdict, cfg),
+      };
+    }
+  }
+  return NO_PAUSE;
+}
+
+/** Reason text builder that has cfg in scope (pauseAt needs interpolation). */
+function buildMaximizeReason(
+  agent: AgentName,
+  key: BudgetWindowKey,
+  window: BudgetWindow,
+  verdict: WindowEntryVerdict,
+  cfg: BudgetConfig,
+): string {
+  const head = `${AGENT_LABEL[agent]} ${WINDOW_LABEL[key]}窗口 util ${pct(window.util)}`;
+  if (verdict.line !== null) {
+    const rate = window.burnRate;
+    const rateText = typeof rate === "number" ? `，燃尽率≈${pct(rate)}/h` : "";
+    return `${head} ≥ 动态暂停线 ${pct(verdict.line)}${rateText}`;
+  }
+  if (verdict.admission) {
+    return `${head} 触发收尾保护硬线（≥ pauseAt ${pct(cfg.pauseAt)}）`;
+  }
+  return `${head} ≥ pauseAt ${pct(cfg.pauseAt)}（燃尽率采样中，退保守判据）`;
+}
+
+/**
+ * Decide whether an agent may resume. conserve mode is a verbatim port of the
+ * old `canAgentResume`; maximize mode requires that NO fresh window still blocks
+ * resume (symmetric to entry, with hysteresis).
+ */
+export function agentCanResume(usage: AgentUsage | null, cfg: BudgetConfig, now: number): boolean {
+  if (!isDecisionGrade(usage, now)) return false;
+  if (usage!.rateLimitedUntil > now) return false;
+
+  if (cfg.strategy !== "maximize") {
+    return usage!.gateUtil < cfg.resumeBelow;
+  }
+
+  // maximize: resume only when every fresh window has receded. A window that has
+  // already reset (resetEpoch <= now) is excluded by freshWindows — that is the
+  // "window reset → resume" path (fresh data shows util cliff-dropped, and the
+  // expired window no longer blocks).
+  const windows = freshWindows(usage!, now);
+  for (const { window } of windows) {
+    if (maximizeWindowBlocksResume(window, cfg, now)) return false;
+  }
+  return true;
+}
+
+/**
+ * Display-only (snapshot/render): the binding maximize dynamic line for an
+ * agent — the numeric line of the fresh, confident window with the SMALLEST
+ * headroom (util − line), i.e. the window closest to (or past) tripping. Returns
+ * null in conserve mode, on non-decision-grade data, or when no confident window
+ * yields a numeric line (degraded / admission-closed / will-not-fill). NEVER a
+ * decision input — `agentShouldPause` owns the gating; this only mirrors it.
+ */
+export function effectiveDynamicLine(usage: AgentUsage | null, cfg: BudgetConfig, now: number): number | null {
+  if (cfg.strategy !== "maximize") return null;
+  if (!usage || !isDecisionGrade(usage, now)) return null;
+  let bestLine: number | null = null;
+  let bestHeadroom = Number.POSITIVE_INFINITY;
+  for (const { window } of freshWindows(usage, now)) {
+    const rate = confidentRate(window);
+    if (rate === null) continue;
+    const line = dynamicPauseAt(window, rate, cfg, now);
+    if (line === "admission-closed" || line >= 100) continue;
+    const headroom = line - window.util;
+    if (headroom < bestHeadroom) {
+      bestHeadroom = headroom;
+      bestLine = line;
+    }
+  }
+  return bestLine;
+}
+
+/**
+ * Strategy-aware "earliest plausible resume" epoch (Q10 alignment). conserve
+ * delegates to the existing budget-gate helper. maximize returns the soonest
+ * reset among windows that still block resume (the natural recovery point at a
+ * 93–96 pause line), the active rate-limit, or 0 when nothing blocks.
+ */
+export function resumeBlockingEpochFor(usage: AgentUsage | null, cfg: BudgetConfig, now: number): number {
+  if (!usage) return 0;
+  if (cfg.strategy !== "maximize") return conserveResumeBlockingEpoch(usage, cfg, now);
+  if (usage.rateLimitedUntil > now) return usage.rateLimitedUntil;
+  // Non-decision-grade (stale / all-reset): we cannot evaluate per-window resume,
+  // and `agentCanResume` returns false here (phantom-hold keeps the side paused).
+  // The honest "earliest plausible resume" is the next window reset — but ONLY if
+  // it is still in the FUTURE. When every window has already reset, matchingGateReset
+  // returns a PAST epoch; returning that here would clobber the sticky good
+  // resumeEpoch with a time in the past (resumeAfterEpoch keeps any epoch > 0),
+  // contradicting "still paused". Returning 0 instead lets the fingerprint reducer
+  // fall back to the last known-good future resumeEpoch (Codex Q10 edge).
+  if (!isDecisionGrade(usage, now)) {
+    const reset = matchingGateReset(usage);
+    return reset > now ? reset : 0;
+  }
+
+  const blockingResets = freshWindows(usage, now)
+    .filter(({ window }) => maximizeWindowBlocksResume(window, cfg, now))
+    .map(({ window }) => window.resetEpoch)
+    .filter((epoch) => epoch > 0);
+  if (blockingResets.length === 0) return 0;
+  return Math.min(...blockingResets);
+}

--- a/src/budget/budget-fingerprint.ts
+++ b/src/budget/budget-fingerprint.ts
@@ -25,8 +25,12 @@
  * Keep this file dependency-free beyond ./types, ./budget-gate and
  * ./budget-state; it is bundled into the plugin daemon.
  */
-import { resumeBlockingEpoch } from "./budget-gate";
-import { isDecisionGrade } from "./budget-state";
+import {
+  agentCanResume,
+  agentShouldPause,
+  isDecisionGrade,
+  resumeBlockingEpochFor,
+} from "./budget-decision";
 import type { PendingEntry } from "./pending-reader";
 import type { AgentName, AgentUsage, BudgetConfig, BudgetState } from "./types";
 
@@ -190,29 +194,21 @@ function agentsToSide(agents: ReadonlySet<AgentName>): PauseSide {
   return null;
 }
 
-function shouldEnter(usage: AgentUsage | null, cfg: BudgetConfig, now: number): boolean {
-  if (!isDecisionGrade(usage, now)) return false;
-  return usage!.gateUtil >= cfg.pauseAt;
-}
-
-function canAgentResume(usage: AgentUsage | null, cfg: BudgetConfig, now: number): boolean {
-  if (!isDecisionGrade(usage, now)) return false;
-  if (usage!.rateLimitedUntil > now) return false;
-  return usage!.gateUtil < cfg.resumeBelow;
-}
-
 /**
- * Hysteresis transition over the activeSides set: shouldEnter adds, an already
- * active side that canAgentResume is removed. Verbatim port of the old
- * updateActiveSides, made pure over the prior side.
+ * Hysteresis transition over the activeSides set: agentShouldPause adds, an
+ * already active side that agentCanResume is removed. Both predicates are the
+ * strategy-aware single source of truth in budget-decision.ts (conserve =
+ * verbatim port of the former local gateUtil checks; maximize = per-window
+ * dynamic line), so the coordinator's gating can never diverge from the
+ * rendered state in budget-state.ts.
  */
 function nextActiveSide(prevSide: PauseSide, state: BudgetState, cfg: BudgetConfig): PauseSide {
   const active = new Set<AgentName>(sideToAgents(prevSide));
   for (const agent of ["claude", "codex"] as const) {
     const usage = state.perAgent[agent];
-    if (shouldEnter(usage, cfg, state.now)) {
+    if (agentShouldPause(agent, usage, cfg, state.now).pause) {
       active.add(agent);
-    } else if (active.has(agent) && canAgentResume(usage, cfg, state.now)) {
+    } else if (active.has(agent) && agentCanResume(usage, cfg, state.now)) {
       active.delete(agent);
     }
   }
@@ -229,10 +225,13 @@ function activeSideReason(agent: AgentName, usage: AgentUsage | null, cfg: Budge
   if (usage.rateLimitedUntil > now) {
     return `${AGENT_LABEL[agent]} 探针被限流至 ${formatEpoch(usage.rateLimitedUntil)}`;
   }
-  if (usage.gateUtil >= cfg.pauseAt) {
-    return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} ≥ pauseAt ${pct(cfg.pauseAt)}`;
-  }
-  return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} 尚未低于 resumeBelow ${pct(cfg.resumeBelow)}`;
+  // Delegate the "why paused" text to the strategy-aware decision (conserve =
+  // the old gateUtil≥pauseAt string; maximize = the dynamic-line string).
+  const decision = agentShouldPause(agent, usage, cfg, now);
+  if (decision.pause) return decision.reason;
+  // Still in the active set but no longer tripping entry → in the hysteresis
+  // exit band, holding until canAgentResume clears.
+  return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} 尚未满足出闸条件`;
 }
 
 function interventionReason(side: PauseSide, state: BudgetState, cfg: BudgetConfig): string {
@@ -243,7 +242,7 @@ function interventionReason(side: PauseSide, state: BudgetState, cfg: BudgetConf
 
 function resumeAfterEpoch(side: PauseSide, state: BudgetState, cfg: BudgetConfig): number | null {
   const epochs = sideToAgents(side)
-    .map((agent) => resumeBlockingEpoch(state.perAgent[agent], cfg, state.now))
+    .map((agent) => resumeBlockingEpochFor(state.perAgent[agent], cfg, state.now))
     .filter((epoch) => epoch > 0);
   if (epochs.length === 0) return null;
   return Math.max(...epochs);
@@ -264,6 +263,14 @@ function activeSideProbeUncertain(side: PauseSide, state: BudgetState): boolean 
 /**
  * Stable dedup fingerprint for a directive. When `activeSide` is set we are
  * paused; otherwise the phase (balance/parallel) drives the side selection.
+ *
+ * v3 P2 / R6 note: the maximize dynamic line is deliberately NOT folded into the
+ * fingerprint. Design R6 suggested quantizing the line (1 pct) and tH (0.5h) to
+ * avoid re-emit spam; this implementation takes the stricter route — the line
+ * never enters the fingerprint, so a slowly drifting line cannot re-emit a pause
+ * banner at all (the reset-epoch bucket below still distinguishes a real window
+ * reset). Mid-pause drift is additionally frozen by the hold-uncertain path. Net
+ * effect is ≥ as stable as the quantized design, with no extra fingerprint axis.
  */
 export function directiveFingerprint(state: BudgetState, activeSide?: ActivePauseSide): string {
   const side = activeSide ?? (state.phase === "balance"
@@ -430,7 +437,7 @@ export function resumeCandidateSides(effect: CoordinatorEffect): AgentName[] {
  * Pure resume-candidate reducer (PR2 — detection only, no emit/inject). For each
  * EXPLICITLY supplied side, decides whether ALL four readiness predicates hold:
  *
- *   1. window refreshed — reuse the existing hysteresis `canAgentResume`
+ *   1. window refreshed — reuse the existing hysteresis `agentCanResume`
  *      (decision-grade AND gateUtil < resumeBelow AND no live rate_limit). This
  *      is the SINGLE source of truth for "window reset"; we deliberately do NOT
  *      reinvent an epoch-diff detector (a second source would STALE-fork).
@@ -456,7 +463,7 @@ export function computeResumeCandidate(
   const candidate: ResumeCandidate = {};
   const detail: Partial<Record<AgentName, ResumeCandidateDetail>> = {};
   for (const agent of sides) {
-    const windowRefreshed = canAgentResume(state.perAgent[agent], cfg, state.now);
+    const windowRefreshed = agentCanResume(state.perAgent[agent], cfg, state.now);
     const ready =
       windowRefreshed &&
       signals.pendingExists[agent] &&

--- a/src/budget/budget-state.ts
+++ b/src/budget/budget-state.ts
@@ -1,6 +1,11 @@
-import { matchingGateReset, resumeBlockingEpoch } from "./budget-gate";
-import { STALE_MAX_AGE_SEC } from "./types";
+import { matchingGateReset } from "./budget-gate";
+import { agentShouldPause, isDecisionGrade, resumeBlockingEpochFor } from "./budget-decision";
 import type { AgentName, AgentUsage, BudgetConfig, BudgetState, CodexTier } from "./types";
+
+// isDecisionGrade moved to budget-decision.ts (the strategy-aware decision
+// module needs it too); re-export keeps existing importers (budget-fingerprint,
+// burn-view) working unchanged.
+export { isDecisionGrade } from "./budget-decision";
 
 interface PauseTrigger {
   agent: AgentName;
@@ -39,40 +44,23 @@ function resumeAfterEpoch(
   now: number,
 ): number | null {
   const epochs = [
-    resumeBlockingEpoch(claude, cfg, now),
-    resumeBlockingEpoch(codex, cfg, now),
+    resumeBlockingEpochFor(claude, cfg, now),
+    resumeBlockingEpochFor(codex, cfg, now),
   ].filter((epoch) => epoch > 0);
   if (epochs.length === 0) return null;
   return Math.max(...epochs);
 }
 
 /**
- * Decision-grade data check: a record whose every window has already reset,
- * or that was fetched long ago (stale probe cache during an upstream outage),
- * describes a PAST quota window — its utils must not trigger an intervention
- * now, nor authorize a resume. Single source of truth for both the entry-side
- * guard (here) and the coordinator's resume gate.
+ * Strategy-aware pause-entry trigger for one agent. Delegates the whole decision
+ * (conserve gateUtil threshold OR maximize per-window dynamic line) to the
+ * single source of truth in budget-decision.ts, so the rendered state here can
+ * never diverge from the coordinator's gating in budget-fingerprint.ts.
  */
-export function isDecisionGrade(usage: AgentUsage | null, now: number): boolean {
-  if (!usage) return false;
-  const freshWindow =
-    (usage.fiveHour !== null && usage.fiveHour.resetEpoch > now) ||
-    (usage.weekly !== null && usage.weekly.resetEpoch > now);
-  if (!freshWindow) return false;
-  if (usage.fetchedAt > 0 && now - usage.fetchedAt > STALE_MAX_AGE_SEC) return false;
-  return true;
-}
-
 function pauseTrigger(agent: AgentName, usage: AgentUsage | null, cfg: BudgetConfig, now: number): PauseTrigger | null {
-  if (!usage) return null;
-  if (!isDecisionGrade(usage, now)) return null;
-  if (usage.gateUtil >= cfg.pauseAt) {
-    return {
-      agent,
-      reason: `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} ≥ pauseAt ${pct(cfg.pauseAt)}`,
-    };
-  }
-  return null;
+  const decision = agentShouldPause(agent, usage, cfg, now);
+  if (!decision.pause) return null;
+  return { agent, reason: decision.reason };
 }
 
 function driftFor(
@@ -125,12 +113,25 @@ export function renderBudgetInterventionDirective(
   cfg: BudgetConfig,
 ): string {
   const resumeText = `预计恢复时间（以实测为准；提前刷新会更早解除）：${formatEpoch(resumeEpoch)}。`;
+  // Q10: the resume CONDITION text must match the active strategy. conserve =
+  // the historical gateUtil<resumeBelow wording (byte-identical); maximize exits
+  // per-window at `util < dynamicPauseAt − resumeHysteresisPct` (or window
+  // reset), NOT at resumeBelow — saying "低于 30%" there misleads Claude into
+  // expecting a days-long wait instead of the dynamic-line / reset recovery.
+  const resumeCondSingle =
+    cfg.strategy === "maximize"
+      ? `各窗口 util 回落至动态暂停线 − ${pct(cfg.maximize.resumeHysteresisPct)} 以下或对应窗口刷新`
+      : `gateUtil 低于 ${pct(cfg.resumeBelow)}`;
+  const resumeCondBoth =
+    cfg.strategy === "maximize"
+      ? `各窗口 util 都回落至动态暂停线 − ${pct(cfg.maximize.resumeHysteresisPct)} 以下或对应窗口刷新`
+      : `gateUtil 都低于 ${pct(cfg.resumeBelow)}`;
   if (side === "claude") {
     return [
       "【预算协调 · 账号级】Claude 侧额度紧张，进入接力模式。",
       `触发方：Claude；原因：${reason}。`,
       `${usageSummary("claude", claude)}；${usageSummary("codex", codex)}。`,
-      `恢复参考：Claude gateUtil 低于 ${pct(cfg.resumeBelow)} 且没有有效 rate_limit；${resumeText}`,
+      `恢复参考：Claude ${resumeCondSingle} 且没有有效 rate_limit；${resumeText}`,
       "请立即交接：把剩余任务清单、关键上下文、产出位置、验收标准打包成一条 reply 发给 Codex。",
       "交接后 Claude 停手；要求 Codex 在单 turn 内尽量完成，尾巴写 checkpoint，暂停期不要期待 Claude 回复。",
     ].join("\n");
@@ -141,7 +142,7 @@ export function renderBudgetInterventionDirective(
       "【预算协调 · 账号级】Codex 侧额度紧张，暂停委派。",
       `触发方：Codex；原因：${reason}。`,
       `${usageSummary("claude", claude)}；${usageSummary("codex", codex)}。`,
-      `恢复参考：Codex gateUtil 低于 ${pct(cfg.resumeBelow)} 且没有有效 rate_limit；${resumeText}`,
+      `恢复参考：Codex ${resumeCondSingle} 且没有有效 rate_limit；${resumeText}`,
       "请 Claude 写 checkpoint，并可 solo 推进不依赖 Codex 的独立部分；不要继续向 Codex 委派，标注清楚分工断点。",
     ].join("\n");
   }
@@ -150,7 +151,7 @@ export function renderBudgetInterventionDirective(
     "【预算协调 · 账号级】进入联合暂停。",
     `触发方：双方；原因：${reason}。`,
     `${usageSummary("claude", claude)}；${usageSummary("codex", codex)}。`,
-    `恢复条件：Claude 与 Codex 的 gateUtil 都低于 ${pct(cfg.resumeBelow)}，且没有有效 rate_limit；${resumeText}`,
+    `恢复条件：Claude 与 Codex 的 ${resumeCondBoth}，且没有有效 rate_limit；${resumeText}`,
     "请收尾当前步、写 checkpoint、停止继续委派；pause 期间不要重试向 Codex 发送 reply。",
   ].join("\n");
 }

--- a/src/budget/render.ts
+++ b/src/budget/render.ts
@@ -192,6 +192,29 @@ function formatFiveHourWindowsLeftLine(snapshot: BudgetSnapshot): string | null 
   return `按当前节奏，周额度还够 ${byAgent} 个 5h 窗口`;
 }
 
+/**
+ * v3 P2 (maximize, display-only): the binding dynamic pause line per agent and
+ * its headroom to the agent's gateUtil. Present only when the snapshot carries
+ * `dynamicPauseLine` (maximize mode) and at least one side has a numeric line.
+ * Never a decision input — mirrors the decision layer's effectiveDynamicLine.
+ */
+function formatDynamicLineLine(snapshot: BudgetSnapshot): string | null {
+  const lines = snapshot.dynamicPauseLine;
+  if (!lines) return null;
+  const parts: string[] = [];
+  const entries: Array<[string, number | null, AgentUsage | null]> = [
+    ["Claude", lines.claude, snapshot.claude],
+    ["Codex", lines.codex, snapshot.codex],
+  ];
+  for (const [name, line, usage] of entries) {
+    if (line === null) continue;
+    const headroom = usage ? `（util ${usage.gateUtil}%，余量 ${(line - usage.gateUtil).toFixed(1)}）` : "";
+    parts.push(`${name} ${line.toFixed(1)}%${headroom}`);
+  }
+  if (parts.length === 0) return null;
+  return `动态暂停线（maximize）：${parts.join(" · ")}`;
+}
+
 const PHASE_LABELS: Record<BudgetSnapshot["phase"], string> = {
   normal: "normal（正常）",
   balance: "balance（需均衡）",
@@ -237,6 +260,9 @@ export function renderBudgetSnapshot(
   }
   const fiveHourWindowsLeftLine = formatFiveHourWindowsLeftLine(snapshot);
   if (fiveHourWindowsLeftLine) lines.push(fiveHourWindowsLeftLine);
+
+  const dynamicLineLine = formatDynamicLineLine(snapshot);
+  if (dynamicLineLine) lines.push(dynamicLineLine);
 
   if (snapshot.claude && snapshot.codex) {
     const abs = Math.abs(snapshot.driftPct);

--- a/src/budget/types.ts
+++ b/src/budget/types.ts
@@ -92,9 +92,9 @@ export type BudgetPhase = "normal" | "balance" | "parallel" | "paused";
 export type CodexTier = "full" | "balanced" | "eco";
 
 /**
- * Budget strategy selector (v3). P1 parses and validates this key but the
- * decision path is hard-wired to conserve behavior — `maximize` is consumed
- * ONLY by `abg doctor` (Q7 guard-hardline warning) until P2 lands.
+ * Budget strategy selector (v3). conserve = v2-equivalent gateUtil thresholds.
+ * maximize (P2) = per-window time-aware dynamic pause line (§3.1), consumed by
+ * budget-decision.ts; every degradation path falls back to conserve.
  */
 export type BudgetStrategy = "conserve" | "maximize";
 
@@ -136,6 +136,26 @@ export interface RunwayEstimate {
   depletedAtEpoch: number | null;
 }
 
+/**
+ * Maximize-strategy parameters (v3 §3.1/§4.1). Only consumed when
+ * `strategy:"maximize"`. All have defaults and bounded validation in
+ * config-service.ts. P2 consumes every key here; the P3 admission gate adds its
+ * own keys (admissionAt / wrapUpQuota) when it lands, so they are intentionally
+ * NOT defined yet (no parse-only keys).
+ */
+export interface MaximizeConfig {
+  /** Reset-point target utilization; default 97, range [90, 99]. Must be > pauseAt. */
+  targetUtil: number;
+  /** Extra reserve per hour-to-reset; default 0.4 pct/h, range [0, 5] (fractional). */
+  reserveSlopePctPerHour: number;
+  /** Reserve ceiling; default 7, range [0, 30]. Far-from-reset → ≈ conserve. */
+  reserveMaxPct: number;
+  /** Expected in-flight wrap-up duration; default 30 min, range [5, 180]. */
+  finishingHorizonMinutes: number;
+  /** Symmetric-resume hysteresis below the dynamic line; default 5, range [1, 30]. */
+  resumeHysteresisPct: number;
+}
+
 /** Budget section of AgentBridgeConfig (defaults in config-service.ts). */
 export interface BudgetConfig {
   enabled: boolean;
@@ -166,6 +186,8 @@ export interface BudgetConfig {
    * follows probe field presence — no toggle needed.
    */
   strategy: BudgetStrategy;
+  /** maximize-strategy parameters (only consumed when strategy="maximize"). */
+  maximize: MaximizeConfig;
 }
 
 /** Pure-function output of computeBudgetState(). */
@@ -233,6 +255,13 @@ export interface BudgetSnapshot {
    * rate on at least one decision-grade window.
    */
   runway?: { claude: RunwayEstimate | null; codex: RunwayEstimate | null };
+  /**
+   * v3 P2 (optional, maximize only): the effective numeric dynamic pause line
+   * per agent that tripped (or would trip) the pause this poll. null in
+   * conserve mode, when the agent is not gated by a confident maximize window,
+   * or on legacy daemons. Display-only — never a decision input.
+   */
+  dynamicPauseLine?: { claude: number | null; codex: number | null };
 }
 
 /** Optional per-turn overrides injected into Codex turn/start (sticky on the thread). */

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -561,9 +561,10 @@ function configParseabilityCheck(cwd: string, cli: string): DoctorCheck {
 }
 
 /**
- * Default v3 maximize target utilization (design §3.1). P1 does not parse the
- * maximize parameter block yet (that lands with P2), so the doctor check
- * compares the guard hard line against this design default.
+ * Default v3 maximize target utilization (design §3.1), used as the fallback
+ * when a caller does not pass an explicit targetUtil. Since P2, the resolved
+ * value comes from `budget.maximize.targetUtil` (config + env), so this is only
+ * the package default mirrored from DEFAULT_BUDGET_CONFIG.maximize.targetUtil.
  */
 export const V3_DEFAULT_TARGET_UTIL = 97;
 
@@ -615,7 +616,11 @@ export function evaluateBudgetStrategyGuard(
 function budgetStrategyGuardCheck(cwd: string): DoctorCheck {
   const config = new ConfigService(cwd).loadOrDefault();
   const budget = applyBudgetEnvOverrides(config.budget);
-  return evaluateBudgetStrategyGuard(budget.strategy, resolveGuardHardHint());
+  return evaluateBudgetStrategyGuard(
+    budget.strategy,
+    resolveGuardHardHint(),
+    budget.maximize.targetUtil,
+  );
 }
 
 function logCheck(name: string, path: string, cli: string): DoctorCheck {

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -1,7 +1,7 @@
 import { readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { atomicWriteJson } from "./atomic-json";
-import type { BudgetConfig, BudgetStrategy, CodexTierMap, CodexTurnOverrides } from "./budget/types";
+import type { BudgetConfig, BudgetStrategy, CodexTierMap, CodexTurnOverrides, MaximizeConfig } from "./budget/types";
 
 /** Machine-readable project config schema. */
 export interface AgentBridgeConfig {
@@ -38,10 +38,20 @@ const DEFAULT_BUDGET_CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  // v3 P1: strategy is parse-and-validate only (behavior stays conserve; the
-  // value feeds the doctor Q7 guard-hardline check). Burn-rate data is
-  // consumed from the guard probe — no collection config on this side.
+  // v3: strategy selector. conserve = v2-equivalent gateUtil thresholds (the
+  // default — opt-in is required to change behavior). maximize (P2) activates
+  // the per-window time-aware dynamic pause line. Burn-rate data is consumed
+  // from the guard probe — no collection config on this side.
   strategy: "conserve",
+  // v3 P2 maximize parameters (only consumed when strategy="maximize"). Defaults
+  // and ranges per design budget-strategy-v3.md §3.1/§4.1.
+  maximize: {
+    targetUtil: 97,
+    reserveSlopePctPerHour: 0.4,
+    reserveMaxPct: 7,
+    finishingHorizonMinutes: 30,
+    resumeHysteresisPct: 5,
+  },
 };
 
 const DEFAULT_CONFIG: AgentBridgeConfig = {
@@ -165,6 +175,26 @@ function findShapeViolation(raw: Record<string, unknown>): string | null {
         }
       }
     }
+    if ("maximize" in budget) {
+      const maximize = budget.maximize;
+      if (!isRecord(maximize)) {
+        return "budget.maximize is present but not an object";
+      }
+      // Symmetric to budget.parallel: a present-but-garbage maximize numeric
+      // (e.g. targetUtil:"ninety") fails loud instead of silently reverting to
+      // the design default, matching the other decision-grade thresholds.
+      for (const key of [
+        "targetUtil",
+        "reserveSlopePctPerHour",
+        "reserveMaxPct",
+        "finishingHorizonMinutes",
+        "resumeHysteresisPct",
+      ] as const) {
+        if (key in maximize && !isCoercibleNumber(maximize[key])) {
+          return `budget.maximize.${key} is present but not a number`;
+        }
+      }
+    }
   }
   return null;
 }
@@ -191,7 +221,16 @@ function hasCustomDecisionValues(config: AgentBridgeConfig): boolean {
     b.syncDriftPct !== db.syncDriftPct ||
     b.parallel.minRemainingPct !== db.parallel.minRemainingPct ||
     b.parallel.timeWindowSec !== db.parallel.timeWindowSec ||
-    b.codexTierControl !== db.codexTierControl
+    b.codexTierControl !== db.codexTierControl ||
+    // v3: strategy + maximize parameters are decision-grade — surface them so
+    // `abg doctor` reports "custom values in effect" when the user opts into
+    // maximize or tunes its line, not a misleading "all values match defaults".
+    b.strategy !== db.strategy ||
+    b.maximize.targetUtil !== db.maximize.targetUtil ||
+    b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour ||
+    b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct ||
+    b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes ||
+    b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct
   );
 }
 
@@ -245,6 +284,51 @@ export function normalizeBoundedNumber(
 /** v3 strategy selector: anything but the two known literals falls back. */
 function normalizeStrategy(value: unknown, fallback: BudgetStrategy): BudgetStrategy {
   return value === "conserve" || value === "maximize" ? value : fallback;
+}
+
+/**
+ * Normalize the v3 maximize parameter block. Each field is bounds-checked
+ * (out-of-range → fallback). The relation constraint `targetUtil > pauseAt`
+ * (§4.1) is unsatisfiable otherwise — the dynamic line floor is pauseAt, so a
+ * target at/below it leaves no maximize band — so the WHOLE block resets to
+ * defaults when violated. Silent reset mirrors the existing pauseAt<=resumeBelow
+ * handling in normalizeBudgetConfig (both keep normalize pure / logger-free).
+ */
+function normalizeMaximizeConfig(
+  raw: unknown,
+  pauseAt: number,
+  fallback: MaximizeConfig = DEFAULT_BUDGET_CONFIG.maximize,
+): MaximizeConfig {
+  const m = isRecord(raw) ? raw : {};
+  const normalized: MaximizeConfig = {
+    targetUtil: normalizeBoundedInteger(m.targetUtil, fallback.targetUtil, 90, 99),
+    reserveSlopePctPerHour: normalizeBoundedNumber(
+      m.reserveSlopePctPerHour,
+      fallback.reserveSlopePctPerHour,
+      0,
+      5,
+    ),
+    reserveMaxPct: normalizeBoundedInteger(m.reserveMaxPct, fallback.reserveMaxPct, 0, 30),
+    finishingHorizonMinutes: normalizeBoundedInteger(
+      m.finishingHorizonMinutes,
+      fallback.finishingHorizonMinutes,
+      5,
+      180,
+    ),
+    resumeHysteresisPct: normalizeBoundedInteger(
+      m.resumeHysteresisPct,
+      fallback.resumeHysteresisPct,
+      1,
+      30,
+    ),
+  };
+  // Unsatisfiable relation → reset the whole block to the package defaults so a
+  // typo cannot silently produce a maximize line that never pauses (or one that
+  // collapses onto pauseAt for the wrong reason).
+  if (normalized.targetUtil <= pauseAt) {
+    return { ...DEFAULT_BUDGET_CONFIG.maximize };
+  }
+  return normalized;
 }
 
 function normalizeBoolean(value: unknown, fallback: boolean): boolean {
@@ -342,6 +426,9 @@ function normalizeBudgetConfig(
       codexTiers.full !== null,
     codexTiers,
     strategy: normalizeStrategy(budget.strategy, fallback.strategy),
+    // Pass the already-resolved pauseAt (post pauseAt<=resumeBelow reset) so the
+    // targetUtil > pauseAt relation is checked against the effective floor.
+    maximize: normalizeMaximizeConfig(budget.maximize, pauseAt, fallback.maximize),
   };
 }
 
@@ -370,6 +457,16 @@ export function applyBudgetEnvOverrides(
     // re-normalization re-applies the full-restore activation rule.
     codexTiers: budget.codexTiers,
     strategy: env.AGENTBRIDGE_BUDGET_STRATEGY ?? budget.strategy,
+    maximize: {
+      targetUtil: env.AGENTBRIDGE_BUDGET_TARGET_UTIL ?? budget.maximize.targetUtil,
+      reserveSlopePctPerHour:
+        env.AGENTBRIDGE_BUDGET_RESERVE_SLOPE_PCT_PER_HOUR ?? budget.maximize.reserveSlopePctPerHour,
+      reserveMaxPct: env.AGENTBRIDGE_BUDGET_RESERVE_MAX_PCT ?? budget.maximize.reserveMaxPct,
+      finishingHorizonMinutes:
+        env.AGENTBRIDGE_BUDGET_FINISHING_HORIZON_MINUTES ?? budget.maximize.finishingHorizonMinutes,
+      resumeHysteresisPct:
+        env.AGENTBRIDGE_BUDGET_RESUME_HYSTERESIS_PCT ?? budget.maximize.resumeHysteresisPct,
+    },
   };
   return normalizeBudgetConfig(overlay, budget);
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -500,9 +500,16 @@ function budgetPauseGateError(): string {
   const sideHint = snapshot?.pauseSide === "both"
     ? "双侧额度均已耗尽，请写 checkpoint 等待刷新"
     : "你可继续 solo 推进可独立部分，并写 checkpoint 标注分工断点";
+  // Q10: the resume-condition text must match the active strategy. maximize
+  // reopens the gate per-window (dynamic line − hysteresis, or window reset),
+  // not at resumeBelow.
+  const reopenText =
+    BUDGET_CONFIG.strategy === "maximize"
+      ? `Codex 侧各窗口 util 回落至动态暂停线 − ${BUDGET_CONFIG.maximize.resumeHysteresisPct}% 以下或对应窗口刷新后闸门自动放开`
+      : `Codex 侧 gateUtil 低于 ${BUDGET_CONFIG.resumeBelow}% 后闸门自动放开`;
   return (
     `预算暂停（闸门关闭），已拒绝转发：${reason}。` +
-    `Codex 侧 gateUtil 低于 ${BUDGET_CONFIG.resumeBelow}% 后闸门自动放开` +
+    reopenText +
     (resumeAt ? `（预计恢复 ${resumeAt}，以实测为准；提前刷新会更早解除）` : "") +
     `。收到 RESUME 通知前请勿重试向 Codex 发送 reply；${sideHint}。`
   );

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -22,6 +22,7 @@ const CONFIG: BudgetConfig = {
     eco: { effort: "low" },
   },
   strategy: "conserve",
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 
 type FetchResult = { claude: AgentUsage | null; codex: AgentUsage | null } | null;
@@ -515,6 +516,58 @@ describe("BudgetCoordinator", () => {
     expect(resume?.content).toContain("reply");
     expect(resume?.content).toContain("唤醒 Codex");
     expect(coordinator.getSnapshot()).toMatchObject({ paused: false, gateClosed: false, pauseSide: null });
+  });
+
+  test("maximize: recovery directive describes the dynamic line, not resumeBelow (Q10)", async () => {
+    const maximizeConfig: BudgetConfig = { ...CONFIG, strategy: "maximize" };
+    const source = new FakeSource([
+      { claude: usage(), codex: usage() },
+      { claude: usage(), codex: usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }) },
+      { claude: usage(), codex: usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }) },
+    ]);
+    const { coordinator, emitted } = makeCoordinator(source, maximizeConfig);
+
+    await coordinator.start();
+    await waitFor(() => emitted.some((event) => event.id.startsWith("system_budget_pause")));
+    await waitFor(() => emitted.some((event) => event.id.startsWith("system_budget_resume")));
+    coordinator.stop();
+
+    const resume = emitted.find((event) => event.id.startsWith("system_budget_resume"));
+    expect(resume?.content).toContain("动态暂停线");
+    expect(resume?.content).not.toContain("低于 30%");
+  });
+
+  test("maximize CONFIDENT path: coordinator enter→exit on the dynamic line", async () => {
+    const maximizeConfig: BudgetConfig = { ...CONFIG, strategy: "maximize" };
+    // fiveHour with a confident guard burn rate: tH=1h, rate=1.2 → line 95.6.
+    const codexUsage = (fiveHourUtil: number): AgentUsage => ({
+      ok: true,
+      stale: false,
+      gateUtil: fiveHourUtil,
+      warnUtil: fiveHourUtil,
+      fiveHour: { util: fiveHourUtil, resetEpoch: NOW + 3600, burnRate: 1.2, burnConfident: true },
+      weekly: { util: 10, resetEpoch: NOW + 500_000, burnRate: 0.4, burnConfident: true },
+      remaining: 100 - fiveHourUtil,
+      rateLimitedUntil: 0,
+      fetchedAt: NOW,
+      parsedVia: "id-match",
+    });
+    const source = new FakeSource([
+      { claude: usage(), codex: codexUsage(96) }, // 96 ≥ line 95.6 → pause (confident b-branch)
+      { claude: usage(), codex: codexUsage(88) }, // 88 → projected 89.2 ≤ 97 → won't-fill → resume
+    ]);
+    const { coordinator, emitted, pauseChanges } = makeCoordinator(source, maximizeConfig);
+
+    await coordinator.start();
+    await waitFor(() => emitted.some((e) => e.id.startsWith("system_budget_pause")));
+    await waitFor(() => emitted.some((e) => e.id.startsWith("system_budget_resume")));
+    coordinator.stop();
+
+    expect(pauseChanges).toEqual([true, false]);
+    const pause = emitted.find((e) => e.id.startsWith("system_budget_pause"));
+    expect(pause?.content).toContain("动态暂停线"); // confident path → dynamic-line reason
+    const resume = emitted.find((e) => e.id.startsWith("system_budget_resume"));
+    expect(resume?.content).toContain("动态暂停线");
   });
 
   test("Claude-side handoff keeps intervention visible but leaves the gate open", async () => {

--- a/src/unit-test/budget-fingerprint.test.ts
+++ b/src/unit-test/budget-fingerprint.test.ts
@@ -25,6 +25,7 @@ const CONFIG: BudgetConfig = {
     eco: { effort: "low" },
   },
   strategy: "conserve",
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 
 function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {

--- a/src/unit-test/budget-maximize.test.ts
+++ b/src/unit-test/budget-maximize.test.ts
@@ -1,0 +1,424 @@
+/**
+ * v3 P2 — time-aware maximize pause line (design budget-strategy-v3.md §3.1).
+ *
+ * Covers the acceptance set called out in §6 P2:
+ *   - the §3.1 calibration table (today's live case / last-1h (a)+(b) / far term
+ *     / hard caps), each row asserting its branch;
+ *   - the full degradation matrix (resetEpoch=0 / stale / non-confident /
+ *     both-unknown) → conserve fallback;
+ *   - symmetric resume + window-reset recovery;
+ *   - invariant I1 (maximize never pauses below pauseAt) as a property test;
+ *   - invariant I2 (phantom-hold: stale data never opens a closed gate) via
+ *     classifyPoll;
+ *   - conserve mode untouched (sanity guards alongside the existing suites).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  agentCanResume,
+  agentShouldPause,
+  dynamicPauseAt,
+  effectiveDynamicLine,
+  resumeBlockingEpochFor,
+} from "../budget/budget-decision";
+import { classifyPoll, INITIAL_FINGERPRINT_STATE } from "../budget/budget-fingerprint";
+import { computeBudgetState, renderBudgetInterventionDirective } from "../budget/budget-state";
+import type { AgentUsage, BudgetConfig, BudgetWindow } from "../budget/types";
+
+const NOW = 1_000_000;
+
+const MAXIMIZE: BudgetConfig = {
+  enabled: true,
+  pollSeconds: 300,
+  pauseAt: 90,
+  resumeBelow: 30,
+  syncDriftPct: 10,
+  parallel: { minRemainingPct: 60, timeWindowSec: 3600 },
+  codexTierControl: false,
+  codexTiers: { full: null, balanced: { effort: "medium" }, eco: { effort: "low" } },
+  strategy: "maximize",
+  maximize: {
+    targetUtil: 97,
+    reserveSlopePctPerHour: 0.4,
+    reserveMaxPct: 7,
+    finishingHorizonMinutes: 30,
+    resumeHysteresisPct: 5,
+  },
+};
+
+const CONSERVE: BudgetConfig = { ...MAXIMIZE, strategy: "conserve" };
+
+/** Build a window resetting `tHours` from NOW, optionally with a guard burn rate. */
+function win(util: number, tHours: number, rate?: number, confident = true): BudgetWindow {
+  const w: BudgetWindow = { util, resetEpoch: NOW + Math.round(tHours * 3600) };
+  if (rate !== undefined) {
+    w.burnRate = rate;
+    w.burnConfident = confident;
+  }
+  return w;
+}
+
+/** Build a decision-grade AgentUsage from optional 5h/weekly windows. */
+function usage(opts: {
+  fiveHour?: BudgetWindow | null;
+  weekly?: BudgetWindow | null;
+  gateUtil?: number;
+  rateLimitedUntil?: number;
+  fetchedAt?: number;
+}): AgentUsage {
+  const fiveHour = opts.fiveHour ?? null;
+  const weekly = opts.weekly ?? null;
+  const gateUtil = opts.gateUtil ?? Math.max(fiveHour?.util ?? 0, weekly?.util ?? 0);
+  return {
+    ok: true,
+    stale: false,
+    gateUtil,
+    warnUtil: gateUtil,
+    fiveHour,
+    weekly,
+    remaining: Math.max(0, 100 - gateUtil),
+    rateLimitedUntil: opts.rateLimitedUntil ?? 0,
+    fetchedAt: opts.fetchedAt ?? NOW,
+    parsedVia: "id-match",
+  };
+}
+
+describe("dynamicPauseAt — §3.1 calibration table", () => {
+  test("today's live case (util=92, tH=6.5, rate=1.2) → branch (b), line≈93.4, does not pause", () => {
+    const line = dynamicPauseAt(win(92, 6.5, 1.2), 1.2, MAXIMIZE, NOW);
+    expect(typeof line).toBe("number");
+    expect(line as number).toBeCloseTo(93.4, 5);
+    expect(92 >= (line as number)).toBe(false); // util below line → no pause
+  });
+
+  test("last 1h (i): util=92, tH=1, rate=1.2 → branch (a) won't-fill → 100 (no pause)", () => {
+    expect(dynamicPauseAt(win(92, 1, 1.2), 1.2, MAXIMIZE, NOW)).toBe(100);
+  });
+
+  test("last 1h (ii): util=96, tH=1, rate=1.2 → branch (b), line≈95.6 → pause", () => {
+    const line = dynamicPauseAt(win(96, 1, 1.2), 1.2, MAXIMIZE, NOW);
+    expect(line as number).toBeCloseTo(95.6, 5);
+    expect(96 >= (line as number)).toBe(true);
+  });
+
+  test("far term (tH=120, rate=1.2) → reserve saturates → clamps to pauseAt=90 (≈conserve)", () => {
+    expect(dynamicPauseAt(win(50, 120, 1.2), 1.2, MAXIMIZE, NOW)).toBeCloseTo(90, 5);
+  });
+
+  test("hard cap 1: util≥targetUtil with zero rate → admission-closed", () => {
+    expect(dynamicPauseAt(win(97, 2, 0), 0, MAXIMIZE, NOW)).toBe("admission-closed");
+  });
+
+  test("hard cap 2 (Codex counterexample): near-reset finishing band → admission-closed", () => {
+    // finishingHorizon=30min, rate=20 → finishingMargin=10; tH=0.25<0.5, util=88≥87.
+    expect(dynamicPauseAt(win(88, 0.25, 20), 20, MAXIMIZE, NOW)).toBe("admission-closed");
+  });
+
+  test("past reset (resetEpoch<=now) → 100 (never pause on a stale window)", () => {
+    expect(dynamicPauseAt({ util: 99, resetEpoch: NOW - 10 }, 5, MAXIMIZE, NOW)).toBe(100);
+  });
+
+  test("tH clamped at 7 days so a bogus far-future reset cannot blow up the line", () => {
+    const sane = dynamicPauseAt(win(50, 7 * 24, 1.2), 1.2, MAXIMIZE, NOW);
+    const bogus = dynamicPauseAt(win(50, 7 * 24 * 100, 1.2), 1.2, MAXIMIZE, NOW);
+    expect(bogus).toBe(sane);
+  });
+
+  test("branch (a) won't-fill with rate=0 and util<target → 100 (no hard cap)", () => {
+    // projected=96≤97 → (a); cap1 (96≥97) no; cap2 (tH 2 < 0.5) no → 100.
+    expect(dynamicPauseAt(win(96, 2, 0), 0, MAXIMIZE, NOW)).toBe(100);
+  });
+
+  test("hard cap 2 boundary is strict (tH < horizon): tH=0.5 does NOT fire", () => {
+    // finishingHorizon=30min→0.5h; rate=20→margin=10; util=87→projected=97≤97 (a).
+    expect(dynamicPauseAt(win(87, 0.49, 20), 20, MAXIMIZE, NOW)).toBe("admission-closed");
+    expect(dynamicPauseAt(win(87, 0.5, 20), 20, MAXIMIZE, NOW)).toBe(100);
+  });
+});
+
+describe("agentShouldPause — maximize entry", () => {
+  test("today's live case: codex weekly 92 / tH 6.5 / rate 1.2 → NOT paused", () => {
+    const d = agentShouldPause("codex", usage({ weekly: win(92, 6.5, 1.2), fiveHour: win(22, 0.3, 0.4) }), MAXIMIZE, NOW);
+    expect(d.pause).toBe(false);
+  });
+
+  test("util=96 last 1h → paused, window=weekly, line≈95.6", () => {
+    const d = agentShouldPause("codex", usage({ weekly: win(96, 1, 1.2) }), MAXIMIZE, NOW);
+    expect(d.pause).toBe(true);
+    expect(d.window).toBe("weekly");
+    expect(d.line as number).toBeCloseTo(95.6, 5);
+  });
+
+  test("hard cap 1 (util=97, rate=0) → paused (admission-closed, util≥pauseAt)", () => {
+    const d = agentShouldPause("claude", usage({ weekly: win(97, 2, 0) }), MAXIMIZE, NOW);
+    expect(d.pause).toBe(true);
+  });
+
+  test("I1 floor: admission-closed below pauseAt (util=88) → NOT paused", () => {
+    const d = agentShouldPause("codex", usage({ fiveHour: win(88, 0.25, 20) }), MAXIMIZE, NOW);
+    expect(d.pause).toBe(false);
+  });
+
+  test("degraded (no confident rate): util≥pauseAt pauses, util<pauseAt does not", () => {
+    expect(agentShouldPause("codex", usage({ weekly: win(91, 5) }), MAXIMIZE, NOW).pause).toBe(true);
+    expect(agentShouldPause("codex", usage({ weekly: win(89, 5) }), MAXIMIZE, NOW).pause).toBe(false);
+  });
+
+  test("degraded (burnConfident=false) falls back to conserve per-window", () => {
+    expect(agentShouldPause("codex", usage({ weekly: win(91, 5, 1.2, false) }), MAXIMIZE, NOW).pause).toBe(true);
+  });
+
+  test("non-decision-grade (all windows expired) → not paused", () => {
+    const u = usage({ weekly: { util: 99, resetEpoch: NOW - 10 } });
+    expect(agentShouldPause("codex", u, MAXIMIZE, NOW).pause).toBe(false);
+  });
+
+  test("stale fetch → not paused (isDecisionGrade gate)", () => {
+    const u = usage({ weekly: win(96, 1, 1.2), fetchedAt: NOW - 601 });
+    expect(agentShouldPause("codex", u, MAXIMIZE, NOW).pause).toBe(false);
+  });
+
+  test("expired window is skipped; a fresh tripping window still pauses", () => {
+    const u = usage({ fiveHour: { util: 99, resetEpoch: NOW - 5 }, weekly: win(96, 1, 1.2) });
+    expect(agentShouldPause("codex", u, MAXIMIZE, NOW).pause).toBe(true);
+  });
+
+  test("both windows trip → reason reports the FIRST (fiveHour) per WINDOW_KEYS order", () => {
+    const u = usage({ fiveHour: win(96, 1, 1.2), weekly: win(96, 1, 1.2) });
+    const d = agentShouldPause("codex", u, MAXIMIZE, NOW);
+    expect(d.pause).toBe(true);
+    expect(d.window).toBe("fiveHour");
+  });
+});
+
+describe("invariant I1 — maximize never pauses below pauseAt (property)", () => {
+  test("dynamicPauseAt numeric result is always within [pauseAt, 99]", () => {
+    for (let i = 0; i < 400; i++) {
+      const pauseAt = 80 + (i % 15); // 80..94
+      const targetUtil = Math.min(99, pauseAt + 1 + (i % 8)); // > pauseAt
+      const cfg: BudgetConfig = {
+        ...MAXIMIZE,
+        pauseAt,
+        maximize: {
+          targetUtil,
+          reserveSlopePctPerHour: (i % 6) * 0.7,
+          reserveMaxPct: i % 20,
+          finishingHorizonMinutes: 5 + (i % 170),
+          resumeHysteresisPct: 1 + (i % 29),
+        },
+      };
+      const rate = (i % 25) * 0.5;
+      const tH = 0.05 + (i % 200);
+      const util = i % 101;
+      const line = dynamicPauseAt(win(util, tH, rate), rate, cfg, NOW);
+      if (typeof line === "number" && line !== 100) {
+        expect(line).toBeGreaterThanOrEqual(pauseAt);
+        expect(line).toBeLessThanOrEqual(99);
+      }
+    }
+  });
+
+  test("I1 edge: pauseAt=100 (degenerate) → line floors to 100, never pauses below conserve", () => {
+    // clamp(line, 100, max(100,99)=100) = 100. A 99 ceiling would clamp DOWN to
+    // 99 and pause at util≥99 — earlier than conserve (which never pauses at
+    // pauseAt=100). The floor must win.
+    const cfg: BudgetConfig = { ...MAXIMIZE, pauseAt: 100 };
+    expect(dynamicPauseAt(win(99, 6.5, 1.2), 1.2, cfg, NOW)).toBe(100);
+    expect(agentShouldPause("codex", usage({ weekly: win(99, 6.5, 1.2) }), cfg, NOW).pause).toBe(false);
+  });
+
+  test("agentShouldPause: a tripping window always has util ≥ pauseAt", () => {
+    for (let i = 0; i < 400; i++) {
+      const pauseAt = 80 + (i % 15);
+      const targetUtil = Math.min(99, pauseAt + 1 + (i % 8));
+      const cfg: BudgetConfig = {
+        ...MAXIMIZE,
+        pauseAt,
+        maximize: {
+          targetUtil,
+          reserveSlopePctPerHour: (i % 6) * 0.7,
+          reserveMaxPct: i % 20,
+          finishingHorizonMinutes: 5 + (i % 170),
+          resumeHysteresisPct: 1 + (i % 29),
+        },
+      };
+      const u = usage({
+        fiveHour: win((i * 7) % 101, 0.1 + (i % 50), (i % 10) * 0.8),
+        weekly: win((i * 13) % 101, 0.2 + (i % 160), (i % 7) * 1.1),
+      });
+      const d = agentShouldPause("codex", u, cfg, NOW);
+      if (d.pause && d.window) {
+        expect(u[d.window]!.util).toBeGreaterThanOrEqual(pauseAt);
+      }
+    }
+  });
+});
+
+describe("agentCanResume — maximize symmetric exit", () => {
+  test("still above the line (util=96, line≈95.6) → cannot resume", () => {
+    expect(agentCanResume(usage({ weekly: win(96, 1, 1.2) }), MAXIMIZE, NOW)).toBe(false);
+  });
+
+  test("util receded into won't-fill band (util=90, tH=1) → resumes", () => {
+    expect(agentCanResume(usage({ weekly: win(90, 1, 1.2) }), MAXIMIZE, NOW)).toBe(true);
+  });
+
+  test("(b)→(a) transition: util=92/tH=1 drops into won't-fill → resumes", () => {
+    // projected=93.2≤97 → (a) → line 100 (won't-fill) → never blocks resume.
+    expect(agentCanResume(usage({ weekly: win(92, 1, 1.2) }), MAXIMIZE, NOW)).toBe(true);
+  });
+
+  test("won't-fill window at HIGH util (line=100, util=95) does NOT block resume", () => {
+    // util=95/tH=1/rate=1 → projected 96≤97 → (a) won't-fill → line 100. This
+    // window never triggers entry, so it must never block resume (symmetry) —
+    // even though util 95 ≥ 100−hyst(5). Regression guard for the line=100 fix.
+    expect(agentCanResume(usage({ weekly: win(95, 1, 1) }), MAXIMIZE, NOW)).toBe(true);
+  });
+
+  test("a won't-fill window does not keep another recovered side paused", () => {
+    // weekly recovered into won't-fill (line 100) at util 96; fiveHour also
+    // won't-fill. Neither gates entry → resume must be allowed.
+    const u = usage({ fiveHour: win(80, 1, 0.5), weekly: win(96, 1, 0.5) });
+    expect(agentShouldPause("codex", u, MAXIMIZE, NOW).pause).toBe(false);
+    expect(agentCanResume(u, MAXIMIZE, NOW)).toBe(true);
+  });
+
+  test("window reset (expired) + other window low → resumes", () => {
+    const u = usage({ fiveHour: win(10, 0.3, 0.4), weekly: { util: 99, resetEpoch: NOW - 5 } });
+    expect(agentCanResume(u, MAXIMIZE, NOW)).toBe(true);
+  });
+
+  test("active rate-limit blocks resume regardless of util", () => {
+    expect(
+      agentCanResume(usage({ weekly: win(10, 1, 0.4), rateLimitedUntil: NOW + 100 }), MAXIMIZE, NOW),
+    ).toBe(false);
+  });
+
+  test("degraded window resumes only below resumeBelow (conserve exit)", () => {
+    expect(agentCanResume(usage({ weekly: win(40, 5) }), MAXIMIZE, NOW)).toBe(false);
+    expect(agentCanResume(usage({ weekly: win(29, 5) }), MAXIMIZE, NOW)).toBe(true);
+  });
+});
+
+describe("resumeBlockingEpochFor — maximize Q10 alignment", () => {
+  test("returns the blocking window's reset while still over the line", () => {
+    const weekly = win(96, 1, 1.2);
+    expect(resumeBlockingEpochFor(usage({ weekly }), MAXIMIZE, NOW)).toBe(weekly.resetEpoch);
+  });
+
+  test("returns 0 once no window blocks resume", () => {
+    expect(resumeBlockingEpochFor(usage({ weekly: win(90, 1, 1.2) }), MAXIMIZE, NOW)).toBe(0);
+  });
+
+  test("active rate-limit wins", () => {
+    expect(
+      resumeBlockingEpochFor(usage({ weekly: win(96, 1, 1.2), rateLimitedUntil: NOW + 500 }), MAXIMIZE, NOW),
+    ).toBe(NOW + 500);
+  });
+});
+
+describe("effectiveDynamicLine — display only", () => {
+  test("maximize today's case → ≈93.4", () => {
+    expect(effectiveDynamicLine(usage({ weekly: win(92, 6.5, 1.2) }), MAXIMIZE, NOW)).toBeCloseTo(93.4, 5);
+  });
+
+  test("conserve mode → null", () => {
+    expect(effectiveDynamicLine(usage({ weekly: win(92, 6.5, 1.2) }), CONSERVE, NOW)).toBeNull();
+  });
+
+  test("picks the binding (smallest-headroom) window", () => {
+    // Both windows: tH 6.5, rate 1.2. weekly util=92 → projected 99.8 > 97 → (b)
+    // line 93.4. fiveHour util=50 → projected 57.8 ≤ 97 → (a) won't-fill → line
+    // 100, which effectiveDynamicLine skips (>=100). So weekly is the only
+    // numeric line and is correctly chosen as binding.
+    const u = usage({ fiveHour: win(50, 6.5, 1.2), weekly: win(92, 6.5, 1.2) });
+    expect(effectiveDynamicLine(u, MAXIMIZE, NOW)).toBeCloseTo(93.4, 5);
+  });
+
+  test("two confident numeric lines → smallest headroom wins", () => {
+    // Both will-fill (b), same line 93.4 (tH 6.5, rate 1.2). fiveHour util=93
+    // (headroom 0.4) vs weekly util=91 (headroom 2.4) → fiveHour is binding.
+    const u = usage({ fiveHour: win(93, 6.5, 1.2), weekly: win(91, 6.5, 1.2) });
+    expect(effectiveDynamicLine(u, MAXIMIZE, NOW)).toBeCloseTo(93.4, 5);
+  });
+});
+
+describe("invariant I2 — phantom-hold under maximize (classifyPoll)", () => {
+  test("a paused maximize side holds when its data goes non-decision-grade", () => {
+    // Poll 1: codex weekly trips the line (util=96, tH=1, rate=1.2 → line 95.6).
+    const s1 = computeBudgetState(null, usage({ weekly: win(96, 1, 1.2) }), MAXIMIZE, NOW);
+    const r1 = classifyPoll(INITIAL_FINGERPRINT_STATE, s1, MAXIMIZE);
+    expect(r1.next.side).toBe("codex");
+
+    // Poll 2: codex probe goes stale (non-decision-grade) — must HOLD, not open.
+    const staleCodex = usage({ weekly: win(96, 1, 1.2), fetchedAt: NOW - 601 });
+    const s2 = computeBudgetState(null, staleCodex, MAXIMIZE, NOW + 60);
+    const r2 = classifyPoll(r1.next, s2, MAXIMIZE);
+    expect(r2.next.side).toBe("codex");
+    expect(r2.effect.kind).toBe("hold-uncertain");
+  });
+
+  test("stale/expired hold keeps the sticky FUTURE resumeEpoch (no past-time clobber)", () => {
+    // Poll 1: codex weekly trips (util=96, tH=1, rate=1.2 → line 95.6); the
+    // blocking window's reset (NOW+3600) becomes the resumeEpoch.
+    const s1 = computeBudgetState(null, usage({ weekly: win(96, 1, 1.2) }), MAXIMIZE, NOW);
+    const r1 = classifyPoll(INITIAL_FINGERPRINT_STATE, s1, MAXIMIZE);
+    expect(r1.next.side).toBe("codex");
+    expect(r1.next.resumeEpoch).toBe(NOW + 3600);
+
+    // Poll 2: codex probe is stale AND its only window has already reset
+    // (resetEpoch in the past). The gate must HOLD and the resumeEpoch must NOT
+    // be overwritten with the past reset — it stays the last known-good future.
+    const expiredStale = usage({
+      fiveHour: { util: 99, resetEpoch: NOW - 10 },
+      weekly: null,
+      fetchedAt: NOW - 700,
+    });
+    const s2 = computeBudgetState(null, expiredStale, MAXIMIZE, NOW + 60);
+    const r2 = classifyPoll(r1.next, s2, MAXIMIZE);
+    expect(r2.next.side).toBe("codex");
+    expect(r2.next.resumeEpoch).toBe(NOW + 3600); // sticky future, not NOW-10
+  });
+});
+
+describe("renderBudgetInterventionDirective — Q10 resume-condition text", () => {
+  const claudeU = usage({ weekly: win(96, 1, 1.2) });
+  const codexU = usage({ weekly: win(40, 6.5, 0.4) });
+
+  test("conserve: resume text keeps the historical gateUtil<resumeBelow wording", () => {
+    const text = renderBudgetInterventionDirective(claudeU, codexU, "codex", "r", NOW + 3600, CONSERVE);
+    expect(text).toContain("gateUtil 低于 30%");
+    expect(text).not.toContain("动态暂停线");
+  });
+
+  test("maximize (codex side): resume text describes the dynamic line, not 30%", () => {
+    const text = renderBudgetInterventionDirective(claudeU, codexU, "codex", "r", NOW + 3600, MAXIMIZE);
+    expect(text).toContain("动态暂停线");
+    expect(text).toContain("− 5%");
+    expect(text).not.toContain("gateUtil 低于 30%");
+  });
+
+  test("maximize (claude side): handoff resume text is strategy-aware", () => {
+    const text = renderBudgetInterventionDirective(claudeU, codexU, "claude", "r", NOW + 3600, MAXIMIZE);
+    expect(text).toContain("动态暂停线");
+    expect(text).not.toContain("低于 30%");
+  });
+
+  test("maximize (both sides): joint resume text is strategy-aware", () => {
+    const text = renderBudgetInterventionDirective(claudeU, codexU, "both", "r", NOW + 3600, MAXIMIZE);
+    expect(text).toContain("动态暂停线");
+    expect(text).not.toContain("都低于 30%");
+  });
+});
+
+describe("conserve mode is unchanged by the maximize path", () => {
+  test("conserve still gates on gateUtil ≥ pauseAt, ignoring the dynamic line", () => {
+    // util=92 with tH 6.5 would NOT pause under maximize (line 93.4) but DOES
+    // under conserve (92 ≥ pauseAt 90).
+    expect(agentShouldPause("codex", usage({ weekly: win(92, 6.5, 1.2) }), CONSERVE, NOW).pause).toBe(true);
+  });
+
+  test("conserve resume still requires gateUtil < resumeBelow", () => {
+    expect(agentCanResume(usage({ weekly: win(40, 6.5, 1.2) }), CONSERVE, NOW)).toBe(false);
+    expect(agentCanResume(usage({ weekly: win(20, 6.5, 1.2) }), CONSERVE, NOW)).toBe(true);
+  });
+});

--- a/src/unit-test/budget-render.test.ts
+++ b/src/unit-test/budget-render.test.ts
@@ -54,6 +54,30 @@ describe("renderBudgetSnapshot", () => {
     expect(text).toContain("预警 45%");
   });
 
+  test("renders the maximize dynamic line with per-agent headroom", () => {
+    const text = renderBudgetSnapshot(
+      snapshot({ dynamicPauseLine: { claude: 93.4, codex: 95.6 } }),
+    );
+    expect(text).toContain("动态暂停线（maximize）：");
+    expect(text).toContain("Claude 93.4%");
+    expect(text).toContain("Codex 95.6%");
+    // headroom = line - gateUtil (Claude 93.4-42=51.4, Codex 95.6-10=85.6)
+    expect(text).toContain("余量 51.4");
+    expect(text).toContain("余量 85.6");
+  });
+
+  test("omits the dynamic line entirely in conserve mode (no field)", () => {
+    expect(renderBudgetSnapshot(snapshot())).not.toContain("动态暂停线");
+  });
+
+  test("shows only the side that has a numeric dynamic line", () => {
+    const text = renderBudgetSnapshot(
+      snapshot({ dynamicPauseLine: { claude: null, codex: 95.6 } }),
+    );
+    expect(text).toContain("Codex 95.6%");
+    expect(text).not.toContain("Claude 93");
+  });
+
   test("shows drift direction with heavier side first", () => {
     const text = renderBudgetSnapshot(snapshot({ driftPct: 31 }));
     expect(text).toContain("Claude 比 Codex 高 31 个百分点");

--- a/src/unit-test/budget-state.test.ts
+++ b/src/unit-test/budget-state.test.ts
@@ -21,6 +21,7 @@ const CONFIG: BudgetConfig = {
     eco: { effort: "low" },
   },
   strategy: "conserve",
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 
 function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -392,6 +392,7 @@ describe("ConfigService — budget section", () => {
         eco: { effort: "low" },
       },
       strategy: "conserve",
+      maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
     });
   });
 
@@ -433,6 +434,7 @@ describe("ConfigService — budget section", () => {
       },
       // v3 P1 keys absent in the raw file normalize to defaults.
       strategy: "conserve",
+      maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
     });
   });
 
@@ -595,6 +597,7 @@ describe("applyBudgetEnvOverrides", () => {
       eco: { effort: "low" },
     },
     strategy: "conserve" as const,
+    maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
   };
 
   test("env values override the base config", () => {
@@ -650,6 +653,7 @@ describe("applyBudgetEnvOverrides — boolean spellings", () => {
       eco: { effort: "low" },
     },
     strategy: "conserve" as const,
+    maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
   };
 
   test('accepts "0"/"1" alongside "true"/"false"', () => {
@@ -760,6 +764,7 @@ describe("applyBudgetEnvOverrides — v3 P1 keys", () => {
       eco: { effort: "low" },
     },
     strategy: "conserve" as const,
+    maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
   };
 
   test("AGENTBRIDGE_BUDGET_STRATEGY overrides the strategy", () => {
@@ -782,5 +787,106 @@ describe("applyBudgetEnvOverrides — v3 P1 keys", () => {
     });
     expect(result.pauseAt).toBe(90);
     expect(result.resumeBelow).toBe(30);
+  });
+});
+
+describe("normalizeBudgetConfig — v3 P2 maximize block", () => {
+  let tempDir: string;
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "abg-max-"));
+  });
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+  function writeRawConfig(raw: unknown) {
+    mkdirSync(join(tempDir, ".agentbridge"), { recursive: true });
+    writeFileSync(join(tempDir, ".agentbridge", "config.json"), JSON.stringify(raw));
+  }
+  function loadBudget() {
+    const result = new ConfigService(tempDir).load();
+    expect(result.state).toBe("parsed");
+    if (result.state !== "parsed") throw new Error("unreachable");
+    return result.config.budget;
+  }
+
+  test("absent maximize block fills package defaults", () => {
+    writeRawConfig({ version: "1.0" });
+    expect(loadBudget().maximize).toEqual(DEFAULT_CONFIG.budget.maximize);
+  });
+
+  test("valid custom maximize values pass through (incl. fractional slope)", () => {
+    writeRawConfig({
+      budget: {
+        strategy: "maximize",
+        maximize: {
+          targetUtil: 95,
+          reserveSlopePctPerHour: 1.25,
+          reserveMaxPct: 10,
+          finishingHorizonMinutes: 45,
+          resumeHysteresisPct: 8,
+        },
+      },
+    });
+    expect(loadBudget().maximize).toEqual({
+      targetUtil: 95,
+      reserveSlopePctPerHour: 1.25,
+      reserveMaxPct: 10,
+      finishingHorizonMinutes: 45,
+      resumeHysteresisPct: 8,
+    });
+  });
+
+  test("out-of-range fields fall back per field (others preserved)", () => {
+    writeRawConfig({
+      budget: {
+        maximize: {
+          targetUtil: 200, // > 99 → fallback 97
+          reserveSlopePctPerHour: -1, // < 0 → fallback 0.4
+          finishingHorizonMinutes: 999, // > 180 → fallback 30
+        },
+      },
+    });
+    const m = loadBudget().maximize;
+    expect(m.targetUtil).toBe(97);
+    expect(m.reserveSlopePctPerHour).toBe(0.4);
+    expect(m.finishingHorizonMinutes).toBe(30);
+  });
+
+  test("targetUtil <= pauseAt resets the WHOLE maximize block to defaults", () => {
+    writeRawConfig({
+      budget: {
+        pauseAt: 95,
+        maximize: { targetUtil: 94, reserveMaxPct: 20 }, // 94 <= 95 → unsatisfiable
+      },
+    });
+    expect(loadBudget().maximize).toEqual(DEFAULT_CONFIG.budget.maximize);
+  });
+
+  test("env overrides land on the maximize block", () => {
+    const overridden = applyBudgetEnvOverrides(DEFAULT_CONFIG.budget, {
+      AGENTBRIDGE_BUDGET_TARGET_UTIL: "96",
+      AGENTBRIDGE_BUDGET_RESERVE_SLOPE_PCT_PER_HOUR: "0.9",
+      AGENTBRIDGE_BUDGET_FINISHING_HORIZON_MINUTES: "60",
+    });
+    expect(overridden.maximize.targetUtil).toBe(96);
+    expect(overridden.maximize.reserveSlopePctPerHour).toBe(0.9);
+    expect(overridden.maximize.finishingHorizonMinutes).toBe(60);
+  });
+
+  test("describeConfig reports custom values when strategy/maximize are tuned", () => {
+    writeRawConfig({ budget: { strategy: "maximize", maximize: { targetUtil: 95 } } });
+    expect(new ConfigService(tempDir).describeConfig().customValues).toBe(true);
+  });
+
+  test("garbage maximize numeric fails loud as corrupt (not silent default)", () => {
+    writeRawConfig({ budget: { maximize: { targetUtil: "ninety" } } });
+    const result = new ConfigService(tempDir).load();
+    expect(result.state).toBe("corrupt");
+    if (result.state === "corrupt") expect(result.reason).toContain("budget.maximize.targetUtil");
+  });
+
+  test("non-object maximize block fails loud as corrupt", () => {
+    writeRawConfig({ budget: { maximize: 42 } });
+    expect(new ConfigService(tempDir).load().state).toBe("corrupt");
   });
 });

--- a/src/unit-test/resume-candidate-e2e.test.ts
+++ b/src/unit-test/resume-candidate-e2e.test.ts
@@ -48,6 +48,7 @@ const CONFIG: BudgetConfig = {
     eco: { effort: "low" },
   },
   strategy: "conserve",
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 
 type FetchResult = { claude: AgentUsage | null; codex: AgentUsage | null } | null;

--- a/src/unit-test/resume-candidate.test.ts
+++ b/src/unit-test/resume-candidate.test.ts
@@ -26,6 +26,7 @@ const CONFIG: BudgetConfig = {
     eco: { effort: "low" },
   },
   strategy: "conserve",
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 
 /** Decision-grade probe with healthy (resumable) defaults — gateUtil 20 < resumeBelow 30. */


### PR DESCRIPTION
## 摘要 / Summary

把 budget 策略 v3 的 `strategy:"maximize"` 从 **P1 仅解析、无行为** 推进到 **P2 真正生效**：按窗口的**时间感知动态暂停线**（设计 [`docs/design/budget-strategy-v3.md`](docs/design/budget-strategy-v3.md) §3.1 / §6 P2）。`conserve` 模式字节级零回归。

Promotes `strategy:"maximize"` from parse-only (P1) to actually effective (P2): a per-window **time-aware dynamic pause line** replacing the single `gateUtil ≥ pauseAt` threshold. `conserve` is byte-for-byte unchanged.

## 核心设计 / Core design

- **单一决策源** `src/budget/budget-decision.ts`（新）：`dynamicPauseAt` / `agentShouldPause` / `agentCanResume` / `resumeBlockingEpochFor` / `effectiveDynamicLine` / `isDecisionGrade`。由 `budget-state.pauseTrigger`（渲染态）与 `budget-fingerprint`（协调器门控）**共用一份判据**，杜绝两处分叉。
- **动态暂停线**（§3.1）：离窗口刷新越近线越高（多烧代价越低）；`floor=pauseAt`（不变量 I1）、`ceiling=max(pauseAt,99)`（防 pauseAt=100 退化时 ceiling 反压 floor）。
- **对称出闸**：`util < 动态线 − resumeHysteresis` 或窗口刷新；`won't-fill`（line=100）窗口永不入闸也永不阻塞 resume。
- **降级矩阵**：非 confident / 缺 burn rate / `resetEpoch=0` / stale → 全退 conserve；不变量 I1（绝不早于 conserve 暂停）、I2（stale 绝不开闸 phantom-hold）保持。
- **Q10 出闸对称化**：三处恢复/出闸指令文案按 strategy 分支（`renderBudgetInterventionDirective` / `recoveryDirective` / `budgetPauseGateError`）——maximize 描述动态线，conserve 字节不变。
- **配置**：`maximize` 块（`targetUtil`/`reserveSlopePctPerHour`/`reserveMaxPct`/`finishingHorizonMinutes`/`resumeHysteresisPct`）+ `targetUtil>pauseAt` 关系约束 + env 覆盖 + `findShapeViolation`/`hasCustomDecisionValues`/doctor Q7 一致性。
- **展示**：`BudgetSnapshot.dynamicPauseLine` + `render` 动态线行（仅 maximize，旧消费者不破）。

> P3（三态 admission 闸门）/ P4（runway 分配判据）仍待实施。

## 标定表回归 / Calibration (§3.1, asserted line-by-line)

| 场景 | 输入 | 结果 |
|---|---|---|
| 今日活案例 | util=92, tH=6.5h, rate=1.2 | (b) line=93.4 → **不暂停** |
| 最后 1h (i) | util=92, tH=1h, rate=1.2 | (a) 烧不满 → 100 → **不暂停** |
| 最后 1h (ii) | util=96, tH=1h, rate=1.2 | (b) line=95.6 → **暂停** |
| 远期 | tH=120h, rate=1.2 | reserve 顶 7 → clamp pauseAt=90 → **=conserve** |

## 测试 / Tests

- 新增 `src/unit-test/budget-maximize.test.ts`（48 测试）：标定表、I1 property（400 组随机）、I2 phantom-hold（含 stale-expired sticky resumeEpoch）、对称出闸、降级矩阵、hard cap 边界、pauseAt=100 I1 边界、directive 文案。
- 扩展 `config-service` / `budget-coordinator`（confident + degraded recovery）/ `budget-render` 测试。
- 全量 `bun test src` = **1502 pass / 0 fail**；typecheck 干净；plugin bundle 已同步；manifest 版本对齐。

## Cross-review

4 轮共 8 个独立 subagent（每轮 2 个全新、正交视角，连续两轮收敛到 0 真实 issue）+ **Codex 跨引擎复算/审查/sign-off**。逐轮修复：
- **HIGH**：三处恢复/出闸指令文案在 maximize 下硬编码 conserve `resumeBelow=30%`（与实际出闸点差 60+ 点）→ 已 strategy 化。
- **REAL**：① stale/expired 非 decision-grade 把 paused 的 `resumeEpoch` 覆盖成过去时间（Codex 实证）→ future-guard；② `line=100` 烧不满窗口误阻塞 resume → 短路；③ `pauseAt=100` clamp ceiling 反压 floor 违反 I1 → `ceiling=max(pauseAt,99)`。
- config shape/doctor 对 maximize 块的一致性补齐。

### backlog（非阻塞 RECOMMEND）
- property test 的 pauseAt 仅覆盖 80–94（边界已由专项测试覆盖）；
- `resumeBlockingEpochFor` 多窗口同时阻塞时展示最早 reset（门控正确，展示偏乐观，文案已注「以实测为准」）；
- `activeSideReason` 滞回带文案以 gateUtil 为主语；
- Q2 用 guard `hist_*.jsonl` 真实样本批量回放的参数标定表。

## Test plan

- [x] `bun run typecheck`
- [x] `bun test src`（1502 pass）
- [x] `bun run check`（typecheck + tests + plugin sync + 版本）
- [x] `bun run build:plugin` 已重建、`verify:plugin-sync` 通过
- [ ] 手动 E2E：开 maximize 会话观察动态线展示 + 临近线时的 directive 文案（合并后部署验证）
