### PR TITLE
feat(budget): shared budget-pacing prompt + clock-windows render line / 共享额度节奏提示词 + 时钟窗口渲染行

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14007,6 +14007,29 @@ function formatFiveHourWindowsLeftLine(snapshot) {
   const byAgent = values.map(([name, value]) => `${name} ~${value.toFixed(1)}`).join(" / ");
   return `\u6309\u5F53\u524D\u8282\u594F\uFF0C\u5468\u989D\u5EA6\u8FD8\u591F ${byAgent} \u4E2A 5h \u7A97\u53E3`;
 }
+var FIVE_HOUR_WINDOW_SEC = 5 * 3600;
+function clockWindowsLeft(usage, snapshotAt) {
+  const weekly = usage?.weekly;
+  if (!weekly || weekly.resetEpoch <= snapshotAt)
+    return null;
+  return (weekly.resetEpoch - snapshotAt) / FIVE_HOUR_WINDOW_SEC;
+}
+function formatClockWindowsLine(snapshot) {
+  const values = [];
+  const claude = clockWindowsLeft(snapshot.claude, snapshot.updatedAt);
+  const codex = clockWindowsLeft(snapshot.codex, snapshot.updatedAt);
+  if (claude !== null)
+    values.push(["Claude", claude]);
+  if (codex !== null)
+    values.push(["Codex", codex]);
+  if (values.length === 0)
+    return null;
+  const unique = [...new Set(values.map(([, value]) => value.toFixed(1)))];
+  if (unique.length === 1)
+    return `\u8DDD\u5468\u5237\u65B0\u8FD8\u80FD\u5BB9\u7EB3 ~${unique[0]} \u4E2A 5h \u7A97\u53E3\uFF08\u65F6\u949F\uFF09`;
+  const byAgent = values.map(([name, value]) => `${name} ~${value.toFixed(1)}`).join(" / ");
+  return `\u8DDD\u5468\u5237\u65B0\u8FD8\u80FD\u5BB9\u7EB3 ${byAgent} \u4E2A 5h \u7A97\u53E3\uFF08\u65F6\u949F\uFF09`;
+}
 function formatDynamicLineLine(snapshot) {
   const lines = snapshot.dynamicPauseLine;
   if (!lines)
@@ -14050,6 +14073,9 @@ function renderBudgetSnapshot(snapshot, options = {}) {
   const fiveHourWindowsLeftLine = formatFiveHourWindowsLeftLine(snapshot);
   if (fiveHourWindowsLeftLine)
     lines.push(fiveHourWindowsLeftLine);
+  const clockWindowsLine = formatClockWindowsLine(snapshot);
+  if (clockWindowsLine)
+    lines.push(clockWindowsLine);
   const dynamicLineLine = formatDynamicLineLine(snapshot);
   if (dynamicLineLine)
     lines.push(dynamicLineLine);
@@ -14597,10 +14623,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.17", "0.0.0-source"),
-  commit: defineString("ad365c0", "source"),
+  commit: defineString("0d1e1bd", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("c22387f3269f", "source")
+  codeHash: defineString("8c19ce8879bd", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.17", "0.0.0-source"),
-  commit: defineString("ad365c0", "source"),
+  commit: defineString("0d1e1bd", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("c22387f3269f", "source")
+  codeHash: defineString("8c19ce8879bd", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };

--- a/src/budget/render.ts
+++ b/src/budget/render.ts
@@ -193,6 +193,37 @@ function formatFiveHourWindowsLeftLine(snapshot: BudgetSnapshot): string | null 
   return `按当前节奏，周额度还够 ${byAgent} 个 5h 窗口`;
 }
 
+/** Seconds in one 5h window — the rate-limit window length. */
+const FIVE_HOUR_WINDOW_SEC = 5 * 3600;
+
+/**
+ * "Clock-windows": how many 5h windows physically fit before each side's WEEKLY
+ * reset = (weekly reset − now) ÷ 5h. Pure time arithmetic (no burn data needed),
+ * rendered alongside the burn-based "周额度还够 ~N 个" line so the model can apply
+ * the even-pacing test (budget-windows vs clock-windows) without doing the
+ * date math itself. Null when no weekly reset is known / already past.
+ */
+function clockWindowsLeft(usage: AgentUsage | null, snapshotAt: number): number | null {
+  const weekly = usage?.weekly;
+  if (!weekly || weekly.resetEpoch <= snapshotAt) return null;
+  return (weekly.resetEpoch - snapshotAt) / FIVE_HOUR_WINDOW_SEC;
+}
+
+function formatClockWindowsLine(snapshot: BudgetSnapshot): string | null {
+  const values: Array<[string, number]> = [];
+  const claude = clockWindowsLeft(snapshot.claude, snapshot.updatedAt);
+  const codex = clockWindowsLeft(snapshot.codex, snapshot.updatedAt);
+  if (claude !== null) values.push(["Claude", claude]);
+  if (codex !== null) values.push(["Codex", codex]);
+  if (values.length === 0) return null;
+
+  const unique = [...new Set(values.map(([, value]) => value.toFixed(1)))];
+  if (unique.length === 1) return `距周刷新还能容纳 ~${unique[0]} 个 5h 窗口（时钟）`;
+
+  const byAgent = values.map(([name, value]) => `${name} ~${value.toFixed(1)}`).join(" / ");
+  return `距周刷新还能容纳 ${byAgent} 个 5h 窗口（时钟）`;
+}
+
 /**
  * v3.2 (display-only): the binding dynamic pause line per agent and its headroom
  * to the agent's gateUtil. Present when the snapshot carries `dynamicPauseLine`
@@ -267,6 +298,8 @@ export function renderBudgetSnapshot(
   }
   const fiveHourWindowsLeftLine = formatFiveHourWindowsLeftLine(snapshot);
   if (fiveHourWindowsLeftLine) lines.push(fiveHourWindowsLeftLine);
+  const clockWindowsLine = formatClockWindowsLine(snapshot);
+  if (clockWindowsLine) lines.push(clockWindowsLine);
 
   const dynamicLineLine = formatDynamicLineLine(snapshot);
   if (dynamicLineLine) lines.push(dynamicLineLine);

--- a/src/collaboration-content.ts
+++ b/src/collaboration-content.ts
@@ -4,12 +4,31 @@
  * These are injected by `abg init` into project-level instruction files
  * so that agents auto-discover the multi-agent collaboration setup.
  *
- * Content must be generic (not project-specific) and under ~30 lines each.
- * Tool usage details are already covered by MCP server instructions —
- * these sections focus on *when* and *why* to collaborate.
+ * Content must be generic (not project-specific). The collaboration intro is
+ * kept short; the shared BUDGET_PACING governance block below is longer by
+ * design (it encodes the quota-pacing policy both agents follow). Tool usage
+ * details are otherwise covered by MCP server instructions — these sections
+ * focus on *when* and *why* to collaborate.
  */
 
 export const MARKER_ID = "AgentBridge";
+
+/**
+ * Shared budget-pacing governance block, injected verbatim into BOTH CLAUDE.md
+ * and AGENTS.md so Claude and Codex follow ONE identical policy. Code enforces
+ * only the hard floor (the near-limit pause/handoff gate) and edge cases; this
+ * block delegates the live "raise / hold / reduce intensity" decision to the
+ * model, driven by the probe data.
+ */
+export const BUDGET_PACING = `\
+### Budget pacing — drive the WEEKLY quota to ~100% over the week, evenly, without reaching a 5h cap (active when agent-quota-guard is installed)
+- **Core principle: token is the means, value is the end.** Raising intensity means producing more real parallel value (deeper reviews, more independent exploration / verification / genuine subtasks) — never manufacturing low-value work to consume quota. The budget to MAXIMIZE is the **weekly** quota (refreshed once a week): drive each side's weekly toward ~100% by its weekly reset, and consume it **evenly** across the week — front-loading then starving, or under-consuming throughout, both leave weekly quota unredeemed (forfeited). The **5h window is NOT a quota bucket to fill — it is a RATE CAP**: stay under it within any 5h period; reaching it = a forced pause until the 5h resets = wasted time, not progress.
+- **Re-query your budget before EVERY allocation decision** — Claude: \`get_budget\` → **rendered text** covering both sides; Codex: \`check_budget\` with \`agent:"claude"|"codex"\` → **normalized JSON**, per side. (Two different shapes — read the right one below.) Never reuse remembered numbers: a weekly window can refresh EARLY (resetting both 5h and weekly), fully restoring a side you believed was exhausted.
+- **Even-pacing test (per side — Claude runs it)** — compare two quantities: *budget-windows* = how many 5h windows the weekly quota still covers at the current burn rate; *clock-windows* = how many 5h windows physically fit before the weekly reset = (weekly reset − now) ÷ 5h. **Claude** (\`get_budget\` text) carries BOTH, pre-computed for BOTH sides: the lines "按当前节奏，周额度还够 … 个 5h 窗口" (budget-windows) and "距周刷新还能容纳 … 个 5h 窗口（时钟）" (clock-windows). **Codex** (\`check_budget\` JSON) today carries only per-bucket \`util\` / \`reset_epoch\` / \`reset_after_seconds\` — no burn rate, no \`five_hour_windows_left\` — so Codex CANNOT compute budget-windows itself; it reads its weekly \`util\` and clock-windows only. To locate Codex's weekly bucket: of the \`buckets[]\` entries whose \`id\` contains \`seven_day\` or \`secondary_window\` (there can be several — e.g. a model-specific \`additional_rate_limits[…]\` one at 0%), take the HIGHEST-util one (the binding account-level window, matching how the bridge parses it); its clock-windows = \`reset_after_seconds\` ÷ 5h (never the top-level \`reset_epoch\`, which tracks the current limiter, not necessarily the weekly window). For the budget-windows half and the raise/hold/reduce verdict, Codex relies on Claude's \`get_budget\` (the burn projection lives there, for both sides) and reports its own weekly \`util\` + reset timing so Claude can run the test. (If a future \`check_budget\` exposes \`five_hour_windows_left\` on the weekly bucket, Codex reads it directly.) **The verdict (Claude computes it, per side):** budget > clock → **under-consuming** (weekly will be left unused) → **raise intensity**; budget < clock → **over-consuming** (won't last to the weekly reset) → **reduce intensity**; within ~1 window, or no confident rate → **hold**. **Codex, absent a fresh Claude verdict, holds at its current intensity (it never escalates unilaterally) and stays clear of the 5h cap — surfacing its weekly \`util\` + reset timing so Claude can issue the verdict.**
+- **Raise intensity — use the levers your role has.** Orchestrator (Claude): pick larger, more-decomposable tasks; run more parallel subagents at once (3–5+ vs 1); raise delegation density; open more concurrent streams (review + explore + verify in parallel). Executor (Codex): go deeper in-turn, take larger chunks, run more verification/repro. Both: deepen quality (multi-angle review, broader test/repro) — never manufacture make-work. **Reduce intensity:** fewer/serial subagents (Claude), short bounded chunks, defer optional deep work. Stay below the **动态暂停线** (shown in \`get_budget\`; its \`余量\` = headroom from your current util to that soft line, measured on the resettable hard-winner window — the 5h OR the weekly window, whichever currently limits you) — that soft ceiling, not the raw 5h cap, is the "do not cross, avoid a forced pause" line. **If that line is absent, or you only have JSON (Codex),** fall back to the 5h bucket's raw util vs 100% (Codex: of the \`buckets[]\` entries whose \`id\` contains \`five_hour\` or \`primary_window\`, take the HIGHEST-util one) and keep clear of the 5h cap.
+- **Distinguish 5h from weekly:** a 5h window resetting does NOT consume or waste weekly budget — it only refreshes your rate headroom, so you can keep going when weekly is under-consumed. A near 5h reset is therefore not urgency but the release of a rate limit. The real "unused = forfeited" is the **weekly budget as its WEEKLY reset nears**: if weekly is still under-consumed then, raise intensity (within the 5h cap) to use it. If even pacing needs a rate beyond one 5h window's capacity, you are rate-limited → keep each 5h window as full as possible (under the cap).
+- **Two-subscription imbalance — the quotas are INDEPENDENT and differ in BOTH amount AND reset timing** (each side's weekly and 5h windows reset on different clocks). **The cross-side split is the orchestrator's (Claude) decision:** route more work to the side that is MORE under-consuming on the even-pacing test (the larger budget-windows − clock-windows gap); when EITHER side lacks a confident rate (so the gap can't be compared), fall back to the more budget-rich side (larger absolute weekly headroom). On any tie (equal gap, or equal headroom), prefer the side whose **weekly resets SOONER** (its leftover is forfeited earlier). **As the executor (Codex) you do NOT decide the global split** — execute what you're assigned, and when your own budget is rich report it (with evidence) so Claude routes more to you. The tighter / over-consuming side carries less.
+- **Side-aware pause (the hard floor the code enforces — obey, do not reinvent), with each side's own action:** **Codex exhausted** (\`system_budget_pause\`) → Codex's turns stop (gate closed); **Claude** must not retry replies and continues solo on independent work, checkpointing the split point — but the SAME \`system_budget_pause\` is ALSO emitted when both sides are exhausted, so do not infer "solo" from the directive name alone: read its content (it names the paused side[s]) or re-check \`get_budget\`, and continue solo ONLY while Claude's own side is healthy; if Claude is also at its line, handle it as **Both** below. **Claude exhausted** (\`system_budget_handoff\`) → **Claude** sends ONE handoff (remaining tasks / context / artifact locations / acceptance criteria) then stops; **Codex** receives the baton and carries the work forward as far as its remaining quota allows that turn. **Both** → joint pause; checkpoint and wait for \`resume\` (Claude's own quota-guard also hard-stops Claude independently). A transient probe **429 is NOT exhaustion** → fall back to cached util and keep working.`;
 
 export const CLAUDE_MD_SECTION = `\
 ## AgentBridge — Multi-Agent Collaboration
@@ -43,14 +62,7 @@ Another AI agent (Codex, by OpenAI) is available in a parallel session on this m
 3. Ask for Codex's agreement or counter-proposal before proceeding.
 4. After task completion, **cross-review** each other's work.
 
-### Budget awareness (active when agent-quota-guard is installed)
-- Goal: **keep the task moving while fully using the subscription quota**. The bridge polls both agents' account-level 5h/weekly windows and may send \`system_budget_*\` notices: **balance** (route more work to the side with more runway / remaining work-time), **underutilized** (the account won't use its weekly quota before reset — split more parallel subtasks / raise delegation density), **pause/handoff/resume**.
-- \`get_budget\` shows BOTH sides' quota — re-check it **before every task-allocation decision**. NEVER rely on quota numbers remembered from earlier in the conversation: the weekly window can refresh EARLY (resetting both 5h and weekly), so a side you remember as nearly exhausted may be fully restored.
-- Side-aware pause semantics:
-  - **Codex exhausted** (\`system_budget_pause\`): the reply gate closes. Do not retry replies; continue solo on independent work, note the split point in a checkpoint.
-  - **You (Claude) exhausted** (\`system_budget_handoff\`): the gate stays OPEN — immediately send ONE handoff reply to Codex packaging the remaining task list, context, artifact locations and acceptance criteria, then stop working (your own quota-guard will hard-stop you at 92%). Codex relays the baton.
-  - **Both exhausted**: joint pause; checkpoint and wait for the resume notice.
-- Save quota with model tiers: route mechanical subagent work to **haiku**, routine work to **sonnet**, reserve **opus** for architecture decisions; when your side is the heavier consumer, delegate more to Codex.`;
+${BUDGET_PACING}`;
 
 export const AGENTS_MD_SECTION = `\
 ## AgentBridge — Multi-Agent Collaboration
@@ -106,9 +118,4 @@ You MUST NOT run git **write** commands: \`commit\`, \`push\`, \`pull\`, \`fetch
 - Do not blindly follow Claude — challenge with evidence when you disagree.
 - Use explicit collaboration phrases: "My independent view is:", "I agree on:", "I disagree on:", "Current consensus:".
 
-### Budget awareness (active when agent-quota-guard is installed)
-- Goal: **keep the task moving while fully using the subscription quota**. You can check BOTH sides' quota yourself via your quota-guard MCP tool \`check_budget\` with \`agent: "claude"\` or \`"codex"\` — re-check **before negotiating task splits**, and NEVER rely on remembered numbers: the weekly window can refresh early (resetting both 5h and weekly windows).
-- During a **budget pause** (your side exhausted) you simply stop receiving new turns — that IS the pause. Your own quota-guard hooks still apply; work resumes when Claude's next message arrives.
-- **Handoff (Claude's side exhausted)**: you may receive a baton message packaging the remaining work. Push as far as possible within that single turn; write leftovers to a checkpoint file; do NOT expect Claude to respond until its quota refreshes.
-- Claude may route more or less work to you based on **remaining work-time (runway), not just raw usage %** — a side that looks heavily used but is close to a window reset still has plenty of runway. Expected load balancing, not preference. Claude may also ask for more parallel subtasks when the account will not use its weekly quota before reset (underutilization).
-- When the user enabled tier control, the bridge may adjust your model/reasoning-effort via turn parameters under budget pressure; if asked to economize, prefer lower effort and concise outputs.`;
+${BUDGET_PACING}`;

--- a/src/unit-test/budget-render.test.ts
+++ b/src/unit-test/budget-render.test.ts
@@ -332,6 +332,27 @@ describe("renderBudgetSnapshot — burn rate & runway (v3 P1, layered amendment)
     expect(text).toContain("按当前节奏，周额度还够 ~2.4 个 5h 窗口");
   });
 
+  test("renders clock-windows (5h windows that physically fit before the weekly reset)", () => {
+    const text = renderBudgetSnapshot(
+      snapshot({
+        // weekly resets 2.5 × 5h after the snapshot's updatedAt → 2.5 clock-windows
+        claude: usage({ weekly: { util: 19, resetEpoch: 1_780_711_700 + Math.round(2.5 * 5 * 3600) } }),
+      }),
+    );
+    expect(text).toContain("距周刷新还能容纳");
+    expect(text).toContain("~2.5");
+  });
+
+  test("omits clock-windows when both sides' weekly reset is already past", () => {
+    const text = renderBudgetSnapshot(
+      snapshot({
+        claude: usage({ weekly: { util: 19, resetEpoch: 1_780_711_700 - 100 } }),
+        codex: usage({ weekly: { util: 10, resetEpoch: 1_780_711_700 - 100 } }),
+      }),
+    );
+    expect(text).not.toContain("距周刷新");
+  });
+
   test("omits weekly five-hour window count when the guard field is absent", () => {
     const text = renderBudgetSnapshot(snapshot());
     expect(text).not.toContain("周额度还够");


### PR DESCRIPTION
## 摘要 / Summary

把额度节奏策略从「散落在 CLAUDE.md / AGENTS.md 各自的 Budget awareness 段」收敛成**一个共享的 `BUDGET_PACING` 治理块**，由 `abg init` 逐字注入两侧，让 Claude 和 Codex 遵循**同一份**策略。代码只兜底**硬线 + 边缘场景**（暂停/交接闸、429、bucket 解析），「提速 / 保持 / 降速」的强度决策交给模型按实时探针数据自行判断。

Consolidates quota-pacing guidance into a single shared `BUDGET_PACING` block injected verbatim into both `CLAUDE.md` and `AGENTS.md`, so Claude and Codex follow ONE identical policy. Code enforces only the hard floor + edge cases; the model decides raise / hold / reduce intensity from live probe data.

### 核心原则 / Core principles
- **最大化的是「周额度」**：把每侧周额度尽量**均匀**地用到约 100%（到各自 weekly reset）；前期猛用后期没得用、或全程欠载，都会浪费周额度。
- **5h 窗口是「速率帽」不是「要填满的桶」**：在任意 5h 内不撞上限；撞上=被迫暂停=浪费时间。5h 重置只是释放速率余量，不消耗/不浪费周额度。
- **均匀度判据（每侧；由 Claude 跑）**：*budget-windows*（按燃尽率周额度还够几个 5h 窗口）vs *clock-windows*（到周刷新物理上还能放几个 5h 窗口）→ 大于则欠载提速 / 小于则过载降速 / 约等则保持。
- **两套订阅不均衡**：额度独立、且**重置时刻也不同**；跨侧分配由编排方 **Claude** 决定（路由给更欠载的一侧，平局看谁周刷新更早），执行方 **Codex** 只上报自己的 util+重置时刻、不决定全局拆分。
- **side-aware 暂停**：`system_budget_pause`（codex **或** 双方竭）vs `system_budget_handoff`（claude 竭）；瞬时探针 429 ≠ 额度耗尽。

### 改动 / Changes
- `src/collaboration-content.ts`：新增 `export const BUDGET_PACING`，在 `CLAUDE_MD_SECTION` / `AGENTS_MD_SECTION` 用 `${BUDGET_PACING}` 共享注入（替换原各自的 Budget awareness 块）。
- `src/budget/render.ts`：`get_budget` 增加 `距周刷新还能容纳 ~M 个 5h 窗口（时钟）` 行（`clockWindowsLeft` = weekly bucket 的剩余秒数 ÷ 5h），与燃尽口径的 `周额度还够 ~N 个` 行并列，让模型直接拿到 even-pacing 两个量、无需自己算日期。
- `src/unit-test/budget-render.test.ts`：+2 用例（时钟行渲染 / 双侧 weekly 均过期时省略）。
- `plugins/agentbridge/server/*.js`：`build:plugin` 重建产物（render 改动）。

> 不含本机 `AGENTS.md` / `CLAUDE.md` / `.agentbridge/config.json` 的本地注入态（按项目规则不提交；用户 `abg init` 会按 source 重新生成）。

## 测试 / Test plan
- `bun run check`：**1544 pass / 0 fail**；plugin bundles in sync with source；manifests version-aligned at 0.1.17。
- `bun run typecheck`：clean。
- 真实探针实证：`get_budget` 现场渲染出 `周额度还够 Claude ~9.5 / Codex ~3.5 个 5h 窗口` 与 `动态暂停线：Codex 90.0%（余量 34.0）`；Codex 实测 `check_budget({agent:"codex"})` 可按新文案执行（取 util 最高 weekly/5h bucket、`reset_after_seconds ÷ 5h` 算 clock-windows）。

## Cross-review
跨引擎交叉 review **8 轮**收敛（Claude 本地 reviewer + Codex 实测真实 `check_budget`），直到连续两轮 0 真实 REAL。关键 REAL：
1. `check_budget` 包的是 **bash `budget-probe`**（只有 util+reset timing，无 burn/`five_hour_windows_left`）→ budget-windows 只活在 Claude 的 `get_budget`（daemon 优先 `probe.mjs`）；
2. weekly/5h bucket 多候选歧义（`additional_rate_limits[…]` 0% 干扰项）→ 取 util 最高者，对齐 `quota-source.ts` `pickHighestUtil`；
3. `system_budget_pause` 同时覆盖「仅 Codex 竭」与「双方竭」→ Claude 需读 directive 内容/复查 get_budget 才能判 solo vs 联合暂停；
4. `余量` 是「到 resettable hard-winner 窗口 soft line 的余量」而非「5h 余量」；
5. 跨侧路由判据统一到 even-pacing gap + budget-rich 回退 + weekly-resets-sooner tie-break。

## 部署 / Deploy（需用户，新会话生效）
- `abg init`：把新 `BUDGET_PACING` 重新注入项目的 `CLAUDE.md` / `AGENTS.md`。
- `bun run install:global`：部署 `render.ts` 改动（`get_budget` 时钟行）到全局 + plugin cache。
- 之后 `agentbridge claude` + `agentbridge codex` 拉起新会话。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
