### PR TITLE
feat(budget): v3.2 maximize-only 默认 + 逼近 98 / dynamic line as sole strategy

### DIFF
--- a/docs/design/budget-strategy-v3.md
+++ b/docs/design/budget-strategy-v3.md
@@ -3,6 +3,31 @@
 > 状态：**v3.1 实施中**。Codex 对抗审 2026-06-11（4 REAL + 2 SUSPECT + 2 RECOMMEND 全采纳，Q1-Q10 共识）已落定为实施基线。**进度：P1（燃尽率展示 + Q7 doctor）已上线 master；P2（时间感知暂停线 / maximize）已实现并通过 cross-review（见 §6 P2 实现落点）；P3（三态闸门）/ P4（runway 分配判据）待实施。** 原稿基于 master dfc093b。
 > 作者：Claude；评审：Codex（对抗审记录见 §8，开放问题共识见 §7）。
 
+> **v3.2 修订（2026-06-15，用户指令 + Codex 双方共识）—— 见下方 addendum**：删除 `conserve|maximize` 二选一，时间感知动态线成为**唯一默认策略**；`targetUtil` 97→**98**；外层 guard `BUDGET_HARD` 92→**99**（最后保险丝，bridge pacing 停 ~98 为主）；新增 guard `BUDGET_CHECKPOINT_LEAD≈95` 早写 checkpoint + provider rate-limit/429 也写 pending（强制停可恢复）。
+
+---
+
+## 0. v3.2 addendum — maximize-only / 逼近 98 / 强制停可恢复
+
+> 本节是 §1–§8 之上的修订层，落地时以本节为准（与下文 conserve/maximize 二选一表述冲突处以本节为准）。
+
+**动机**：用户要求「默认就用满额度、不再要 conserve、不再设 92/97 这种限制、写死逼近 99 再停」。澄清：「逼近 99 再停」**正是 §3.1 动态线的渐近语义**（线随窗口刷新临近而升），不是 flat `util≥X` gate（会离刷新远时早早烧满→冻结数天）。所以删的是**策略选择 + 过度配置**，不是 pacing。
+
+**bridge 侧（已实现，feat/budget-v3.2-maximize-default）**：
+1. 删 `BudgetConfig.strategy` 字段 + `BudgetStrategy` 类型；决策恒走时间感知动态线（`budget-decision.ts` 删所有 `cfg.strategy==="maximize"` 分支）。旧 config 残留 `strategy` 键被容忍（忽略）。
+2. `targetUtil` 默认 97→**98**（渐近线；留 2% 给供应商计量抖动，比 99 稳）。reserve*/finishingHorizon/resumeHysteresis 收为内部常量 + env 逃生口。
+3. `pauseAt`(90)/`resumeBelow`(30) 保留**原名**，角色重定义为**无 burn 数据时的固定兜底线**（`fallbackPauseLine`：confident=false/stale/reset-unknown → `util≥pauseAt` 进、`util<resumeBelow` 出），不再是用户可选模式。动态线 floor 仍 = pauseAt（I1）。
+4. doctor Q7：`evaluateBudgetStrategyGuard` 去 strategy 参；guard≥target→OK，guard<target→warn（默认 guard99≥target98 即 OK）。展示侧 `DEFAULT_GUARD_HARD_PCT` 92→99。
+
+**guard 侧（agent-quota-guard 仓库，已实现）**：
+5. `BUDGET_HARD` 默认 92→**99**（bridge target 98 之上 1 点作最后保险丝）；**保留**轮末硬停 `phaseStop continue:false + writePending`。
+6. 新增独立 `BUDGET_CHECKPOINT_LEAD` 默认动态 `clamp(95, warnRepeat, hard-1)`：~95 起强 checkpoint 提醒（不随 hard 抬到 99），保证 agent 有 lead 写 checkpoint 再被停（修「无-checkpoint-lead」缺口）。
+7. provider **rate-limit/429 也写 pending**（pre/post/stop 的 `!usage.ok` 早退前处理，用同一 `writePending` schema，无第二套 identity；含 stale-cache 带 active 429 的边界）（修「429-无-pending → 卡死不自动恢复」缺口）。
+
+**强制停恢复三层防线**：bridge 动态线 pacing 停 ~98（主）→ guard ~95 提醒写 checkpoint → guard 99 轮末硬停保险丝；任一层停下都有 checkpoint+pending，窗口刷新后自动续接（链路 #175 已硬化）。**98/99 是 best-effort 目标上限，非数学极限**（计量延迟/并发/probe lag/轮末停 → 实际 98.x 或偶发更高才停）。
+
+**未并入 v3.2（独立 phase）**：P3 三态 admission 闸门（拒新任务/放收尾 turn/wrapUp 配额/checkpoint baton）—— 碰 live injection/gate 语义、风险面大；v3.2 的 6/7 已兜住强制停恢复。bridge synthetic resume candidate（rateLimited+checkpoint+无pending）= 可选 belt-and-suspenders，记 backlog。
+
 ---
 
 ## 1. 背景与宗旨

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13895,7 +13895,7 @@ function agentWeeklyFiveHourWindowsLeft(usage, now) {
 }
 
 // src/budget/render.ts
-var DEFAULT_GUARD_HARD_PCT = 92;
+var DEFAULT_GUARD_HARD_PCT = 99;
 function resolveGuardHardHint(env = process.env) {
   const raw = env.AGENTBRIDGE_GUARD_HARD_HINT;
   if (raw === undefined || raw.trim() === "")
@@ -14024,7 +14024,7 @@ function formatDynamicLineLine(snapshot) {
   }
   if (parts.length === 0)
     return null;
-  return `\u52A8\u6001\u6682\u505C\u7EBF\uFF08maximize\uFF09\uFF1A${parts.join(" \xB7 ")}`;
+  return `\u52A8\u6001\u6682\u505C\u7EBF\uFF1A${parts.join(" \xB7 ")}`;
 }
 var PHASE_LABELS = {
   normal: "normal\uFF08\u6B63\u5E38\uFF09",
@@ -14596,10 +14596,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("2a906d2", "source"),
+  commit: defineString("9861512", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("b2a5ce6d71b3", "source")
+  codeHash: defineString("0c4f360df15e", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)
@@ -15634,9 +15634,8 @@ var DEFAULT_BUDGET_CONFIG = {
     balanced: { effort: "medium" },
     eco: { effort: "low" }
   },
-  strategy: "conserve",
   maximize: {
-    targetUtil: 97,
+    targetUtil: 98,
     reserveSlopePctPerHour: 0.4,
     reserveMaxPct: 7,
     finishingHorizonMinutes: 30,
@@ -15718,7 +15717,7 @@ function hasCustomDecisionValues(config2) {
   const d = DEFAULT_CONFIG;
   const b = config2.budget;
   const db = d.budget;
-  return config2.idleShutdownSeconds !== d.idleShutdownSeconds || config2.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config2.codex.appPort !== d.codex.appPort || config2.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.strategy !== db.strategy || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct;
+  return config2.idleShutdownSeconds !== d.idleShutdownSeconds || config2.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config2.codex.appPort !== d.codex.appPort || config2.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -15750,9 +15749,6 @@ function normalizeBoundedNumber(value, fallback, min, max) {
   if (parsed < min || parsed > max)
     return fallback;
   return parsed;
-}
-function normalizeStrategy(value, fallback) {
-  return value === "conserve" || value === "maximize" ? value : fallback;
 }
 function normalizeMaximizeConfig(raw, pauseAt, fallback = DEFAULT_BUDGET_CONFIG.maximize) {
   const m = isRecord(raw) ? raw : {};
@@ -15817,7 +15813,6 @@ function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
     },
     codexTierControl: normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) && codexTiers.full !== null,
     codexTiers,
-    strategy: normalizeStrategy(budget.strategy, fallback.strategy),
     maximize: normalizeMaximizeConfig(budget.maximize, pauseAt, fallback.maximize)
   };
 }

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.16", "0.0.0-source"),
-  commit: defineString("2a906d2", "source"),
+  commit: defineString("9861512", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("b2a5ce6d71b3", "source")
+  codeHash: defineString("0c4f360df15e", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -3405,9 +3405,8 @@ var DEFAULT_BUDGET_CONFIG = {
     balanced: { effort: "medium" },
     eco: { effort: "low" }
   },
-  strategy: "conserve",
   maximize: {
-    targetUtil: 97,
+    targetUtil: 98,
     reserveSlopePctPerHour: 0.4,
     reserveMaxPct: 7,
     finishingHorizonMinutes: 30,
@@ -3489,7 +3488,7 @@ function hasCustomDecisionValues(config) {
   const d = DEFAULT_CONFIG;
   const b = config.budget;
   const db = d.budget;
-  return config.idleShutdownSeconds !== d.idleShutdownSeconds || config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config.codex.appPort !== d.codex.appPort || config.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.strategy !== db.strategy || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct;
+  return config.idleShutdownSeconds !== d.idleShutdownSeconds || config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config.codex.appPort !== d.codex.appPort || config.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -3521,9 +3520,6 @@ function normalizeBoundedNumber(value, fallback, min, max) {
   if (parsed < min || parsed > max)
     return fallback;
   return parsed;
-}
-function normalizeStrategy(value, fallback) {
-  return value === "conserve" || value === "maximize" ? value : fallback;
 }
 function normalizeMaximizeConfig(raw, pauseAt, fallback = DEFAULT_BUDGET_CONFIG.maximize) {
   const m = isRecord(raw) ? raw : {};
@@ -3588,7 +3584,6 @@ function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
     },
     codexTierControl: normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) && codexTiers.full !== null,
     codexTiers,
-    strategy: normalizeStrategy(budget.strategy, fallback.strategy),
     maximize: normalizeMaximizeConfig(budget.maximize, pauseAt, fallback.maximize)
   };
 }
@@ -3605,7 +3600,6 @@ function applyBudgetEnvOverrides(budget, env = process.env) {
     },
     codexTierControl: env.AGENTBRIDGE_BUDGET_CODEX_TIER_CONTROL ?? budget.codexTierControl,
     codexTiers: budget.codexTiers,
-    strategy: env.AGENTBRIDGE_BUDGET_STRATEGY ?? budget.strategy,
     maximize: {
       targetUtil: env.AGENTBRIDGE_BUDGET_TARGET_UTIL ?? budget.maximize.targetUtil,
       reserveSlopePctPerHour: env.AGENTBRIDGE_BUDGET_RESERVE_SLOPE_PCT_PER_HOUR ?? budget.maximize.reserveSlopePctPerHour,
@@ -3736,15 +3730,6 @@ function matchingGateReset(usage) {
     return 0;
   return Math.min(...candidates.map((window) => window.resetEpoch));
 }
-function resumeBlockingEpoch(usage, cfg, now) {
-  if (!usage)
-    return 0;
-  if (usage.rateLimitedUntil > now)
-    return usage.rateLimitedUntil;
-  if (usage.gateUtil >= cfg.resumeBelow)
-    return matchingGateReset(usage);
-  return 0;
-}
 function retryAfterMsForResume(resumeAfterEpoch, nowMs) {
   if (resumeAfterEpoch === null)
     return;
@@ -3848,24 +3833,18 @@ function freshWindows(usage, now) {
   return out;
 }
 var NO_PAUSE = { pause: false, window: null, line: null, reason: "" };
-function conserveReason(agent, usage, cfg) {
-  return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} \u2265 pauseAt ${pct(cfg.pauseAt)}`;
+function fallbackPauseReason(agent, usage, cfg) {
+  return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} \u2265 pauseAt ${pct(cfg.pauseAt)}\uFF08\u515C\u5E95\u5224\u636E\uFF09`;
 }
 function agentShouldPause(agent, usage, cfg, now) {
   if (!usage)
     return NO_PAUSE;
   if (!isDecisionGrade(usage, now))
     return NO_PAUSE;
-  if (cfg.strategy !== "maximize") {
-    if (usage.gateUtil >= cfg.pauseAt) {
-      return { pause: true, window: null, line: null, reason: conserveReason(agent, usage, cfg) };
-    }
-    return NO_PAUSE;
-  }
   const windows = freshWindows(usage, now);
   if (windows.length === 0) {
     if (usage.gateUtil >= cfg.pauseAt) {
-      return { pause: true, window: null, line: null, reason: conserveReason(agent, usage, cfg) };
+      return { pause: true, window: null, line: null, reason: fallbackPauseReason(agent, usage, cfg) };
     }
     return NO_PAUSE;
   }
@@ -3892,16 +3871,13 @@ function buildMaximizeReason(agent, key, window, verdict, cfg) {
   if (verdict.admission) {
     return `${head} \u89E6\u53D1\u6536\u5C3E\u4FDD\u62A4\u786C\u7EBF\uFF08\u2265 pauseAt ${pct(cfg.pauseAt)}\uFF09`;
   }
-  return `${head} \u2265 pauseAt ${pct(cfg.pauseAt)}\uFF08\u71C3\u5C3D\u7387\u91C7\u6837\u4E2D\uFF0C\u9000\u4FDD\u5B88\u5224\u636E\uFF09`;
+  return `${head} \u2265 pauseAt ${pct(cfg.pauseAt)}\uFF08\u71C3\u5C3D\u7387\u91C7\u6837\u4E2D\uFF0C\u9000\u515C\u5E95\u5224\u636E\uFF09`;
 }
 function agentCanResume(usage, cfg, now) {
   if (!isDecisionGrade(usage, now))
     return false;
   if (usage.rateLimitedUntil > now)
     return false;
-  if (cfg.strategy !== "maximize") {
-    return usage.gateUtil < cfg.resumeBelow;
-  }
   const windows = freshWindows(usage, now);
   for (const { window } of windows) {
     if (maximizeWindowBlocksResume(window, cfg, now))
@@ -3910,8 +3886,6 @@ function agentCanResume(usage, cfg, now) {
   return true;
 }
 function effectiveDynamicLine(usage, cfg, now) {
-  if (cfg.strategy !== "maximize")
-    return null;
   if (!usage || !isDecisionGrade(usage, now))
     return null;
   let bestLine = null;
@@ -3934,8 +3908,6 @@ function effectiveDynamicLine(usage, cfg, now) {
 function resumeBlockingEpochFor(usage, cfg, now) {
   if (!usage)
     return 0;
-  if (cfg.strategy !== "maximize")
-    return resumeBlockingEpoch(usage, cfg, now);
   if (usage.rateLimitedUntil > now)
     return usage.rateLimitedUntil;
   if (!isDecisionGrade(usage, now)) {
@@ -4018,8 +3990,8 @@ function parallelState(claude, codex, cfg, now) {
 }
 function renderBudgetInterventionDirective(claude, codex, side, reason, resumeEpoch, cfg) {
   const resumeText = `\u9884\u8BA1\u6062\u590D\u65F6\u95F4\uFF08\u4EE5\u5B9E\u6D4B\u4E3A\u51C6\uFF1B\u63D0\u524D\u5237\u65B0\u4F1A\u66F4\u65E9\u89E3\u9664\uFF09\uFF1A${formatEpoch(resumeEpoch)}\u3002`;
-  const resumeCondSingle = cfg.strategy === "maximize" ? `\u5404\u7A97\u53E3 util \u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${pct2(cfg.maximize.resumeHysteresisPct)} \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0` : `gateUtil \u4F4E\u4E8E ${pct2(cfg.resumeBelow)}`;
-  const resumeCondBoth = cfg.strategy === "maximize" ? `\u5404\u7A97\u53E3 util \u90FD\u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${pct2(cfg.maximize.resumeHysteresisPct)} \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0` : `gateUtil \u90FD\u4F4E\u4E8E ${pct2(cfg.resumeBelow)}`;
+  const resumeCondSingle = `\u5404\u7A97\u53E3 util \u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${pct2(cfg.maximize.resumeHysteresisPct)} \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0`;
+  const resumeCondBoth = `\u5404\u7A97\u53E3 util \u90FD\u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${pct2(cfg.maximize.resumeHysteresisPct)} \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0`;
   if (side === "claude") {
     return [
       "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Claude \u4FA7\u989D\u5EA6\u7D27\u5F20\uFF0C\u8FDB\u5165\u63A5\u529B\u6A21\u5F0F\u3002",
@@ -4665,22 +4637,20 @@ class BudgetCoordinator {
     return renderBudgetInterventionDirective(state.perAgent.claude, state.perAgent.codex, side, reason || "\u9884\u7B97\u63A5\u8FD1\u8017\u5C3D", resumeEpoch, this.config);
   }
   recoveryDirective(state, side) {
-    const maximizeRecoveredText = `\u5404\u7A97\u53E3 util \u5DF2\u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${pct4(this.config.maximize.resumeHysteresisPct)} \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5DF2\u5237\u65B0`;
+    const recoveredText = `\u5404\u7A97\u53E3 util \u5DF2\u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${pct4(this.config.maximize.resumeHysteresisPct)} \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5DF2\u5237\u65B0`;
     if (side === "claude") {
-      const condClaude = this.config.strategy === "maximize" ? maximizeRecoveredText : `gateUtil \u5DF2\u4F4E\u4E8E ${pct4(this.config.resumeBelow)}`;
       return [
         "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Claude \u4FA7\u9884\u7B97\u5DF2\u6062\u590D\u3002",
         `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
-        `Claude ${condClaude}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
+        `Claude ${recoveredText}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
         "Claude \u53EF\u6062\u590D orchestrator \u89D2\u8272\uFF1B\u540E\u7EED\u5206\u914D\u524D\u8BF7\u91CD\u65B0\u67E5\u8BE2\u5B9E\u65F6\u989D\u5EA6\uFF0C\u4E0D\u8981\u4F9D\u8D56\u65E7\u6570\u5B57\u3002"
       ].join(`
 `);
     }
-    const condCodex = this.config.strategy === "maximize" ? maximizeRecoveredText : `gateUtil \u4F4E\u4E8E ${pct4(this.config.resumeBelow)}`;
     return [
       "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Codex \u4FA7\u9884\u7B97\u95F8\u95E8\u89E3\u9664\u3002",
       `${usageLine("claude", state.perAgent.claude)}\uFF1B${usageLine("codex", state.perAgent.codex)}\u3002`,
-      `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1ACodex ${condCodex}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
+      `\u95F8\u95E8\u5DF2\u653E\u5F00\uFF1ACodex ${recoveredText}\uFF0C\u4E14\u6CA1\u6709\u6709\u6548 rate_limit\u3002`,
       "\u5EFA\u8BAE Claude \u7528 reply \u5E26\u4E0A\u5F53\u524D\u76EE\u6807\u3001checkpoint \u548C\u4E0B\u4E00\u6B65\uFF0C\u5524\u9192 Codex \u63A5\u7EED\u6267\u884C\u3002"
     ].join(`
 `);
@@ -4706,8 +4676,6 @@ class BudgetCoordinator {
     };
   }
   dynamicLineSnapshotFields(state) {
-    if (this.config.strategy !== "maximize")
-      return {};
     return {
       dynamicPauseLine: {
         claude: effectiveDynamicLine(state.perAgent.claude, this.config, state.now),
@@ -6306,7 +6274,7 @@ function ensureBudgetCoordinatorStarted() {
   if (!BUDGET_CONFIG.enabled)
     return;
   if (!budgetCoordinator) {
-    log(`Budget coordinator config: pollSeconds=${BUDGET_CONFIG.pollSeconds} pauseAt=${BUDGET_CONFIG.pauseAt} ` + `resumeBelow=${BUDGET_CONFIG.resumeBelow} syncDriftPct=${BUDGET_CONFIG.syncDriftPct} ` + `parallel=${BUDGET_CONFIG.parallel.minRemainingPct}%/${BUDGET_CONFIG.parallel.timeWindowSec}s ` + `codexTierControl=${BUDGET_CONFIG.codexTierControl} ` + `codexTiersFull=${BUDGET_CONFIG.codexTiers.full ? "configured" : "missing"} ` + `strategy=${BUDGET_CONFIG.strategy}`);
+    log(`Budget coordinator config: pollSeconds=${BUDGET_CONFIG.pollSeconds} pauseAt=${BUDGET_CONFIG.pauseAt} ` + `resumeBelow=${BUDGET_CONFIG.resumeBelow} syncDriftPct=${BUDGET_CONFIG.syncDriftPct} ` + `parallel=${BUDGET_CONFIG.parallel.minRemainingPct}%/${BUDGET_CONFIG.parallel.timeWindowSec}s ` + `codexTierControl=${BUDGET_CONFIG.codexTierControl} ` + `codexTiersFull=${BUDGET_CONFIG.codexTiers.full ? "configured" : "missing"} ` + `targetUtil=${BUDGET_CONFIG.maximize.targetUtil} fallback=${BUDGET_CONFIG.pauseAt}/${BUDGET_CONFIG.resumeBelow}`);
     budgetCoordinator = new BudgetCoordinator({
       source: createQuotaSource({ log }),
       config: BUDGET_CONFIG,
@@ -6340,7 +6308,7 @@ function budgetPauseGateError() {
   const reason = snapshot?.pauseReason ?? "Codex \u4FA7\u989D\u5EA6\u63A5\u8FD1\u8017\u5C3D";
   const resumeAt = snapshot?.resumeAfterEpoch ? new Date(snapshot.resumeAfterEpoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z") : null;
   const sideHint = snapshot?.pauseSide === "both" ? "\u53CC\u4FA7\u989D\u5EA6\u5747\u5DF2\u8017\u5C3D\uFF0C\u8BF7\u5199 checkpoint \u7B49\u5F85\u5237\u65B0" : "\u4F60\u53EF\u7EE7\u7EED solo \u63A8\u8FDB\u53EF\u72EC\u7ACB\u90E8\u5206\uFF0C\u5E76\u5199 checkpoint \u6807\u6CE8\u5206\u5DE5\u65AD\u70B9";
-  const reopenText = BUDGET_CONFIG.strategy === "maximize" ? `Codex \u4FA7\u5404\u7A97\u53E3 util \u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${BUDGET_CONFIG.maximize.resumeHysteresisPct}% \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0\u540E\u95F8\u95E8\u81EA\u52A8\u653E\u5F00` : `Codex \u4FA7 gateUtil \u4F4E\u4E8E ${BUDGET_CONFIG.resumeBelow}% \u540E\u95F8\u95E8\u81EA\u52A8\u653E\u5F00`;
+  const reopenText = `Codex \u4FA7\u5404\u7A97\u53E3 util \u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${BUDGET_CONFIG.maximize.resumeHysteresisPct}% \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0\u540E\u95F8\u95E8\u81EA\u52A8\u653E\u5F00`;
   return `\u9884\u7B97\u6682\u505C\uFF08\u95F8\u95E8\u5173\u95ED\uFF09\uFF0C\u5DF2\u62D2\u7EDD\u8F6C\u53D1\uFF1A${reason}\u3002` + reopenText + (resumeAt ? `\uFF08\u9884\u8BA1\u6062\u590D ${resumeAt}\uFF0C\u4EE5\u5B9E\u6D4B\u4E3A\u51C6\uFF1B\u63D0\u524D\u5237\u65B0\u4F1A\u66F4\u65E9\u89E3\u9664\uFF09` : "") + `\u3002\u6536\u5230 RESUME \u901A\u77E5\u524D\u8BF7\u52FF\u91CD\u8BD5\u5411 Codex \u53D1\u9001 reply\uFF1B${sideHint}\u3002`;
 }
 var tuiConnectionState = new TuiConnectionState({

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -462,31 +462,22 @@ export class BudgetCoordinator {
   }
 
   private recoveryDirective(state: BudgetState, side: AgentName): string {
-    // Q10: the recovery-condition text must match the active strategy. maximize
-    // exits per-window (dynamic line − hysteresis, or window reset), not at
-    // resumeBelow — see renderBudgetInterventionDirective for the same fix.
-    const maximizeRecoveredText = `各窗口 util 已回落至动态暂停线 − ${pct(this.config.maximize.resumeHysteresisPct)} 以下或对应窗口已刷新`;
+    // v3.2: recovery is per-window (dynamic line − hysteresis, or window reset),
+    // not at resumeBelow — the dynamic line is the sole strategy.
+    const recoveredText = `各窗口 util 已回落至动态暂停线 − ${pct(this.config.maximize.resumeHysteresisPct)} 以下或对应窗口已刷新`;
     if (side === "claude") {
-      const condClaude =
-        this.config.strategy === "maximize"
-          ? maximizeRecoveredText
-          : `gateUtil 已低于 ${pct(this.config.resumeBelow)}`;
       return [
         "【预算协调 · 账号级】Claude 侧预算已恢复。",
         `${usageLine("claude", state.perAgent.claude)}；${usageLine("codex", state.perAgent.codex)}。`,
-        `Claude ${condClaude}，且没有有效 rate_limit。`,
+        `Claude ${recoveredText}，且没有有效 rate_limit。`,
         "Claude 可恢复 orchestrator 角色；后续分配前请重新查询实时额度，不要依赖旧数字。",
       ].join("\n");
     }
 
-    const condCodex =
-      this.config.strategy === "maximize"
-        ? maximizeRecoveredText
-        : `gateUtil 低于 ${pct(this.config.resumeBelow)}`;
     return [
       "【预算协调 · 账号级】Codex 侧预算闸门解除。",
       `${usageLine("claude", state.perAgent.claude)}；${usageLine("codex", state.perAgent.codex)}。`,
-      `闸门已放开：Codex ${condCodex}，且没有有效 rate_limit。`,
+      `闸门已放开：Codex ${recoveredText}，且没有有效 rate_limit。`,
       "建议 Claude 用 reply 带上当前目标、checkpoint 和下一步，唤醒 Codex 接续执行。",
     ].join("\n");
   }
@@ -513,12 +504,12 @@ export class BudgetCoordinator {
   }
 
   /**
-   * v3 P2 (display-only): the binding maximize dynamic pause line per agent.
-   * Omitted entirely in conserve mode so the legacy snapshot shape is unchanged;
-   * mirrors the decision layer (effectiveDynamicLine) without ever feeding it.
+   * v3.2 (display-only): the binding dynamic pause line per agent. The dynamic
+   * line is always-on now, so this is always present; each side is null when no
+   * confident window yields a numeric line. Mirrors the decision layer
+   * (effectiveDynamicLine) without ever feeding it.
    */
-  private dynamicLineSnapshotFields(state: BudgetState): Pick<BudgetSnapshot, "dynamicPauseLine"> | Record<never, never> {
-    if (this.config.strategy !== "maximize") return {};
+  private dynamicLineSnapshotFields(state: BudgetState): Pick<BudgetSnapshot, "dynamicPauseLine"> {
     return {
       dynamicPauseLine: {
         claude: effectiveDynamicLine(state.perAgent.claude, this.config, state.now),

--- a/src/budget/budget-decision.ts
+++ b/src/budget/budget-decision.ts
@@ -1,23 +1,25 @@
 /**
- * Single source of truth for strategy-aware pause/resume decisions (v3 P2).
+ * Single source of truth for pause/resume decisions (v3.2).
  *
  * Both the directive-content path (budget-state.ts `pauseTrigger`) and the
- * coordinator's gating state machine (budget-fingerprint.ts `shouldEnter` /
- * `canAgentResume`) must agree on whether an agent is paused, or the rendered
- * state and the fingerprint state drift apart. This module centralizes that
- * decision so the two callers can never fork.
+ * coordinator's gating state machine (budget-fingerprint.ts) must agree on
+ * whether an agent is paused, or the rendered state and the fingerprint state
+ * drift apart. This module centralizes that decision so the two callers can
+ * never fork.
  *
- * conserve mode is a byte-for-byte port of the previous gateUtil ≥ pauseAt /
- * gateUtil < resumeBelow logic. maximize mode (opt-in `strategy:"maximize"`)
- * replaces the single gateUtil scalar with a per-window time-aware pause line
- * (design budget-strategy-v3.md §3.1). Every maximize degradation path falls
- * back to conserve behavior (invariant I1: maximize never pauses earlier than
- * conserve; invariant I2: missing/stale data never opens a gate).
+ * v3.2: the per-window time-aware dynamic pause line (design §3.1) is the SOLE
+ * strategy — the old `conserve|maximize` selector is gone. When per-window
+ * burn-rate data is unavailable (non-confident / stale / reset-unknown), each
+ * window degrades to a fixed gateUtil FALLBACK line (`util ≥ pauseAt` to enter,
+ * `util < resumeBelow` to resume) — the same safe gating the former conserve
+ * mode used, now an internal fallback rather than a user-selectable mode.
+ * Invariant I1: the dynamic line never pauses earlier than the pauseAt floor;
+ * invariant I2: missing/stale data never opens a gate.
  *
  * Keep this file dependency-light (only ./types + ./budget-gate); it is bundled
  * into the plugin daemon.
  */
-import { matchingGateReset, resumeBlockingEpoch as conserveResumeBlockingEpoch } from "./budget-gate";
+import { matchingGateReset } from "./budget-gate";
 import { STALE_MAX_AGE_SEC } from "./types";
 import type {
   AgentName,
@@ -155,13 +157,13 @@ function confidentRate(window: BudgetWindow): number | null {
 }
 
 /**
- * Evaluate one fresh window for the maximize ENTRY side. Degraded windows
- * (no confident rate) fall back to conserve's per-window `util ≥ pauseAt`.
+ * Evaluate one fresh window for the ENTRY side. Degraded windows (no confident
+ * rate) fall back to the fixed per-window gateUtil line `util ≥ pauseAt`.
  */
 function maximizeWindowEntry(window: BudgetWindow, cfg: BudgetConfig, now: number): WindowEntryVerdict {
   const rate = confidentRate(window);
   if (rate === null) {
-    // Degraded: conserve criterion on THIS window (per design §3.1 degrade path).
+    // Degraded: fixed fallback line on THIS window (per design §3.1 degrade path).
     return { blocks: window.util >= cfg.pauseAt, line: null, admission: false };
   }
   const line = dynamicPauseAt(window, rate, cfg, now);
@@ -175,10 +177,10 @@ function maximizeWindowEntry(window: BudgetWindow, cfg: BudgetConfig, now: numbe
 }
 
 /**
- * Evaluate one fresh window for the maximize RESUME side (symmetric to entry):
- * the window still BLOCKS resume until its util recedes below the relaxed
- * threshold. Degraded windows use conserve's `util ≥ resumeBelow` (asymmetric
- * 90-in/30-out, no hysteresis — matches design "degrade to conserve").
+ * Evaluate one fresh window for the RESUME side (symmetric to entry): the window
+ * still BLOCKS resume until its util recedes below the relaxed threshold.
+ * Degraded windows use the fixed fallback `util ≥ resumeBelow` (asymmetric
+ * 90-in/30-out, no hysteresis — matches the design "degrade to fallback" path).
  */
 function maximizeWindowBlocksResume(window: BudgetWindow, cfg: BudgetConfig, now: number): boolean {
   const rate = confidentRate(window);
@@ -224,14 +226,15 @@ export interface AgentPauseDecision {
 
 const NO_PAUSE: AgentPauseDecision = { pause: false, window: null, line: null, reason: "" };
 
-function conserveReason(agent: AgentName, usage: AgentUsage, cfg: BudgetConfig): string {
-  return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} ≥ pauseAt ${pct(cfg.pauseAt)}`;
+function fallbackPauseReason(agent: AgentName, usage: AgentUsage, cfg: BudgetConfig): string {
+  return `${AGENT_LABEL[agent]} gateUtil ${pct(usage.gateUtil)} ≥ pauseAt ${pct(cfg.pauseAt)}（兜底判据）`;
 }
 
 /**
- * Decide whether an agent should enter a budget pause. conserve mode is a
- * verbatim port of the old `pauseTrigger`/`shouldEnter`; maximize mode evaluates
- * each fresh window via the dynamic line and trips on the FIRST blocking window.
+ * Decide whether an agent should enter a budget pause. v3.2: always the
+ * per-window time-aware evaluation — trips on the FIRST blocking window. A
+ * window with no confident burn rate degrades to the gateUtil fallback inside
+ * `maximizeWindowEntry`.
  */
 export function agentShouldPause(
   agent: AgentName,
@@ -242,20 +245,12 @@ export function agentShouldPause(
   if (!usage) return NO_PAUSE;
   if (!isDecisionGrade(usage, now)) return NO_PAUSE;
 
-  if (cfg.strategy !== "maximize") {
-    if (usage.gateUtil >= cfg.pauseAt) {
-      return { pause: true, window: null, line: null, reason: conserveReason(agent, usage, cfg) };
-    }
-    return NO_PAUSE;
-  }
-
-  // maximize: per-window evaluation.
   const windows = freshWindows(usage, now);
   if (windows.length === 0) {
     // Defensive: isDecisionGrade guarantees ≥1 fresh window, so this is
-    // unreachable. Degrade to conserve on gateUtil if it ever is reached.
+    // unreachable. Fall back to the gateUtil line if it ever is reached.
     if (usage.gateUtil >= cfg.pauseAt) {
-      return { pause: true, window: null, line: null, reason: conserveReason(agent, usage, cfg) };
+      return { pause: true, window: null, line: null, reason: fallbackPauseReason(agent, usage, cfg) };
     }
     return NO_PAUSE;
   }
@@ -291,24 +286,21 @@ function buildMaximizeReason(
   if (verdict.admission) {
     return `${head} 触发收尾保护硬线（≥ pauseAt ${pct(cfg.pauseAt)}）`;
   }
-  return `${head} ≥ pauseAt ${pct(cfg.pauseAt)}（燃尽率采样中，退保守判据）`;
+  return `${head} ≥ pauseAt ${pct(cfg.pauseAt)}（燃尽率采样中，退兜底判据）`;
 }
 
 /**
- * Decide whether an agent may resume. conserve mode is a verbatim port of the
- * old `canAgentResume`; maximize mode requires that NO fresh window still blocks
- * resume (symmetric to entry, with hysteresis).
+ * Decide whether an agent may resume. v3.2: always per-window — resume only when
+ * NO fresh window still blocks (symmetric to entry, with hysteresis). A window
+ * with no confident burn rate degrades to the gateUtil fallback inside
+ * `maximizeWindowBlocksResume` (`util < resumeBelow`).
  */
 export function agentCanResume(usage: AgentUsage | null, cfg: BudgetConfig, now: number): boolean {
   if (!isDecisionGrade(usage, now)) return false;
   if (usage!.rateLimitedUntil > now) return false;
 
-  if (cfg.strategy !== "maximize") {
-    return usage!.gateUtil < cfg.resumeBelow;
-  }
-
-  // maximize: resume only when every fresh window has receded. A window that has
-  // already reset (resetEpoch <= now) is excluded by freshWindows — that is the
+  // Resume only when every fresh window has receded. A window that has already
+  // reset (resetEpoch <= now) is excluded by freshWindows — that is the
   // "window reset → resume" path (fresh data shows util cliff-dropped, and the
   // expired window no longer blocks).
   const windows = freshWindows(usage!, now);
@@ -319,15 +311,14 @@ export function agentCanResume(usage: AgentUsage | null, cfg: BudgetConfig, now:
 }
 
 /**
- * Display-only (snapshot/render): the binding maximize dynamic line for an
- * agent — the numeric line of the fresh, confident window with the SMALLEST
- * headroom (util − line), i.e. the window closest to (or past) tripping. Returns
- * null in conserve mode, on non-decision-grade data, or when no confident window
- * yields a numeric line (degraded / admission-closed / will-not-fill). NEVER a
- * decision input — `agentShouldPause` owns the gating; this only mirrors it.
+ * Display-only (snapshot/render): the binding dynamic line for an agent — the
+ * numeric line of the fresh, confident window with the SMALLEST headroom
+ * (util − line), i.e. the window closest to (or past) tripping. Returns null on
+ * non-decision-grade data, or when no confident window yields a numeric line
+ * (degraded / admission-closed / will-not-fill). NEVER a decision input —
+ * `agentShouldPause` owns the gating; this only mirrors it.
  */
 export function effectiveDynamicLine(usage: AgentUsage | null, cfg: BudgetConfig, now: number): number | null {
-  if (cfg.strategy !== "maximize") return null;
   if (!usage || !isDecisionGrade(usage, now)) return null;
   let bestLine: number | null = null;
   let bestHeadroom = Number.POSITIVE_INFINITY;
@@ -346,14 +337,13 @@ export function effectiveDynamicLine(usage: AgentUsage | null, cfg: BudgetConfig
 }
 
 /**
- * Strategy-aware "earliest plausible resume" epoch (Q10 alignment). conserve
- * delegates to the existing budget-gate helper. maximize returns the soonest
- * reset among windows that still block resume (the natural recovery point at a
- * 93–96 pause line), the active rate-limit, or 0 when nothing blocks.
+ * "Earliest plausible resume" epoch (Q10 alignment). Returns the active
+ * rate-limit if any, else the soonest reset among windows that still block
+ * resume (the natural recovery point at a ~94–98 pause line), else 0 when
+ * nothing blocks.
  */
 export function resumeBlockingEpochFor(usage: AgentUsage | null, cfg: BudgetConfig, now: number): number {
   if (!usage) return 0;
-  if (cfg.strategy !== "maximize") return conserveResumeBlockingEpoch(usage, cfg, now);
   if (usage.rateLimitedUntil > now) return usage.rateLimitedUntil;
   // Non-decision-grade (stale / all-reset): we cannot evaluate per-window resume,
   // and `agentCanResume` returns false here (phantom-hold keeps the side paused).

--- a/src/budget/budget-fingerprint.ts
+++ b/src/budget/budget-fingerprint.ts
@@ -197,10 +197,9 @@ function agentsToSide(agents: ReadonlySet<AgentName>): PauseSide {
 /**
  * Hysteresis transition over the activeSides set: agentShouldPause adds, an
  * already active side that agentCanResume is removed. Both predicates are the
- * strategy-aware single source of truth in budget-decision.ts (conserve =
- * verbatim port of the former local gateUtil checks; maximize = per-window
- * dynamic line), so the coordinator's gating can never diverge from the
- * rendered state in budget-state.ts.
+ * single source of truth in budget-decision.ts (v3.2: the per-window dynamic
+ * line, with a gateUtil fallback when burn data is absent), so the coordinator's
+ * gating can never diverge from the rendered state in budget-state.ts.
  */
 function nextActiveSide(prevSide: PauseSide, state: BudgetState, cfg: BudgetConfig): PauseSide {
   const active = new Set<AgentName>(sideToAgents(prevSide));
@@ -225,8 +224,8 @@ function activeSideReason(agent: AgentName, usage: AgentUsage | null, cfg: Budge
   if (usage.rateLimitedUntil > now) {
     return `${AGENT_LABEL[agent]} 探针被限流至 ${formatEpoch(usage.rateLimitedUntil)}`;
   }
-  // Delegate the "why paused" text to the strategy-aware decision (conserve =
-  // the old gateUtil≥pauseAt string; maximize = the dynamic-line string).
+  // Delegate the "why paused" text to the decision layer (dynamic-line string,
+  // or the gateUtil fallback string when burn data is absent).
   const decision = agentShouldPause(agent, usage, cfg, now);
   if (decision.pause) return decision.reason;
   // Still in the active set but no longer tripping entry → in the hysteresis

--- a/src/budget/budget-gate.ts
+++ b/src/budget/budget-gate.ts
@@ -1,16 +1,15 @@
 /**
  * Shared resume-gate helpers for the budget coordination layer.
  *
- * `matchingGateReset` and `resumeBlockingEpoch` were previously duplicated
- * verbatim in budget-coordinator.ts and budget-state.ts. types.ts already
- * warns that a fork between the entry-side guard and the coordinator's resume
- * gate is an accident waiting to happen (see STALE_MAX_AGE_SEC); these two
- * helpers are the same shape, so they live here as the single source of truth.
+ * `matchingGateReset` is the single source of truth for "the reset epoch that
+ * explains the current gateUtil". (v3.2 removed the conserve-era
+ * `resumeBlockingEpoch` from here — the strategy-aware `resumeBlockingEpochFor`
+ * in budget-decision.ts is the sole resume-epoch helper now.)
  *
  * Keep this file dependency-free beyond ./types; it is bundled into the plugin
  * daemon.
  */
-import type { AgentUsage, BudgetConfig } from "./types";
+import type { AgentUsage } from "./types";
 
 /**
  * Earliest reset epoch among the windows that explain the current gateUtil.
@@ -28,18 +27,6 @@ export function matchingGateReset(usage: AgentUsage | null): number {
   const candidates = matching.length > 0 ? matching : windows;
   if (candidates.length === 0) return 0;
   return Math.min(...candidates.map((window) => window.resetEpoch));
-}
-
-/**
- * Epoch at which this side stops blocking resume: the active rate-limit if one
- * is in effect, else the gate-window reset while gateUtil is still at/above
- * resumeBelow, else 0 (this side no longer blocks resume).
- */
-export function resumeBlockingEpoch(usage: AgentUsage | null, cfg: BudgetConfig, now: number): number {
-  if (!usage) return 0;
-  if (usage.rateLimitedUntil > now) return usage.rateLimitedUntil;
-  if (usage.gateUtil >= cfg.resumeBelow) return matchingGateReset(usage);
-  return 0;
 }
 
 /**

--- a/src/budget/budget-state.ts
+++ b/src/budget/budget-state.ts
@@ -52,8 +52,8 @@ function resumeAfterEpoch(
 }
 
 /**
- * Strategy-aware pause-entry trigger for one agent. Delegates the whole decision
- * (conserve gateUtil threshold OR maximize per-window dynamic line) to the
+ * Pause-entry trigger for one agent. Delegates the whole decision (per-window
+ * dynamic line, with the gateUtil fallback when burn data is absent) to the
  * single source of truth in budget-decision.ts, so the rendered state here can
  * never diverge from the coordinator's gating in budget-fingerprint.ts.
  */
@@ -113,19 +113,10 @@ export function renderBudgetInterventionDirective(
   cfg: BudgetConfig,
 ): string {
   const resumeText = `预计恢复时间（以实测为准；提前刷新会更早解除）：${formatEpoch(resumeEpoch)}。`;
-  // Q10: the resume CONDITION text must match the active strategy. conserve =
-  // the historical gateUtil<resumeBelow wording (byte-identical); maximize exits
-  // per-window at `util < dynamicPauseAt − resumeHysteresisPct` (or window
-  // reset), NOT at resumeBelow — saying "低于 30%" there misleads Claude into
-  // expecting a days-long wait instead of the dynamic-line / reset recovery.
-  const resumeCondSingle =
-    cfg.strategy === "maximize"
-      ? `各窗口 util 回落至动态暂停线 − ${pct(cfg.maximize.resumeHysteresisPct)} 以下或对应窗口刷新`
-      : `gateUtil 低于 ${pct(cfg.resumeBelow)}`;
-  const resumeCondBoth =
-    cfg.strategy === "maximize"
-      ? `各窗口 util 都回落至动态暂停线 − ${pct(cfg.maximize.resumeHysteresisPct)} 以下或对应窗口刷新`
-      : `gateUtil 都低于 ${pct(cfg.resumeBelow)}`;
+  // v3.2: resume happens per-window at `util < dynamicPauseAt − resumeHysteresisPct`
+  // (or window reset), NOT at resumeBelow — the dynamic line is the sole strategy.
+  const resumeCondSingle = `各窗口 util 回落至动态暂停线 − ${pct(cfg.maximize.resumeHysteresisPct)} 以下或对应窗口刷新`;
+  const resumeCondBoth = `各窗口 util 都回落至动态暂停线 − ${pct(cfg.maximize.resumeHysteresisPct)} 以下或对应窗口刷新`;
   if (side === "claude") {
     return [
       "【预算协调 · 账号级】Claude 侧额度紧张，进入接力模式。",

--- a/src/budget/render.ts
+++ b/src/budget/render.ts
@@ -18,15 +18,16 @@ import type {
 
 /**
  * Default outer quota-guard hard line (the user's agent-quota-guard
- * BUDGET_HARD default). Display-only context for the v3 Q7 annotation —
- * never feeds any pause/resume decision.
+ * BUDGET_HARD default). v3.2: the guard default moved 92→99 (last fuse above the
+ * bridge's targetUtil 98). Display-only context for the guard annotation — never
+ * feeds any pause/resume decision; AGENTBRIDGE_GUARD_HARD_HINT overrides it.
  */
-export const DEFAULT_GUARD_HARD_PCT = 92;
+export const DEFAULT_GUARD_HARD_PCT = 99;
 
 /**
  * Resolve the guard hard-line DISPLAY hint: AGENTBRIDGE_GUARD_HARD_HINT
- * overrides the default 92; invalid or out-of-range values fall back. Only
- * affects rendering (Q7 enhanced-B), never the strategy layer.
+ * overrides the default; invalid or out-of-range values fall back. Only affects
+ * rendering, never the decision layer.
  */
 export function resolveGuardHardHint(
   env: Record<string, string | undefined> = process.env,
@@ -145,7 +146,7 @@ function formatRunwaySegment(
  *
  * Claude guard annotation (Q7, honesty-first choice): the guard's
  * runway_seconds is the NEUTRAL "to 100%" estimate, but quota-guard
- * hard-stops the Claude process at its own hard line (default 92%) first.
+ * hard-stops the Claude process at its own hard line (default 99%) first.
  * Rather than scaling the number ourselves (a proportional fold assumes
  * linear burn AND breaks when the runway is reset-truncated — effectively a
  * recomputation, which constraint #2 forbids), we display the guard's number
@@ -193,10 +194,10 @@ function formatFiveHourWindowsLeftLine(snapshot: BudgetSnapshot): string | null 
 }
 
 /**
- * v3 P2 (maximize, display-only): the binding dynamic pause line per agent and
- * its headroom to the agent's gateUtil. Present only when the snapshot carries
- * `dynamicPauseLine` (maximize mode) and at least one side has a numeric line.
- * Never a decision input — mirrors the decision layer's effectiveDynamicLine.
+ * v3.2 (display-only): the binding dynamic pause line per agent and its headroom
+ * to the agent's gateUtil. Present when the snapshot carries `dynamicPauseLine`
+ * (always-on since v3.2) and at least one side has a numeric line. Never a
+ * decision input — mirrors the decision layer's effectiveDynamicLine.
  */
 function formatDynamicLineLine(snapshot: BudgetSnapshot): string | null {
   const lines = snapshot.dynamicPauseLine;
@@ -212,7 +213,7 @@ function formatDynamicLineLine(snapshot: BudgetSnapshot): string | null {
     parts.push(`${name} ${line.toFixed(1)}%${headroom}`);
   }
   if (parts.length === 0) return null;
-  return `动态暂停线（maximize）：${parts.join(" · ")}`;
+  return `动态暂停线：${parts.join(" · ")}`;
 }
 
 const PHASE_LABELS: Record<BudgetSnapshot["phase"], string> = {

--- a/src/budget/types.ts
+++ b/src/budget/types.ts
@@ -91,13 +91,6 @@ export type BudgetPhase = "normal" | "balance" | "parallel" | "paused";
 
 export type CodexTier = "full" | "balanced" | "eco";
 
-/**
- * Budget strategy selector (v3). conserve = v2-equivalent gateUtil thresholds.
- * maximize (P2) = per-window time-aware dynamic pause line (§3.1), consumed by
- * budget-decision.ts; every degradation path falls back to conserve.
- */
-export type BudgetStrategy = "conserve" | "maximize";
-
 /** Identifies one of the two quota windows tracked per agent. */
 export type BudgetWindowKey = "fiveHour" | "weekly";
 
@@ -137,18 +130,19 @@ export interface RunwayEstimate {
 }
 
 /**
- * Maximize-strategy parameters (v3 §3.1/§4.1). Only consumed when
- * `strategy:"maximize"`. All have defaults and bounded validation in
- * config-service.ts. P2 consumes every key here; the P3 admission gate adds its
- * own keys (admissionAt / wrapUpQuota) when it lands, so they are intentionally
- * NOT defined yet (no parse-only keys).
+ * Time-aware dynamic-pause-line parameters (v3 §3.1/§4.1). These are the SOLE
+ * budget strategy as of v3.2 (the conserve|maximize selector is gone). All have
+ * defaults + bounded validation in config-service.ts and are tuned via env
+ * escape hatches, not as product-facing config. The P3 admission gate will add
+ * its own keys (admissionAt / wrapUpQuota) when it lands — intentionally not
+ * defined yet (no parse-only keys).
  */
 export interface MaximizeConfig {
-  /** Reset-point target utilization; default 97, range [90, 99]. Must be > pauseAt. */
+  /** Reset-point target utilization (asymptote); default 98, range [90, 99]. Must be > pauseAt. */
   targetUtil: number;
   /** Extra reserve per hour-to-reset; default 0.4 pct/h, range [0, 5] (fractional). */
   reserveSlopePctPerHour: number;
-  /** Reserve ceiling; default 7, range [0, 30]. Far-from-reset → ≈ conserve. */
+  /** Reserve ceiling; default 7, range [0, 30]. Far-from-reset → line floors at pauseAt. */
   reserveMaxPct: number;
   /** Expected in-flight wrap-up duration; default 30 min, range [5, 180]. */
   finishingHorizonMinutes: number;
@@ -161,7 +155,7 @@ export interface BudgetConfig {
   enabled: boolean;
   /** Coordinator poll interval in seconds (first poll fires immediately on start()). */
   pollSeconds: number;
-  /** Joint-pause entry threshold on gateUtil; intentionally below guard's hard=92. */
+  /** Dynamic-line floor + no-burn-data fallback entry threshold on gateUtil; below guard's hard=99. */
   pauseAt: number;
   /** Joint-pause exit threshold; BOTH sides must drop below this on gateUtil. */
   resumeBelow: number;
@@ -178,15 +172,12 @@ export interface BudgetConfig {
   /** Tier → override mapping; `full` must be configured for tier control to activate. */
   codexTiers: CodexTierMap;
   /**
-   * v3 strategy selector. P1: parse-and-validate only — behavior is always
-   * conserve; the value is consumed solely by the doctor Q7 check.
-   *
-   * NOTE (layered amendment): burn-rate collection moved to agent-quota-guard;
-   * the former `burnRate.{enabled,sampleCap}` config keys are gone. Display
-   * follows probe field presence — no toggle needed.
+   * v3.2: pauseAt / resumeBelow above are the FALLBACK gateUtil line (used only
+   * when per-window burn data is unavailable); the time-aware dynamic line below
+   * is the primary, always-on strategy. The legacy `strategy` selector is gone —
+   * an old config that still carries `strategy:"conserve"` is tolerated (the key
+   * is silently ignored — normalizeBudgetConfig only reads known keys).
    */
-  strategy: BudgetStrategy;
-  /** maximize-strategy parameters (only consumed when strategy="maximize"). */
   maximize: MaximizeConfig;
 }
 
@@ -256,10 +247,12 @@ export interface BudgetSnapshot {
    */
   runway?: { claude: RunwayEstimate | null; codex: RunwayEstimate | null };
   /**
-   * v3 P2 (optional, maximize only): the effective numeric dynamic pause line
-   * per agent that tripped (or would trip) the pause this poll. null in
-   * conserve mode, when the agent is not gated by a confident maximize window,
-   * or on legacy daemons. Display-only — never a decision input.
+   * v3.2: the effective numeric dynamic pause line per agent that tripped (or
+   * would trip) the pause this poll. Always present on current daemons (the
+   * dynamic line is the sole strategy); each side is null when no confident
+   * window yields a numeric line. Optional only for backward-compatible
+   * deserialization of legacy daemon snapshots. Display-only — never a decision
+   * input.
    */
   dynamicPauseLine?: { claude: number | null; codex: number | null };
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -10,9 +10,8 @@ import {
   type AgentBridgeBuildInfo,
 } from "../build-info";
 import { cliInvocationName } from "../cli-invocation";
-import { ConfigService, applyBudgetEnvOverrides } from "../config-service";
+import { ConfigService, applyBudgetEnvOverrides, DEFAULT_BUDGET_CONFIG } from "../config-service";
 import { resolveGuardHardHint } from "../budget/render";
-import type { BudgetStrategy } from "../budget/types";
 import { fetchDaemonStatus } from "../daemon-status";
 import { inspectAgentBridgeEnv } from "../env-guard";
 import {
@@ -561,51 +560,45 @@ function configParseabilityCheck(cwd: string, cli: string): DoctorCheck {
 }
 
 /**
- * Default v3 maximize target utilization (design §3.1), used as the fallback
- * when a caller does not pass an explicit targetUtil. Since P2, the resolved
- * value comes from `budget.maximize.targetUtil` (config + env), so this is only
- * the package default mirrored from DEFAULT_BUDGET_CONFIG.maximize.targetUtil.
+ * Default dynamic-line target utilization (design §3.1), used as the fallback
+ * when a caller does not pass an explicit targetUtil. The resolved value comes
+ * from `budget.maximize.targetUtil` (config + env); this mirrors the package
+ * default in DEFAULT_BUDGET_CONFIG.maximize.targetUtil (v3.2: 98).
  */
-export const V3_DEFAULT_TARGET_UTIL = 97;
+export const V3_DEFAULT_TARGET_UTIL = DEFAULT_BUDGET_CONFIG.maximize.targetUtil;
 
 /**
- * Pure verdict for the v3 Q7 enhanced-B doctor check: with strategy=maximize,
- * the OUTER quota-guard hard line (default 92, the guard's BUDGET_HARD
- * default) hard-stops the Claude process BEFORE v3's targetUtil — the
- * 92→targetUtil band is unreachable until the user raises the guard line.
- * v3 never crosses or bypasses the guard (REAL-3); this check makes that
- * boundary visible instead of letting runway displays mislead.
+ * Pure verdict for the budget-target doctor check (v3.2). The bridge paces
+ * toward `targetUtil`; the OUTER quota-guard hard line is the last fuse. When
+ * the guard line covers targetUtil it is fine (OK). When the guard line is BELOW
+ * targetUtil, the band above the guard is unreachable for Claude (the guard
+ * hard-stops the process first). With the v3.2 default (guard 99 ≥ target 98)
+ * the covered case is the norm (OK); the below-target case fires only when a user
+ * lowers the guard below targetUtil — a real misconfiguration that defeats the
+ * feature, so it warns (REAL-3: the bridge never crosses the guard).
  */
 export function evaluateBudgetStrategyGuard(
-  strategy: BudgetStrategy,
   guardHardPct: number,
   targetUtilPct: number = V3_DEFAULT_TARGET_UTIL,
 ): DoctorCheck {
-  if (strategy !== "maximize") {
-    return {
-      name: "budget strategy",
-      status: "ok",
-      detail: "strategy=conserve — v2-equivalent budget behavior (v3 maximize is opt-in)",
-    };
-  }
   if (guardHardPct >= targetUtilPct) {
     return {
-      name: "budget strategy",
+      name: "budget target",
       status: "ok",
       detail:
-        `strategy=maximize — outer guard hard line ${guardHardPct}% covers targetUtil ${targetUtilPct}%`,
+        `dynamic line → targetUtil ${targetUtilPct}%; outer guard hard line ${guardHardPct}% covers it`,
     };
   }
   return {
-    name: "budget strategy",
+    name: "budget target",
     status: "warn",
     detail:
-      `strategy=maximize but the outer quota-guard hard line (${guardHardPct}%) is below ` +
-      `targetUtil (${targetUtilPct}%) — the ${guardHardPct}→${targetUtilPct} band is unreachable for Claude`,
+      `outer quota-guard hard line (${guardHardPct}%) is below targetUtil (${targetUtilPct}%) — ` +
+      `the ${guardHardPct}→${targetUtilPct}% band is unreachable for Claude`,
     hint:
-      "v3 不可越过外层 quota-guard 硬线：Claude 侧达到 guard 硬线时进程会被外层强停，" +
-      `maximize 的 ${guardHardPct}%→${targetUtilPct}% 区间实际烧不到。想真正用到 targetUtil，` +
-      "需自行调高 quota-guard 的 BUDGET_HARD（本仓库不代改外层配置）；展示侧已按 guard 线收口。",
+      "外层 quota-guard 硬线先于 bridge 动态线停 Claude 进程（REAL-3，不可越过）：" +
+      `${guardHardPct}%→${targetUtilPct}% 区间烧不到。想用满到 targetUtil，调高 quota-guard 的 ` +
+      "BUDGET_HARD（本仓库不代改外层配置）；展示侧已按 guard 线收口。",
   };
 }
 
@@ -617,7 +610,6 @@ function budgetStrategyGuardCheck(cwd: string): DoctorCheck {
   const config = new ConfigService(cwd).loadOrDefault();
   const budget = applyBudgetEnvOverrides(config.budget);
   return evaluateBudgetStrategyGuard(
-    budget.strategy,
     resolveGuardHardHint(),
     budget.maximize.targetUtil,
   );

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -1,7 +1,7 @@
 import { readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { atomicWriteJson } from "./atomic-json";
-import type { BudgetConfig, BudgetStrategy, CodexTierMap, CodexTurnOverrides, MaximizeConfig } from "./budget/types";
+import type { BudgetConfig, CodexTierMap, CodexTurnOverrides, MaximizeConfig } from "./budget/types";
 
 /** Machine-readable project config schema. */
 export interface AgentBridgeConfig {
@@ -20,9 +20,10 @@ export interface AgentBridgeConfig {
 const DEFAULT_BUDGET_CONFIG: BudgetConfig = {
   enabled: true,
   pollSeconds: 300,
-  // Intentionally below quota-guard's per-agent hard line (92) so the bridge's
-  // coordinated pause fires first and leaves wrap-up headroom; the guard stays
-  // as the per-agent backstop.
+  // v3.2: pauseAt/resumeBelow are the no-burn-data FALLBACK line (the dynamic
+  // line is primary). pauseAt also floors the dynamic line (I1). Kept well below
+  // the outer quota-guard hard line (99) so the bridge pauses first and leaves
+  // wrap-up headroom; the guard 99 is the last-resort fuse.
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,
@@ -38,15 +39,14 @@ const DEFAULT_BUDGET_CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  // v3: strategy selector. conserve = v2-equivalent gateUtil thresholds (the
-  // default — opt-in is required to change behavior). maximize (P2) activates
-  // the per-window time-aware dynamic pause line. Burn-rate data is consumed
-  // from the guard probe — no collection config on this side.
-  strategy: "conserve",
-  // v3 P2 maximize parameters (only consumed when strategy="maximize"). Defaults
-  // and ranges per design budget-strategy-v3.md §3.1/§4.1.
+  // v3.2: pauseAt(90)/resumeBelow(30) above are now the FALLBACK gateUtil line
+  // (only used when per-window burn data is unavailable). The time-aware dynamic
+  // line below is the sole, always-on strategy — the conserve|maximize selector
+  // is gone. Burn-rate data is consumed from the guard probe.
   maximize: {
-    targetUtil: 97,
+    // Reset-point target (asymptote). 98 leaves ~2% for provider metering jitter;
+    // the bridge paces toward it, the outer guard hard line (99) is the last fuse.
+    targetUtil: 98,
     reserveSlopePctPerHour: 0.4,
     reserveMaxPct: 7,
     finishingHorizonMinutes: 30,
@@ -222,10 +222,9 @@ function hasCustomDecisionValues(config: AgentBridgeConfig): boolean {
     b.parallel.minRemainingPct !== db.parallel.minRemainingPct ||
     b.parallel.timeWindowSec !== db.parallel.timeWindowSec ||
     b.codexTierControl !== db.codexTierControl ||
-    // v3: strategy + maximize parameters are decision-grade — surface them so
-    // `abg doctor` reports "custom values in effect" when the user opts into
-    // maximize or tunes its line, not a misleading "all values match defaults".
-    b.strategy !== db.strategy ||
+    // v3.2: dynamic-line (maximize) parameters are decision-grade — surface them
+    // so `abg doctor` reports "custom values in effect" when the user tunes the
+    // line, not a misleading "all values match defaults".
     b.maximize.targetUtil !== db.maximize.targetUtil ||
     b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour ||
     b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct ||
@@ -279,11 +278,6 @@ export function normalizeBoundedNumber(
   if (!Number.isFinite(parsed)) return fallback;
   if (parsed < min || parsed > max) return fallback;
   return parsed;
-}
-
-/** v3 strategy selector: anything but the two known literals falls back. */
-function normalizeStrategy(value: unknown, fallback: BudgetStrategy): BudgetStrategy {
-  return value === "conserve" || value === "maximize" ? value : fallback;
 }
 
 /**
@@ -425,7 +419,6 @@ function normalizeBudgetConfig(
       normalizeBoolean(budget.codexTierControl, fallback.codexTierControl) &&
       codexTiers.full !== null,
     codexTiers,
-    strategy: normalizeStrategy(budget.strategy, fallback.strategy),
     // Pass the already-resolved pauseAt (post pauseAt<=resumeBelow reset) so the
     // targetUtil > pauseAt relation is checked against the effective floor.
     maximize: normalizeMaximizeConfig(budget.maximize, pauseAt, fallback.maximize),
@@ -456,7 +449,6 @@ export function applyBudgetEnvOverrides(
     // Tier mapping is file-config only (nested structure doesn't fit env vars);
     // re-normalization re-applies the full-restore activation rule.
     codexTiers: budget.codexTiers,
-    strategy: env.AGENTBRIDGE_BUDGET_STRATEGY ?? budget.strategy,
     maximize: {
       targetUtil: env.AGENTBRIDGE_BUDGET_TARGET_UTIL ?? budget.maximize.targetUtil,
       reserveSlopePctPerHour:

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -437,10 +437,9 @@ function ensureBudgetCoordinatorStarted() {
       // Normalization degrades tier control to false when the sticky-restore
       // point is missing; surface that state so the degrade is diagnosable.
       `codexTiersFull=${BUDGET_CONFIG.codexTiers.full ? "configured" : "missing"} ` +
-      // v3 P1: strategy is parse-only (behavior stays conserve). Burn-rate
-      // data is CONSUMED from the guard probe (layered amendment) — the
-      // daemon collects nothing.
-      `strategy=${BUDGET_CONFIG.strategy}`,
+      // v3.2: the time-aware dynamic line is the sole strategy; targetUtil is the
+      // reset-point asymptote, pauseAt/resumeBelow are the no-burn-data fallback.
+      `targetUtil=${BUDGET_CONFIG.maximize.targetUtil} fallback=${BUDGET_CONFIG.pauseAt}/${BUDGET_CONFIG.resumeBelow}`,
     );
     budgetCoordinator = new BudgetCoordinator({
       source: createQuotaSource({ log }),
@@ -501,13 +500,9 @@ function budgetPauseGateError(): string {
   const sideHint = snapshot?.pauseSide === "both"
     ? "双侧额度均已耗尽，请写 checkpoint 等待刷新"
     : "你可继续 solo 推进可独立部分，并写 checkpoint 标注分工断点";
-  // Q10: the resume-condition text must match the active strategy. maximize
-  // reopens the gate per-window (dynamic line − hysteresis, or window reset),
-  // not at resumeBelow.
-  const reopenText =
-    BUDGET_CONFIG.strategy === "maximize"
-      ? `Codex 侧各窗口 util 回落至动态暂停线 − ${BUDGET_CONFIG.maximize.resumeHysteresisPct}% 以下或对应窗口刷新后闸门自动放开`
-      : `Codex 侧 gateUtil 低于 ${BUDGET_CONFIG.resumeBelow}% 后闸门自动放开`;
+  // v3.2: the gate reopens per-window (dynamic line − hysteresis, or window
+  // reset), not at resumeBelow — the dynamic line is the sole strategy.
+  const reopenText = `Codex 侧各窗口 util 回落至动态暂停线 − ${BUDGET_CONFIG.maximize.resumeHysteresisPct}% 以下或对应窗口刷新后闸门自动放开`;
   return (
     `预算暂停（闸门关闭），已拒绝转发：${reason}。` +
     reopenText +

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -21,7 +21,6 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  strategy: "conserve",
   maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 
@@ -519,7 +518,7 @@ describe("BudgetCoordinator", () => {
   });
 
   test("maximize: recovery directive describes the dynamic line, not resumeBelow (Q10)", async () => {
-    const maximizeConfig: BudgetConfig = { ...CONFIG, strategy: "maximize" };
+    const maximizeConfig: BudgetConfig = { ...CONFIG };
     const source = new FakeSource([
       { claude: usage(), codex: usage() },
       { claude: usage(), codex: usage({ gateUtil: 91, warnUtil: 91, remaining: 9 }) },
@@ -538,7 +537,7 @@ describe("BudgetCoordinator", () => {
   });
 
   test("maximize CONFIDENT path: coordinator enter→exit on the dynamic line", async () => {
-    const maximizeConfig: BudgetConfig = { ...CONFIG, strategy: "maximize" };
+    const maximizeConfig: BudgetConfig = { ...CONFIG };
     // fiveHour with a confident guard burn rate: tH=1h, rate=1.2 → line 95.6.
     const codexUsage = (fiveHourUtil: number): AgentUsage => ({
       ok: true,

--- a/src/unit-test/budget-fingerprint.test.ts
+++ b/src/unit-test/budget-fingerprint.test.ts
@@ -24,7 +24,6 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  strategy: "conserve",
   maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 

--- a/src/unit-test/budget-maximize.test.ts
+++ b/src/unit-test/budget-maximize.test.ts
@@ -1,16 +1,17 @@
 /**
- * v3 P2 — time-aware maximize pause line (design budget-strategy-v3.md §3.1).
+ * v3.2 — time-aware dynamic pause line (design budget-strategy-v3.md §3.1), the
+ * SOLE budget strategy (conserve|maximize selector removed). targetUtil = 98.
  *
- * Covers the acceptance set called out in §6 P2:
- *   - the §3.1 calibration table (today's live case / last-1h (a)+(b) / far term
- *     / hard caps), each row asserting its branch;
- *   - the full degradation matrix (resetEpoch=0 / stale / non-confident /
- *     both-unknown) → conserve fallback;
+ * Covers:
+ *   - the §3.1 calibration table (today's live case / won't-fill / will-fill /
+ *     far term / hard caps), each row asserting its branch at targetUtil 98;
+ *   - the degradation matrix (resetEpoch=0 / stale / non-confident) → the fixed
+ *     gateUtil FALLBACK line (pauseAt / resumeBelow);
  *   - symmetric resume + window-reset recovery;
- *   - invariant I1 (maximize never pauses below pauseAt) as a property test;
+ *   - invariant I1 (the line never pauses below pauseAt) as a property test;
  *   - invariant I2 (phantom-hold: stale data never opens a closed gate) via
  *     classifyPoll;
- *   - conserve mode untouched (sanity guards alongside the existing suites).
+ *   - Q10 resume-condition directive text.
  */
 import { describe, expect, test } from "bun:test";
 import {
@@ -35,17 +36,14 @@ const MAXIMIZE: BudgetConfig = {
   parallel: { minRemainingPct: 60, timeWindowSec: 3600 },
   codexTierControl: false,
   codexTiers: { full: null, balanced: { effort: "medium" }, eco: { effort: "low" } },
-  strategy: "maximize",
   maximize: {
-    targetUtil: 97,
+    targetUtil: 98,
     reserveSlopePctPerHour: 0.4,
     reserveMaxPct: 7,
     finishingHorizonMinutes: 30,
     resumeHysteresisPct: 5,
   },
 };
-
-const CONSERVE: BudgetConfig = { ...MAXIMIZE, strategy: "conserve" };
 
 /** Build a window resetting `tHours` from NOW, optionally with a guard burn rate. */
 function win(util: number, tHours: number, rate?: number, confident = true): BudgetWindow {
@@ -82,34 +80,41 @@ function usage(opts: {
   };
 }
 
-describe("dynamicPauseAt — §3.1 calibration table", () => {
-  test("today's live case (util=92, tH=6.5, rate=1.2) → branch (b), line≈93.4, does not pause", () => {
+describe("dynamicPauseAt — §3.1 calibration table (targetUtil=98)", () => {
+  test("today's live case (util=92, tH=6.5, rate=1.2) → branch (b), line≈94.4, does not pause", () => {
+    // fm=clamp(0.6,1,10)=1; projected=92+7.8=99.8>98 → (b); reserve=min(7,2.6)=2.6;
+    // line=98−1−2.6=94.4.
     const line = dynamicPauseAt(win(92, 6.5, 1.2), 1.2, MAXIMIZE, NOW);
     expect(typeof line).toBe("number");
-    expect(line as number).toBeCloseTo(93.4, 5);
+    expect(line as number).toBeCloseTo(94.4, 5);
     expect(92 >= (line as number)).toBe(false); // util below line → no pause
   });
 
-  test("last 1h (i): util=92, tH=1, rate=1.2 → branch (a) won't-fill → 100 (no pause)", () => {
+  test("won't-fill (i): util=92, tH=1, rate=1.2 → branch (a) → 100 (no pause)", () => {
+    // projected=92+1.2=93.2≤98 → (a); no hard cap → 100.
     expect(dynamicPauseAt(win(92, 1, 1.2), 1.2, MAXIMIZE, NOW)).toBe(100);
   });
 
-  test("last 1h (ii): util=96, tH=1, rate=1.2 → branch (b), line≈95.6 → pause", () => {
-    const line = dynamicPauseAt(win(96, 1, 1.2), 1.2, MAXIMIZE, NOW);
-    expect(line as number).toBeCloseTo(95.6, 5);
-    expect(96 >= (line as number)).toBe(true);
+  test("will-fill (ii): util=97, tH=1, rate=2 → branch (b), line≈96.6 → pause", () => {
+    // fm=clamp(1,1,10)=1; projected=97+2=99>98 → (b); reserve=min(7,0.4)=0.4;
+    // line=98−1−0.4=96.6.
+    const line = dynamicPauseAt(win(97, 1, 2), 2, MAXIMIZE, NOW);
+    expect(line as number).toBeCloseTo(96.6, 5);
+    expect(97 >= (line as number)).toBe(true);
   });
 
-  test("far term (tH=120, rate=1.2) → reserve saturates → clamps to pauseAt=90 (≈conserve)", () => {
+  test("far term (tH=120, rate=1.2) → reserve saturates → clamps to pauseAt=90", () => {
+    // (b); reserve=min(7,48)=7; line=98−1−7=90 → clamp[90,99]=90.
     expect(dynamicPauseAt(win(50, 120, 1.2), 1.2, MAXIMIZE, NOW)).toBeCloseTo(90, 5);
   });
 
-  test("hard cap 1: util≥targetUtil with zero rate → admission-closed", () => {
-    expect(dynamicPauseAt(win(97, 2, 0), 0, MAXIMIZE, NOW)).toBe("admission-closed");
+  test("hard cap 1: util≥targetUtil (util=98) with zero rate → admission-closed", () => {
+    // projected=98≤98 → (a); util 98≥targetUtil 98 → admission-closed.
+    expect(dynamicPauseAt(win(98, 2, 0), 0, MAXIMIZE, NOW)).toBe("admission-closed");
   });
 
   test("hard cap 2 (Codex counterexample): near-reset finishing band → admission-closed", () => {
-    // finishingHorizon=30min, rate=20 → finishingMargin=10; tH=0.25<0.5, util=88≥87.
+    // finishingHorizon=30min, rate=20 → fm=10; tH=0.25<0.5, util=88≥98−10=88.
     expect(dynamicPauseAt(win(88, 0.25, 20), 20, MAXIMIZE, NOW)).toBe("admission-closed");
   });
 
@@ -124,32 +129,32 @@ describe("dynamicPauseAt — §3.1 calibration table", () => {
   });
 
   test("branch (a) won't-fill with rate=0 and util<target → 100 (no hard cap)", () => {
-    // projected=96≤97 → (a); cap1 (96≥97) no; cap2 (tH 2 < 0.5) no → 100.
+    // projected=96≤98 → (a); cap1 (96≥98) no; cap2 (tH 2 < 0.5) no → 100.
     expect(dynamicPauseAt(win(96, 2, 0), 0, MAXIMIZE, NOW)).toBe(100);
   });
 
   test("hard cap 2 boundary is strict (tH < horizon): tH=0.5 does NOT fire", () => {
-    // finishingHorizon=30min→0.5h; rate=20→margin=10; util=87→projected=97≤97 (a).
-    expect(dynamicPauseAt(win(87, 0.49, 20), 20, MAXIMIZE, NOW)).toBe("admission-closed");
-    expect(dynamicPauseAt(win(87, 0.5, 20), 20, MAXIMIZE, NOW)).toBe(100);
+    // finishingHorizon=30min→0.5h; rate=20→fm=10; util=88→projected≤98 → (a).
+    expect(dynamicPauseAt(win(88, 0.49, 20), 20, MAXIMIZE, NOW)).toBe("admission-closed");
+    expect(dynamicPauseAt(win(88, 0.5, 20), 20, MAXIMIZE, NOW)).toBe(100);
   });
 });
 
-describe("agentShouldPause — maximize entry", () => {
+describe("agentShouldPause — entry", () => {
   test("today's live case: codex weekly 92 / tH 6.5 / rate 1.2 → NOT paused", () => {
     const d = agentShouldPause("codex", usage({ weekly: win(92, 6.5, 1.2), fiveHour: win(22, 0.3, 0.4) }), MAXIMIZE, NOW);
     expect(d.pause).toBe(false);
   });
 
-  test("util=96 last 1h → paused, window=weekly, line≈95.6", () => {
-    const d = agentShouldPause("codex", usage({ weekly: win(96, 1, 1.2) }), MAXIMIZE, NOW);
+  test("util=97/tH=1/rate=2 → paused, window=weekly, line≈96.6", () => {
+    const d = agentShouldPause("codex", usage({ weekly: win(97, 1, 2) }), MAXIMIZE, NOW);
     expect(d.pause).toBe(true);
     expect(d.window).toBe("weekly");
-    expect(d.line as number).toBeCloseTo(95.6, 5);
+    expect(d.line as number).toBeCloseTo(96.6, 5);
   });
 
-  test("hard cap 1 (util=97, rate=0) → paused (admission-closed, util≥pauseAt)", () => {
-    const d = agentShouldPause("claude", usage({ weekly: win(97, 2, 0) }), MAXIMIZE, NOW);
+  test("hard cap 1 (util=98, rate=0) → paused (admission-closed, util≥pauseAt)", () => {
+    const d = agentShouldPause("claude", usage({ weekly: win(98, 2, 0) }), MAXIMIZE, NOW);
     expect(d.pause).toBe(true);
   });
 
@@ -163,7 +168,7 @@ describe("agentShouldPause — maximize entry", () => {
     expect(agentShouldPause("codex", usage({ weekly: win(89, 5) }), MAXIMIZE, NOW).pause).toBe(false);
   });
 
-  test("degraded (burnConfident=false) falls back to conserve per-window", () => {
+  test("degraded (burnConfident=false) falls back to the gateUtil line per-window", () => {
     expect(agentShouldPause("codex", usage({ weekly: win(91, 5, 1.2, false) }), MAXIMIZE, NOW).pause).toBe(true);
   });
 
@@ -173,24 +178,24 @@ describe("agentShouldPause — maximize entry", () => {
   });
 
   test("stale fetch → not paused (isDecisionGrade gate)", () => {
-    const u = usage({ weekly: win(96, 1, 1.2), fetchedAt: NOW - 601 });
+    const u = usage({ weekly: win(97, 1, 2), fetchedAt: NOW - 601 });
     expect(agentShouldPause("codex", u, MAXIMIZE, NOW).pause).toBe(false);
   });
 
   test("expired window is skipped; a fresh tripping window still pauses", () => {
-    const u = usage({ fiveHour: { util: 99, resetEpoch: NOW - 5 }, weekly: win(96, 1, 1.2) });
+    const u = usage({ fiveHour: { util: 99, resetEpoch: NOW - 5 }, weekly: win(97, 1, 2) });
     expect(agentShouldPause("codex", u, MAXIMIZE, NOW).pause).toBe(true);
   });
 
   test("both windows trip → reason reports the FIRST (fiveHour) per WINDOW_KEYS order", () => {
-    const u = usage({ fiveHour: win(96, 1, 1.2), weekly: win(96, 1, 1.2) });
+    const u = usage({ fiveHour: win(97, 1, 2), weekly: win(97, 1, 2) });
     const d = agentShouldPause("codex", u, MAXIMIZE, NOW);
     expect(d.pause).toBe(true);
     expect(d.window).toBe("fiveHour");
   });
 });
 
-describe("invariant I1 — maximize never pauses below pauseAt (property)", () => {
+describe("invariant I1 — the dynamic line never pauses below pauseAt (property)", () => {
   test("dynamicPauseAt numeric result is always within [pauseAt, 99]", () => {
     for (let i = 0; i < 400; i++) {
       const pauseAt = 80 + (i % 15); // 80..94
@@ -217,10 +222,9 @@ describe("invariant I1 — maximize never pauses below pauseAt (property)", () =
     }
   });
 
-  test("I1 edge: pauseAt=100 (degenerate) → line floors to 100, never pauses below conserve", () => {
+  test("I1 edge: pauseAt=100 (degenerate) → line floors to 100, never pauses below it", () => {
     // clamp(line, 100, max(100,99)=100) = 100. A 99 ceiling would clamp DOWN to
-    // 99 and pause at util≥99 — earlier than conserve (which never pauses at
-    // pauseAt=100). The floor must win.
+    // 99 and pause at util≥99 — earlier than a pauseAt=100 floor. The floor wins.
     const cfg: BudgetConfig = { ...MAXIMIZE, pauseAt: 100 };
     expect(dynamicPauseAt(win(99, 6.5, 1.2), 1.2, cfg, NOW)).toBe(100);
     expect(agentShouldPause("codex", usage({ weekly: win(99, 6.5, 1.2) }), cfg, NOW).pause).toBe(false);
@@ -253,9 +257,9 @@ describe("invariant I1 — maximize never pauses below pauseAt (property)", () =
   });
 });
 
-describe("agentCanResume — maximize symmetric exit", () => {
-  test("still above the line (util=96, line≈95.6) → cannot resume", () => {
-    expect(agentCanResume(usage({ weekly: win(96, 1, 1.2) }), MAXIMIZE, NOW)).toBe(false);
+describe("agentCanResume — symmetric exit", () => {
+  test("still above the line (util=97, line≈96.6) → cannot resume", () => {
+    expect(agentCanResume(usage({ weekly: win(97, 1, 2) }), MAXIMIZE, NOW)).toBe(false);
   });
 
   test("util receded into won't-fill band (util=90, tH=1) → resumes", () => {
@@ -263,20 +267,17 @@ describe("agentCanResume — maximize symmetric exit", () => {
   });
 
   test("(b)→(a) transition: util=92/tH=1 drops into won't-fill → resumes", () => {
-    // projected=93.2≤97 → (a) → line 100 (won't-fill) → never blocks resume.
+    // projected=93.2≤98 → (a) → line 100 (won't-fill) → never blocks resume.
     expect(agentCanResume(usage({ weekly: win(92, 1, 1.2) }), MAXIMIZE, NOW)).toBe(true);
   });
 
   test("won't-fill window at HIGH util (line=100, util=95) does NOT block resume", () => {
-    // util=95/tH=1/rate=1 → projected 96≤97 → (a) won't-fill → line 100. This
-    // window never triggers entry, so it must never block resume (symmetry) —
-    // even though util 95 ≥ 100−hyst(5). Regression guard for the line=100 fix.
+    // util=95/tH=1/rate=1 → projected 96≤98 → (a) won't-fill → line 100. This
+    // window never triggers entry, so it must never block resume (symmetry).
     expect(agentCanResume(usage({ weekly: win(95, 1, 1) }), MAXIMIZE, NOW)).toBe(true);
   });
 
   test("a won't-fill window does not keep another recovered side paused", () => {
-    // weekly recovered into won't-fill (line 100) at util 96; fiveHour also
-    // won't-fill. Neither gates entry → resume must be allowed.
     const u = usage({ fiveHour: win(80, 1, 0.5), weekly: win(96, 1, 0.5) });
     expect(agentShouldPause("codex", u, MAXIMIZE, NOW).pause).toBe(false);
     expect(agentCanResume(u, MAXIMIZE, NOW)).toBe(true);
@@ -293,15 +294,15 @@ describe("agentCanResume — maximize symmetric exit", () => {
     ).toBe(false);
   });
 
-  test("degraded window resumes only below resumeBelow (conserve exit)", () => {
+  test("degraded window resumes only below resumeBelow (fallback exit)", () => {
     expect(agentCanResume(usage({ weekly: win(40, 5) }), MAXIMIZE, NOW)).toBe(false);
     expect(agentCanResume(usage({ weekly: win(29, 5) }), MAXIMIZE, NOW)).toBe(true);
   });
 });
 
-describe("resumeBlockingEpochFor — maximize Q10 alignment", () => {
+describe("resumeBlockingEpochFor — Q10 alignment", () => {
   test("returns the blocking window's reset while still over the line", () => {
-    const weekly = win(96, 1, 1.2);
+    const weekly = win(97, 1, 2);
     expect(resumeBlockingEpochFor(usage({ weekly }), MAXIMIZE, NOW)).toBe(weekly.resetEpoch);
   });
 
@@ -311,46 +312,45 @@ describe("resumeBlockingEpochFor — maximize Q10 alignment", () => {
 
   test("active rate-limit wins", () => {
     expect(
-      resumeBlockingEpochFor(usage({ weekly: win(96, 1, 1.2), rateLimitedUntil: NOW + 500 }), MAXIMIZE, NOW),
+      resumeBlockingEpochFor(usage({ weekly: win(97, 1, 2), rateLimitedUntil: NOW + 500 }), MAXIMIZE, NOW),
     ).toBe(NOW + 500);
   });
 });
 
 describe("effectiveDynamicLine — display only", () => {
-  test("maximize today's case → ≈93.4", () => {
-    expect(effectiveDynamicLine(usage({ weekly: win(92, 6.5, 1.2) }), MAXIMIZE, NOW)).toBeCloseTo(93.4, 5);
+  test("today's case → ≈94.4", () => {
+    expect(effectiveDynamicLine(usage({ weekly: win(92, 6.5, 1.2) }), MAXIMIZE, NOW)).toBeCloseTo(94.4, 5);
   });
 
-  test("conserve mode → null", () => {
-    expect(effectiveDynamicLine(usage({ weekly: win(92, 6.5, 1.2) }), CONSERVE, NOW)).toBeNull();
+  test("non-decision-grade → null", () => {
+    const u = usage({ weekly: { util: 99, resetEpoch: NOW - 10 } });
+    expect(effectiveDynamicLine(u, MAXIMIZE, NOW)).toBeNull();
   });
 
   test("picks the binding (smallest-headroom) window", () => {
-    // Both windows: tH 6.5, rate 1.2. weekly util=92 → projected 99.8 > 97 → (b)
-    // line 93.4. fiveHour util=50 → projected 57.8 ≤ 97 → (a) won't-fill → line
-    // 100, which effectiveDynamicLine skips (>=100). So weekly is the only
-    // numeric line and is correctly chosen as binding.
+    // weekly util=92 → (b) line 94.4. fiveHour util=50 → (a) won't-fill → line 100,
+    // skipped (>=100). So weekly is the only numeric line and is chosen as binding.
     const u = usage({ fiveHour: win(50, 6.5, 1.2), weekly: win(92, 6.5, 1.2) });
-    expect(effectiveDynamicLine(u, MAXIMIZE, NOW)).toBeCloseTo(93.4, 5);
+    expect(effectiveDynamicLine(u, MAXIMIZE, NOW)).toBeCloseTo(94.4, 5);
   });
 
   test("two confident numeric lines → smallest headroom wins", () => {
-    // Both will-fill (b), same line 93.4 (tH 6.5, rate 1.2). fiveHour util=93
-    // (headroom 0.4) vs weekly util=91 (headroom 2.4) → fiveHour is binding.
+    // Both will-fill (b), same line 94.4 (tH 6.5, rate 1.2). fiveHour util=93
+    // (headroom 1.4) vs weekly util=91 (headroom 3.4) → fiveHour is binding.
     const u = usage({ fiveHour: win(93, 6.5, 1.2), weekly: win(91, 6.5, 1.2) });
-    expect(effectiveDynamicLine(u, MAXIMIZE, NOW)).toBeCloseTo(93.4, 5);
+    expect(effectiveDynamicLine(u, MAXIMIZE, NOW)).toBeCloseTo(94.4, 5);
   });
 });
 
-describe("invariant I2 — phantom-hold under maximize (classifyPoll)", () => {
-  test("a paused maximize side holds when its data goes non-decision-grade", () => {
-    // Poll 1: codex weekly trips the line (util=96, tH=1, rate=1.2 → line 95.6).
-    const s1 = computeBudgetState(null, usage({ weekly: win(96, 1, 1.2) }), MAXIMIZE, NOW);
+describe("invariant I2 — phantom-hold (classifyPoll)", () => {
+  test("a paused side holds when its data goes non-decision-grade", () => {
+    // Poll 1: codex weekly trips the line (util=97, tH=1, rate=2 → line 96.6).
+    const s1 = computeBudgetState(null, usage({ weekly: win(97, 1, 2) }), MAXIMIZE, NOW);
     const r1 = classifyPoll(INITIAL_FINGERPRINT_STATE, s1, MAXIMIZE);
     expect(r1.next.side).toBe("codex");
 
     // Poll 2: codex probe goes stale (non-decision-grade) — must HOLD, not open.
-    const staleCodex = usage({ weekly: win(96, 1, 1.2), fetchedAt: NOW - 601 });
+    const staleCodex = usage({ weekly: win(97, 1, 2), fetchedAt: NOW - 601 });
     const s2 = computeBudgetState(null, staleCodex, MAXIMIZE, NOW + 60);
     const r2 = classifyPoll(r1.next, s2, MAXIMIZE);
     expect(r2.next.side).toBe("codex");
@@ -358,9 +358,9 @@ describe("invariant I2 — phantom-hold under maximize (classifyPoll)", () => {
   });
 
   test("stale/expired hold keeps the sticky FUTURE resumeEpoch (no past-time clobber)", () => {
-    // Poll 1: codex weekly trips (util=96, tH=1, rate=1.2 → line 95.6); the
-    // blocking window's reset (NOW+3600) becomes the resumeEpoch.
-    const s1 = computeBudgetState(null, usage({ weekly: win(96, 1, 1.2) }), MAXIMIZE, NOW);
+    // Poll 1: codex weekly trips (util=97, tH=1, rate=2 → line 96.6); the blocking
+    // window's reset (NOW+3600) becomes the resumeEpoch.
+    const s1 = computeBudgetState(null, usage({ weekly: win(97, 1, 2) }), MAXIMIZE, NOW);
     const r1 = classifyPoll(INITIAL_FINGERPRINT_STATE, s1, MAXIMIZE);
     expect(r1.next.side).toBe("codex");
     expect(r1.next.resumeEpoch).toBe(NOW + 3600);
@@ -381,44 +381,25 @@ describe("invariant I2 — phantom-hold under maximize (classifyPoll)", () => {
 });
 
 describe("renderBudgetInterventionDirective — Q10 resume-condition text", () => {
-  const claudeU = usage({ weekly: win(96, 1, 1.2) });
+  const claudeU = usage({ weekly: win(97, 1, 2) });
   const codexU = usage({ weekly: win(40, 6.5, 0.4) });
 
-  test("conserve: resume text keeps the historical gateUtil<resumeBelow wording", () => {
-    const text = renderBudgetInterventionDirective(claudeU, codexU, "codex", "r", NOW + 3600, CONSERVE);
-    expect(text).toContain("gateUtil 低于 30%");
-    expect(text).not.toContain("动态暂停线");
-  });
-
-  test("maximize (codex side): resume text describes the dynamic line, not 30%", () => {
+  test("codex side: resume text describes the dynamic line, not 30%", () => {
     const text = renderBudgetInterventionDirective(claudeU, codexU, "codex", "r", NOW + 3600, MAXIMIZE);
     expect(text).toContain("动态暂停线");
     expect(text).toContain("− 5%");
     expect(text).not.toContain("gateUtil 低于 30%");
   });
 
-  test("maximize (claude side): handoff resume text is strategy-aware", () => {
+  test("claude side: handoff resume text describes the dynamic line", () => {
     const text = renderBudgetInterventionDirective(claudeU, codexU, "claude", "r", NOW + 3600, MAXIMIZE);
     expect(text).toContain("动态暂停线");
     expect(text).not.toContain("低于 30%");
   });
 
-  test("maximize (both sides): joint resume text is strategy-aware", () => {
+  test("both sides: joint resume text describes the dynamic line", () => {
     const text = renderBudgetInterventionDirective(claudeU, codexU, "both", "r", NOW + 3600, MAXIMIZE);
     expect(text).toContain("动态暂停线");
     expect(text).not.toContain("都低于 30%");
-  });
-});
-
-describe("conserve mode is unchanged by the maximize path", () => {
-  test("conserve still gates on gateUtil ≥ pauseAt, ignoring the dynamic line", () => {
-    // util=92 with tH 6.5 would NOT pause under maximize (line 93.4) but DOES
-    // under conserve (92 ≥ pauseAt 90).
-    expect(agentShouldPause("codex", usage({ weekly: win(92, 6.5, 1.2) }), CONSERVE, NOW).pause).toBe(true);
-  });
-
-  test("conserve resume still requires gateUtil < resumeBelow", () => {
-    expect(agentCanResume(usage({ weekly: win(40, 6.5, 1.2) }), CONSERVE, NOW)).toBe(false);
-    expect(agentCanResume(usage({ weekly: win(20, 6.5, 1.2) }), CONSERVE, NOW)).toBe(true);
   });
 });

--- a/src/unit-test/budget-render.test.ts
+++ b/src/unit-test/budget-render.test.ts
@@ -54,11 +54,11 @@ describe("renderBudgetSnapshot", () => {
     expect(text).toContain("预警 45%");
   });
 
-  test("renders the maximize dynamic line with per-agent headroom", () => {
+  test("renders the dynamic line with per-agent headroom", () => {
     const text = renderBudgetSnapshot(
       snapshot({ dynamicPauseLine: { claude: 93.4, codex: 95.6 } }),
     );
-    expect(text).toContain("动态暂停线（maximize）：");
+    expect(text).toContain("动态暂停线：");
     expect(text).toContain("Claude 93.4%");
     expect(text).toContain("Codex 95.6%");
     // headroom = line - gateUtil (Claude 93.4-42=51.4, Codex 95.6-10=85.6)
@@ -66,7 +66,7 @@ describe("renderBudgetSnapshot", () => {
     expect(text).toContain("余量 85.6");
   });
 
-  test("omits the dynamic line entirely in conserve mode (no field)", () => {
+  test("omits the dynamic line when the snapshot carries no field (legacy daemon)", () => {
     expect(renderBudgetSnapshot(snapshot())).not.toContain("动态暂停线");
   });
 
@@ -249,7 +249,7 @@ describe("renderBudgetSnapshot — burn rate & runway (v3 P1, layered amendment)
     );
     // Honesty-first Q7 wording: the number is the guard's NEUTRAL runway,
     // never rescaled by the bridge (constraint #2) — the caveat is textual.
-    expect(text).toContain("外层 guard 硬线 92%（v3 不可越过；runway 为中性口径，Claude 会先在硬线被外层停住）");
+    expect(text).toContain("外层 guard 硬线 99%（v3 不可越过；runway 为中性口径，Claude 会先在硬线被外层停住）");
     expect(text).not.toContain("窗口刷新即截断");
   });
 
@@ -380,18 +380,18 @@ describe("renderBudgetSnapshot — burn rate & runway (v3 P1, layered amendment)
 });
 
 describe("resolveGuardHardHint", () => {
-  test("defaults to 92 (quota-guard BUDGET_HARD default)", () => {
-    expect(resolveGuardHardHint({})).toBe(92);
+  test("defaults to 99 (v3.2 quota-guard BUDGET_HARD default)", () => {
+    expect(resolveGuardHardHint({})).toBe(99);
   });
 
   test("AGENTBRIDGE_GUARD_HARD_HINT overrides the display value", () => {
     expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "85" })).toBe(85);
   });
 
-  test("invalid or out-of-range hints fall back to 92", () => {
-    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "abc" })).toBe(92);
-    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "150" })).toBe(92);
-    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "0" })).toBe(92);
-    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "" })).toBe(92);
+  test("invalid or out-of-range hints fall back to 99", () => {
+    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "abc" })).toBe(99);
+    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "150" })).toBe(99);
+    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "0" })).toBe(99);
+    expect(resolveGuardHardHint({ AGENTBRIDGE_GUARD_HARD_HINT: "" })).toBe(99);
   });
 });

--- a/src/unit-test/budget-state.test.ts
+++ b/src/unit-test/budget-state.test.ts
@@ -20,7 +20,6 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  strategy: "conserve",
   maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 
@@ -92,9 +91,17 @@ describe("computeBudgetState", () => {
     expect(state.directiveToClaude).toContain("提前刷新会更早解除");
   });
 
-  test("does not pause when warnUtil is high but gateUtil is below pauseAt", () => {
+  test("does not pause when warnUtil is high but every window util is below pauseAt", () => {
+    // warnUtil (96) drives drift/balance only; pause gating is per-window util.
+    // Keep both windows' util low so no window crosses the maximize fallback line.
     const state = computeBudgetState(
-      usage({ gateUtil: 20, warnUtil: 96, remaining: 80 }),
+      usage({
+        gateUtil: 20,
+        warnUtil: 96,
+        remaining: 80,
+        fiveHour: { util: 20, resetEpoch: NOW + 7200 },
+        weekly: { util: 20, resetEpoch: NOW + 500_000 },
+      }),
       usage({ gateUtil: 18, warnUtil: 18, remaining: 82 }),
       CONFIG,
       NOW,

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -391,8 +391,7 @@ describe("ConfigService — budget section", () => {
         balanced: { effort: "medium" },
         eco: { effort: "low" },
       },
-      strategy: "conserve",
-      maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+      maximize: { targetUtil: 98, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
     });
   });
 
@@ -402,6 +401,18 @@ describe("ConfigService — budget section", () => {
     const budget = loadBudget(svc);
     expect(budget.pauseAt).toBe(90);
     expect(budget.enabled).toBe(true);
+  });
+
+  test("v3.2: a legacy config carrying strategy:'conserve' is tolerated (key ignored, not corrupt)", () => {
+    const svc = new ConfigService(tempDir);
+    // The v3.2 default is the always-on dynamic line; the removed `strategy` key
+    // must not break an upgraded user's old config — it parses fine, the key is
+    // silently ignored, and the rest of the budget normalizes as usual.
+    writeRawConfig({ budget: { strategy: "conserve", pauseAt: 85 } });
+    expect(svc.load().state).toBe("parsed");
+    const budget = loadBudget(svc);
+    expect("strategy" in budget).toBe(false); // field is gone, not carried through
+    expect(budget.pauseAt).toBe(85); // the rest still applies
   });
 
   test("load accepts valid custom budget values", () => {
@@ -433,8 +444,7 @@ describe("ConfigService — budget section", () => {
         eco: { effort: "minimal" },
       },
       // v3 P1 keys absent in the raw file normalize to defaults.
-      strategy: "conserve",
-      maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+      maximize: { targetUtil: 98, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
     });
   });
 
@@ -596,7 +606,6 @@ describe("applyBudgetEnvOverrides", () => {
       balanced: { effort: "medium" },
       eco: { effort: "low" },
     },
-    strategy: "conserve" as const,
     maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
   };
 
@@ -652,7 +661,6 @@ describe("applyBudgetEnvOverrides — boolean spellings", () => {
       balanced: { effort: "medium" },
       eco: { effort: "low" },
     },
-    strategy: "conserve" as const,
     maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
   };
 
@@ -673,7 +681,7 @@ describe("applyBudgetEnvOverrides — boolean spellings", () => {
   });
 });
 
-describe("ConfigService — budget v3 P1 keys (strategy, parse-only)", () => {
+describe("ConfigService — budget v3 P1 keys (legacy key handling)", () => {
   let tempDir: string;
 
   beforeEach(() => {
@@ -696,25 +704,10 @@ describe("ConfigService — budget v3 P1 keys (strategy, parse-only)", () => {
     return result.config.budget;
   }
 
-  test("strategy=maximize is parsed and preserved (consumed only by doctor in P1)", () => {
-    const svc = new ConfigService(tempDir);
-    writeRawConfig({ budget: { strategy: "maximize" } });
-    expect(loadBudget(svc).strategy).toBe("maximize");
-  });
-
-  test("invalid strategy values fall back to conserve", () => {
-    const svc = new ConfigService(tempDir);
-    writeRawConfig({ budget: { strategy: "yolo" } });
-    expect(loadBudget(svc).strategy).toBe("conserve");
-    writeRawConfig({ budget: { strategy: 42 } });
-    expect(loadBudget(svc).strategy).toBe("conserve");
-  });
-
   test("legacy burnRate keys in the raw file are ignored (layered amendment: collection moved to the guard)", () => {
     const svc = new ConfigService(tempDir);
-    writeRawConfig({ budget: { strategy: "maximize", burnRate: { enabled: false, sampleCap: 100 } } });
+    writeRawConfig({ budget: { burnRate: { enabled: false, sampleCap: 100 } } });
     const budget = loadBudget(svc);
-    expect(budget.strategy).toBe("maximize");
     expect("burnRate" in budget).toBe(false);
   });
 });
@@ -763,27 +756,12 @@ describe("applyBudgetEnvOverrides — v3 P1 keys", () => {
       balanced: { effort: "medium" },
       eco: { effort: "low" },
     },
-    strategy: "conserve" as const,
     maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
   };
 
-  test("AGENTBRIDGE_BUDGET_STRATEGY overrides the strategy", () => {
-    const result = applyBudgetEnvOverrides(base, {
-      AGENTBRIDGE_BUDGET_STRATEGY: "maximize",
-    });
-    expect(result.strategy).toBe("maximize");
-  });
-
-  test("invalid AGENTBRIDGE_BUDGET_STRATEGY keeps the base value", () => {
-    const result = applyBudgetEnvOverrides(base, {
-      AGENTBRIDGE_BUDGET_STRATEGY: "turbo",
-    });
-    expect(result.strategy).toBe("conserve");
-  });
-
   test("v3 env keys leave the rest of the config untouched", () => {
     const result = applyBudgetEnvOverrides(base, {
-      AGENTBRIDGE_BUDGET_STRATEGY: "maximize",
+      AGENTBRIDGE_BUDGET_TARGET_UTIL: "95",
     });
     expect(result.pauseAt).toBe(90);
     expect(result.resumeBelow).toBe(30);
@@ -817,7 +795,6 @@ describe("normalizeBudgetConfig — v3 P2 maximize block", () => {
   test("valid custom maximize values pass through (incl. fractional slope)", () => {
     writeRawConfig({
       budget: {
-        strategy: "maximize",
         maximize: {
           targetUtil: 95,
           reserveSlopePctPerHour: 1.25,
@@ -840,14 +817,14 @@ describe("normalizeBudgetConfig — v3 P2 maximize block", () => {
     writeRawConfig({
       budget: {
         maximize: {
-          targetUtil: 200, // > 99 → fallback 97
+          targetUtil: 200, // > 99 → fallback 98
           reserveSlopePctPerHour: -1, // < 0 → fallback 0.4
           finishingHorizonMinutes: 999, // > 180 → fallback 30
         },
       },
     });
     const m = loadBudget().maximize;
-    expect(m.targetUtil).toBe(97);
+    expect(m.targetUtil).toBe(98);
     expect(m.reserveSlopePctPerHour).toBe(0.4);
     expect(m.finishingHorizonMinutes).toBe(30);
   });
@@ -873,8 +850,8 @@ describe("normalizeBudgetConfig — v3 P2 maximize block", () => {
     expect(overridden.maximize.finishingHorizonMinutes).toBe(60);
   });
 
-  test("describeConfig reports custom values when strategy/maximize are tuned", () => {
-    writeRawConfig({ budget: { strategy: "maximize", maximize: { targetUtil: 95 } } });
+  test("describeConfig reports custom values when maximize is tuned", () => {
+    writeRawConfig({ budget: { maximize: { targetUtil: 95 } } });
     expect(new ConfigService(tempDir).describeConfig().customValues).toBe(true);
   });
 

--- a/src/unit-test/doctor.test.ts
+++ b/src/unit-test/doctor.test.ts
@@ -97,7 +97,7 @@ describe("doctor command", () => {
         "pair registration",
         "env",
         "config.json",
-        "budget strategy", // v3 P1 Q7 enhanced-B check
+        "budget target", // v3.2 maximize-only target/guard check
         "daemon health",
         "daemon readiness",
         "codex app-server",
@@ -364,29 +364,26 @@ describe("describeBuildDrift (basis annotation)", () => {
   });
 });
 
-describe("evaluateBudgetStrategyGuard (v3 P1 Q7 enhanced-B)", () => {
-  test("strategy=conserve → ok (v2-equivalent behavior)", () => {
-    const check = evaluateBudgetStrategyGuard("conserve", 92);
-    expect(check.name).toBe("budget strategy");
-    expect(check.status).toBe("ok");
-    expect(check.detail).toContain("conserve");
-  });
-
-  test("strategy=maximize with guard hardline below targetUtil → warn", () => {
-    const check = evaluateBudgetStrategyGuard("maximize", 92);
+describe("evaluateBudgetStrategyGuard (v3.2 maximize-only)", () => {
+  test("guard hardline below targetUtil → warn", () => {
+    const check = evaluateBudgetStrategyGuard(92);
+    expect(check.name).toBe("budget target");
     expect(check.status).toBe("warn");
     expect(check.detail).toContain("92");
-    expect(check.detail).toContain("97");
+    expect(check.detail).toContain("98");
     expect(check.hint).toContain("外层 quota-guard 硬线");
   });
 
-  test("strategy=maximize with guard hardline at/above targetUtil → ok", () => {
-    expect(evaluateBudgetStrategyGuard("maximize", 97).status).toBe("ok");
-    expect(evaluateBudgetStrategyGuard("maximize", 98).status).toBe("ok");
+  test("guard hardline at/above targetUtil → ok", () => {
+    const check = evaluateBudgetStrategyGuard(98);
+    expect(check.name).toBe("budget target");
+    expect(check.status).toBe("ok");
+    expect(check.detail).toContain("targetUtil");
+    expect(evaluateBudgetStrategyGuard(99).status).toBe("ok");
   });
 
   test("custom targetUtil is honored", () => {
-    expect(evaluateBudgetStrategyGuard("maximize", 92, 90).status).toBe("ok");
-    expect(evaluateBudgetStrategyGuard("maximize", 89, 90).status).toBe("warn");
+    expect(evaluateBudgetStrategyGuard(92, 90).status).toBe("ok");
+    expect(evaluateBudgetStrategyGuard(89, 90).status).toBe("warn");
   });
 });

--- a/src/unit-test/resume-candidate-e2e.test.ts
+++ b/src/unit-test/resume-candidate-e2e.test.ts
@@ -47,7 +47,6 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  strategy: "conserve",
   maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 

--- a/src/unit-test/resume-candidate.test.ts
+++ b/src/unit-test/resume-candidate.test.ts
@@ -25,7 +25,6 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  strategy: "conserve",
   maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
 };
 


### PR DESCRIPTION
见 commit message + docs/design/budget-strategy-v3.md §0 v3.2 addendum。删 conserve/strategy 选择，时间感知动态线唯一默认，targetUtil 98，pauseAt/resumeBelow 变 fallback 兜底。配套 agent-quota-guard v3.2（BUDGET_HARD 99 + checkpoint lead 95 + rate-limit 写 pending）。cross-review：4 subagent（2 轮）+ Codex 跨引擎 sign-off，全量 1502 pass。

🤖 与 Codex 协作完成（bridge: Claude / guard: Codex）