### PR TITLE
fix(budget): resume 续接幂等/可靠性硬化 B6/B3/B4/B5 / resume idempotency & reliability hardening

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14596,10 +14596,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("52a49ef", "source"),
+  commit: defineString("2a906d2", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("e124596f4642", "source")
+  codeHash: defineString("b2a5ce6d71b3", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("52a49ef", "source"),
+  commit: defineString("2a906d2", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("e124596f4642", "source")
+  codeHash: defineString("b2a5ce6d71b3", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -3745,6 +3745,12 @@ function resumeBlockingEpoch(usage, cfg, now) {
     return matchingGateReset(usage);
   return 0;
 }
+function retryAfterMsForResume(resumeAfterEpoch, nowMs) {
+  if (resumeAfterEpoch === null)
+    return;
+  const remainingMs = resumeAfterEpoch * 1000 - nowMs;
+  return remainingMs > 0 ? remainingMs : undefined;
+}
 
 // src/budget/types.ts
 var STALE_MAX_AGE_SEC = 600;
@@ -4996,7 +5002,11 @@ function isDegradedUsage(usage, now = Math.floor(Date.now() / 1000)) {
   if (usage.stale || !usage.ok)
     return true;
   const hasFreshWindow = usage.fiveHour !== null && usage.fiveHour.resetEpoch > now || usage.weekly !== null && usage.weekly.resetEpoch > now;
-  return !hasFreshWindow;
+  if (!hasFreshWindow)
+    return true;
+  if (usage.fetchedAt > 0 && now - usage.fetchedAt > STALE_MAX_AGE_SEC)
+    return true;
+  return false;
 }
 
 class QuotaSource {
@@ -5280,6 +5290,16 @@ class ResumeInjectionQueue {
       }
       return;
     }
+    if (input.claim) {
+      const identity = input.claim.identity;
+      for (const existing of this.entries.values()) {
+        if (existing.claim && existing.claim.identity === identity) {
+          this.log(`resume injection identity-deduped: ${input.resumeId} ~ existing ${existing.resumeId} (identity ${identity})`);
+          existing.claim = input.claim;
+          return;
+        }
+      }
+    }
     this.entries.set(input.resumeId, {
       resumeId: input.resumeId,
       prompt: input.prompt ?? RESUME_PROMPT,
@@ -5314,12 +5334,11 @@ class ResumeInjectionQueue {
       for (const entry of [...this.entries.values()]) {
         if (entry.state === "awaiting_confirm") {
           this.supersedeAwaiting(entry, "turn_tracking_reset");
+          this.countRealAttemptOrAbandon(entry, "turn tracking reset before turn/start confirmation");
         } else if (entry.state === "pending") {
           this.clearRetryTimer(entry);
-        } else {
-          continue;
+          this.scheduleRetry(entry);
         }
-        this.countRealAttemptOrAbandon(entry, "turn tracking reset before turn/start confirmation");
       }
     } finally {
       this.resetSweepDepth--;
@@ -6753,7 +6772,7 @@ async function handleClaudeToCodex(ws, message) {
     const reason = budgetPauseGateError();
     log(`Injection rejected by budget pause gate`);
     const resumeAfterEpoch3 = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
-    const retryAfterMs = resumeAfterEpoch3 !== null ? Math.max(0, resumeAfterEpoch3 * 1000 - Date.now()) : undefined;
+    const retryAfterMs = retryAfterMsForResume(resumeAfterEpoch3, Date.now());
     sendClaudeToCodexResult(ws, message.requestId, {
       success: false,
       code: "budget_paused",

--- a/src/budget/budget-gate.ts
+++ b/src/budget/budget-gate.ts
@@ -41,3 +41,18 @@ export function resumeBlockingEpoch(usage: AgentUsage | null, cfg: BudgetConfig,
   if (usage.gateUtil >= cfg.resumeBelow) return matchingGateReset(usage);
   return 0;
 }
+
+/**
+ * Advisory retry delay (ms) for a budget-paused injection rejection. Returns the
+ * time until `resumeAfterEpoch`, or undefined when there is no trustworthy
+ * FUTURE time — NEVER 0 or negative (B4). A resumeAfterEpoch already in the past
+ * (a window reset landed mid poll-interval before the coordinator re-polled to
+ * clear the gate) must not advertise retryAfterMs=0: the client would retry
+ * immediately, be re-rejected by the still-closed gate, and busy-loop until the
+ * next poll. Omitting it lets the client wait for the RESUME push instead.
+ */
+export function retryAfterMsForResume(resumeAfterEpoch: number | null, nowMs: number): number | undefined {
+  if (resumeAfterEpoch === null) return undefined;
+  const remainingMs = resumeAfterEpoch * 1000 - nowMs;
+  return remainingMs > 0 ? remainingMs : undefined;
+}

--- a/src/budget/quota-source.ts
+++ b/src/budget/quota-source.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
+import { STALE_MAX_AGE_SEC } from "./types";
 import type { AgentName, AgentUsage, BudgetWindow, ProbeParsedVia } from "./types";
 
 export interface ProbeRunOptions {
@@ -398,15 +399,23 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
 
 /**
  * Is this usage record degraded (usable for display, not for decisions)?
- * Freshness uses `resetEpoch > now` — the same standard as isDecisionGrade —
- * so an expired-window record cannot log a premature "recovered" transition.
+ * Freshness uses `resetEpoch > now` AND the `fetchedAt` staleness cutoff — the
+ * SAME two standards as isDecisionGrade — so an expired-window OR stale-cache
+ * record cannot log a premature "recovered" transition while the coordinator
+ * (which gates on isDecisionGrade) is still phantom-holding.
  */
 export function isDegradedUsage(usage: AgentUsage, now: number = Math.floor(Date.now() / 1000)): boolean {
   if (usage.stale || !usage.ok) return true;
   const hasFreshWindow =
     (usage.fiveHour !== null && usage.fiveHour.resetEpoch > now) ||
     (usage.weekly !== null && usage.weekly.resetEpoch > now);
-  return !hasFreshWindow;
+  if (!hasFreshWindow) return true;
+  // B5 fix: align with isDecisionGrade's fetchedAt cutoff. A record fetched
+  // longer than STALE_MAX_AGE_SEC ago is decision-stale even if a window is still
+  // in the future; without this, isDegradedUsage=false logged "recovered to
+  // fresh data" while isDecisionGrade=false kept the gate held.
+  if (usage.fetchedAt > 0 && now - usage.fetchedAt > STALE_MAX_AGE_SEC) return true;
+  return false;
 }
 
 export class QuotaSource {

--- a/src/budget/resume-injection-queue.ts
+++ b/src/budget/resume-injection-queue.ts
@@ -118,6 +118,29 @@ export class ResumeInjectionQueue {
       }
       return;
     }
+    // B6 fix: identity-level dedup. The stale-claim TTL (tryClaimPendingResume)
+    // exists to recover a CRASHED owner, but it cannot tell a crashed owner from
+    // THIS live daemon's still-queued resume: after claimTtlSec a second recovery
+    // for the same pending unlinks the live claim file and re-grants the SAME
+    // identity under a NEW resumeId. claimPath/consumedPath derive solely from
+    // identity, so resume-1 and resume-2 point at the same on-disk files —
+    // enqueuing both would inject AND confirm the same checkpoint twice. Keep the
+    // existing entry and ADOPT the freshly-granted claim (its write is the current
+    // file on disk, with a fresh non-stale timestamp), dropping the old claim
+    // OBJECT without release(): release() unlinks the shared claim file the
+    // surviving entry still needs, and consume() must fire exactly once.
+    if (input.claim) {
+      const identity = input.claim.identity;
+      for (const existing of this.entries.values()) {
+        if (existing.claim && existing.claim.identity === identity) {
+          this.log(
+            `resume injection identity-deduped: ${input.resumeId} ~ existing ${existing.resumeId} (identity ${identity})`,
+          );
+          existing.claim = input.claim;
+          return;
+        }
+      }
+    }
     this.entries.set(input.resumeId, {
       resumeId: input.resumeId,
       prompt: input.prompt ?? RESUME_PROMPT,
@@ -169,13 +192,23 @@ export class ResumeInjectionQueue {
     try {
       for (const entry of [...this.entries.values()]) {
         if (entry.state === "awaiting_confirm") {
+          // A real injection was in flight (turn/start sent, awaiting confirm);
+          // the reset tore it down → count it as a real failed attempt (which
+          // re-arms retry, or abandons at maxAttempts).
           this.supersedeAwaiting(entry, "turn_tracking_reset");
+          this.countRealAttemptOrAbandon(entry, "turn tracking reset before turn/start confirmation");
         } else if (entry.state === "pending") {
+          // B3 fix: a `pending` entry has NO injection in flight — it is either
+          // soft-deferred (inject() returned null: no TUI/no WS, which by design
+          // does NOT count an attempt) or waiting between retries (its attempt was
+          // already counted when it left awaiting_confirm). Counting an attempt
+          // here violated the soft-defer contract: repeated app-server
+          // reconnects (each fires onTurnTrackingReset) burned maxAttempts and
+          // abandoned a resume that never actually injected. Just re-arm the
+          // retry timer so it still advances after the reset.
           this.clearRetryTimer(entry);
-        } else {
-          continue;
+          this.scheduleRetry(entry);
         }
-        this.countRealAttemptOrAbandon(entry, "turn tracking reset before turn/start confirmation");
       }
     } finally {
       this.resetSweepDepth--;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -21,6 +21,7 @@ import { StateDirResolver } from "./state-dir";
 import { ConfigService, applyBudgetEnvOverrides } from "./config-service";
 import { BudgetCoordinator } from "./budget/budget-coordinator";
 import { createQuotaSource } from "./budget/quota-source";
+import { retryAfterMsForResume } from "./budget/budget-gate";
 import { readGuardPending } from "./budget/pending-reader";
 import type { ResumeSignals } from "./budget/budget-fingerprint";
 import { ResumeInjectionQueue, tryClaimPendingResume } from "./budget/resume-injection-queue";
@@ -1217,9 +1218,8 @@ async function handleClaudeToCodex(
     const reason = budgetPauseGateError();
     log(`Injection rejected by budget pause gate`);
     const resumeAfterEpoch = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
-    const retryAfterMs = resumeAfterEpoch !== null
-      ? Math.max(0, resumeAfterEpoch * 1000 - Date.now())
-      : undefined;
+    // B4 fix: only advertise a POSITIVE retry delay (see retryAfterMsForResume).
+    const retryAfterMs = retryAfterMsForResume(resumeAfterEpoch, Date.now());
     sendClaudeToCodexResult(ws, message.requestId, {
       success: false,
       code: "budget_paused",

--- a/src/unit-test/budget-gate.test.ts
+++ b/src/unit-test/budget-gate.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { retryAfterMsForResume } from "../budget/budget-gate";
+
+describe("retryAfterMsForResume (B4)", () => {
+  const NOW_MS = 1_000_000_000;
+
+  test("returns undefined when there is no resume epoch", () => {
+    expect(retryAfterMsForResume(null, NOW_MS)).toBeUndefined();
+  });
+
+  test("returns the positive remaining ms for a future resume epoch", () => {
+    const epochSec = (NOW_MS + 30_000) / 1000; // 30s in the future
+    expect(retryAfterMsForResume(epochSec, NOW_MS)).toBe(30_000);
+  });
+
+  test("returns undefined (NOT 0) for a resume epoch already in the past", () => {
+    // B4: a window reset that landed mid poll-interval leaves resumeAfterEpoch in
+    // the past until the next poll clears the gate. The old Math.max(0, ...) gave
+    // retryAfterMs=0 → "retry now" → busy-loop against the still-closed gate.
+    const pastEpochSec = (NOW_MS - 5_000) / 1000;
+    expect(retryAfterMsForResume(pastEpochSec, NOW_MS)).toBeUndefined();
+  });
+
+  test("returns undefined for a resume epoch exactly at now (no 0)", () => {
+    expect(retryAfterMsForResume(NOW_MS / 1000, NOW_MS)).toBeUndefined();
+  });
+});

--- a/src/unit-test/quota-source.test.ts
+++ b/src/unit-test/quota-source.test.ts
@@ -308,6 +308,34 @@ describe("QuotaSource", () => {
     expect(isDegradedUsage(expired!, NOW)).toBe(true);
   });
 
+  test("B5: stale fetchedAt with a still-fresh window is degraded (aligned with isDecisionGrade)", () => {
+    const staleFetch = normalizeProbeResult({
+      ok: true,
+      util: 50,
+      warn_util: 50,
+      fetched_at: NOW - 700, // > STALE_MAX_AGE_SEC (600) ago
+      buckets: [{ id: "five_hour", util: 50, reset_epoch: NOW + 3600 }], // window still future
+    });
+    expect(staleFetch).not.toBeNull();
+    // Window is fresh (>now) but the data was fetched too long ago: BOTH the
+    // display-side isDegradedUsage and the decision-side isDecisionGrade must
+    // agree it is stale, so no "recovered to fresh" log fires while the
+    // coordinator keeps the gate held (B5 — previously the two diverged).
+    expect(isDegradedUsage(staleFetch!, NOW)).toBe(true);
+    expect(isDecisionGrade(staleFetch!, NOW)).toBe(false);
+
+    // Control: a freshly-fetched record with the same fresh window is NOT degraded.
+    const freshFetch = normalizeProbeResult({
+      ok: true,
+      util: 50,
+      warn_util: 50,
+      fetched_at: NOW,
+      buckets: [{ id: "five_hour", util: 50, reset_epoch: NOW + 3600 }],
+    });
+    expect(isDegradedUsage(freshFetch!, NOW)).toBe(false);
+    expect(isDecisionGrade(freshFetch!, NOW)).toBe(true);
+  });
+
   test("degraded acceptance is logged on transitions only, with recovery (#103)", async () => {
     const logs: string[] = [];
     let stale = true;

--- a/src/unit-test/resume-injection-queue.test.ts
+++ b/src/unit-test/resume-injection-queue.test.ts
@@ -283,7 +283,14 @@ describe("ResumeInjectionQueue", () => {
     expect(queue.get("rid-reset")).toBeUndefined();
   });
 
-  test("turn tracking reset bounds pending retry entries and releases their claim", () => {
+  test("B3: turn tracking reset does NOT burn attempts on a soft-deferred pending entry", () => {
+    // Regression for B3: a `pending` entry whose inject() keeps returning null
+    // (no TUI / no WS) is soft-deferred and by contract does NOT count attempts.
+    // The OLD code called countRealAttemptOrAbandon for pending entries on every
+    // onTurnTrackingReset, so repeated app-server reconnects (each fires a reset)
+    // burned maxAttempts and abandoned a resume that NEVER actually injected,
+    // permanently dropping it (the coordinator had already emitted the recovered
+    // side, so it would not re-enqueue until the next budget transition).
     const scheduler = new FakeScheduler();
     const released: string[] = [];
     const abandoned: string[] = [];
@@ -291,12 +298,12 @@ describe("ResumeInjectionQueue", () => {
     const queue = new ResumeInjectionQueue({
       inject: () => {
         injectCalls += 1;
-        return null;
+        return null; // soft-defer: transport not ready
       },
       scheduler,
       retryMs: 5_000,
       confirmTimeoutMs: 60_000,
-      maxAttempts: 1,
+      maxAttempts: 5,
       onAbandoned: (event) => abandoned.push(event.resumeId),
     });
 
@@ -314,13 +321,96 @@ describe("ResumeInjectionQueue", () => {
     expect(queue.get("rid-pending-reset")?.state).toBe("pending");
     expect(scheduler.activeCount()).toBe(1);
 
+    // Six resets — well past maxAttempts(5). The OLD code abandoned on the 5th.
+    for (let i = 0; i < 6; i++) queue.onTurnTrackingReset();
+
+    expect(abandoned).toEqual([]); // never abandoned — no real injection happened
+    expect(released).toEqual([]); // claim NOT released
+    expect(queue.get("rid-pending-reset")?.state).toBe("pending"); // still queued
+    expect(queue.get("rid-pending-reset")?.attempts).toBe(0); // attempts untouched
+    expect(scheduler.activeCount()).toBe(1); // retry timer re-armed each sweep
+    expect(injectCalls).toBe(1); // only the original enqueue injection probe
+  });
+
+  test("turn tracking reset DOES count + abandon an awaiting_confirm entry (real in-flight attempt)", () => {
+    // Contrast with the B3 case: an entry that actually injected (awaiting_confirm)
+    // and is torn down by a reset DID make a real attempt, so it counts and (at
+    // maxAttempts=1) abandons + releases its claim.
+    const scheduler = new FakeScheduler();
+    const released: string[] = [];
+    const abandoned: string[] = [];
+    const queue = new ResumeInjectionQueue({
+      inject: () => -42, // real injection accepted → awaiting_confirm
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 1,
+      onAbandoned: (event) => abandoned.push(event.resumeId),
+    });
+
+    queue.enqueue({
+      resumeId: "rid-awaiting-reset",
+      prompt: "resume",
+      claim: {
+        identity: "claim-awaiting-reset",
+        claimPath: "/tmp/claim-awaiting-reset.json",
+        consumedPath: "/tmp/consumed-awaiting-reset.json",
+        consume: () => {},
+        release: () => released.push("claim-awaiting-reset"),
+      },
+    });
+    expect(queue.get("rid-awaiting-reset")?.state).toBe("awaiting_confirm");
+
     queue.onTurnTrackingReset();
 
-    expect(abandoned).toEqual(["rid-pending-reset"]);
-    expect(released).toEqual(["claim-pending-reset"]);
-    expect(queue.get("rid-pending-reset")).toBeUndefined();
-    expect(scheduler.activeCount()).toBe(0);
-    expect(injectCalls).toBe(1);
+    expect(abandoned).toEqual(["rid-awaiting-reset"]);
+    expect(released).toEqual(["claim-awaiting-reset"]);
+    expect(queue.get("rid-awaiting-reset")).toBeUndefined();
+  });
+
+  test("B6: identity-dedup prevents the same pending from being queued (and confirmed) twice", () => {
+    // Regression for B6: the stale-claim TTL can re-grant the SAME pending
+    // identity under a NEW resumeId while the original is still queued (live
+    // daemon, soft-deferred). claimPath/consumedPath derive solely from identity,
+    // so both entries would inject AND confirm the same checkpoint twice. enqueue
+    // must dedup by claim.identity, adopt the freshly-granted claim, and drop the
+    // old claim OBJECT without release() (release would unlink the shared file).
+    const scheduler = new FakeScheduler();
+    const consumed: string[] = [];
+    const released: string[] = [];
+    let injectId = 0;
+    const queue = new ResumeInjectionQueue({
+      inject: () => {
+        injectId += 1;
+        return -300 - injectId;
+      },
+      scheduler,
+      retryMs: 5_000,
+      confirmTimeoutMs: 60_000,
+      maxAttempts: 5,
+    });
+    const mkClaim = (tag: string) => ({
+      identity: "same-identity", // SAME identity, distinct claim objects
+      claimPath: "/tmp/claims/same-identity.json",
+      consumedPath: "/tmp/consumed/same-identity.json",
+      consume: () => consumed.push(tag),
+      release: () => released.push(tag),
+    });
+
+    queue.enqueue({ resumeId: "resume-1", prompt: "r", claim: mkClaim("claim-1") });
+    expect(queue.size).toBe(1);
+    expect(queue.get("resume-1")?.state).toBe("awaiting_confirm");
+
+    // TTL reclaim: same identity, new resumeId.
+    queue.enqueue({ resumeId: "resume-2", prompt: "r", claim: mkClaim("claim-2") });
+    expect(queue.size).toBe(1); // resume-2 NOT added
+    expect(queue.get("resume-2")).toBeUndefined();
+    expect(released).toEqual([]); // dropped old claim object WITHOUT release (shared file)
+
+    // Confirm the single surviving entry → exactly ONE consume, on the adopted
+    // (fresh) claim — not two confirmations of the same checkpoint.
+    queue.onBridgeTurnStarted({ resumeId: "resume-1", requestId: -301, turnId: "t1" });
+    expect(consumed).toEqual(["claim-2"]);
   });
 
   test("serializes different resumeIds; second waits until first DRAINS, not when it confirms (Option B)", () => {
@@ -377,7 +467,7 @@ describe("ResumeInjectionQueue", () => {
       scheduler,
       retryMs: 5_000,
       confirmTimeoutMs: 60_000,
-      maxAttempts: 1, // so the reset abandons the swept entries
+      maxAttempts: 1, // so the reset abandons the awaiting_confirm entry (real attempt)
       onAbandoned: (event) => abandoned.push(event.resumeId),
     });
 
@@ -391,8 +481,12 @@ describe("ResumeInjectionQueue", () => {
     queue.onTurnTrackingReset();
 
     expect(injected).toEqual(["a"]); // rid-sweep-b never injected during the sweep
-    expect(abandoned.sort()).toEqual(["rid-sweep-a", "rid-sweep-b"]);
-    expect(queue.size).toBe(0);
+    // rid-sweep-a (awaiting_confirm) made a real attempt → counted → abandoned at
+    // maxAttempts=1. rid-sweep-b (pending, never injected) is NOT abandoned by the
+    // reset (B3 fix); it survives with a re-armed retry timer to advance later.
+    expect(abandoned).toEqual(["rid-sweep-a"]);
+    expect(queue.size).toBe(1);
+    expect(queue.get("rid-sweep-b")?.state).toBe("pending");
   });
 
   test("Option B: after an abort/reset the surviving pending advances via its retry timer (no stall)", () => {


### PR DESCRIPTION
## 摘要 / Summary

修复 deep-review 挖出的 **4 个既有 bug**，集中在 **resume 自动续接链路**（幂等/时序/可靠性）。与 P2 [#174](https://github.com/quilin-ai/agent-bridge/pull/174) **正交**（不同文件/区域，可任意顺序合并）。B6/B3 由 Codex driver 独立实证。

Fix 4 pre-existing bugs surfaced in deep review, in the **auto-resume injection path** (idempotency / timing / reliability). Orthogonal to P2 #174. B6/B3 reproduced by Codex drivers.

## 修复 / Fixes

| # | 级别 | 文件 | 问题 → 修复 |
|---|---|---|---|
| **B6** | REAL | `resume-injection-queue.ts` | resume claim 的 stale-TTL 在同一 daemon 内把**同一 pending identity** 以新 resumeId 二次入队 → 同一 checkpoint 注入+确认**两次**（claimPath/consumedPath 都 = `${dir}/${identity}.json`）。→ `enqueue` 按 `claim.identity` 去重：同 identity 不二次入队，采用新 claim、丢弃旧对象**不 release**（release 会 unlink 共享文件）。 |
| **B3** | REAL | `resume-injection-queue.ts` | `onTurnTrackingReset` 对 `pending` 态条目误计 attempt，违反 soft-defer（`inject→null` 不计 attempt）契约 → Codex app-server 反复重连（每次=一次 reset）烧光 maxAttempts、把**从未真正注入**的续接 abandon、永久丢失。→ pending 分支只 `clearRetryTimer`+`scheduleRetry`、不计 attempt；`awaiting_confirm` 仍 supersede+count。 |
| **B4** | 低 | `budget-gate.ts` + `daemon.ts` | `budget_paused` 拒绝时 resumeAfterEpoch 已过期 → 旧 `Math.max(0,…)` 返回 `retryAfterMs=0` → 客户端立即重试、忙循环到下次 poll。→ 新纯函数 `retryAfterMsForResume` 对 null/已过期/恰好 now 返回 `undefined`。 |
| **B5** | 低 | `quota-source.ts` | `isDegradedUsage` 缺 `fetchedAt` 陈旧检查 → 日志谎报「已恢复」而协调器（用 isDecisionGrade）仍 phantom-hold。→ 补 `now-fetchedAt>STALE_MAX_AGE_SEC` 检查，与 isDecisionGrade 对齐。 |

> **B2**（reset 后 120s 内每 5s 重复轮询，~24 次/reset）= REAL-LOW 效率问题，**未纳入本 PR**（需「最近 reset 已追」记忆，独立小改），已记 backlog。

## 测试 / Tests

- `resume-injection-queue.test.ts`：B3 的 6-reset 不 abandon 回归 + awaiting_confirm 对照（真实在飞仍 count/abandon）+ B6 同 identity dedup（size 仍 1、旧 claim 不 release、confirm 只 consume 一次=新 claim）。**改了 2 个原本编码 B3 buggy 行为的旧断言**（reviewer 已确认是「修正 bug 断言」而非弱化）。
- `budget-gate.test.ts`（新）：B4 边界（null/过去/now/未来）。
- `quota-source.test.ts`：B5（stale fetch + fresh window → degraded=true 且 decision=false 对齐）。
- 全量 `bun test src` = **1450 pass / 0 fail**；typecheck + `verify:plugin-sync` 干净；bundle 已重建。

## Cross-review

- **2 个全新独立 subagent**（正交视角）：均 **0 真实 issue / APPROVE**；逐项验证 B6 边界（awaiting_confirm 替换、≥3 次同 identity、无 double-consume/orphan）、B3 收敛性、B4 epoch 单位、B5 对齐、B3 语义改动无回归面。
- **Codex 跨引擎 driver 验证 + sign-off**（0 REAL / 0 SUSPECT）：B6 x3 同 identity 替换、B3 10-reset 收敛、B4/B5、并排除了「同 resumeId+新 claim release 共享文件」边界（resumeId 单调 sequence → 不可达）。

## Test plan

- [x] `bun run typecheck`
- [x] `bun test src`（1450 pass）
- [x] `bun run build:plugin` + `bun run verify:plugin-sync`
- [ ] 手动 E2E：Codex app-server 反复重连时续接不被误丢（B3）；窗口刷新瞬间不忙重试（B4）——合并后部署验证
