### PR TITLE
feat(budget): v3 P3 — three-state admission gate (M1–M3b) / 三态 admission 闸门

### DIFF
--- a/docs/design/budget-v3-p3-implementation-plan.md
+++ b/docs/design/budget-v3-p3-implementation-plan.md
@@ -1,0 +1,98 @@
+# Budget v3 — P3 三态 admission 闸门 实施计划
+
+> 状态：**计划（待 green-light）**。由 4 个并行只读勘察 subagent（Claude 侧）对照 `budget-strategy-v3.md` §3.2 / §6 P3 + 当前代码产出并交叉收敛。设计稿自标 P3「碰 live injection/gate 语义、风险面大」。
+> 生成时间：2026-06-16（利用 Claude 周额度 surplus 的产物，未动代码）。
+
+## 0. 目标（设计稿 §3.2 / §6 P3）
+
+把闸门从二态（paused / 否）升级为三态：
+
+```
+gateState: "open" | "admission-closed" | "closed"
+```
+
+- `open`：照常放行。
+- `admission-closed`（新增，仅 maximize 生效）：**拒新任务、放收尾**。
+  - 进入条件（任一）：5h 窗口 util ≥ `admissionAt`(默认 85)；或 weekly runway < `finishingHorizon×2`（RECOMMEND-7）；或 §3.1 `dynamicPauseAt` 返回 `"admission-closed"`（REAL-4 hard cap：util≥targetUtil 或临近重置收尾带）。
+  - 退出（滞回）：`util < admissionAt−5` 且 weekly runway 回到下限之上，或对应窗口重置。
+  - 行为：拒新 `turn/start` → 新错误码 `budget_admission`（区别 `budget_paused`）；放行 `on_busy="steer"`；放行 `wrapUp:true` 的 reply，每 5h 窗口至多 `wrapUpQuota`(默认 2) 个、**配额持久化**；**不打断进行中 turn**（等其自然完成后再发 admission directive）。
+- `closed`：维持现状全拒；外加 REAL-2「系统发起的 checkpoint baton」（每窗口 1 次、仅 `turnPhase=idle`、记日志、用过即拒）。
+
+不变量 **I2（phantom-hold）**：曾进入 admission-closed/closed 的窗口，在数据 stale 期维持原状态，绝不因数据缺失开闸。
+
+## 1. 文件级落点（file:line 锚点）
+
+### 1.1 类型 + 配置（纯增量，零行为变化 — 先做）
+- `src/budget/types.ts`
+  - 新增 `gateState: "open"|"admission-closed"|"closed"`（BudgetSnapshot 可选字段，向后兼容）。
+  - `MaximizeConfig`（当前 P2 五键）+ `admissionAt`(默认 85, 范围 [50,99], 须 < targetUtil) + `wrapUpQuota`(默认 2, 范围 [0,10])。P2 已刻意留空给 P3（§P2 note ≈ L423「不做 parse-only 空键」）。
+- `src/config-service.ts`
+  - 解析/校验/默认这两键，套用既有关系约束模式（仿 `pauseAt ≤ resumeBelow`，`admissionAt < targetUtil` 违反则整 maximize 块回默认 + warn）。
+  - env override：`AGENTBRIDGE_BUDGET_ADMISSION_AT` / `..._WRAP_UP_QUOTA`。
+
+### 1.2 决策层
+- `src/budget/budget-decision.ts`
+  - `dynamicPauseAt`（L106-149）**已返回** `number | "admission-closed"` 信号；`maximizeWindowEntry`（L227-241）P2 经 I1 floor 把它映射成 closed（§P2 REAL-4 note ≈ L432）。**P3 直接消费该信号，不再 floor。**
+  - 新增 `agentShouldAdmitClose` / `agentCanAdmitOpen` 谓词（与 `agentShouldPause`/`agentCanResume` 平行；同样以 `isDecisionGrade` 为前置）。
+
+### 1.3 闸门状态机（**Q4 关键决策**）
+- `src/budget/budget-fingerprint.ts`：`PauseSide`(L38) / `FingerprintState`(L63-79) / `classifyPoll`(L330-397) / `nextActiveSide`(L204-215) / `directiveFingerprint`(L274-319，刻意不含动态线，R6) / 相位保持(L370-378)。
+  - **Q4 决议（本计划推荐）= 折中 A′**：在 `FingerprintState` 内**新增独立 admission 车道**（`admissionSide/admissionFingerprint/admissionResumeEpoch/admissionReason`），但保持 `classifyPoll` 为**单一 reducer + 单一 phantom-hold 守卫**覆盖两条车道；admission 的进出滞回抽到独立函数 `nextAdmissionSide`（独立可测）。
+    - 理由：① I2 phantom-hold 只此一处，杜绝 Option B 双份实现漂移；② reset-epoch 600s 桶与 pause 共用，避免 bucket drift；③ admission 逻辑独立成函数，兼顾 Option B 的可测性。
+    - 取舍 vs 纯并列状态机：避免 5×5 状态爆炸只有 ~10 可达；pause 优先于 admission 展示（已 paused 时抑制 admission directive）。
+
+### 1.4 协调器
+- `src/budget/budget-coordinator.ts`
+  - `isGateClosed()`(L231-232) → 新 `gateState(): "open"|"admission-closed"|"closed"`（closed 优先，其次 admission，其余 open）。
+  - 新 `emitAdmissionDirectivePostTurn()`（复用 `emitDirective`/`emit` 通道，新前缀 `system_budget_admission`，指纹去重）。
+  - 新 `checkAndConsumeWrapUpQuota()`（读/校验当前 5h 窗口配额、原子写回）。
+
+### 1.5 daemon 注入咽喉（**风险最高**）
+- `src/daemon.ts`
+  - 注入序（会话校验 → **budget 闸 ~L1212** → busy guard/steer L1248（steer 在闸前，天然放行）→ interrupt L1311-1406 → 注入 L1409）。
+  - L1212 二态 `isGateClosed()` → 三态：`closed`→`budget_paused`；`admission-closed` 且非 steer/非 wrapUp→`budget_admission`；wrapUp→查配额放行/超额拒。
+  - 新 `budgetAdmissionGateError()`（仿 `budgetPauseGateError` L491）：「5h 窗口收尾保护中，仅接收收尾类注入；5h 重置 HH:MM；剩余配额 X/Y」。
+  - `turnPhaseChanged` 监听（L556-559）扩展：`running|stalled → idle` 且 admission-closed → 发 admission directive（指纹防刷屏）。
+  - interrupt 路径 await 后（L1377 域）补 gateState 复检（防 await 期间翻 admission-closed 后误注新 turn）。
+
+### 1.6 协议 + adapter
+- `src/control-protocol.ts`：`claude_to_codex`(L76-101) 加 `wrapUp?: boolean`；result.code 注释加 `budget_admission`。向后兼容：缺字段→false，不需 bump contractVersion（双向可选）。
+- `src/claude-adapter.ts`：`reply` 工具 schema(L393-423) 加 `wrap_up`(可选)；`ReplySender` 签名(L30-35) 透传 `wrapUp`；`handleReply`(L555-643) 抽取 + 渲染 `budget_admission` 文案。
+
+### 1.7 持久化（新模块）
+- 新 `src/budget/wrap-up-quota.ts`（仿 `pending-reader.ts` 原子读写 + 故障隔离）：`<stateDir>/wrap-up-quota.json`，按 5h `resetEpoch` 键计数；resetEpoch 跳变自动清零（Q9 共识，与 R6 抖动护栏共存）；损坏/缺失→从零开始，绝不抛。
+- `src/state-dir.ts`：加 `wrapUpQuotaFile` getter。
+
+## 2. 测试清单（仿 P2 结构）
+- 新 `src/unit-test/budget-admission.test.ts`：
+  - admission-closed：新 turn 拒(`budget_admission`) / steer 放 / wrapUp 配额内放、超额拒。
+  - running turn 不被打断；完成后才发 directive；directive 去重（相位多次跳变只发一次）。
+  - closed 优先 admission（closed 时 wrapUp 也拒，除 REAL-2 baton）。
+  - 5h 重置：admission 退出、wrapUpQuota 清零。
+  - **I2 phantom-hold**：admission-closed 后数据 stale，状态维持，绝不开闸。
+  - weekly runway < 2×finishingHorizon 触发 admission（RECOMMEND-7）。
+  - REAL-2 baton：closed + idle → 每窗口 1 次、记日志、第二次拒。
+  - 配额跨 daemon 重启持久化（Q9）；resetEpoch 跳变清零。
+  - 协议兼容：旧 bridge 无 `wrapUp` 字段 → 默认 false。
+  - 配置：`admissionAt ≥ targetUtil` 违反 → 整块回默认 + warn。
+- 更新 `budget-coordinator.test.ts` / `budget-fingerprint.test.ts` / `config-service.test.ts` / `daemon-wiring.test.ts`。
+
+## 3. 风险登记
+| 风险 | 缓解 |
+|---|---|
+| daemon 注入 await 期间闸状态翻转误注 | interrupt 后 L1377 域 gateState 复检 |
+| wrapUp 配额因 daemon 重启清零后门 | 持久化到 `wrap-up-quota.json`，resetEpoch 跳变才清 |
+| util 在 admissionAt 抖动致 directive 刷屏 | 指纹排除原始 util，仅 reset-epoch 桶 + 滞回 + phantom-hold |
+| pause 与 admission 同时触发，文案重叠 | 协调器优先展示 pause，抑制 admission directive |
+| 幂等重试重复扣配额 | idempotencyKey 守重放，配额只 +1（需测试坐实） |
+| Q4 双份 phantom-hold 漂移 | 采折中 A′（单 reducer 单 phantom-hold） |
+
+## 4. 实施顺序（低风险 → 高风险；每步过 cross-review gate 才提交）
+1. types.ts + config-service.ts（纯增量，零行为变化）→ 单测。
+2. wrap-up-quota.ts + state-dir.ts（持久化模块）→ 单测。
+3. budget-decision.ts 谓词（`agentShouldAdmitClose`/`agentCanAdmitOpen`）→ 单测。
+4. budget-fingerprint.ts admission 车道（Q4 A′）→ 单测。
+5. budget-coordinator.ts `gateState()` + directive + 配额方法 → 单测。
+6. control-protocol.ts + claude-adapter.ts（wrapUp/错误码/兼容）→ 单测。
+7. daemon.ts 三态闸 + turnPhase 监听 + interrupt 复检（**风险最高，最后做**）→ 集成测试。
+8. 全量 `bun run check` + `build:plugin` + 手写 E2E 测试计划 + 2-fresh-reviewer cross-review 循环至连续两轮 0 REAL。

--- a/docs/test-plans/p3-m3b-admission-directive-baton.md
+++ b/docs/test-plans/p3-m3b-admission-directive-baton.md
@@ -1,0 +1,162 @@
+# v3 P3 M3b — Admission Directive + Checkpoint Baton E2E Test Plan
+
+> **For agentic workers:** This plan verifies the LIVE behavior of the v3 P3 M3b
+> milestone against a real daemon + a controllable budget probe. The deterministic
+> paths are already covered by the automated suite (`src/integration-test/daemon-wiring.test.ts`,
+> `src/unit-test/budget-coordinator.test.ts`); this plan is the manual/live backstop
+> the project requires per PR. Do NOT run against the active collaboration pair —
+> use a disposable pair + cwd.
+
+**Goal:** Confirm that the three-state admission gate's M3b layer behaves correctly
+end-to-end: the admission directive reaches Claude (turnPhase-aware), the closed-state
+checkpoint baton fires once per quota window, routing advice is suppressed while
+admission-closed, the Codex pause-recovery is held while admission-closed, and the
+interrupt path re-checks the gate after its await.
+
+**Architecture:** A controllable quota probe (a shell script that cats a per-agent
+JSON fixture) drives `BudgetCoordinator` through the real daemon. The daemon's
+`gateState()` (open / admission-closed / closed) gates `handleClaudeToCodex`, emits
+`system_budget_admission` to Claude, and injects the checkpoint baton via
+`codex.injectMessage`.
+
+**Tech Stack:** Bun, AgentBridge control protocol + `/healthz`, the real daemon
+budget coordinator, a fixture quota probe (`AGENTBRIDGE_QUOTA_PROBE`).
+
+---
+
+## Code anchors (prefer symbols if line numbers drift)
+
+- `src/budget/budget-coordinator.ts` — `gateState()`, `applyAdmissionDirective()`
+  (idempotent emit via `lastEmittedAdmissionFingerprint`, defer/flush via
+  `isCodexTurnActive`/`onCodexTurnIdle`), `admissionResetEpoch()` (codex fresh window),
+  the recoveredSides codex-hold, the advise-case `gateState()!=="open"` re-arm.
+- `src/budget/budget-state.ts` — `renderBudgetAdmissionDirective()`, the
+  `adviceEligible` `!agentShouldAdmitClose(...)` guard.
+- `src/daemon.ts` — `evaluateInjectionBudgetGate()` (top-of-handler + post-interrupt-await
+  re-check), `maybeFireCheckpointBaton()` (onSnapshot + turnPhaseChanged triggers,
+  `codex.canInject()` precheck), `CHECKPOINT_BATON_PROMPT`.
+- `src/codex-adapter.ts` — `canInject()`, `injectMessage()`.
+- `src/budget/admission-quota.ts` — `consumeWrapUp`, `consumeCheckpointBaton` (fail-closed).
+
+## Safety
+
+Do NOT target the active pair. Use a disposable pair + cwd and a fixture probe:
+
+```bash
+export M3B_CWD="/tmp/agentbridge-m3b"
+export M3B_PAIR="m3b-probe"
+mkdir -p "$M3B_CWD/.agent"
+```
+
+The fixture probe reads per-agent JSON so the gate can be driven deterministically:
+
+```bash
+# probe.sh
+#!/bin/sh
+cat "$FIXTURE_ROOT/usage-$2.json"
+```
+
+Set `AGENTBRIDGE_BUDGET_ENABLED=1`, `AGENTBRIDGE_QUOTA_PROBE=<probe.sh>`,
+`AGENTBRIDGE_BUDGET_POLL_SECONDS=5` on the disposable pair's daemon.
+
+`util` levels (5h window, `reset_epoch` in the future): `< 85` = gate open;
+`85 ≤ util < 90` = admission-closed (not paused); `≥ 90` = closed (paused).
+
+---
+
+## T1 — Admission directive reaches Claude, turnPhase-aware
+
+1. Start the pair with codex `util: 20` (gate open). Confirm `/healthz`
+   `budget.gateState === "open"`; Claude receives no admission directive.
+2. With Codex idle, raise codex `util: 86`. Within one poll, `/healthz`
+   `gateState === "admission-closed"` and Claude receives ONE
+   `system_budget_admission` channel message ("收尾保护 … budget_admission … wrap_up").
+3. Reset codex `util: 20` (gate open), then start a Codex turn (any reply), and
+   WHILE it runs raise codex `util: 86`. **Expected:** the admission directive is
+   DEFERRED — Claude does NOT receive it mid-turn. When the Codex turn ends (idle),
+   the directive is flushed (Claude receives exactly one).
+4. Keep codex `util: 86` across several polls. **Expected:** no duplicate admission
+   directive (idempotent dedup).
+
+**Automated mirror:** budget-coordinator.test.ts "admission directive emission" block.
+
+## T2 — New Codex turn rejected; wrap-up + steer allowed
+
+1. Gate `admission-closed` (codex `util: 86`). From Claude, `reply` a normal new
+   task. **Expected:** rejected with `budget_admission`; no Codex turn starts.
+2. `reply` with `wrap_up: true`. **Expected:** injected (one Codex turn); the
+   wrap-up quota in `<stateDir>/admission-quota.json` shows `wrapUpUsed: 1`.
+3. Exceed `maximize.wrapUpQuota` (default 2) wrap-ups. **Expected:** the
+   (quota+1)-th `wrap_up` reply is rejected `budget_admission` (quota exhausted).
+4. A `steer` into a running Codex turn is NOT gated (feeds the turn).
+
+**Automated mirror:** daemon-wiring.test.ts "v3 P3 admission gate" tests.
+
+## T3 — Advice suppressed while admission-closed
+
+1. Drive a drift (e.g. Claude `util: 20`, codex `util: 86`) that would normally
+   produce a `system_budget_balance`/`system_budget_underutilized`. **Expected:**
+   NO routing-advice directive while codex admission-closes; `/healthz`
+   `budget.phase` is NOT "balance"/"underutilized" (it is "normal").
+2. Drop codex below the admission line (`util: 78`, gate open) with the drift still
+   present. **Expected:** the routing advice now fires exactly once (re-armed).
+
+**Automated mirror:** budget-state.test.ts "routing advice is suppressed" + the
+"re-emits suppressed balance advice once the admission gate opens (R2-2)" test.
+
+## T4 — Closed-state checkpoint baton (once per window)
+
+1. Drive codex to `util: 95` (gate closed) with Codex idle and TUI connected.
+   **Expected:** within one poll, ONE checkpoint baton turn is injected into Codex
+   (a turn whose text contains "系统发起 … .agent/checkpoint.md");
+   `admission-quota.json` shows `checkpointBatonUsed: true`.
+2. Hold codex `util: 95` across several more polls. **Expected:** NO further baton
+   (once per quota window). When the 5h window resets, a new baton may fire.
+3. Disconnect the Codex TUI, then drive `util: 95` (gate closed). **Expected:** the
+   baton is NOT consumed while Codex is not injectable (`canInject()` precheck) —
+   `checkpointBatonUsed` stays false; reconnect the TUI → the baton fires.
+
+**Automated mirror:** daemon-wiring.test.ts "closed gate fires the checkpoint baton
+ONCE per window"; codex-adapter.test.ts "canInject" + admission-quota.test.ts.
+
+## T5 — Codex pause-recovery held while admission-closed
+
+1. Burn-regime fixture: codex `util: 96` with confident burn (gate closed/paused).
+   Then drop to `util: 82` (pause clears, admission still holds — gate
+   admission-closed). **Expected:** Claude does NOT receive a `system_budget_resume`
+   for Codex while still admission-closed (no auto-resume turn injected); the
+   admission directive is shown instead. Dropping below `util: 80` (gate open)
+   allows recovery on the next genuine pause-recovery cycle.
+
+**Automated mirror:** budget-coordinator.test.ts "holds the Codex pause-recovery
+while still admission-closed (R2-1)".
+
+## T6 — Interrupt re-checks the gate after the await
+
+1. Gate open (codex `util: 20`), a Codex turn running. From Claude, send a new task
+   with `on_busy: "interrupt"`. While the daemon is parked awaiting the interrupt
+   terminal boundary, raise codex `util: 86` (gate → admission-closed). **Expected:**
+   when the boundary fires, the injection is REJECTED with `budget_admission` (the
+   post-await re-check), NOT injected — no gate bypass.
+
+**Automated mirror:** daemon-wiring.test.ts "interrupt RE-CHECKS the gate after the
+await" (uses `FAKE_APP_INTERRUPT_DELAY_MS` + a raised `AGENTBRIDGE_INTERRUPT_TIMEOUT_MS`).
+
+---
+
+## Pass criteria
+
+All of T1–T6 behave as the **Expected** lines describe, AND `bun run check` is green
+(typecheck + full suite + plugin sync + plugin versions). Any deviation is a
+regression in the M3b admission layer.
+
+## Known backlog (non-blocking, documented)
+
+- `getResumeCandidate().codex` reports `true` for the single de-escalation poll on
+  which the codex recovery is held; the value is unconsumed (the only reader,
+  `enqueueCodexBudgetResume`, is reached via the skipped `onResume`). Consider
+  clearing the codex candidate under the same hold condition.
+- `renderBudgetSnapshot()` does not surface `gateState: "admission-closed"`; during
+  the admission hold band `phase` can read "balance" while the gate is
+  admission-closed. The `gateState` field is the authoritative signal; consider
+  rendering admission-closed for observability.

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13858,6 +13858,9 @@ class StateDirResolver {
   get killedFile() {
     return join(this.stateDir, "killed");
   }
+  get admissionQuotaFile() {
+    return join(this.stateDir, "admission-quota.json");
+  }
   get updateCheckFile() {
     return join(this.stateDir, "update-check.json");
   }
@@ -14130,7 +14133,8 @@ var CLAUDE_INSTRUCTIONS = [
   "",
   "## Budget awareness",
   "- Use the get_budget tool to check both agents' subscription quota (5h/weekly windows, drift, pause state).",
-  "- If the reply tool returns a budget-pause error, do NOT retry; checkpoint your work and wait for the resume notice."
+  "- If the reply tool returns a budget-pause error (code budget_paused), do NOT retry; checkpoint your work and wait for the resume notice.",
+  "- If the reply tool returns a budget_admission error, the 5h window is in finishing-protection: new tasks are declined, but you may bring the CURRENT collaboration to a checkpoint by resending with wrap_up=true (a small per-window quota). Do NOT start new work; once the quota is used or you are done, write a checkpoint and wait for the 5h window to refresh."
 ].join(`
 `);
 
@@ -14374,6 +14378,10 @@ chat_id: ${this.sessionId}`);
               idempotency_key: {
                 type: "string",
                 description: "Optional client-generated key (non-empty, max 128 chars) that makes this reply idempotent: a retry carrying the same key is NOT re-injected \u2014 the bridge answers duplicate_in_flight / duplicate_terminal instead. Use a fresh key per logical message."
+              },
+              wrap_up: {
+                type: "boolean",
+                description: "Set true ONLY to declare a finishing turn when the budget gate is in 5h finishing-protection (you got a budget_admission error or a system_budget_admission notice). A wrap-up reply is let through the admission gate up to a small per-5h-window quota so you can bring the current collaboration to a checkpoint; do NOT use it to start new work. Leave false/unset for normal replies."
               }
             },
             required: ["text"]
@@ -14526,7 +14534,8 @@ chat_id: ${this.sessionId}`);
         isError: true
       };
     }
-    const result = await this.replySender(bridgeMsg, requireReply, onBusy, idempotencyKey);
+    const wrapUp = args?.wrap_up === true;
+    const result = await this.replySender(bridgeMsg, requireReply, onBusy, idempotencyKey, wrapUp);
     if (!result.success) {
       this.log(`Reply delivery failed: ${result.error}${result.code ? ` (code=${result.code})` : ""}`);
       const codePrefix = result.code ? ` [${result.code}]` : "";
@@ -14597,10 +14606,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.17", "0.0.0-source"),
-  commit: defineString("ad365c0", "source"),
+  commit: defineString("02064f0", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("c22387f3269f", "source")
+  codeHash: defineString("6cbaf424d274", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)
@@ -14847,7 +14856,7 @@ class DaemonClient extends EventEmitter2 {
     this.ws = null;
     this.rejectPendingReplies("Daemon connection closed");
   }
-  async sendReply(message, requireReply, onBusy, idempotencyKey) {
+  async sendReply(message, requireReply, onBusy, idempotencyKey, wrapUp) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return { success: false, error: "AgentBridge daemon is not connected." };
     }
@@ -14862,7 +14871,8 @@ class DaemonClient extends EventEmitter2 {
       message,
       ...requireReply ? { requireReply: true } : {},
       ...onBusy && onBusy !== "reject" ? { onBusy } : {},
-      ...idempotencyKey ? { idempotencyKey } : {}
+      ...idempotencyKey ? { idempotencyKey } : {},
+      ...wrapUp ? { wrapUp: true } : {}
     });
     return pending;
   }
@@ -15640,7 +15650,9 @@ var DEFAULT_BUDGET_CONFIG = {
     reserveSlopePctPerHour: 0.4,
     reserveMaxPct: 7,
     finishingHorizonMinutes: 30,
-    resumeHysteresisPct: 5
+    resumeHysteresisPct: 5,
+    admissionAt: 85,
+    wrapUpQuota: 2
   },
   allocation: {
     minRunwayRatio: 50,
@@ -15708,7 +15720,9 @@ function findShapeViolation(raw) {
         "reserveSlopePctPerHour",
         "reserveMaxPct",
         "finishingHorizonMinutes",
-        "resumeHysteresisPct"
+        "resumeHysteresisPct",
+        "admissionAt",
+        "wrapUpQuota"
       ]) {
         if (key in maximize && !isCoercibleNumber(maximize[key])) {
           return `budget.maximize.${key} is present but not a number`;
@@ -15733,7 +15747,7 @@ function hasCustomDecisionValues(config2) {
   const d = DEFAULT_CONFIG;
   const b = config2.budget;
   const db = d.budget;
-  return config2.idleShutdownSeconds !== d.idleShutdownSeconds || config2.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config2.codex.appPort !== d.codex.appPort || config2.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct || b.allocation.minRunwayRatio !== db.allocation.minRunwayRatio || b.allocation.minRunwayGapHours !== db.allocation.minRunwayGapHours;
+  return config2.idleShutdownSeconds !== d.idleShutdownSeconds || config2.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config2.codex.appPort !== d.codex.appPort || config2.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct || b.maximize.admissionAt !== db.maximize.admissionAt || b.maximize.wrapUpQuota !== db.maximize.wrapUpQuota || b.allocation.minRunwayRatio !== db.allocation.minRunwayRatio || b.allocation.minRunwayGapHours !== db.allocation.minRunwayGapHours;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -15773,9 +15787,11 @@ function normalizeMaximizeConfig(raw, pauseAt, fallback = DEFAULT_BUDGET_CONFIG.
     reserveSlopePctPerHour: normalizeBoundedNumber(m.reserveSlopePctPerHour, fallback.reserveSlopePctPerHour, 0, 5),
     reserveMaxPct: normalizeBoundedInteger(m.reserveMaxPct, fallback.reserveMaxPct, 0, 30),
     finishingHorizonMinutes: normalizeBoundedInteger(m.finishingHorizonMinutes, fallback.finishingHorizonMinutes, 5, 180),
-    resumeHysteresisPct: normalizeBoundedInteger(m.resumeHysteresisPct, fallback.resumeHysteresisPct, 1, 30)
+    resumeHysteresisPct: normalizeBoundedInteger(m.resumeHysteresisPct, fallback.resumeHysteresisPct, 1, 30),
+    admissionAt: normalizeBoundedInteger(m.admissionAt, fallback.admissionAt, 50, 99),
+    wrapUpQuota: Math.floor(normalizeBoundedInteger(m.wrapUpQuota, fallback.wrapUpQuota, 0, 10))
   };
-  if (normalized.targetUtil <= pauseAt) {
+  if (normalized.targetUtil <= pauseAt || normalized.admissionAt >= normalized.targetUtil) {
     return { ...DEFAULT_BUDGET_CONFIG.maximize };
   }
   return normalized;
@@ -16357,7 +16373,7 @@ if (process.env.AGENTBRIDGE_TRACE === "1") {
     });
   } catch {}
 }
-claude.setReplySender(async (msg, requireReply, onBusy, idempotencyKey) => {
+claude.setReplySender(async (msg, requireReply, onBusy, idempotencyKey, wrapUp) => {
   if (msg.source !== "claude") {
     return { success: false, error: "Invalid message source" };
   }
@@ -16367,7 +16383,7 @@ claude.setReplySender(async (msg, requireReply, onBusy, idempotencyKey) => {
       error: disabledReplyError(daemonDisabledReason ?? "killed")
     };
   }
-  return daemonClient.sendReply(msg, requireReply, onBusy, idempotencyKey);
+  return daemonClient.sendReply(msg, requireReply, onBusy, idempotencyKey, wrapUp);
 });
 claude.setResumeAckHandler((resumeId, status) => {
   if (daemonDisabled) {

--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14606,10 +14606,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.17", "0.0.0-source"),
-  commit: defineString("02064f0", "source"),
+  commit: defineString("ca19f6a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("6cbaf424d274", "source")
+  codeHash: defineString("1b88232d447e", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.17", "0.0.0-source"),
-  commit: defineString("02064f0", "source"),
+  commit: defineString("ca19f6a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("6cbaf424d274", "source")
+  codeHash: defineString("1b88232d447e", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -1016,6 +1016,9 @@ class CodexAdapter extends EventEmitter {
   }
   get activeThreadId() {
     return this.threadId;
+  }
+  canInject() {
+    return !!this.threadId && this.appServerWs?.readyState === WebSocket.OPEN && !this.turnInProgress;
   }
   get capturedAppServerInfo() {
     return this.appServerInfo;
@@ -3460,6 +3463,14 @@ function consumeWrapUp(path, fiveHourResetEpoch, limit, log = () => {}) {
   }
   return { allowed: true, used: next.wrapUpUsed, remaining: Math.max(0, limit - next.wrapUpUsed) };
 }
+function consumeCheckpointBaton(path, fiveHourResetEpoch, log = () => {}) {
+  if (!Number.isFinite(fiveHourResetEpoch))
+    return false;
+  const state = currentWindowState(path, fiveHourResetEpoch, log);
+  if (state.checkpointBatonUsed)
+    return false;
+  return persist(path, { ...state, checkpointBatonUsed: true }, log);
+}
 
 // src/config-service.ts
 import { readFileSync as readFileSync4, mkdirSync as mkdirSync4, existsSync as existsSync4 } from "fs";
@@ -4268,6 +4279,18 @@ function renderBudgetInterventionDirective(claude, codex, side, reason, resumeEp
   ].join(`
 `);
 }
+function renderBudgetAdmissionDirective(claude, codex, side, reason, resetEpoch, cfg) {
+  const resetText = `\u5BF9\u5E94\u7A97\u53E3\u7EA6 ${formatEpoch(resetEpoch)} \u5237\u65B0\uFF08\u4EE5\u5B9E\u6D4B\u4E3A\u51C6\uFF1B\u63D0\u524D\u5237\u65B0\u4F1A\u66F4\u65E9\u89E3\u9664\uFF09`;
+  const head = side === "both" ? "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011\u53CC\u65B9\u8FDB\u5165\u6536\u5C3E\u4FDD\u62A4\uFF08admission-closed\uFF09\u3002" : "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u8D26\u53F7\u7EA7\u3011Codex \u4FA7\u8FDB\u5165\u6536\u5C3E\u4FDD\u62A4\uFF08admission-closed\uFF09\u3002";
+  return [
+    head,
+    `\u89E6\u53D1\u539F\u56E0\uFF1A${reason}\u3002`,
+    `${usageSummary("claude", claude)}\uFF1B${usageSummary("codex", codex)}\u3002`,
+    `\u95F8\u95E8\u5DF2\u6536\u7D27\uFF1A\u65B0\u7684 Codex \u4EFB\u52A1\u4F1A\u88AB\u62D2\uFF08budget_admission\uFF09\uFF0C\u4F46\u4ECD\u53EF\u7528 reply \u5E26 wrap_up=true \u628A\u5F53\u524D\u534F\u4F5C\u6536\u5C3E\u5230 checkpoint` + `\uFF08\u6BCF\u7A97\u53E3\u81F3\u591A ${cfg.maximize.wrapUpQuota} \u4E2A\uFF09\uFF0Csteer \u4FEE\u6B63\u4E0D\u53D7\u9650\uFF1B${resetText}\u3002`,
+    "\u5EFA\u8BAE\uFF1A\u4E0D\u8981\u518D\u5411 Codex \u6D3E\u65B0\u4EFB\u52A1\uFF1B\u628A\u5F53\u524D Codex \u534F\u4F5C\u6536\u5C3E\u3001\u5199 checkpoint\uFF0C\u53EF\u72EC\u7ACB\u63A8\u8FDB\u7684\u90E8\u5206 Claude \u53EF solo \u7EE7\u7EED\u3002"
+  ].join(`
+`);
+}
 function balanceDirective(claude, codex, drift, basis, runway) {
   const heavier = drift.heavier ? AGENT_LABEL2[drift.heavier] : "\u672A\u77E5";
   const lighter = drift.lighter ? AGENT_LABEL2[drift.lighter] : "\u672A\u77E5";
@@ -4310,7 +4333,7 @@ function computeBudgetState(claude, codex, cfg, now, runway = NO_RUNWAY) {
   const paused = triggers.length > 0;
   const { drift, basis } = allocationDrift(claude, codex, runway, cfg);
   const parallel = { recommended: false, reason: null };
-  const adviceEligible = !paused && claude !== null && codex !== null && claude.rateLimitedUntil <= now && codex.rateLimitedUntil <= now && isDecisionGrade(claude, now) && isDecisionGrade(codex, now);
+  const adviceEligible = !paused && claude !== null && codex !== null && claude.rateLimitedUntil <= now && codex.rateLimitedUntil <= now && isDecisionGrade(claude, now) && isDecisionGrade(codex, now) && !agentShouldAdmitClose("claude", claude, cfg, now).admitClose && !agentShouldAdmitClose("codex", codex, cfg, now).admitClose;
   const balanceActive = adviceEligible && drift.heavier !== null && drift.lighter !== null;
   const underutilization = adviceEligible && !balanceActive ? underutilizationState(claude, codex, cfg, now) : { recommended: false, reason: null };
   const resetEpochs = {
@@ -4794,10 +4817,13 @@ class BudgetCoordinator {
   onResume;
   resumeSignals;
   adviceCooldown;
+  isCodexTurnActive;
   timer = null;
   running = false;
   fpState = INITIAL_FINGERPRINT_STATE;
   admissionState = INITIAL_ADMISSION_STATE;
+  pendingAdmissionDirective = null;
+  lastEmittedAdmissionFingerprint = null;
   resumeCandidate = {};
   latestSnapshot = null;
   pendingOverrideTier = null;
@@ -4821,6 +4847,7 @@ class BudgetCoordinator {
       cooldownSec: resolveAdviceCooldownSec(),
       log: this.log
     });
+    this.isCodexTurnActive = options.isCodexTurnActive ?? (() => false);
   }
   async start() {
     if (this.running || !this.config.enabled)
@@ -4939,8 +4966,13 @@ class BudgetCoordinator {
     const { next, effect } = classifyPoll(this.fpState, state, this.config);
     this.fpState = next;
     this.admissionState = classifyAdmission(this.admissionState, state, this.config).next;
+    this.applyAdmissionDirective(state);
     this.resumeCandidate = this.resumeSignals ? computeResumeCandidate(resumeCandidateSides(effect), state, this.config, this.resumeSignals()) : {};
     for (const side of effect.recoveredSides) {
+      if (side === "codex" && (this.admissionState.side === "codex" || this.admissionState.side === "both")) {
+        this.log(`Budget recovery for Codex held: pause cleared but still admission-closed`);
+        continue;
+      }
       const { id, directive } = this.emitRecovery(side, state);
       this.onResume(side, directive, id);
     }
@@ -4959,6 +4991,10 @@ class BudgetCoordinator {
         return;
       }
       case "advise": {
+        if (this.gateState() !== "open") {
+          this.fpState = { ...this.fpState, fingerprint: null };
+          return;
+        }
         if (effect.phase === "underutilized") {
           if (!this.adviceCooldown.tryAcquire("underutilization", state.now))
             return;
@@ -4971,6 +5007,51 @@ class BudgetCoordinator {
       case "none":
         return;
     }
+  }
+  applyAdmissionDirective(state) {
+    const side = this.admissionState.side;
+    if (side !== "codex" && side !== "both") {
+      this.pendingAdmissionDirective = null;
+      this.lastEmittedAdmissionFingerprint = null;
+      return;
+    }
+    const fingerprint = this.admissionState.fingerprint;
+    if (fingerprint === null || fingerprint === this.lastEmittedAdmissionFingerprint) {
+      this.pendingAdmissionDirective = null;
+      return;
+    }
+    if (this.isPaused()) {
+      this.pendingAdmissionDirective = null;
+      return;
+    }
+    const content = renderBudgetAdmissionDirective(state.perAgent.claude, state.perAgent.codex, side, this.admissionState.reason ?? "\u989D\u5EA6\u7A97\u53E3\u6536\u5C3E\u4FDD\u62A4", this.admissionResetEpoch(state), this.config);
+    if (this.isCodexTurnActive()) {
+      this.pendingAdmissionDirective = { content, fingerprint };
+      return;
+    }
+    this.emitAdmission(content, fingerprint);
+  }
+  emitAdmission(content, fingerprint) {
+    this.emitDirective("system_budget_admission", content);
+    this.lastEmittedAdmissionFingerprint = fingerprint;
+    this.pendingAdmissionDirective = null;
+  }
+  admissionResetEpoch(state) {
+    const usage = state.perAgent.codex;
+    const now = state.now;
+    const fiveHour = usage?.fiveHour?.resetEpoch ?? 0;
+    const weekly = usage?.weekly?.resetEpoch ?? 0;
+    const fresh = fiveHour > now ? fiveHour : weekly > now ? weekly : 0;
+    return fresh > 0 ? fresh : null;
+  }
+  onCodexTurnIdle() {
+    const pending = this.pendingAdmissionDirective;
+    if (!pending)
+      return;
+    this.pendingAdmissionDirective = null;
+    if (this.isPaused() || this.gateState() !== "admission-closed")
+      return;
+    this.emitAdmission(pending.content, pending.fingerprint);
   }
   tierControlEnabled() {
     if (!this.config.codexTierControl)
@@ -6669,7 +6750,10 @@ function ensureBudgetCoordinatorStarted() {
       onPauseChange: (paused) => {
         log(`Budget intervention ${paused ? "ACTIVE" : "CLEARED"} ` + `(gate ${budgetCoordinator?.isGateClosed() ? "CLOSED" : "OPEN"})`);
       },
-      onSnapshot: () => broadcastStatus(),
+      onSnapshot: () => {
+        broadcastStatus();
+        maybeFireCheckpointBaton("snapshot");
+      },
       log,
       onResume: (side, _directive, resumeId) => {
         if (side === "claude") {
@@ -6680,7 +6764,8 @@ function ensureBudgetCoordinatorStarted() {
           enqueueCodex: enqueueCodexBudgetResume
         });
       },
-      resumeSignals: readResumeSignals
+      resumeSignals: readResumeSignals,
+      isCodexTurnActive: () => codex.turnInProgress
     });
   }
   budgetCoordinator.start();
@@ -6704,6 +6789,71 @@ function budgetAdmissionGateError(windowResetEpoch, wrapUpLeft, quotaExhausted) 
   }
   return `\u989D\u5EA6\u7A97\u53E3\u6536\u5C3E\u4FDD\u62A4\u4E2D\uFF08admission-closed\uFF09\uFF1A\u4EC5\u63A5\u6536\u6536\u5C3E\u7C7B\u6CE8\u5165\uFF0C\u5DF2\u62D2\u7EDD\u8BE5\u65B0\u4EFB\u52A1\u3002` + `\u5982\u9700\u628A\u5F53\u524D\u534F\u4F5C\u6536\u5C3E\u5230 checkpoint\uFF0C\u53EF\u7528 reply \u5E26 wrap_up=true \u91CD\u53D1\uFF08\u672C\u7A97\u53E3\u8FD8\u5269 ${wrapUpLeft} \u4E2A\u6536\u5C3E\u914D\u989D\uFF09\uFF1Bsteer \u4FEE\u6B63\u4E0D\u53D7\u9650\u3002` + `\u65B0\u4EFB\u52A1\u8BF7\u7B49\u989D\u5EA6\u7A97\u53E3\u5237\u65B0\uFF08\u7EA6 ${resetAt}\uFF09\u540E\u518D\u6D3E\u3002`;
 }
+function evaluateInjectionBudgetGate(message, willInject, isSteer) {
+  const gateState = budgetCoordinator?.gateState() ?? "open";
+  if (gateState === "closed") {
+    log(`Injection rejected by budget pause gate`);
+    const resumeAfterEpoch3 = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
+    const retryAfterMs = retryAfterMsForResume(resumeAfterEpoch3, Date.now());
+    return {
+      allow: false,
+      code: "budget_paused",
+      error: budgetPauseGateError(),
+      ...retryAfterMs !== undefined ? { retryAfterMs } : {}
+    };
+  }
+  if (gateState === "admission-closed" && !isSteer) {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const admSnap = budgetCoordinator?.getSnapshot()?.codex;
+    const admFiveHour = admSnap?.fiveHour?.resetEpoch ?? 0;
+    const admWeekly = admSnap?.weekly?.resetEpoch ?? 0;
+    const admissionWindowReset = admFiveHour > nowSec ? admFiveHour : admWeekly > nowSec ? admWeekly : 0;
+    if (admissionWindowReset <= 0) {
+      log(`Injection rejected by admission gate: no fresh quota window (probe stale / snapshot lost)`);
+      return { allow: false, code: "budget_admission", error: budgetAdmissionGateError(0, 0, true) };
+    }
+    if (message.wrapUp === true && willInject) {
+      const peek = currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log);
+      if (peek.wrapUpUsed >= BUDGET_CONFIG.maximize.wrapUpQuota) {
+        log(`Injection rejected by admission gate: wrap-up quota exhausted`);
+        return { allow: false, code: "budget_admission", error: budgetAdmissionGateError(admissionWindowReset, 0, true) };
+      }
+      log(`Admission-closed: wrap-up permitted (${peek.wrapUpUsed}/${BUDGET_CONFIG.maximize.wrapUpQuota} used; slot committed on inject)`);
+      return { allow: true, pendingWrapUpReset: admissionWindowReset };
+    }
+    if (message.wrapUp === true && !willInject) {
+      return { allow: true, pendingWrapUpReset: null };
+    }
+    const left = Math.max(0, BUDGET_CONFIG.maximize.wrapUpQuota - currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log).wrapUpUsed);
+    log(`Injection rejected by admission gate: new task (set wrap_up to finish the current work)`);
+    return { allow: false, code: "budget_admission", error: budgetAdmissionGateError(admissionWindowReset, left, false) };
+  }
+  return { allow: true, pendingWrapUpReset: null };
+}
+var CHECKPOINT_BATON_PROMPT = "\u3010\u9884\u7B97\u534F\u8C03 \xB7 \u7CFB\u7EDF\u53D1\u8D77\u3011\u8D26\u53F7\u7EA7\u989D\u5EA6\u5373\u5C06\u8017\u5C3D\uFF0C\u95F8\u95E8\u5DF2\u5173\u95ED\u3002\u8FD9\u662F\u672C\u989D\u5EA6\u7A97\u53E3\u552F\u4E00\u4E00\u6B21\u7CFB\u7EDF\u63D0\u9192\uFF1A" + "\u8BF7\u7ACB\u5373\u628A\u5F53\u524D\u8FDB\u5EA6\u5199\u5165 checkpoint\uFF08.agent/checkpoint.md\uFF1A\u4EFB\u52A1 / \u5DF2\u5B8C\u6210 / \u8FDB\u884C\u4E2D\u65AD\u70B9 / \u4E0B\u4E00\u6B65 / \u5173\u952E\u51B3\u7B56\u4E0E\u7EA6\u675F\uFF09\uFF0C" + "\u7136\u540E\u505C\u624B\u7B49\u5F85\u989D\u5EA6\u7A97\u53E3\u5237\u65B0\uFF1B\u5237\u65B0\u524D\u4E0D\u8981\u518D\u5F00\u65B0\u4EFB\u52A1\u3002\u6B64\u4E3A\u7CFB\u7EDF\u63D0\u9192\uFF0C\u65E0\u9700\u56DE\u590D Claude\u3002";
+function maybeFireCheckpointBaton(trigger) {
+  if (!budgetCoordinator)
+    return;
+  if (budgetCoordinator.gateState() !== "closed")
+    return;
+  if (!codex.canInject())
+    return;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const snap = budgetCoordinator.getSnapshot()?.codex;
+  const fiveHour = snap?.fiveHour?.resetEpoch ?? 0;
+  const weekly = snap?.weekly?.resetEpoch ?? 0;
+  const windowReset = fiveHour > nowSec ? fiveHour : weekly > nowSec ? weekly : 0;
+  if (windowReset <= 0)
+    return;
+  if (!consumeCheckpointBaton(stateDir.admissionQuotaFile, windowReset, log))
+    return;
+  const injectionId = codex.injectMessage(CHECKPOINT_BATON_PROMPT);
+  if (injectionId === null) {
+    log(`Checkpoint baton (${trigger}): inject failed after consume \u2014 baton lost this window (reset ${windowReset})`);
+    return;
+  }
+  log(`Checkpoint baton fired (${trigger}, window reset ${windowReset})`);
+}
 var tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
   log,
@@ -6725,6 +6875,10 @@ function tryWriteStatusFile(reason) {
 codex.on("turnPhaseChanged", ({ phase, previous }) => {
   log(`Codex turn phase: ${previous} \u2192 ${phase}`);
   tryWriteStatusFile(`turnPhase:${phase}`);
+  if (phase === "idle" || phase === "aborted") {
+    budgetCoordinator?.onCodexTurnIdle();
+    maybeFireCheckpointBaton("turnIdle");
+  }
   broadcastStatus();
 });
 codex.on("steerFailed", ({ requestId, reason }) => {
@@ -7130,62 +7284,20 @@ async function handleClaudeToCodex(ws, message) {
     return;
   }
   let pendingWrapUpReset = null;
-  const gateState = budgetCoordinator?.gateState() ?? "open";
-  if (gateState === "closed") {
-    const reason = budgetPauseGateError();
-    log(`Injection rejected by budget pause gate`);
-    const resumeAfterEpoch3 = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
-    const retryAfterMs = retryAfterMsForResume(resumeAfterEpoch3, Date.now());
-    sendClaudeToCodexResult(ws, message.requestId, {
-      success: false,
-      code: "budget_paused",
-      error: reason,
-      ...retryAfterMs !== undefined ? { retryAfterMs } : {}
-    });
-    return;
-  }
-  if (gateState === "admission-closed") {
+  {
     const isSteer = codex.turnInProgress && message.onBusy === "steer";
-    if (!isSteer) {
-      const nowSec = Math.floor(Date.now() / 1000);
-      const admSnap = budgetCoordinator?.getSnapshot()?.codex;
-      const admFiveHour = admSnap?.fiveHour?.resetEpoch ?? 0;
-      const admWeekly = admSnap?.weekly?.resetEpoch ?? 0;
-      const admissionWindowReset = admFiveHour > nowSec ? admFiveHour : admWeekly > nowSec ? admWeekly : 0;
-      if (admissionWindowReset <= 0) {
-        log(`Injection rejected by admission gate: no fresh quota window (probe stale / snapshot lost)`);
-        sendClaudeToCodexResult(ws, message.requestId, {
-          success: false,
-          code: "budget_admission",
-          error: budgetAdmissionGateError(0, 0, true)
-        });
-        return;
-      }
-      const willInject = !codex.turnInProgress || message.onBusy === "interrupt";
-      if (message.wrapUp === true && willInject) {
-        const peek = currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log);
-        if (peek.wrapUpUsed >= BUDGET_CONFIG.maximize.wrapUpQuota) {
-          log(`Injection rejected by admission gate: wrap-up quota exhausted`);
-          sendClaudeToCodexResult(ws, message.requestId, {
-            success: false,
-            code: "budget_admission",
-            error: budgetAdmissionGateError(admissionWindowReset, 0, true)
-          });
-          return;
-        }
-        pendingWrapUpReset = admissionWindowReset;
-        log(`Admission-closed: wrap-up permitted (${peek.wrapUpUsed}/${BUDGET_CONFIG.maximize.wrapUpQuota} used; slot committed on inject)`);
-      } else if (message.wrapUp === true && !willInject) {} else {
-        const left = Math.max(0, BUDGET_CONFIG.maximize.wrapUpQuota - currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log).wrapUpUsed);
-        log(`Injection rejected by admission gate: new task (set wrap_up to finish the current work)`);
-        sendClaudeToCodexResult(ws, message.requestId, {
-          success: false,
-          code: "budget_admission",
-          error: budgetAdmissionGateError(admissionWindowReset, left, false)
-        });
-        return;
-      }
+    const willInject = !codex.turnInProgress || message.onBusy === "interrupt";
+    const gate = evaluateInjectionBudgetGate(message, willInject, isSteer);
+    if (!gate.allow) {
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: gate.code,
+        error: gate.error,
+        ...gate.retryAfterMs !== undefined ? { retryAfterMs: gate.retryAfterMs } : {}
+      });
+      return;
     }
+    pendingWrapUpReset = gate.pendingWrapUpReset;
   }
   const requireReply = !!message.requireReply;
   let contentToSend = message.message.content;
@@ -7273,6 +7385,21 @@ async function handleClaudeToCodex(ws, message) {
     }
     if (interruptThreadId && codex.activeThreadId !== interruptThreadId) {
       releaseInterruptKey();
+    }
+    {
+      const gate = evaluateInjectionBudgetGate(message, true, false);
+      if (!gate.allow) {
+        releaseInterruptKey();
+        log(`Interrupt-path injection rejected by budget gate after await (${gate.code})`);
+        sendClaudeToCodexResult(ws, message.requestId, {
+          success: false,
+          code: gate.code,
+          error: gate.error,
+          ...gate.retryAfterMs !== undefined ? { retryAfterMs: gate.retryAfterMs } : {}
+        });
+        return;
+      }
+      pendingWrapUpReset = gate.pendingWrapUpReset;
     }
   }
   const injectThreadId = codex.activeThreadId;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.17", "0.0.0-source"),
-  commit: defineString("ad365c0", "source"),
+  commit: defineString("02064f0", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("c22387f3269f", "source")
+  codeHash: defineString("6cbaf424d274", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -289,6 +289,9 @@ class StateDirResolver {
   }
   get killedFile() {
     return join(this.stateDir, "killed");
+  }
+  get admissionQuotaFile() {
+    return join(this.stateDir, "admission-quota.json");
   }
   get updateCheckFile() {
     return join(this.stateDir, "update-check.json");
@@ -3386,6 +3389,78 @@ async function fetchWithTimeout(url, timeoutMs = HEALTH_FETCH_TIMEOUT_MS) {
   }
 }
 
+// src/budget/admission-quota.ts
+function nodeFs() {
+  return __require("fs");
+}
+function freshState(fiveHourResetEpoch) {
+  return { version: 1, fiveHourResetEpoch, wrapUpUsed: 0, checkpointBatonUsed: false };
+}
+function parseAdmissionQuota(value) {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return null;
+  const record = value;
+  if (record.version !== 1)
+    return null;
+  const epoch = record.fiveHourResetEpoch;
+  const used = record.wrapUpUsed;
+  if (typeof epoch !== "number" || !Number.isFinite(epoch))
+    return null;
+  if (typeof used !== "number" || !Number.isFinite(used) || used < 0)
+    return null;
+  return {
+    version: 1,
+    fiveHourResetEpoch: epoch,
+    wrapUpUsed: Math.floor(used),
+    checkpointBatonUsed: record.checkpointBatonUsed === true
+  };
+}
+function currentWindowState(path, fiveHourResetEpoch, log = () => {}) {
+  let raw;
+  try {
+    raw = nodeFs().readFileSync(path, "utf-8");
+  } catch {
+    return freshState(fiveHourResetEpoch);
+  }
+  const text = String(raw).trim();
+  if (text === "")
+    return freshState(fiveHourResetEpoch);
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    log(`admission-quota: skip malformed JSON ${path}`);
+    return freshState(fiveHourResetEpoch);
+  }
+  const state = parseAdmissionQuota(parsed);
+  if (!state || state.fiveHourResetEpoch !== fiveHourResetEpoch) {
+    return freshState(fiveHourResetEpoch);
+  }
+  return state;
+}
+function persist(path, state, log) {
+  try {
+    atomicWriteJson(path, state);
+    return true;
+  } catch (error) {
+    log(`admission-quota: write failed ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
+}
+function consumeWrapUp(path, fiveHourResetEpoch, limit, log = () => {}) {
+  if (!Number.isFinite(fiveHourResetEpoch))
+    return { allowed: false, used: 0, remaining: 0 };
+  const state = currentWindowState(path, fiveHourResetEpoch, log);
+  if (state.wrapUpUsed >= limit) {
+    return { allowed: false, used: state.wrapUpUsed, remaining: Math.max(0, limit - state.wrapUpUsed) };
+  }
+  const next = { ...state, wrapUpUsed: state.wrapUpUsed + 1 };
+  if (!persist(path, next, log)) {
+    return { allowed: false, used: state.wrapUpUsed, remaining: Math.max(0, limit - state.wrapUpUsed) };
+  }
+  return { allowed: true, used: next.wrapUpUsed, remaining: Math.max(0, limit - next.wrapUpUsed) };
+}
+
 // src/config-service.ts
 import { readFileSync as readFileSync4, mkdirSync as mkdirSync4, existsSync as existsSync4 } from "fs";
 import { join as join4 } from "path";
@@ -3410,7 +3485,9 @@ var DEFAULT_BUDGET_CONFIG = {
     reserveSlopePctPerHour: 0.4,
     reserveMaxPct: 7,
     finishingHorizonMinutes: 30,
-    resumeHysteresisPct: 5
+    resumeHysteresisPct: 5,
+    admissionAt: 85,
+    wrapUpQuota: 2
   },
   allocation: {
     minRunwayRatio: 50,
@@ -3478,7 +3555,9 @@ function findShapeViolation(raw) {
         "reserveSlopePctPerHour",
         "reserveMaxPct",
         "finishingHorizonMinutes",
-        "resumeHysteresisPct"
+        "resumeHysteresisPct",
+        "admissionAt",
+        "wrapUpQuota"
       ]) {
         if (key in maximize && !isCoercibleNumber(maximize[key])) {
           return `budget.maximize.${key} is present but not a number`;
@@ -3503,7 +3582,7 @@ function hasCustomDecisionValues(config) {
   const d = DEFAULT_CONFIG;
   const b = config.budget;
   const db = d.budget;
-  return config.idleShutdownSeconds !== d.idleShutdownSeconds || config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config.codex.appPort !== d.codex.appPort || config.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct || b.allocation.minRunwayRatio !== db.allocation.minRunwayRatio || b.allocation.minRunwayGapHours !== db.allocation.minRunwayGapHours;
+  return config.idleShutdownSeconds !== d.idleShutdownSeconds || config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config.codex.appPort !== d.codex.appPort || config.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct || b.maximize.admissionAt !== db.maximize.admissionAt || b.maximize.wrapUpQuota !== db.maximize.wrapUpQuota || b.allocation.minRunwayRatio !== db.allocation.minRunwayRatio || b.allocation.minRunwayGapHours !== db.allocation.minRunwayGapHours;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -3543,9 +3622,11 @@ function normalizeMaximizeConfig(raw, pauseAt, fallback = DEFAULT_BUDGET_CONFIG.
     reserveSlopePctPerHour: normalizeBoundedNumber(m.reserveSlopePctPerHour, fallback.reserveSlopePctPerHour, 0, 5),
     reserveMaxPct: normalizeBoundedInteger(m.reserveMaxPct, fallback.reserveMaxPct, 0, 30),
     finishingHorizonMinutes: normalizeBoundedInteger(m.finishingHorizonMinutes, fallback.finishingHorizonMinutes, 5, 180),
-    resumeHysteresisPct: normalizeBoundedInteger(m.resumeHysteresisPct, fallback.resumeHysteresisPct, 1, 30)
+    resumeHysteresisPct: normalizeBoundedInteger(m.resumeHysteresisPct, fallback.resumeHysteresisPct, 1, 30),
+    admissionAt: normalizeBoundedInteger(m.admissionAt, fallback.admissionAt, 50, 99),
+    wrapUpQuota: Math.floor(normalizeBoundedInteger(m.wrapUpQuota, fallback.wrapUpQuota, 0, 10))
   };
-  if (normalized.targetUtil <= pauseAt) {
+  if (normalized.targetUtil <= pauseAt || normalized.admissionAt >= normalized.targetUtil) {
     return { ...DEFAULT_BUDGET_CONFIG.maximize };
   }
   return normalized;
@@ -3628,7 +3709,9 @@ function applyBudgetEnvOverrides(budget, env = process.env) {
       reserveSlopePctPerHour: env.AGENTBRIDGE_BUDGET_RESERVE_SLOPE_PCT_PER_HOUR ?? budget.maximize.reserveSlopePctPerHour,
       reserveMaxPct: env.AGENTBRIDGE_BUDGET_RESERVE_MAX_PCT ?? budget.maximize.reserveMaxPct,
       finishingHorizonMinutes: env.AGENTBRIDGE_BUDGET_FINISHING_HORIZON_MINUTES ?? budget.maximize.finishingHorizonMinutes,
-      resumeHysteresisPct: env.AGENTBRIDGE_BUDGET_RESUME_HYSTERESIS_PCT ?? budget.maximize.resumeHysteresisPct
+      resumeHysteresisPct: env.AGENTBRIDGE_BUDGET_RESUME_HYSTERESIS_PCT ?? budget.maximize.resumeHysteresisPct,
+      admissionAt: env.AGENTBRIDGE_BUDGET_ADMISSION_AT ?? budget.maximize.admissionAt,
+      wrapUpQuota: env.AGENTBRIDGE_BUDGET_WRAP_UP_QUOTA ?? budget.maximize.wrapUpQuota
     },
     allocation: {
       minRunwayRatio: env.AGENTBRIDGE_BUDGET_MIN_RUNWAY_RATIO ?? budget.allocation.minRunwayRatio,
@@ -3966,6 +4049,79 @@ function resumeBlockingEpochFor(usage, cfg, now) {
   if (blockingResets.length === 0)
     return 0;
   return Math.min(...blockingResets);
+}
+var ADMISSION_WEEKLY_RUNWAY_ENTER_MULT = 2;
+var ADMISSION_WEEKLY_RUNWAY_EXIT_MULT = 3;
+function weeklyRunwayFloorSec(cfg, mult) {
+  return cfg.maximize.finishingHorizonMinutes * 60 * mult;
+}
+function weeklyRunwayShort(usage, cfg, now, floorSec) {
+  const weekly = usage.weekly;
+  if (!weekly || weekly.resetEpoch <= now)
+    return false;
+  if (dynamicWindowVerdict(weekly, cfg, now).kind !== "will-fill")
+    return false;
+  const runway = weekly.runwaySeconds;
+  if (typeof runway !== "number" || !Number.isFinite(runway))
+    return false;
+  return runway < floorSec;
+}
+function hardCapWindow(usage, cfg, now) {
+  for (const { key, window } of freshWindows(usage, now)) {
+    const rate = confidentRate(window);
+    if (rate === null)
+      continue;
+    if (dynamicPauseAt(window, rate, cfg, now) === "admission-closed")
+      return key;
+  }
+  return null;
+}
+var NO_ADMIT_CLOSE = { admitClose: false, window: null, reason: "" };
+function agentShouldAdmitClose(agent, usage, cfg, now) {
+  if (!usage)
+    return NO_ADMIT_CLOSE;
+  if (!isDecisionGrade(usage, now))
+    return NO_ADMIT_CLOSE;
+  const fiveHour = usage.fiveHour;
+  if (fiveHour && fiveHour.resetEpoch > now && fiveHour.util >= cfg.maximize.admissionAt) {
+    return {
+      admitClose: true,
+      window: "fiveHour",
+      reason: `${AGENT_LABEL[agent]} 5h\u7A97\u53E3 util ${pct(fiveHour.util)} \u2265 admissionAt ${pct(cfg.maximize.admissionAt)}\uFF08\u6536\u5C3E\u4FDD\u62A4\uFF1A\u62D2\u65B0\u4EFB\u52A1\u3001\u653E\u6536\u5C3E\uFF09`
+    };
+  }
+  const hard = hardCapWindow(usage, cfg, now);
+  if (hard !== null) {
+    return {
+      admitClose: true,
+      window: hard,
+      reason: `${AGENT_LABEL[agent]} ${WINDOW_LABEL[hard]}\u7A97\u53E3\u89E6\u53D1\u6536\u5C3E\u4FDD\u62A4\u786C\u7EBF\uFF08util \u5DF2\u8FBE targetUtil \u6216\u4E34\u8FD1\u91CD\u7F6E\u6536\u5C3E\u5E26\uFF09`
+    };
+  }
+  if (weeklyRunwayShort(usage, cfg, now, weeklyRunwayFloorSec(cfg, ADMISSION_WEEKLY_RUNWAY_ENTER_MULT))) {
+    return {
+      admitClose: true,
+      window: "weekly",
+      reason: `${AGENT_LABEL[agent]} \u5468\u7A97\u53E3 runway \u4F4E\u4E8E ${ADMISSION_WEEKLY_RUNWAY_ENTER_MULT}\xD7\u6536\u5C3E\u89C6\u91CE\uFF08\u9632\u65B0\u957F\u4EFB\u52A1\u649E\u7A7F\u5468\u989D\u5EA6\uFF09`
+    };
+  }
+  return NO_ADMIT_CLOSE;
+}
+function agentCanAdmitOpen(usage, cfg, now) {
+  if (!isDecisionGrade(usage, now))
+    return false;
+  if (usage.rateLimitedUntil > now)
+    return false;
+  const fiveHour = usage.fiveHour;
+  if (fiveHour && fiveHour.resetEpoch > now) {
+    if (fiveHour.util >= cfg.maximize.admissionAt - cfg.maximize.resumeHysteresisPct)
+      return false;
+  }
+  if (hardCapWindow(usage, cfg, now) !== null)
+    return false;
+  if (weeklyRunwayShort(usage, cfg, now, weeklyRunwayFloorSec(cfg, ADMISSION_WEEKLY_RUNWAY_EXIT_MULT)))
+    return false;
+  return true;
 }
 
 // src/budget/budget-state.ts
@@ -4445,6 +4601,58 @@ function computeResumeCandidate(sides, state, cfg, signals) {
     candidate.detail = detail;
   return candidate;
 }
+var INITIAL_ADMISSION_STATE = { side: null, fingerprint: null, reason: null };
+function nextAdmissionSide(prevSide, state, cfg) {
+  const active = new Set(sideToAgents(prevSide));
+  for (const agent of ["claude", "codex"]) {
+    const usage = state.perAgent[agent];
+    if (agentShouldAdmitClose(agent, usage, cfg, state.now).admitClose) {
+      active.add(agent);
+    } else if (active.has(agent) && agentCanAdmitOpen(usage, cfg, state.now)) {
+      active.delete(agent);
+    }
+  }
+  return agentsToSide(active);
+}
+function admissionReason(side, state, cfg) {
+  return sideToAgents(side).map((agent) => {
+    const usage = state.perAgent[agent];
+    if (!usage)
+      return `${AGENT_LABEL3[agent]} \u63A2\u6D4B\u6682\u65F6\u4E0D\u53EF\u7528\uFF0C\u4FDD\u6301\u4E0A\u4E00\u8F6E\u6536\u5C3E\u4FDD\u62A4`;
+    if (usage.rateLimitedUntil > state.now) {
+      return `${AGENT_LABEL3[agent]} \u63A2\u9488\u88AB\u9650\u6D41\u81F3 ${formatEpoch2(usage.rateLimitedUntil)}\uFF0C\u4FDD\u6301\u6536\u5C3E\u4FDD\u62A4`;
+    }
+    const decision = agentShouldAdmitClose(agent, usage, cfg, state.now);
+    if (decision.admitClose)
+      return decision.reason;
+    return `${AGENT_LABEL3[agent]} \u6536\u5C3E\u4FDD\u62A4\u51FA\u95F8\u6EDE\u56DE\u5E26\uFF0C\u5C1A\u672A\u6EE1\u8DB3\u5F00\u95F8\u6761\u4EF6`;
+  }).join("\uFF1B");
+}
+function admissionFingerprint(state, side) {
+  let reset = 0;
+  for (const agent of sideToAgents(side)) {
+    reset = Math.max(reset, state.pause.resetEpochs[agent] ?? 0);
+  }
+  return ["admission", side, Math.round(reset / RESET_FINGERPRINT_BUCKET_SEC)].join("|");
+}
+function classifyAdmission(prev, state, cfg) {
+  const previousSide = prev.side;
+  const currentSide = nextAdmissionSide(previousSide, state, cfg);
+  if (currentSide) {
+    const reason = admissionReason(currentSide, state, cfg);
+    const uncertain = previousSide === currentSide && activeSideProbeUncertain(currentSide, state) && prev.fingerprint;
+    const fingerprint = uncertain ? prev.fingerprint : admissionFingerprint(state, currentSide);
+    const emit = !previousSide || previousSide !== currentSide || fingerprint !== prev.fingerprint;
+    return {
+      next: { side: currentSide, fingerprint, reason },
+      effect: { kind: uncertain ? "hold-uncertain" : "enter", side: currentSide, reason, emit }
+    };
+  }
+  if (previousSide) {
+    return { next: INITIAL_ADMISSION_STATE, effect: { kind: "exit", previousSide } };
+  }
+  return { next: INITIAL_ADMISSION_STATE, effect: { kind: "none" } };
+}
 
 // src/budget/burn-view.ts
 function windowBurnRate(window) {
@@ -4589,6 +4797,7 @@ class BudgetCoordinator {
   timer = null;
   running = false;
   fpState = INITIAL_FINGERPRINT_STATE;
+  admissionState = INITIAL_ADMISSION_STATE;
   resumeCandidate = {};
   latestSnapshot = null;
   pendingOverrideTier = null;
@@ -4633,6 +4842,13 @@ class BudgetCoordinator {
   }
   isGateClosed() {
     return this.fpState.side === "codex" || this.fpState.side === "both";
+  }
+  gateState() {
+    if (this.fpState.side === "codex" || this.fpState.side === "both")
+      return "closed";
+    if (this.admissionState.side === "codex" || this.admissionState.side === "both")
+      return "admission-closed";
+    return "open";
   }
   getSnapshot() {
     return this.latestSnapshot;
@@ -4722,6 +4938,7 @@ class BudgetCoordinator {
   applyState(state) {
     const { next, effect } = classifyPoll(this.fpState, state, this.config);
     this.fpState = next;
+    this.admissionState = classifyAdmission(this.admissionState, state, this.config).next;
     this.resumeCandidate = this.resumeSignals ? computeResumeCandidate(resumeCandidateSides(effect), state, this.config, this.resumeSignals()) : {};
     for (const side of effect.recoveredSides) {
       const { id, directive } = this.emitRecovery(side, state);
@@ -4836,6 +5053,7 @@ class BudgetCoordinator {
       driftPct: state.drift.pct,
       paused,
       gateClosed: this.isGateClosed(),
+      gateState: this.gateState(),
       pauseSide: this.fpState.side,
       pauseReason: paused ? this.fpState.reason ?? state.pause.reason : null,
       resumeAfterEpoch: paused ? this.fpState.resumeEpoch ?? state.pause.resumeAfterEpoch : null,
@@ -5258,14 +5476,14 @@ function createQuotaSource(options) {
 // src/budget/pending-reader.ts
 import { createHash } from "crypto";
 import { join as join7 } from "path";
-function nodeFs() {
+function nodeFs2() {
   return __require("fs");
 }
 function cwdMatches(entryCwd, optsCwd) {
   if (entryCwd === optsCwd)
     return true;
   try {
-    const fs2 = nodeFs();
+    const fs2 = nodeFs2();
     return fs2.realpathSync(entryCwd) === fs2.realpathSync(optsCwd);
   } catch {
     return false;
@@ -5303,7 +5521,7 @@ function resolveStateDir2(homeDir) {
 function readPendingFile(path, log) {
   let raw;
   try {
-    raw = nodeFs().readFileSync(path, "utf-8");
+    raw = nodeFs2().readFileSync(path, "utf-8");
   } catch (error) {
     log(`pending reader: skip unreadable ${path}: ${error instanceof Error ? error.message : String(error)}`);
     return null;
@@ -5327,7 +5545,7 @@ function listScopeFiles(stateDir, agent, log) {
   const pendingDir = join7(stateDir, "pending");
   let names;
   try {
-    names = nodeFs().readdirSync(pendingDir);
+    names = nodeFs2().readdirSync(pendingDir);
   } catch {
     return [];
   }
@@ -6478,6 +6696,14 @@ function budgetPauseGateError() {
   const reopenText = `Codex \u4FA7\u5404\u7A97\u53E3 util \u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${BUDGET_CONFIG.maximize.resumeHysteresisPct}% \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0\u540E\u95F8\u95E8\u81EA\u52A8\u653E\u5F00`;
   return `\u9884\u7B97\u6682\u505C\uFF08\u95F8\u95E8\u5173\u95ED\uFF09\uFF0C\u5DF2\u62D2\u7EDD\u8F6C\u53D1\uFF1A${reason}\u3002` + reopenText + (resumeAt ? `\uFF08\u9884\u8BA1\u6062\u590D ${resumeAt}\uFF0C\u4EE5\u5B9E\u6D4B\u4E3A\u51C6\uFF1B\u63D0\u524D\u5237\u65B0\u4F1A\u66F4\u65E9\u89E3\u9664\uFF09` : "") + `\u3002\u6536\u5230 RESUME \u901A\u77E5\u524D\u8BF7\u52FF\u91CD\u8BD5\u5411 Codex \u53D1\u9001 reply\uFF1B${sideHint}\u3002`;
 }
+function budgetAdmissionGateError(windowResetEpoch, wrapUpLeft, quotaExhausted) {
+  const resetAt = windowResetEpoch > 0 ? new Date(windowResetEpoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z") : "\u672A\u77E5";
+  const quota = BUDGET_CONFIG.maximize.wrapUpQuota;
+  if (quotaExhausted) {
+    return `\u989D\u5EA6\u7A97\u53E3\u6536\u5C3E\u4FDD\u62A4\u4E2D\uFF08admission-closed\uFF09\uFF1A\u672C\u7A97\u53E3 wrap-up \u914D\u989D\uFF08\u6BCF\u7A97\u53E3 ${quota} \u4E2A\uFF09\u5DF2\u7528\u5C3D\uFF0C\u5DF2\u62D2\u7EDD\u8F6C\u53D1\u3002` + `\u8BF7\u52FF\u518D\u6D3E\u65B0\u4EFB\u52A1\uFF1B\u5199 checkpoint\uFF0C\u7B49\u989D\u5EA6\u7A97\u53E3\u5237\u65B0\uFF08\u7EA6 ${resetAt}\uFF09\u540E\u518D\u7EE7\u7EED\u3002`;
+  }
+  return `\u989D\u5EA6\u7A97\u53E3\u6536\u5C3E\u4FDD\u62A4\u4E2D\uFF08admission-closed\uFF09\uFF1A\u4EC5\u63A5\u6536\u6536\u5C3E\u7C7B\u6CE8\u5165\uFF0C\u5DF2\u62D2\u7EDD\u8BE5\u65B0\u4EFB\u52A1\u3002` + `\u5982\u9700\u628A\u5F53\u524D\u534F\u4F5C\u6536\u5C3E\u5230 checkpoint\uFF0C\u53EF\u7528 reply \u5E26 wrap_up=true \u91CD\u53D1\uFF08\u672C\u7A97\u53E3\u8FD8\u5269 ${wrapUpLeft} \u4E2A\u6536\u5C3E\u914D\u989D\uFF09\uFF1Bsteer \u4FEE\u6B63\u4E0D\u53D7\u9650\u3002` + `\u65B0\u4EFB\u52A1\u8BF7\u7B49\u989D\u5EA6\u7A97\u53E3\u5237\u65B0\uFF08\u7EA6 ${resetAt}\uFF09\u540E\u518D\u6D3E\u3002`;
+}
 var tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
   log,
@@ -6903,7 +7129,9 @@ async function handleClaudeToCodex(ws, message) {
     });
     return;
   }
-  if (budgetCoordinator?.isGateClosed()) {
+  let pendingWrapUpReset = null;
+  const gateState = budgetCoordinator?.gateState() ?? "open";
+  if (gateState === "closed") {
     const reason = budgetPauseGateError();
     log(`Injection rejected by budget pause gate`);
     const resumeAfterEpoch3 = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
@@ -6915,6 +7143,49 @@ async function handleClaudeToCodex(ws, message) {
       ...retryAfterMs !== undefined ? { retryAfterMs } : {}
     });
     return;
+  }
+  if (gateState === "admission-closed") {
+    const isSteer = codex.turnInProgress && message.onBusy === "steer";
+    if (!isSteer) {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const admSnap = budgetCoordinator?.getSnapshot()?.codex;
+      const admFiveHour = admSnap?.fiveHour?.resetEpoch ?? 0;
+      const admWeekly = admSnap?.weekly?.resetEpoch ?? 0;
+      const admissionWindowReset = admFiveHour > nowSec ? admFiveHour : admWeekly > nowSec ? admWeekly : 0;
+      if (admissionWindowReset <= 0) {
+        log(`Injection rejected by admission gate: no fresh quota window (probe stale / snapshot lost)`);
+        sendClaudeToCodexResult(ws, message.requestId, {
+          success: false,
+          code: "budget_admission",
+          error: budgetAdmissionGateError(0, 0, true)
+        });
+        return;
+      }
+      const willInject = !codex.turnInProgress || message.onBusy === "interrupt";
+      if (message.wrapUp === true && willInject) {
+        const peek = currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log);
+        if (peek.wrapUpUsed >= BUDGET_CONFIG.maximize.wrapUpQuota) {
+          log(`Injection rejected by admission gate: wrap-up quota exhausted`);
+          sendClaudeToCodexResult(ws, message.requestId, {
+            success: false,
+            code: "budget_admission",
+            error: budgetAdmissionGateError(admissionWindowReset, 0, true)
+          });
+          return;
+        }
+        pendingWrapUpReset = admissionWindowReset;
+        log(`Admission-closed: wrap-up permitted (${peek.wrapUpUsed}/${BUDGET_CONFIG.maximize.wrapUpQuota} used; slot committed on inject)`);
+      } else if (message.wrapUp === true && !willInject) {} else {
+        const left = Math.max(0, BUDGET_CONFIG.maximize.wrapUpQuota - currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log).wrapUpUsed);
+        log(`Injection rejected by admission gate: new task (set wrap_up to finish the current work)`);
+        sendClaudeToCodexResult(ws, message.requestId, {
+          success: false,
+          code: "budget_admission",
+          error: budgetAdmissionGateError(admissionWindowReset, left, false)
+        });
+        return;
+      }
+    }
   }
   const requireReply = !!message.requireReply;
   let contentToSend = message.message.content;
@@ -7005,6 +7276,19 @@ async function handleClaudeToCodex(ws, message) {
     }
   }
   const injectThreadId = codex.activeThreadId;
+  if (pendingWrapUpReset !== null) {
+    const committed = consumeWrapUp(stateDir.admissionQuotaFile, pendingWrapUpReset, BUDGET_CONFIG.maximize.wrapUpQuota, log);
+    if (!committed.allowed) {
+      log(`Injection rejected by admission gate: wrap-up slot not durably recorded (write failure or raced to cap)`);
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: "budget_admission",
+        error: budgetAdmissionGateError(pendingWrapUpReset, 0, true)
+      });
+      return;
+    }
+    log(`Admission wrap-up slot committed (${committed.used}/${BUDGET_CONFIG.maximize.wrapUpQuota})`);
+  }
   const injectionId = codex.injectMessage(contentToSend, tierOverrides);
   if (injectionId === null) {
     if (idempotencyKey && injectThreadId) {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -104,6 +104,7 @@ claude.setReplySender(async (
   requireReply?: boolean,
   onBusy?: "reject" | "steer" | "interrupt",
   idempotencyKey?: string,
+  wrapUp?: boolean,
 ) => {
   if (msg.source !== "claude") {
     return { success: false, error: "Invalid message source" };
@@ -116,7 +117,7 @@ claude.setReplySender(async (
     };
   }
 
-  return daemonClient.sendReply(msg, requireReply, onBusy, idempotencyKey);
+  return daemonClient.sendReply(msg, requireReply, onBusy, idempotencyKey, wrapUp);
 });
 
 // PR4: forward Claude's budget-resume ack to the daemon's ResumeAckTracker.

--- a/src/budget/admission-quota.ts
+++ b/src/budget/admission-quota.ts
@@ -1,0 +1,182 @@
+/**
+ * Persistent per-5h-window quota for the P3 admission gate (§3.2).
+ *
+ * Two counters live here, both keyed to the CURRENT 5h window's reset epoch so a
+ * window change (resetEpoch jump) automatically zeroes them — Q9 consensus: the
+ * counts must survive a daemon restart WITHIN a window, but never carry across
+ * one (a restart must not become a back door for extra wrap-ups / batons):
+ *   - `wrapUpUsed`        — wrap-up turns let through `admission-closed`
+ *                           (capped at `maximize.wrapUpQuota`).
+ *   - `checkpointBatonUsed` — whether the system-initiated checkpoint baton has
+ *                           already fired in the fully-`closed` state (REAL-2:
+ *                           at most once per 5h window).
+ *
+ * Single-writer model: exactly one daemon per pair owns this file, so the
+ * read-modify-write below needs no locking. Stored as a single current-window
+ * record (not a map) — a stale window is detected on read by resetEpoch mismatch
+ * and discarded, so the file never grows.
+ *
+ * Resilience contract (mirrors pending-reader.ts): every READ fs touch and
+ * JSON.parse is fault-isolated — ENOENT / TOCTOU / malformed / empty / wrong-shape
+ * all degrade to a fresh zero state, never throw.
+ *
+ * WRITE failures are FAIL-CLOSED, not fail-open: a grant is returned ONLY when the
+ * incremented record was durably persisted. This is deliberate — swallowing a
+ * write error and still returning a grant would OVER-grant the rationed resource
+ * (the next read sees the un-incremented count and re-allows; the once-per-window
+ * baton would re-fire every poll), bypassing the wrap-up cap and breaking the
+ * baton's "at most once per 5h window" invariant. So consumeWrapUp returns
+ * allowed:false and consumeCheckpointBaton returns false when the write fails —
+ * denying that one grant (the daemon rejects the turn / withholds the baton, then
+ * retries next poll) rather than risk an unbounded over-grant. Writes never throw
+ * to the caller either way (the gate never crashes on a disk error).
+ *
+ * A non-finite `fiveHourResetEpoch` (NaN/Infinity from a degraded caller) is
+ * treated as non-decision-grade: no grant, no persist (I2 self-enforced here).
+ *
+ * `fs` is resolved via require() at call time (not a static import) so tests can
+ * monkey-patch readFileSync to simulate TOCTOU — the same seam pending-reader.ts
+ * uses (Bun keeps the ESM namespace and the CJS object distinct).
+ */
+import { atomicWriteJson } from "../atomic-json";
+
+type FsModule = Pick<typeof import("node:fs"), "readFileSync">;
+function nodeFs(): FsModule {
+  return require("node:fs") as FsModule;
+}
+
+/** Persisted admission-quota record for one 5h window. */
+export interface AdmissionQuotaState {
+  version: 1;
+  /** The 5h window's reset epoch this record belongs to; mismatch ⇒ stale ⇒ reset. */
+  fiveHourResetEpoch: number;
+  /** Wrap-up turns let through `admission-closed` in this window. */
+  wrapUpUsed: number;
+  /** Whether the system checkpoint baton has fired in this window (REAL-2). */
+  checkpointBatonUsed: boolean;
+}
+
+function freshState(fiveHourResetEpoch: number): AdmissionQuotaState {
+  return { version: 1, fiveHourResetEpoch, wrapUpUsed: 0, checkpointBatonUsed: false };
+}
+
+/**
+ * Pure parser over `unknown` (no IO — the test seam). Returns null for anything
+ * that is not a usable v1 record; callers map null to a fresh zero state.
+ */
+export function parseAdmissionQuota(value: unknown): AdmissionQuotaState | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (record.version !== 1) return null;
+  const epoch = record.fiveHourResetEpoch;
+  const used = record.wrapUpUsed;
+  if (typeof epoch !== "number" || !Number.isFinite(epoch)) return null;
+  if (typeof used !== "number" || !Number.isFinite(used) || used < 0) return null;
+  return {
+    version: 1,
+    fiveHourResetEpoch: epoch,
+    wrapUpUsed: Math.floor(used),
+    checkpointBatonUsed: record.checkpointBatonUsed === true,
+  };
+}
+
+/**
+ * Read the persisted record and return the state for the CURRENT window: a fresh
+ * zero state when the file is absent / unreadable / malformed, OR when its stored
+ * `fiveHourResetEpoch` does not match `fiveHourResetEpoch` (a window change zeroes
+ * the counters). Never throws.
+ */
+export function currentWindowState(
+  path: string,
+  fiveHourResetEpoch: number,
+  log: (msg: string) => void = () => {},
+): AdmissionQuotaState {
+  let raw: string;
+  try {
+    raw = nodeFs().readFileSync(path, "utf-8");
+  } catch {
+    return freshState(fiveHourResetEpoch);
+  }
+  const text = String(raw).trim();
+  if (text === "") return freshState(fiveHourResetEpoch);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    log(`admission-quota: skip malformed JSON ${path}`);
+    return freshState(fiveHourResetEpoch);
+  }
+  const state = parseAdmissionQuota(parsed);
+  if (!state || state.fiveHourResetEpoch !== fiveHourResetEpoch) {
+    return freshState(fiveHourResetEpoch);
+  }
+  return state;
+}
+
+/** Persist the record; returns true on durable write, false on any failure (never throws). */
+function persist(path: string, state: AdmissionQuotaState, log: (msg: string) => void): boolean {
+  try {
+    atomicWriteJson(path, state);
+    return true;
+  } catch (error) {
+    // Never crash the gate on a disk error — but report failure so the caller can
+    // FAIL CLOSED (deny this grant) rather than over-grant against a stale count.
+    log(`admission-quota: write failed ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
+}
+
+/** Result of a wrap-up admission attempt. */
+export interface WrapUpResult {
+  /** Whether this wrap-up turn is allowed through `admission-closed`. */
+  allowed: boolean;
+  /** Wrap-ups used in this window AFTER this attempt (unchanged when rejected). */
+  used: number;
+  /** Wrap-ups still available after this attempt (0 when rejected at the cap). */
+  remaining: number;
+}
+
+/**
+ * Attempt to consume one wrap-up slot in the current 5h window. Allows + persists
+ * the increment when `used < limit`; rejects (no write) at the cap. `limit` is
+ * `maximize.wrapUpQuota` (0 disables wrap-ups entirely).
+ */
+export function consumeWrapUp(
+  path: string,
+  fiveHourResetEpoch: number,
+  limit: number,
+  log: (msg: string) => void = () => {},
+): WrapUpResult {
+  // Non-finite epoch (degraded caller) → non-decision-grade → no grant (I2).
+  if (!Number.isFinite(fiveHourResetEpoch)) return { allowed: false, used: 0, remaining: 0 };
+  const state = currentWindowState(path, fiveHourResetEpoch, log);
+  if (state.wrapUpUsed >= limit) {
+    return { allowed: false, used: state.wrapUpUsed, remaining: Math.max(0, limit - state.wrapUpUsed) };
+  }
+  const next: AdmissionQuotaState = { ...state, wrapUpUsed: state.wrapUpUsed + 1 };
+  // FAIL CLOSED: grant only when the increment was durably persisted, else a write
+  // failure would re-allow on the next read (over-grant, cap bypass).
+  if (!persist(path, next, log)) {
+    return { allowed: false, used: state.wrapUpUsed, remaining: Math.max(0, limit - state.wrapUpUsed) };
+  }
+  return { allowed: true, used: next.wrapUpUsed, remaining: Math.max(0, limit - next.wrapUpUsed) };
+}
+
+/**
+ * Attempt to fire the system checkpoint baton in the current 5h window (REAL-2:
+ * at most once per window). Returns true + persists the flag on the first call in
+ * a window; false on every subsequent call until the window resets.
+ */
+export function consumeCheckpointBaton(
+  path: string,
+  fiveHourResetEpoch: number,
+  log: (msg: string) => void = () => {},
+): boolean {
+  // Non-finite epoch (degraded caller) → non-decision-grade → do not fire (I2).
+  if (!Number.isFinite(fiveHourResetEpoch)) return false;
+  const state = currentWindowState(path, fiveHourResetEpoch, log);
+  if (state.checkpointBatonUsed) return false;
+  // FAIL CLOSED: fire ONLY when the flag was durably persisted — otherwise a write
+  // failure would let the baton re-fire every poll (breaks once-per-window).
+  return persist(path, { ...state, checkpointBatonUsed: true }, log);
+}

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -4,10 +4,13 @@ import type { RunwayInput } from "./budget-state";
 import { effectiveDynamicLine } from "./budget-decision";
 import { AdviceCooldown, resolveAdviceCooldownSec } from "./advice-cooldown";
 import {
+  classifyAdmission,
   classifyPoll,
   computeResumeCandidate,
   resumeCandidateSides,
+  INITIAL_ADMISSION_STATE,
   INITIAL_FINGERPRINT_STATE,
+  type AdmissionState,
   type FingerprintState,
   type ResumeCandidate,
   type ResumeSignals,
@@ -21,6 +24,7 @@ import type {
   BudgetState,
   CodexTier,
   CodexTurnOverrides,
+  GateState,
 } from "./types";
 import type { QuotaSource } from "./quota-source";
 
@@ -179,6 +183,9 @@ export class BudgetCoordinator {
   // / resume bookkeeping). Replaces the former 4 mutable fields
   // (activeSides, lastDirectiveFingerprint, pauseReason, pauseResumeAfterEpoch).
   private fpState: FingerprintState = INITIAL_FINGERPRINT_STATE;
+  // v3 P3 (§3.2): admission lane, parallel to the pause fpState. In-memory only
+  // (recomputed each poll); the durable per-window quota is in admission-quota.ts.
+  private admissionState: AdmissionState = INITIAL_ADMISSION_STATE;
   // PR2: latest per-side resume candidate (detection only — read-only exposure
   // via getResumeCandidate(); the coordinator never acts on it).
   private resumeCandidate: ResumeCandidate = {};
@@ -230,6 +237,19 @@ export class BudgetCoordinator {
 
   isGateClosed(): boolean {
     return this.fpState.side === "codex" || this.fpState.side === "both";
+  }
+
+  /**
+   * v3 P3 (§3.2): the three-state daemon gate. `closed` (the existing pause gate,
+   * = isGateClosed) takes precedence over `admission-closed`. Both tiers key on
+   * the CODEX side (incl. "both") because the daemon gates Codex turn/start —
+   * Claude self-governs via the prompt. Observability today (snapshot.gateState);
+   * the daemon begins enforcing the admission tier in M3.
+   */
+  gateState(): GateState {
+    if (this.fpState.side === "codex" || this.fpState.side === "both") return "closed";
+    if (this.admissionState.side === "codex" || this.admissionState.side === "both") return "admission-closed";
+    return "open";
   }
 
   getSnapshot(): BudgetSnapshot | null {
@@ -364,6 +384,10 @@ export class BudgetCoordinator {
   private applyState(state: BudgetState): void {
     const { next, effect } = classifyPoll(this.fpState, state, this.config);
     this.fpState = next;
+    // v3 P3 (§3.2): advance the parallel admission lane. M2 stores the state for
+    // gateState() / snapshot observability only; M3 wires the directive emission
+    // (turnPhase-aware) and the daemon's three-state enforcement.
+    this.admissionState = classifyAdmission(this.admissionState, state, this.config).next;
 
     // PR2 (detection only): recompute the per-side resume candidate from the
     // EFFECT, not the post-transition fingerprint. The hysteresis removes a side
@@ -537,6 +561,7 @@ export class BudgetCoordinator {
       driftPct: state.drift.pct,
       paused,
       gateClosed: this.isGateClosed(),
+      gateState: this.gateState(),
       pauseSide: this.fpState.side,
       pauseReason: paused ? this.fpState.reason ?? state.pause.reason : null,
       resumeAfterEpoch: paused ? this.fpState.resumeEpoch ?? state.pause.resumeAfterEpoch : null,

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -1,5 +1,9 @@
 import { homedir } from "node:os";
-import { computeBudgetState, renderBudgetInterventionDirective } from "./budget-state";
+import {
+  computeBudgetState,
+  renderBudgetAdmissionDirective,
+  renderBudgetInterventionDirective,
+} from "./budget-state";
 import type { RunwayInput } from "./budget-state";
 import { effectiveDynamicLine } from "./budget-decision";
 import { AdviceCooldown, resolveAdviceCooldownSec } from "./advice-cooldown";
@@ -88,6 +92,15 @@ export interface BudgetCoordinatorOptions {
    * guard state dir (BUDGET_STATE_DIR ?? ~/.budget-guard), shared across pairs.
    */
   adviceCooldown?: AdviceCooldown;
+  /**
+   * v3 P3 (§3.2, M3b): whether Codex currently has a turn in progress (daemon
+   * passes `codex.turnInProgress`). Read at poll time to make the admission
+   * directive turnPhase-aware: while a Codex turn runs the directive is DEFERRED
+   * (not emitted mid-turn) and flushed by {@link onCodexTurnIdle} when the turn
+   * ends. Absent (tests / no wiring) → treated as never-active, so the directive
+   * emits immediately on entry — the safe default for unit tests.
+   */
+  isCodexTurnActive?: () => boolean;
 }
 
 const AGENT_LABEL: Record<AgentName, string> = {
@@ -176,6 +189,7 @@ export class BudgetCoordinator {
   private readonly onResume: (side: AgentName, directive: string, resumeId: string) => void;
   private readonly resumeSignals: (() => ResumeSignals) | null;
   private readonly adviceCooldown: AdviceCooldown;
+  private readonly isCodexTurnActive: () => boolean;
 
   private timer: BudgetPollTimer | null = null;
   private running = false;
@@ -186,6 +200,17 @@ export class BudgetCoordinator {
   // v3 P3 (§3.2): admission lane, parallel to the pause fpState. In-memory only
   // (recomputed each poll); the durable per-window quota is in admission-quota.ts.
   private admissionState: AdmissionState = INITIAL_ADMISSION_STATE;
+  // v3 P3 (§3.2, M3b): the admission directive deferred because a Codex turn was
+  // running when the admission lane closed (turnPhase-aware emission). Flushed by
+  // onCodexTurnIdle() when the turn ends; dropped if the gate reopens/escalates
+  // first. Holds the LATEST rendered content + its fingerprint (a later poll that
+  // changes the fingerprint mid-turn overwrites it).
+  private pendingAdmissionDirective: { content: string; fingerprint: string } | null = null;
+  // Fingerprint of the last admission directive actually emitted — dedup guard so
+  // a deferred-then-flushed directive (or a phantom re-decide) never double-emits
+  // for the same admission episode. Cleared on admission exit so a fresh episode
+  // emits again.
+  private lastEmittedAdmissionFingerprint: string | null = null;
   // PR2: latest per-side resume candidate (detection only — read-only exposure
   // via getResumeCandidate(); the coordinator never acts on it).
   private resumeCandidate: ResumeCandidate = {};
@@ -214,6 +239,7 @@ export class BudgetCoordinator {
         cooldownSec: resolveAdviceCooldownSec(),
         log: this.log,
       });
+    this.isCodexTurnActive = options.isCodexTurnActive ?? (() => false);
   }
 
   async start(): Promise<void> {
@@ -384,10 +410,11 @@ export class BudgetCoordinator {
   private applyState(state: BudgetState): void {
     const { next, effect } = classifyPoll(this.fpState, state, this.config);
     this.fpState = next;
-    // v3 P3 (§3.2): advance the parallel admission lane. M2 stores the state for
-    // gateState() / snapshot observability only; M3 wires the directive emission
-    // (turnPhase-aware) and the daemon's three-state enforcement.
+    // v3 P3 (§3.2): advance the parallel admission lane and apply its directive
+    // effect (M3b — turnPhase-aware emission). The daemon's three-state gate reads
+    // gateState(); this only governs the advisory directive to Claude.
     this.admissionState = classifyAdmission(this.admissionState, state, this.config).next;
+    this.applyAdmissionDirective(state);
 
     // PR2 (detection only): recompute the per-side resume candidate from the
     // EFFECT, not the post-transition fingerprint. The hysteresis removes a side
@@ -403,6 +430,25 @@ export class BudgetCoordinator {
       : {};
 
     for (const side of effect.recoveredSides) {
+      // v3 P3 (M3b, round-2 REAL): a side recovering from PAUSE may still be
+      // ADMISSION-closed — the closed→admission-closed de-escalation (codex util
+      // crosses below the pause-resume line into the admission hold band). Firing
+      // the codex recovery here would (a) tell Claude codex is fully recovered and
+      // (b) route an auto-resume turn through enqueueCodexBudgetResume → the resume
+      // queue → codex.injectMessage, which BYPASSES the codex_to_codex admission
+      // gate and would inject an unbounded continuation that never consumes a wrap-up
+      // slot — both wrong while codex is still in finishing protection. HOLD the
+      // codex recovery until the admission lane also opens. (admission is
+      // codex-scoped, so a claude recovery is never gated by it.) Trade-off: in a
+      // monotonic recovery (pause → admission-closed → open with no re-pause) the
+      // codex auto-resume is skipped for this episode; it re-fires on the next
+      // genuine pause-recovery cycle, and once the gate is open Claude can resume
+      // Codex manually via reply. The SAFE direction — no gate bypass. (follow-up:
+      // optionally re-fire the held resume on the admission-exit transition.)
+      if (side === "codex" && (this.admissionState.side === "codex" || this.admissionState.side === "both")) {
+        this.log(`Budget recovery for Codex held: pause cleared but still admission-closed`);
+        continue;
+      }
       const { id, directive } = this.emitRecovery(side, state);
       this.onResume(side, directive, id);
     }
@@ -424,6 +470,25 @@ export class BudgetCoordinator {
         return;
       }
       case "advise": {
+        // v3 P3 (M3b): hard-gate routing advice on an OPEN gate. computeBudgetState
+        // already suppresses the advise PHASE when either side admit-closes (raw
+        // predicate), so an advise effect normally never reaches here while the gate
+        // is admission-closed. This catches the residual hysteresis EXIT band: the
+        // raw predicate reads "open" (advise phase produced) while the coordinator's
+        // admissionState still HOLDS admission-closed — emitting "route work to
+        // Codex" then would contradict the still-active daemon admission gate.
+        if (this.gateState() !== "open") {
+          // RE-ARM the advice fingerprint (null) instead of a plain return.
+          // classifyPoll already committed `this.fpState = next` with the advise
+          // fingerprint (budget-fingerprint.ts advise branch), so a bare return
+          // would burn the dedup key WITHOUT emitting — and once the gate opens the
+          // same persistent drift yields an identical fingerprint → classifyPoll
+          // returns kind:"none" → the legitimate balance/underutilization advice is
+          // permanently lost for the episode (round-2 REAL, both review engines).
+          // Nulling it makes the next OPEN-gate poll recompute and emit exactly once.
+          this.fpState = { ...this.fpState, fingerprint: null };
+          return;
+        }
         // state.directiveToClaude is non-null whenever the reducer emits advise.
         if (effect.phase === "underutilized") {
           // v3 P4: the accelerate/underutilization advice is account-level — gate
@@ -451,6 +516,115 @@ export class BudgetCoordinator {
       case "none":
         return;
     }
+  }
+
+  /**
+   * v3 P3 (§3.2, M3b): decide the admission directive each poll. The daemon gate
+   * (gateState) is independent of this — this only governs the advisory
+   * `system_budget_admission` directive to Claude.
+   *
+   * IDEMPOTENT by design: the emit decision is driven off the coordinator's own
+   * `lastEmittedAdmissionFingerprint`, NOT the reducer's one-shot `emit` flag. The
+   * one-shot flag fires only on the poll an episode first enters; if THAT poll is
+   * blocked (a pause is active, or a Codex turn is running) the directive must
+   * still emit on a LATER poll once the blocker clears. The classic miss this
+   * prevents: codex enters pause+admission together (admission suppressed by the
+   * pause), then de-escalates to admission-only (burn-data regime: util in
+   * [admissionAt, dynamicLine−hysteresis) clears pause but holds admission) — with
+   * a one-shot flag the directive would NEVER emit yet the daemon rejects every new
+   * Codex turn. Driving off lastEmitted re-evaluates every poll until it lands.
+   *
+   * Suppression cases do NOT advance lastEmitted, so they re-arm naturally:
+   *   - admission open / claude-only → reset bookkeeping (a fresh codex episode
+   *     re-emits; the daemon gate is codex-scoped, Claude self-governs its line).
+   *   - a pause is active → pause has display priority (its directive covers
+   *     winding down); HOLD (re-evaluated next poll once the pause clears).
+   *   - a Codex turn is running → DEFER (store the rendered directive; flushed by
+   *     onCodexTurnIdle when the turn ends, with a poll-driven backstop here).
+   */
+  private applyAdmissionDirective(state: BudgetState): void {
+    const side = this.admissionState.side;
+    if (side !== "codex" && side !== "both") {
+      // Gate open on the codex axis (or claude-only) → nothing to announce; clear
+      // bookkeeping so a future codex episode emits fresh.
+      this.pendingAdmissionDirective = null;
+      this.lastEmittedAdmissionFingerprint = null;
+      return;
+    }
+    const fingerprint = this.admissionState.fingerprint;
+    // Already announced this episode (fingerprint unchanged) → no-op. Drop any
+    // stale pending (e.g. the directive was already flushed by onCodexTurnIdle).
+    if (fingerprint === null || fingerprint === this.lastEmittedAdmissionFingerprint) {
+      this.pendingAdmissionDirective = null;
+      return;
+    }
+    // Pause display priority: HOLD without marking emitted, so it re-fires the
+    // poll the pause clears. Drop any deferred copy (the pause directive supersedes).
+    if (this.isPaused()) {
+      this.pendingAdmissionDirective = null;
+      return;
+    }
+    const content = renderBudgetAdmissionDirective(
+      state.perAgent.claude,
+      state.perAgent.codex,
+      side,
+      this.admissionState.reason ?? "额度窗口收尾保护",
+      this.admissionResetEpoch(state),
+      this.config,
+    );
+    // turnPhase-aware: defer while a Codex turn runs (re-rendered each poll so the
+    // deferred copy never goes stale); onCodexTurnIdle flushes it the moment the
+    // turn ends, and the next poll here is the backstop if that event is missed.
+    if (this.isCodexTurnActive()) {
+      this.pendingAdmissionDirective = { content, fingerprint };
+      return;
+    }
+    this.emitAdmission(content, fingerprint);
+  }
+
+  private emitAdmission(content: string, fingerprint: string): void {
+    this.emitDirective("system_budget_admission", content);
+    this.lastEmittedAdmissionFingerprint = fingerprint;
+    this.pendingAdmissionDirective = null;
+  }
+
+  /**
+   * The reset epoch for the admission directive's "window refreshes at" line. ALWAYS
+   * the CODEX fresh window (fresh 5h, else fresh weekly) — the admission gate is
+   * codex-scoped (the daemon rejects Codex turns and keys the wrap-up/baton quota on
+   * exactly this codex window), and Claude self-governs its own line. Even for a
+   * side="both" directive the actionable "when can I delegate to Codex again" answer
+   * is the codex window, NOT max(claude,codex): a later-resetting Claude window would
+   * mislead Claude into waiting past the point Codex's gate actually reopens (round-2
+   * REAL). NOT matchingGateReset (state.pause.resetEpochs): that admits a window whose
+   * epoch is merely > 0, so a weekly-triggered admission with an EXPIRED 5h window
+   * would display the stale 5h time. `now` from state keeps it consistent with the poll.
+   */
+  private admissionResetEpoch(state: BudgetState): number | null {
+    const usage = state.perAgent.codex;
+    const now = state.now;
+    const fiveHour = usage?.fiveHour?.resetEpoch ?? 0;
+    const weekly = usage?.weekly?.resetEpoch ?? 0;
+    const fresh = fiveHour > now ? fiveHour : weekly > now ? weekly : 0;
+    return fresh > 0 ? fresh : null;
+  }
+
+  /**
+   * v3 P3 (§3.2, M3b): flush a deferred admission directive when the Codex turn
+   * ends (daemon calls this on turnPhaseChanged → idle/aborted) — the immediacy
+   * optimization over the poll-driven backstop in applyAdmissionDirective. `pending`
+   * is poll-managed: every poll re-evaluates it and CLEARS it on a pause escalation
+   * or an admission exit, so a non-null `pending` already means the last poll
+   * confirmed admission-closed + not paused. The isPaused()/gateState() re-check is
+   * defense-in-depth against future event/poll interleaving; it never fires today.
+   * No-op when nothing is pending.
+   */
+  onCodexTurnIdle(): void {
+    const pending = this.pendingAdmissionDirective;
+    if (!pending) return;
+    this.pendingAdmissionDirective = null;
+    if (this.isPaused() || this.gateState() !== "admission-closed") return;
+    this.emitAdmission(pending.content, pending.fingerprint);
   }
 
   private tierControlEnabled(): boolean {

--- a/src/budget/budget-decision.ts
+++ b/src/budget/budget-decision.ts
@@ -429,3 +429,149 @@ export function resumeBlockingEpochFor(usage: AgentUsage | null, cfg: BudgetConf
   if (blockingResets.length === 0) return 0;
   return Math.min(...blockingResets);
 }
+
+// ---------------------------------------------------------------------------
+// v3 P3 (§3.2): admission-gate predicates (three-state finishing protection).
+//
+// Parallel to agentShouldPause / agentCanResume, but for the WIDER, EARLIER
+// `admission-closed` state: it rejects NEW turns at `admissionAt` (default 85),
+// while the pause/`closed` gate only trips at the dynamic line (~95). These are
+// PURE decision functions; the coordinator's fingerprint applies STATE-level
+// hysteresis (phantom-hold included) on top. The per-predicate hysteresis here
+// (resumeHysteresisPct on util; the 2×/3× runway enter/exit band) prevents flap
+// at the thresholds. `closed` > `admission-closed` precedence is resolved by the
+// GATE (coordinator/daemon), never here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Weekly-runway guard multipliers (RECOMMEND-7). Admission CLOSES when the weekly
+ * window will fill before reset AND its depletion runway is under
+ * finishingHorizon×ENTER; it RE-OPENS only once the runway recovers above
+ * finishingHorizon×EXIT — the one-horizon gap is hysteresis so probe jitter at
+ * the floor cannot flap the gate.
+ */
+const ADMISSION_WEEKLY_RUNWAY_ENTER_MULT = 2;
+const ADMISSION_WEEKLY_RUNWAY_EXIT_MULT = 3;
+
+function weeklyRunwayFloorSec(cfg: BudgetConfig, mult: number): number {
+  return cfg.maximize.finishingHorizonMinutes * 60 * mult;
+}
+
+/**
+ * True when the weekly window is genuinely at depletion risk within `floorSec`:
+ * it will FILL before reset (a `will-fill` verdict — not merely reset-truncated)
+ * and its guard runway is under the floor. Returns false for degraded /
+ * will-not-fill / admission-closed verdicts: admission-closed is handled by the
+ * hard-cap branch, and will-not-fill / degraded are not depletion signals. Using
+ * the verdict (not raw `runwaySeconds`) avoids false-triggering near a weekly
+ * RESET, where the guard truncates runway at the reset rather than at depletion.
+ */
+function weeklyRunwayShort(usage: AgentUsage, cfg: BudgetConfig, now: number, floorSec: number): boolean {
+  const weekly = usage.weekly;
+  if (!weekly || weekly.resetEpoch <= now) return false;
+  if (dynamicWindowVerdict(weekly, cfg, now).kind !== "will-fill") return false;
+  const runway = weekly.runwaySeconds;
+  if (typeof runway !== "number" || !Number.isFinite(runway)) return false;
+  return runway < floorSec;
+}
+
+/** First fresh window (stable order) whose §3.1 hard cap fires; null when none. */
+function hardCapWindow(usage: AgentUsage, cfg: BudgetConfig, now: number): BudgetWindowKey | null {
+  for (const { key, window } of freshWindows(usage, now)) {
+    const rate = confidentRate(window);
+    if (rate === null) continue;
+    if (dynamicPauseAt(window, rate, cfg, now) === "admission-closed") return key;
+  }
+  return null;
+}
+
+/** Structured admission-entry decision for one agent (parallel to AgentPauseDecision). */
+export interface AgentAdmissionDecision {
+  /** Should this agent's gate enter admission-closed this poll. */
+  admitClose: boolean;
+  /** Window/condition that tripped (for reason + fingerprint); null when open. */
+  window: BudgetWindowKey | null;
+  /** Human-readable Chinese reason; empty string when not admission-closed. */
+  reason: string;
+}
+
+const NO_ADMIT_CLOSE: AgentAdmissionDecision = { admitClose: false, window: null, reason: "" };
+
+/**
+ * Decide whether an agent's admission gate should CLOSE (reject new turns, allow
+ * wrap-up). Three independent triggers (design §3.2), first match wins the
+ * reason: (1) 5h util ≥ admissionAt — the primary, rate-free finishing line;
+ * (2) a §3.1 hard cap fires on any fresh window (REAL-4); (3) the weekly window
+ * is at depletion risk within finishingHorizon×2 (RECOMMEND-7). Non-decision-grade
+ * data never closes here (I2); the asymmetric "stale never OPENS an already-closed
+ * window" lives in the fingerprint phantom-hold, not here.
+ */
+export function agentShouldAdmitClose(
+  agent: AgentName,
+  usage: AgentUsage | null,
+  cfg: BudgetConfig,
+  now: number,
+): AgentAdmissionDecision {
+  if (!usage) return NO_ADMIT_CLOSE;
+  if (!isDecisionGrade(usage, now)) return NO_ADMIT_CLOSE;
+
+  // (1) 5h util ≥ admissionAt — primary, rate-free.
+  const fiveHour = usage.fiveHour;
+  if (fiveHour && fiveHour.resetEpoch > now && fiveHour.util >= cfg.maximize.admissionAt) {
+    return {
+      admitClose: true,
+      window: "fiveHour",
+      reason: `${AGENT_LABEL[agent]} 5h窗口 util ${pct(fiveHour.util)} ≥ admissionAt ${pct(cfg.maximize.admissionAt)}（收尾保护：拒新任务、放收尾）`,
+    };
+  }
+
+  // (2) §3.1 hard cap on any fresh window (REAL-4).
+  const hard = hardCapWindow(usage, cfg, now);
+  if (hard !== null) {
+    return {
+      admitClose: true,
+      window: hard,
+      reason: `${AGENT_LABEL[agent]} ${WINDOW_LABEL[hard]}窗口触发收尾保护硬线（util 已达 targetUtil 或临近重置收尾带）`,
+    };
+  }
+
+  // (3) weekly window at depletion risk within finishingHorizon×2 (RECOMMEND-7).
+  if (weeklyRunwayShort(usage, cfg, now, weeklyRunwayFloorSec(cfg, ADMISSION_WEEKLY_RUNWAY_ENTER_MULT))) {
+    return {
+      admitClose: true,
+      window: "weekly",
+      reason: `${AGENT_LABEL[agent]} 周窗口 runway 低于 ${ADMISSION_WEEKLY_RUNWAY_ENTER_MULT}×收尾视野（防新长任务撞穿周额度）`,
+    };
+  }
+
+  return NO_ADMIT_CLOSE;
+}
+
+/**
+ * Decide whether an agent's admission gate may RE-OPEN — symmetric to
+ * agentShouldAdmitClose with hysteresis: every trigger must have receded — 5h
+ * util < admissionAt − resumeHysteresisPct, no hard cap firing on any fresh
+ * window, and the weekly runway recovered above finishingHorizon×EXIT (> the
+ * ENTER floor → a one-horizon hold band). A window that has already RESET drops
+ * out of freshWindows (the "window reset → open" path). Non-decision-grade data
+ * never opens (I2: missing/stale data must not release a closed gate).
+ */
+export function agentCanAdmitOpen(usage: AgentUsage | null, cfg: BudgetConfig, now: number): boolean {
+  if (!isDecisionGrade(usage, now)) return false;
+  // A live rate-limit means the provider is throttling probes — do not RELEASE a
+  // protective gate on it (parity with agentCanResume; the stale-flag hold beyond
+  // this is the fingerprint phantom-hold's job in the coordinator layer).
+  if (usage!.rateLimitedUntil > now) return false;
+
+  // (1) 5h util must recede below the hysteresis-relaxed admission line.
+  const fiveHour = usage!.fiveHour;
+  if (fiveHour && fiveHour.resetEpoch > now) {
+    if (fiveHour.util >= cfg.maximize.admissionAt - cfg.maximize.resumeHysteresisPct) return false;
+  }
+  // (2) no §3.1 hard cap may still be firing on any fresh window.
+  if (hardCapWindow(usage!, cfg, now) !== null) return false;
+  // (3) weekly runway must have recovered above the EXIT floor (> ENTER → hysteresis).
+  if (weeklyRunwayShort(usage!, cfg, now, weeklyRunwayFloorSec(cfg, ADMISSION_WEEKLY_RUNWAY_EXIT_MULT))) return false;
+
+  return true;
+}

--- a/src/budget/budget-fingerprint.ts
+++ b/src/budget/budget-fingerprint.ts
@@ -26,7 +26,9 @@
  * ./budget-state; it is bundled into the plugin daemon.
  */
 import {
+  agentCanAdmitOpen,
   agentCanResume,
+  agentShouldAdmitClose,
   agentShouldPause,
   isDecisionGrade,
   resumeBlockingEpochFor,
@@ -479,4 +481,128 @@ export function computeResumeCandidate(
   }
   if (sides.length > 0) candidate.detail = detail;
   return candidate;
+}
+
+// ---------------------------------------------------------------------------
+// v3 P3 (§3.2): admission lane — a SECOND hysteresis state machine, parallel to
+// the pause lane above, for the `admission-closed` gate. Kept separate from
+// classifyPoll (the pause reducer is a battle-tested verbatim port; we do not
+// restructure it). The two lanes SHARE their I2 mechanism: nextAdmissionSide
+// preserves a closed side whenever the predicates abstain on non-decision-grade
+// data (agentShouldAdmitClose / agentCanAdmitOpen both return false there) —
+// identical to how nextActiveSide holds the pause side — and the fingerprint
+// hold reuses activeSideProbeUncertain. Coordinator-held + recomputed each poll
+// (never persisted); the durable per-window quota lives in admission-quota.ts.
+// ---------------------------------------------------------------------------
+
+/** Admission-gate hysteresis state (parallel to the pause fields of FingerprintState). */
+export interface AdmissionState {
+  /** Which side(s) are admission-closed (activeSides rendered as a value); null when open. */
+  side: PauseSide;
+  /** Last emitted admission-directive fingerprint; null when none. */
+  fingerprint: string | null;
+  /** Sticky admission reason while closed; null otherwise. */
+  reason: string | null;
+}
+
+export const INITIAL_ADMISSION_STATE: AdmissionState = { side: null, fingerprint: null, reason: null };
+
+/** What the coordinator must DO after an admission poll (mirrors CoordinatorEffect, narrower). */
+export type AdmissionEffect =
+  | { kind: "enter" | "hold-uncertain"; side: ActivePauseSide; reason: string; emit: boolean }
+  | { kind: "exit"; previousSide: ActivePauseSide }
+  | { kind: "none" };
+
+export interface AdmissionResult {
+  next: AdmissionState;
+  effect: AdmissionEffect;
+}
+
+/**
+ * Hysteresis transition over the admission active set (parallel to
+ * nextActiveSide): agentShouldAdmitClose adds, an already-closed side that
+ * agentCanAdmitOpen removes. On non-decision-grade data BOTH predicates return
+ * false, so a closed side neither adds nor removes → it HOLDS (I2: stale never
+ * opens), exactly as the pause lane behaves.
+ */
+function nextAdmissionSide(prevSide: PauseSide, state: BudgetState, cfg: BudgetConfig): PauseSide {
+  const active = new Set<AgentName>(sideToAgents(prevSide));
+  for (const agent of ["claude", "codex"] as const) {
+    const usage = state.perAgent[agent];
+    if (agentShouldAdmitClose(agent, usage, cfg, state.now).admitClose) {
+      active.add(agent);
+    } else if (active.has(agent) && agentCanAdmitOpen(usage, cfg, state.now)) {
+      active.delete(agent);
+    }
+  }
+  return agentsToSide(active);
+}
+
+function admissionReason(side: PauseSide, state: BudgetState, cfg: BudgetConfig): string {
+  return sideToAgents(side)
+    .map((agent) => {
+      const usage = state.perAgent[agent];
+      if (!usage) return `${AGENT_LABEL[agent]} 探测暂时不可用，保持上一轮收尾保护`;
+      // Rate-limit FIRST, mirroring activeSideReason: a rate-limited probe holds
+      // the side closed via agentCanAdmitOpen (which returns false on
+      // rateLimitedUntil > now) even though agentShouldAdmitClose no longer trips
+      // — without this branch that hold would mislabel as the hysteresis band.
+      if (usage.rateLimitedUntil > state.now) {
+        return `${AGENT_LABEL[agent]} 探针被限流至 ${formatEpoch(usage.rateLimitedUntil)}，保持收尾保护`;
+      }
+      const decision = agentShouldAdmitClose(agent, usage, cfg, state.now);
+      if (decision.admitClose) return decision.reason;
+      // Still closed but no longer tripping entry → in the admission exit band,
+      // holding until agentCanAdmitOpen clears.
+      return `${AGENT_LABEL[agent]} 收尾保护出闸滞回带，尚未满足开闸条件`;
+    })
+    .join("；");
+}
+
+/**
+ * Dedup fingerprint for an admission directive: side + the closed side's
+ * gate-EXPLAINING reset bucket. Keys on `state.pause.resetEpochs`
+ * (= matchingGateReset per agent — the window that explains gateUtil, precomputed
+ * in computeBudgetState), NOT the 5h reset: admission can close on a weekly
+ * trigger (hard-cap / weekly-runway), so a 5h-only key would (a) spuriously
+ * re-emit on a 5h reset while a weekly trigger still holds, and (b) collapse two
+ * distinct weekly episodes across a weekly reset. This mirrors directiveFingerprint
+ * (the pause lane), keeping the two lanes faithful parallels on the reset axis.
+ */
+function admissionFingerprint(state: BudgetState, side: ActivePauseSide): string {
+  let reset = 0;
+  for (const agent of sideToAgents(side)) {
+    reset = Math.max(reset, state.pause.resetEpochs[agent] ?? 0);
+  }
+  return ["admission", side, Math.round(reset / RESET_FINGERPRINT_BUCKET_SEC)].join("|");
+}
+
+/**
+ * Pure reducer for the admission lane (parallel to classifyPoll). Mirrors the
+ * pause lane's enter / hold-uncertain / exit / none transitions and its
+ * fingerprint-hold-on-uncertain dedup, but for `admission-closed`. The side-level
+ * I2 hold lives in nextAdmissionSide (see above); this adds the directive-dedup
+ * hold so a probe-quality flap mid-close cannot re-emit the admission banner.
+ */
+export function classifyAdmission(prev: AdmissionState, state: BudgetState, cfg: BudgetConfig): AdmissionResult {
+  const previousSide = prev.side;
+  const currentSide = nextAdmissionSide(previousSide, state, cfg);
+
+  if (currentSide) {
+    const reason = admissionReason(currentSide, state, cfg);
+    const uncertain =
+      previousSide === currentSide && activeSideProbeUncertain(currentSide, state) && prev.fingerprint;
+    const fingerprint = uncertain ? prev.fingerprint! : admissionFingerprint(state, currentSide);
+    const emit = !previousSide || previousSide !== currentSide || fingerprint !== prev.fingerprint;
+    return {
+      next: { side: currentSide, fingerprint, reason },
+      effect: { kind: uncertain ? "hold-uncertain" : "enter", side: currentSide, reason, emit },
+    };
+  }
+
+  if (previousSide) {
+    return { next: INITIAL_ADMISSION_STATE, effect: { kind: "exit", previousSide } };
+  }
+
+  return { next: INITIAL_ADMISSION_STATE, effect: { kind: "none" } };
 }

--- a/src/budget/budget-state.ts
+++ b/src/budget/budget-state.ts
@@ -1,5 +1,6 @@
 import { matchingGateReset } from "./budget-gate";
 import {
+  agentShouldAdmitClose,
   agentShouldPause,
   dynamicWindowVerdict,
   isDecisionGrade,
@@ -263,6 +264,40 @@ export function renderBudgetInterventionDirective(
   ].join("\n");
 }
 
+/**
+ * v3 P3 (§3.2): the `admission-closed` directive to Claude — the Codex-side
+ * finishing-protection notice. Emitted (turnPhase-aware: only when Codex is not
+ * mid-turn) when the admission lane closes the codex/both side. Tells Claude the
+ * daemon will now decline NEW Codex turns (`budget_admission`) while still
+ * accepting wrap-up replies, so Claude routes toward winding the collaboration
+ * down rather than starting new Codex work. Pure render; the emission/dedup and
+ * the daemon gate live in the coordinator and daemon respectively. `side` is
+ * always "codex" or "both" here (the daemon gate is codex-scoped — Claude
+ * self-governs its own line via the always-on budget prompt).
+ */
+export function renderBudgetAdmissionDirective(
+  claude: AgentUsage | null,
+  codex: AgentUsage | null,
+  side: AgentName | "both",
+  reason: string,
+  resetEpoch: number | null,
+  cfg: BudgetConfig,
+): string {
+  const resetText = `对应窗口约 ${formatEpoch(resetEpoch)} 刷新（以实测为准；提前刷新会更早解除）`;
+  const head =
+    side === "both"
+      ? "【预算协调 · 账号级】双方进入收尾保护（admission-closed）。"
+      : "【预算协调 · 账号级】Codex 侧进入收尾保护（admission-closed）。";
+  return [
+    head,
+    `触发原因：${reason}。`,
+    `${usageSummary("claude", claude)}；${usageSummary("codex", codex)}。`,
+    `闸门已收紧：新的 Codex 任务会被拒（budget_admission），但仍可用 reply 带 wrap_up=true 把当前协作收尾到 checkpoint` +
+      `（每窗口至多 ${cfg.maximize.wrapUpQuota} 个），steer 修正不受限；${resetText}。`,
+    "建议：不要再向 Codex 派新任务；把当前 Codex 协作收尾、写 checkpoint，可独立推进的部分 Claude 可 solo 继续。",
+  ].join("\n");
+}
+
 function balanceDirective(
   claude: AgentUsage,
   codex: AgentUsage,
@@ -340,7 +375,18 @@ export function computeBudgetState(
     // this is not a send-path fix — it keeps the rendered snapshot.phase honest
     // (no balance/underutilized label on stale data via get_budget / abg budget).
     isDecisionGrade(claude, now) &&
-    isDecisionGrade(codex, now);
+    isDecisionGrade(codex, now) &&
+    // v3 P3 (M3b): the routing advice (balance / underutilization) moves work
+    // DENSITY between the two sides; it is meaningless — and directly
+    // contradictory — while EITHER side is in admission-closed finishing
+    // protection (the daemon gate would reject new turns the advice routes
+    // toward that side). Suppress at the source so snapshot.phase stays honest
+    // AND classifyPoll never produces an advise effect whose fingerprint would
+    // otherwise get advanced-but-suppressed. Uses the raw predicate (the
+    // hysteresis lives in the coordinator); the coordinator additionally hard-
+    // gates the advise EMISSION on gateState()==="open" to cover the exit band.
+    !agentShouldAdmitClose("claude", claude, cfg, now).admitClose &&
+    !agentShouldAdmitClose("codex", codex, cfg, now).admitClose;
   const balanceActive = adviceEligible && drift.heavier !== null && drift.lighter !== null;
   // Compute underutilization only when it could actually become the phase (not
   // paused, advice-eligible, and balance has not already claimed the advise

--- a/src/budget/types.ts
+++ b/src/budget/types.ts
@@ -136,9 +136,7 @@ export interface RunwayEstimate {
  * Time-aware dynamic-pause-line parameters (v3 §3.1/§4.1). These are the SOLE
  * budget strategy as of v3.2 (the conserve|maximize selector is gone). All have
  * defaults + bounded validation in config-service.ts and are tuned via env
- * escape hatches, not as product-facing config. The P3 admission gate will add
- * its own keys (admissionAt / wrapUpQuota) when it lands — intentionally not
- * defined yet (no parse-only keys).
+ * escape hatches, not as product-facing config.
  */
 export interface MaximizeConfig {
   /** Reset-point target utilization (asymptote); default 98, range [90, 99]. Must be > pauseAt. */
@@ -151,7 +149,30 @@ export interface MaximizeConfig {
   finishingHorizonMinutes: number;
   /** Symmetric-resume hysteresis below the dynamic line; default 5, range [1, 30]. */
   resumeHysteresisPct: number;
+  /**
+   * v3 P3 (§3.2): 5h-window util at/above which the admission gate enters
+   * `admission-closed` (reject new turns, allow wrap-up). Default 85, range
+   * [50, 99]. Must be < targetUtil (else the whole maximize block resets).
+   */
+  admissionAt: number;
+  /**
+   * v3 P3 (§3.2): max wrap-up turns let through `admission-closed` per 5h
+   * window (persisted, survives daemon restart). Default 2, range [0, 10].
+   */
+  wrapUpQuota: number;
 }
+
+/**
+ * v3 P3 (§3.2): three-state admission gate.
+ * - `open`: admit everything.
+ * - `admission-closed`: reject NEW turns (error `budget_admission`), allow
+ *   `on_busy:"steer"` and `wrapUp:true` replies (bounded by `wrapUpQuota` per
+ *   5h window); never interrupt a running turn.
+ * - `closed`: the existing pause gate — reject all (error `budget_paused`),
+ *   except the system-initiated checkpoint baton.
+ * `closed` takes precedence over `admission-closed`.
+ */
+export type GateState = "open" | "admission-closed" | "closed";
 
 /** Budget section of AgentBridgeConfig (defaults in config-service.ts). */
 export interface BudgetConfig {

--- a/src/budget/types.ts
+++ b/src/budget/types.ts
@@ -278,6 +278,13 @@ export interface BudgetSnapshot {
    * is exhausted ({codex} or {claude,codex}); false for Claude-only handoff.
    */
   gateClosed: boolean;
+  /**
+   * v3 P3 (§3.2): the three-state daemon gate (`open` | `admission-closed` |
+   * `closed`). Optional for backward-compatible deserialization of legacy daemon
+   * snapshots (absent → treat as `open`/`closed` per `gateClosed`). `closed`
+   * mirrors `gateClosed`; `admission-closed` is the new finishing-protection tier.
+   */
+  gateState?: GateState;
   /** Which side(s) are budget-exhausted per the coordinator's activeSides set. */
   pauseSide: AgentName | "both" | null;
   pauseReason: string | null;

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -32,6 +32,7 @@ export type ReplySender = (
   requireReply?: boolean,
   onBusy?: "reject" | "steer" | "interrupt",
   idempotencyKey?: string,
+  wrapUp?: boolean,
 ) => Promise<{ success: boolean; error?: string; code?: string; phase?: string; retryAfterMs?: number }>;
 
 export interface ClaudeAdapterOptions {
@@ -82,7 +83,8 @@ export const CLAUDE_INSTRUCTIONS = [
   "",
   "## Budget awareness",
   "- Use the get_budget tool to check both agents' subscription quota (5h/weekly windows, drift, pause state).",
-  "- If the reply tool returns a budget-pause error, do NOT retry; checkpoint your work and wait for the resume notice.",
+  "- If the reply tool returns a budget-pause error (code budget_paused), do NOT retry; checkpoint your work and wait for the resume notice.",
+  "- If the reply tool returns a budget_admission error, the 5h window is in finishing-protection: new tasks are declined, but you may bring the CURRENT collaboration to a checkpoint by resending with wrap_up=true (a small per-window quota). Do NOT start new work; once the quota is used or you are done, write a checkpoint and wait for the 5h window to refresh.",
 ].join("\n");
 
 export class ClaudeAdapter extends EventEmitter {
@@ -417,6 +419,10 @@ export class ClaudeAdapter extends EventEmitter {
                 type: "string",
                 description: "Optional client-generated key (non-empty, max 128 chars) that makes this reply idempotent: a retry carrying the same key is NOT re-injected — the bridge answers duplicate_in_flight / duplicate_terminal instead. Use a fresh key per logical message.",
               },
+              wrap_up: {
+                type: "boolean",
+                description: "Set true ONLY to declare a finishing turn when the budget gate is in 5h finishing-protection (you got a budget_admission error or a system_budget_admission notice). A wrap-up reply is let through the admission gate up to a small per-5h-window quota so you can bring the current collaboration to a checkpoint; do NOT use it to start new work. Leave false/unset for normal replies.",
+              },
             },
             required: ["text"],
           },
@@ -608,7 +614,8 @@ export class ClaudeAdapter extends EventEmitter {
       };
     }
 
-    const result = await this.replySender(bridgeMsg, requireReply, onBusy, idempotencyKey);
+    const wrapUp = args?.wrap_up === true;
+    const result = await this.replySender(bridgeMsg, requireReply, onBusy, idempotencyKey, wrapUp);
     if (!result.success) {
       this.log(`Reply delivery failed: ${result.error}${result.code ? ` (code=${result.code})` : ""}`);
       // Surface the machine-readable code (PR B structured result) alongside

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -284,6 +284,22 @@ export class CodexAdapter extends EventEmitter {
   get proxyUrl() { return `ws://127.0.0.1:${this.proxyPort}`; }
   get activeThreadId() { return this.threadId; }
   /**
+   * True iff {@link injectMessage} would currently reach the wire — i.e. its three
+   * synchronous pre-send guards (active thread, app-server socket OPEN, no turn in
+   * progress) all hold. Lets a caller PRECHECK before consuming an irreplaceable
+   * once-per-window token (the P3 checkpoint baton): without this, a closed-gate
+   * poll fired while the TUI is disconnected would burn the baton flag and then get
+   * a null inject, losing the window's only baton. Mirrors the guards at
+   * {@link injectMessage} (codex-adapter L504/508/512) exactly.
+   */
+  canInject(): boolean {
+    return (
+      !!this.threadId &&
+      this.appServerWs?.readyState === WebSocket.OPEN &&
+      !this.turnInProgress
+    );
+  }
+  /**
    * Captured Codex app-server identity (P1 #5). null until the first
    * `initialize` handshake response is observed. Read by the daemon's status
    * builder so /healthz + status.json + `abg doctor` can surface which

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -51,6 +51,11 @@ const DEFAULT_BUDGET_CONFIG: BudgetConfig = {
     reserveMaxPct: 7,
     finishingHorizonMinutes: 30,
     resumeHysteresisPct: 5,
+    // v3 P3 (§3.2): admission gate. admissionAt is the 5h-util finishing line
+    // (well below targetUtil so new tasks stop before the pace line); wrapUpQuota
+    // bounds the wrap-up turns let through per 5h window.
+    admissionAt: 85,
+    wrapUpQuota: 2,
   },
   // v3 P4 (§3.4): runway-difference balance double gate. A balance directive
   // fires only when the shorter/longer runway ratio is below minRunwayRatio AND
@@ -197,6 +202,8 @@ function findShapeViolation(raw: Record<string, unknown>): string | null {
         "reserveMaxPct",
         "finishingHorizonMinutes",
         "resumeHysteresisPct",
+        "admissionAt",
+        "wrapUpQuota",
       ] as const) {
         if (key in maximize && !isCoercibleNumber(maximize[key])) {
           return `budget.maximize.${key} is present but not a number`;
@@ -250,6 +257,10 @@ function hasCustomDecisionValues(config: AgentBridgeConfig): boolean {
     b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct ||
     b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes ||
     b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct ||
+    // v3 P3: admission gate parameters are decision-grade (they gate new-turn
+    // admission), so a tuned value should report as "custom values in effect".
+    b.maximize.admissionAt !== db.maximize.admissionAt ||
+    b.maximize.wrapUpQuota !== db.maximize.wrapUpQuota ||
     // v3 P4: allocation thresholds are decision-grade (they gate the balance
     // directive), so a tuned value should report as "custom values in effect".
     b.allocation.minRunwayRatio !== db.allocation.minRunwayRatio ||
@@ -306,11 +317,13 @@ export function normalizeBoundedNumber(
 
 /**
  * Normalize the v3 maximize parameter block. Each field is bounds-checked
- * (out-of-range → fallback). The relation constraint `targetUtil > pauseAt`
- * (§4.1) is unsatisfiable otherwise — the dynamic line floor is pauseAt, so a
- * target at/below it leaves no maximize band — so the WHOLE block resets to
- * defaults when violated. Silent reset mirrors the existing pauseAt<=resumeBelow
- * handling in normalizeBudgetConfig (both keep normalize pure / logger-free).
+ * (out-of-range → fallback). Two relation constraints reset the WHOLE block to
+ * defaults when violated (§4.1): `targetUtil > pauseAt` (the dynamic line floor
+ * is pauseAt, so a target at/below it leaves no maximize band) and `admissionAt
+ * < targetUtil` (P3 §3.2 — admission must fire BEFORE the pace target, else the
+ * finishing gate is degenerate). Silent reset mirrors the existing
+ * pauseAt<=resumeBelow handling in normalizeBudgetConfig (both keep normalize
+ * pure / logger-free).
  */
 function normalizeMaximizeConfig(
   raw: unknown,
@@ -339,11 +352,16 @@ function normalizeMaximizeConfig(
       1,
       30,
     ),
+    admissionAt: normalizeBoundedInteger(m.admissionAt, fallback.admissionAt, 50, 99),
+    // wrapUpQuota is a turn COUNT — floor a fractional input (normalizeBoundedInteger
+    // accepts "1.5"); a non-integer cap would let consumeWrapUp admit ceil(quota) turns.
+    wrapUpQuota: Math.floor(normalizeBoundedInteger(m.wrapUpQuota, fallback.wrapUpQuota, 0, 10)),
   };
-  // Unsatisfiable relation → reset the whole block to the package defaults so a
+  // Unsatisfiable relations → reset the whole block to the package defaults so a
   // typo cannot silently produce a maximize line that never pauses (or one that
-  // collapses onto pauseAt for the wrong reason).
-  if (normalized.targetUtil <= pauseAt) {
+  // collapses onto pauseAt for the wrong reason), nor an admission line at/above
+  // the pace target (which would never fire its finishing protection in time).
+  if (normalized.targetUtil <= pauseAt || normalized.admissionAt >= normalized.targetUtil) {
     return { ...DEFAULT_BUDGET_CONFIG.maximize };
   }
   return normalized;
@@ -499,6 +517,8 @@ export function applyBudgetEnvOverrides(
         env.AGENTBRIDGE_BUDGET_FINISHING_HORIZON_MINUTES ?? budget.maximize.finishingHorizonMinutes,
       resumeHysteresisPct:
         env.AGENTBRIDGE_BUDGET_RESUME_HYSTERESIS_PCT ?? budget.maximize.resumeHysteresisPct,
+      admissionAt: env.AGENTBRIDGE_BUDGET_ADMISSION_AT ?? budget.maximize.admissionAt,
+      wrapUpQuota: env.AGENTBRIDGE_BUDGET_WRAP_UP_QUOTA ?? budget.maximize.wrapUpQuota,
     },
     allocation: {
       minRunwayRatio:

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -98,6 +98,15 @@ export type ControlClientMessage =
        * Messages without a key bypass the machine entirely (backward compat).
        */
       idempotencyKey?: string;
+      /**
+       * v3 P3 (§3.2): finishing-turn declaration. When the admission gate is
+       * `admission-closed` (5h finishing protection), new turns are rejected with
+       * `budget_admission` — EXCEPT a reply flagged `wrapUp: true`, which is let
+       * through up to `maximize.wrapUpQuota` per 5h window so an in-flight
+       * collaboration can be wrapped to a checkpoint. Absent/false on an older
+       * client → treated as a normal (non-wrap-up) turn (backward compat).
+       */
+      wrapUp?: boolean;
     }
   | { type: "status" }
   /**
@@ -127,7 +136,7 @@ export type ControlServerMessage =
       /**
        * Structured result (protocol v2 PR B). `ok` mirrors `success` and both
        * are populated for one version; `code` is the machine-readable failure
-       * code (e.g. busy_reject / budget_paused / steer_failed /
+       * code (e.g. busy_reject / budget_paused / budget_admission / steer_failed /
        * interrupt_timeout / interrupt_rejected / interrupt_unavailable /
        * duplicate_in_flight / duplicate_terminal / no_thread); `phase` is the
        * codex turnPhase at result time; `retryAfterMs` is advisory and only

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -273,6 +273,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
     requireReply?: boolean,
     onBusy?: "reject" | "steer" | "interrupt",
     idempotencyKey?: string,
+    wrapUp?: boolean,
   ): Promise<SendReplyResult> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return { success: false, error: "AgentBridge daemon is not connected." };
@@ -299,6 +300,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       ...(requireReply ? { requireReply: true } : {}),
       ...(onBusy && onBusy !== "reject" ? { onBusy } : {}),
       ...(idempotencyKey ? { idempotencyKey } : {}),
+      ...(wrapUp ? { wrapUp: true } : {}),
     });
     return pending;
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -18,7 +18,7 @@ import {
 import { TuiConnectionState } from "./tui-connection-state";
 import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
-import { consumeWrapUp, currentWindowState } from "./budget/admission-quota";
+import { consumeCheckpointBaton, consumeWrapUp, currentWindowState } from "./budget/admission-quota";
 import { ConfigService, applyBudgetEnvOverrides } from "./config-service";
 import { BudgetCoordinator } from "./budget/budget-coordinator";
 import { createQuotaSource } from "./budget/quota-source";
@@ -456,7 +456,17 @@ function ensureBudgetCoordinatorStarted() {
           `(gate ${budgetCoordinator?.isGateClosed() ? "CLOSED" : "OPEN"})`,
         );
       },
-      onSnapshot: () => broadcastStatus(),
+      onSnapshot: () => {
+        broadcastStatus();
+        // v3 P3 (§3.2, M3b): the gate closing while Codex is already idle emits no
+        // turnPhaseChanged event, so re-check the checkpoint baton every poll here.
+        // onSnapshot fires AFTER the coordinator commits latestSnapshot (unlike
+        // onPauseChange, which runs mid-applyState before the snapshot is set), so
+        // maybeFireCheckpointBaton can read the fresh 5h/weekly reset to key on.
+        // Self-gates on gateState()==="closed" + Codex idle; consumeCheckpointBaton
+        // dedups to once per window, so polling it every snapshot is harmless.
+        maybeFireCheckpointBaton("snapshot");
+      },
       log,
       onResume: (side, _directive, resumeId) => {
         // Side-aware routing lives in the pure, exported routeResume so the
@@ -480,6 +490,9 @@ function ensureBudgetCoordinatorStarted() {
       // booleans. Each read is fault-isolated so a transient fs error never
       // breaks the poll loop.
       resumeSignals: readResumeSignals,
+      // v3 P3 (§3.2, M3b): turnPhase-aware admission directive — defer while a
+      // Codex turn runs, flush on idle (see turnPhaseChanged → onCodexTurnIdle).
+      isCodexTurnActive: () => codex.turnInProgress,
     });
   }
   void budgetCoordinator.start();
@@ -543,6 +556,142 @@ function budgetAdmissionGateError(
   );
 }
 
+/** A budget-gate decision for one Claude→Codex injection attempt. */
+type BudgetGateDecision =
+  | { allow: false; code: "budget_paused" | "budget_admission"; error: string; retryAfterMs?: number }
+  | { allow: true; pendingWrapUpReset: number | null };
+
+/**
+ * v3 P3 (§3.2): evaluate the three-state budget gate for a Claude→Codex injection.
+ * A pure DECISION (reads only the coordinator snapshot + a quota-file PEEK — never
+ * consumes; the caller sends the result and commits any wrap-up slot). Extracted so
+ * the SAME logic runs at the top of the handler AND is RE-EVALUATED after the
+ * interrupt path awaits its terminal boundary — the gate can flip during that await
+ * (a budget poll lands while waitForInterruptOutcome blocks), and re-checking is the
+ * only thing that stops a tightened gate from being bypassed (P3 plan §1.5; the
+ * re-check was missed in M3a and caught by the cross-engine round-4 review).
+ *
+ *   - willInject: whether THIS attempt will actually inject (top: !turnInProgress ||
+ *     interrupt; post-interrupt-await: always true). Only an injecting wrap-up
+ *     reserves a quota slot; a wrap-up that will bounce off the busy guard does not.
+ *   - isSteer: a steer feeding a RUNNING turn — admission lets it through (the steer
+ *     path handles it; it is not a new task). Always false on the post-await path.
+ *     A fully `closed` gate still rejects everything (steer included), unchanged.
+ */
+function evaluateInjectionBudgetGate(
+  message: { wrapUp?: boolean },
+  willInject: boolean,
+  isSteer: boolean,
+): BudgetGateDecision {
+  const gateState = budgetCoordinator?.gateState() ?? "open";
+  if (gateState === "closed") {
+    log(`Injection rejected by budget pause gate`);
+    const resumeAfterEpoch = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
+    // B4 fix: only advertise a POSITIVE retry delay (see retryAfterMsForResume).
+    const retryAfterMs = retryAfterMsForResume(resumeAfterEpoch, Date.now());
+    return {
+      allow: false,
+      code: "budget_paused",
+      error: budgetPauseGateError(),
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    };
+  }
+  if (gateState === "admission-closed" && !isSteer) {
+    // Key the wrap-up quota on a FRESH admission window (resetEpoch > now): the 5h
+    // window when fresh, else the weekly window. EXPIRED 5h epochs are excluded (>0
+    // yet past) and a total probe outage (no fresh window) FAILS CLOSED below — both
+    // are M3a round-3/round-4 REALs, preserved verbatim by this extraction.
+    const nowSec = Math.floor(Date.now() / 1000);
+    const admSnap = budgetCoordinator?.getSnapshot()?.codex;
+    const admFiveHour = admSnap?.fiveHour?.resetEpoch ?? 0;
+    const admWeekly = admSnap?.weekly?.resetEpoch ?? 0;
+    const admissionWindowReset = admFiveHour > nowSec ? admFiveHour : admWeekly > nowSec ? admWeekly : 0;
+    if (admissionWindowReset <= 0) {
+      log(`Injection rejected by admission gate: no fresh quota window (probe stale / snapshot lost)`);
+      return { allow: false, code: "budget_admission", error: budgetAdmissionGateError(0, 0, true) };
+    }
+    if (message.wrapUp === true && willInject) {
+      // PEEK availability; the actual consume is deferred to the pre-inject commit
+      // (fail-closed) so a failed interrupt / null inject never burns a slot.
+      const peek = currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log);
+      if (peek.wrapUpUsed >= BUDGET_CONFIG.maximize.wrapUpQuota) {
+        log(`Injection rejected by admission gate: wrap-up quota exhausted`);
+        return { allow: false, code: "budget_admission", error: budgetAdmissionGateError(admissionWindowReset, 0, true) };
+      }
+      log(`Admission-closed: wrap-up permitted (${peek.wrapUpUsed}/${BUDGET_CONFIG.maximize.wrapUpQuota} used; slot committed on inject)`);
+      return { allow: true, pendingWrapUpReset: admissionWindowReset };
+    }
+    if (message.wrapUp === true && !willInject) {
+      // Turn running + reject policy: let the busy guard answer; do not consume.
+      return { allow: true, pendingWrapUpReset: null };
+    }
+    const left = Math.max(
+      0,
+      BUDGET_CONFIG.maximize.wrapUpQuota - currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log).wrapUpUsed,
+    );
+    log(`Injection rejected by admission gate: new task (set wrap_up to finish the current work)`);
+    return { allow: false, code: "budget_admission", error: budgetAdmissionGateError(admissionWindowReset, left, false) };
+  }
+  return { allow: true, pendingWrapUpReset: null };
+}
+
+/**
+ * v3 P3 (§3.2, REAL-2): the system-initiated checkpoint baton injected into Codex
+ * once per quota window when the gate is fully `closed`. A last useful turn before
+ * the side goes dark: have Codex capture its own progress so a fresh session can
+ * resume. Deliberately self-describing as system-initiated and "no reply needed".
+ */
+const CHECKPOINT_BATON_PROMPT =
+  "【预算协调 · 系统发起】账号级额度即将耗尽，闸门已关闭。这是本额度窗口唯一一次系统提醒：" +
+  "请立即把当前进度写入 checkpoint（.agent/checkpoint.md：任务 / 已完成 / 进行中断点 / 下一步 / 关键决策与约束），" +
+  "然后停手等待额度窗口刷新；刷新前不要再开新任务。此为系统提醒，无需回复 Claude。";
+
+/**
+ * v3 P3 (§3.2, REAL-2): fire the closed-state checkpoint baton at most ONCE per
+ * quota window. Triggers: turnPhaseChanged → idle/aborted (a turn just ended) and
+ * onSnapshot (every poll — catches the gate closing while Codex was already idle,
+ * which emits no turnPhaseChanged). Both self-gate + consumeCheckpointBaton dedups,
+ * so over-calling is harmless. Guards, in order:
+ *   - gate must be fully `closed` (not admission-closed / open).
+ *   - Codex must NOT have a turn in progress (idle/aborted) — never interrupt;
+ *     injectMessage would reject a busy turn anyway.
+ *   - a FRESH quota window (5h if fresh, else weekly) must exist to key the
+ *     per-window flag on — keyed identically to the wrap-up gate so the two
+ *     counters never thrash a divergent key on the shared admission-quota record.
+ *     No fresh window (probe outage while phantom-held closed) → skip (degraded).
+ *   - consumeCheckpointBaton is FAIL-CLOSED once-per-window (true only on a
+ *     durable write). Consume BEFORE inject: a rare post-consume inject failure
+ *     costs one advisory baton (the over-protect direction) but the "at most once
+ *     per window" anti-spam invariant is absolute — re-firing a checkpoint nudge
+ *     at a budget-exhausted Codex every idle would be the worse failure.
+ */
+function maybeFireCheckpointBaton(trigger: string): void {
+  if (!budgetCoordinator) return;
+  if (budgetCoordinator.gateState() !== "closed") return;
+  // Injectability PRECHECK before consuming the once-per-window token. canInject()
+  // covers all three of injectMessage's synchronous pre-send guards (active thread,
+  // app-server socket OPEN, no turn in progress). Without it, a closed-gate poll
+  // fired while the TUI/app-server is disconnected would consumeCheckpointBaton
+  // (durable write) and then get a null inject — permanently burning the window's
+  // only baton (REAL: cross-engine + workflow). The whole body below is synchronous
+  // (no await between canInject(), the sync consume write, and injectMessage), so
+  // there is no TOCTOU gap to reopen the socket-closed race.
+  if (!codex.canInject()) return;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const snap = budgetCoordinator.getSnapshot()?.codex;
+  const fiveHour = snap?.fiveHour?.resetEpoch ?? 0;
+  const weekly = snap?.weekly?.resetEpoch ?? 0;
+  const windowReset = fiveHour > nowSec ? fiveHour : weekly > nowSec ? weekly : 0;
+  if (windowReset <= 0) return;
+  if (!consumeCheckpointBaton(stateDir.admissionQuotaFile, windowReset, log)) return;
+  const injectionId = codex.injectMessage(CHECKPOINT_BATON_PROMPT);
+  if (injectionId === null) {
+    log(`Checkpoint baton (${trigger}): inject failed after consume — baton lost this window (reset ${windowReset})`);
+    return;
+  }
+  log(`Checkpoint baton fired (${trigger}, window reset ${windowReset})`);
+}
+
 const tuiConnectionState = new TuiConnectionState({
   disconnectGraceMs: TUI_DISCONNECT_GRACE_MS,
   log,
@@ -588,6 +737,14 @@ function tryWriteStatusFile(reason: string) {
 codex.on("turnPhaseChanged", ({ phase, previous }: { phase: string; previous: string }) => {
   log(`Codex turn phase: ${previous} → ${phase}`);
   tryWriteStatusFile(`turnPhase:${phase}`);
+  // v3 P3 (§3.2, M3b): a turn just ended (Codex is now injectable). This is the
+  // natural decision point — flush any deferred admission directive to Claude and
+  // give the closed-state checkpoint baton its idle window. Both self-gate, so
+  // running→stalled / stalled→running transitions fall through harmlessly.
+  if (phase === "idle" || phase === "aborted") {
+    budgetCoordinator?.onCodexTurnIdle();
+    maybeFireCheckpointBaton("turnIdle");
+  }
   broadcastStatus();
 });
 
@@ -1241,100 +1398,27 @@ async function handleClaudeToCodex(
   // handoff keeps the gate OPEN so the baton reaches Codex). `admission-closed`
   // (5h finishing protection) → reject NEW turns with budget_admission, but let
   // a `wrapUp` reply through up to maximize.wrapUpQuota per 5h window, and let a
-  // steer feed a RUNNING turn (steer is handled below; not a new task).
-  // Set when an admission wrap-up turn is PERMITTED but its quota slot is deferred
-  // to the post-injection commit below (so a failed interrupt / null injection
-  // never burns a slot). null = nothing to commit.
+  // steer feed a RUNNING turn (steer is handled below; not a new task). The full
+  // decision lives in evaluateInjectionBudgetGate so the interrupt path can
+  // RE-EVALUATE it after its await (the gate can flip during the wait). On an
+  // admission wrap-up the reserved window is carried in `pendingWrapUpReset` and
+  // committed (fail-closed) only just before the inject, so a failed interrupt /
+  // null injection never burns a slot. null = nothing to commit.
   let pendingWrapUpReset: number | null = null;
-  const gateState = budgetCoordinator?.gateState() ?? "open";
-  if (gateState === "closed") {
-    const reason = budgetPauseGateError();
-    log(`Injection rejected by budget pause gate`);
-    const resumeAfterEpoch = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
-    // B4 fix: only advertise a POSITIVE retry delay (see retryAfterMsForResume).
-    const retryAfterMs = retryAfterMsForResume(resumeAfterEpoch, Date.now());
-    sendClaudeToCodexResult(ws, message.requestId, {
-      success: false,
-      code: "budget_paused",
-      error: reason,
-      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
-    });
-    return;
-  }
-  if (gateState === "admission-closed") {
-    // A steer feeds a RUNNING turn (handled below) — never a new task, always
-    // allowed through admission. A "steer" with no running turn is a new turn and
-    // is gated like any other (isSteer stays false).
+  {
     const isSteer = codex.turnInProgress && message.onBusy === "steer";
-    if (!isSteer) {
-      // Key the wrap-up quota on a FRESH admission window (resetEpoch > now): the
-      // 5h window when fresh, else the weekly window. admission-closed can fire from
-      // a WEEKLY trigger with no fresh 5h window (round-3 REAL), and an EXISTING but
-      // EXPIRED 5h epoch must NOT be used (>0 yet past — it would mis-key vs the fresh
-      // weekly, and the next poll's fresh 5h would reset the counter; round-4 REAL).
-      // admission-closed normally implies ≥1 fresh window, BUT a total probe failure
-      // nulls latestSnapshot while admissionState stays phantom-held → no key → we
-      // FAIL CLOSED just below (never fall back to an uncounted bypass; round-4 REAL).
-      const nowSec = Math.floor(Date.now() / 1000);
-      const admSnap = budgetCoordinator?.getSnapshot()?.codex;
-      const admFiveHour = admSnap?.fiveHour?.resetEpoch ?? 0;
-      const admWeekly = admSnap?.weekly?.resetEpoch ?? 0;
-      const admissionWindowReset = admFiveHour > nowSec ? admFiveHour : (admWeekly > nowSec ? admWeekly : 0);
-      if (admissionWindowReset <= 0) {
-        // No fresh window to key the per-window quota on (probe outage while the
-        // gate is held, or all windows stale). FAIL CLOSED: reject — admitting an
-        // UNCOUNTED turn here would bypass the cap. Transient: recovers as soon as
-        // the next probe restores a fresh window.
-        log(`Injection rejected by admission gate: no fresh quota window (probe stale / snapshot lost)`);
-        sendClaudeToCodexResult(ws, message.requestId, {
-          success: false,
-          code: "budget_admission",
-          error: budgetAdmissionGateError(0, 0, true),
-        });
-        return;
-      }
-      // Only a turn that will actually INJECT consumes a wrap-up slot: a direct
-      // turn (no turn running) or an interrupt (which terminates then injects).
-      // A wrap-up while a turn is running on the default/reject busy policy is
-      // NOT consumed — it falls through to the busy guard (busy_reject) and Claude
-      // resends once Codex is idle.
-      const willInject = !codex.turnInProgress || message.onBusy === "interrupt";
-      if (message.wrapUp === true && willInject) {
-        // PRE-CHECK availability here, but DEFER the actual consume to the pre-inject
-        // commit below — a wrapUp+interrupt whose interrupt fails (5 non-injecting
-        // exits) must NOT burn a slot (round-1 REAL); the commit is FAIL CLOSED
-        // (round-2 REAL). admissionWindowReset is guaranteed > 0 (checked above).
-        const peek = currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log);
-        if (peek.wrapUpUsed >= BUDGET_CONFIG.maximize.wrapUpQuota) {
-          log(`Injection rejected by admission gate: wrap-up quota exhausted`);
-          sendClaudeToCodexResult(ws, message.requestId, {
-            success: false,
-            code: "budget_admission",
-            error: budgetAdmissionGateError(admissionWindowReset, 0, true),
-          });
-          return;
-        }
-        pendingWrapUpReset = admissionWindowReset; // committed only after a confirmed inject
-        log(`Admission-closed: wrap-up permitted (${peek.wrapUpUsed}/${BUDGET_CONFIG.maximize.wrapUpQuota} used; slot committed on inject)`);
-        // fall through to inject the wrap-up turn normally.
-      } else if (message.wrapUp === true && !willInject) {
-        // Turn running + reject policy: let the busy guard answer; do not consume.
-        // (fall through)
-      } else {
-        // A new task while admission-closed → reject.
-        const left = Math.max(
-          0,
-          BUDGET_CONFIG.maximize.wrapUpQuota - currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log).wrapUpUsed,
-        );
-        log(`Injection rejected by admission gate: new task (set wrap_up to finish the current work)`);
-        sendClaudeToCodexResult(ws, message.requestId, {
-          success: false,
-          code: "budget_admission",
-          error: budgetAdmissionGateError(admissionWindowReset, left, false),
-        });
-        return;
-      }
+    const willInject = !codex.turnInProgress || message.onBusy === "interrupt";
+    const gate = evaluateInjectionBudgetGate(message, willInject, isSteer);
+    if (!gate.allow) {
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: gate.code,
+        error: gate.error,
+        ...(gate.retryAfterMs !== undefined ? { retryAfterMs: gate.retryAfterMs } : {}),
+      });
+      return;
     }
+    pendingWrapUpReset = gate.pendingWrapUpReset;
   }
 
   const requireReply = !!message.requireReply;
@@ -1514,6 +1598,30 @@ async function handleClaudeToCodex(
     // injection block re-registers under the thread it actually injects into.
     if (interruptThreadId && codex.activeThreadId !== interruptThreadId) {
       releaseInterruptKey();
+    }
+    // v3 P3 (§3.2, plan §1.5): RE-EVALUATE the budget gate after the await. The
+    // top-of-handler check ran against the PRE-await gate, but waitForInterruptOutcome
+    // yields to the event loop, during which a budget poll can tighten the gate to
+    // admission-closed or closed. Without this re-check the interrupt would inject a
+    // NEW turn past the freshly-tightened gate — bypassing budget_admission / the
+    // wrap-up quota, or injecting into a fully-closed gate (round-4 cross-engine REAL).
+    // An interrupt always starts a NEW turn (willInject=true, isSteer=false); re-derive
+    // pendingWrapUpReset so a now-open gate drops a stale reservation and a now-closed
+    // gate rejects. Mirrors the post-await attach re-check above.
+    {
+      const gate = evaluateInjectionBudgetGate(message, true, false);
+      if (!gate.allow) {
+        releaseInterruptKey();
+        log(`Interrupt-path injection rejected by budget gate after await (${gate.code})`);
+        sendClaudeToCodexResult(ws, message.requestId, {
+          success: false,
+          code: gate.code,
+          error: gate.error,
+          ...(gate.retryAfterMs !== undefined ? { retryAfterMs: gate.retryAfterMs } : {}),
+        });
+        return;
+      }
+      pendingWrapUpReset = gate.pendingWrapUpReset;
     }
     // Fall through to the shared injection block.
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -18,6 +18,7 @@ import {
 import { TuiConnectionState } from "./tui-connection-state";
 import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
+import { consumeWrapUp, currentWindowState } from "./budget/admission-quota";
 import { ConfigService, applyBudgetEnvOverrides } from "./config-service";
 import { BudgetCoordinator } from "./budget/budget-coordinator";
 import { createQuotaSource } from "./budget/quota-source";
@@ -508,6 +509,37 @@ function budgetPauseGateError(): string {
     reopenText +
     (resumeAt ? `（预计恢复 ${resumeAt}，以实测为准；提前刷新会更早解除）` : "") +
     `。收到 RESUME 通知前请勿重试向 Codex 发送 reply；${sideHint}。`
+  );
+}
+
+/**
+ * v3 P3 (§3.2): error text for the `admission-closed` gate. New turns are
+ * declined; the model may bring the current collaboration to a checkpoint by
+ * resending with wrap_up=true (up to maximize.wrapUpQuota per quota window).
+ * Steer (mid-turn correction) is unaffected. The quota window is the 5h window
+ * (or the weekly window when admission fired from a weekly trigger), so the
+ * wording is window-agnostic. `wrapUpLeft` is the remaining quota for the
+ * new-task case; `quotaExhausted` switches to the "no budget left" wording.
+ */
+function budgetAdmissionGateError(
+  windowResetEpoch: number,
+  wrapUpLeft: number,
+  quotaExhausted: boolean,
+): string {
+  const resetAt = windowResetEpoch > 0
+    ? new Date(windowResetEpoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z")
+    : "未知";
+  const quota = BUDGET_CONFIG.maximize.wrapUpQuota;
+  if (quotaExhausted) {
+    return (
+      `额度窗口收尾保护中（admission-closed）：本窗口 wrap-up 配额（每窗口 ${quota} 个）已用尽，已拒绝转发。` +
+      `请勿再派新任务；写 checkpoint，等额度窗口刷新（约 ${resetAt}）后再继续。`
+    );
+  }
+  return (
+    `额度窗口收尾保护中（admission-closed）：仅接收收尾类注入，已拒绝该新任务。` +
+    `如需把当前协作收尾到 checkpoint，可用 reply 带 wrap_up=true 重发（本窗口还剩 ${wrapUpLeft} 个收尾配额）；steer 修正不受限。` +
+    `新任务请等额度窗口刷新（约 ${resetAt}）后再派。`
   );
 }
 
@@ -1204,12 +1236,18 @@ async function handleClaudeToCodex(
     return;
   }
 
-  // Budget pause gate (plan v2.4 side-aware R4): the gate protects the
-  // TARGET side's quota, so it closes only when the Codex side is exhausted
-  // (gateClosed = pauseSide codex/both). A Claude-only handoff keeps the
-  // gate OPEN so the baton reply can reach Codex. Same rejection shape as
-  // the busy-guard below.
-  if (budgetCoordinator?.isGateClosed()) {
+  // Budget gate (v3 P3 §3.2 three-state). `closed` (Codex side exhausted) →
+  // reject budget_paused (unchanged v2.4 side-aware semantics: a Claude-only
+  // handoff keeps the gate OPEN so the baton reaches Codex). `admission-closed`
+  // (5h finishing protection) → reject NEW turns with budget_admission, but let
+  // a `wrapUp` reply through up to maximize.wrapUpQuota per 5h window, and let a
+  // steer feed a RUNNING turn (steer is handled below; not a new task).
+  // Set when an admission wrap-up turn is PERMITTED but its quota slot is deferred
+  // to the post-injection commit below (so a failed interrupt / null injection
+  // never burns a slot). null = nothing to commit.
+  let pendingWrapUpReset: number | null = null;
+  const gateState = budgetCoordinator?.gateState() ?? "open";
+  if (gateState === "closed") {
     const reason = budgetPauseGateError();
     log(`Injection rejected by budget pause gate`);
     const resumeAfterEpoch = budgetCoordinator?.getSnapshot()?.resumeAfterEpoch ?? null;
@@ -1222,6 +1260,81 @@ async function handleClaudeToCodex(
       ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
     });
     return;
+  }
+  if (gateState === "admission-closed") {
+    // A steer feeds a RUNNING turn (handled below) — never a new task, always
+    // allowed through admission. A "steer" with no running turn is a new turn and
+    // is gated like any other (isSteer stays false).
+    const isSteer = codex.turnInProgress && message.onBusy === "steer";
+    if (!isSteer) {
+      // Key the wrap-up quota on a FRESH admission window (resetEpoch > now): the
+      // 5h window when fresh, else the weekly window. admission-closed can fire from
+      // a WEEKLY trigger with no fresh 5h window (round-3 REAL), and an EXISTING but
+      // EXPIRED 5h epoch must NOT be used (>0 yet past — it would mis-key vs the fresh
+      // weekly, and the next poll's fresh 5h would reset the counter; round-4 REAL).
+      // admission-closed normally implies ≥1 fresh window, BUT a total probe failure
+      // nulls latestSnapshot while admissionState stays phantom-held → no key → we
+      // FAIL CLOSED just below (never fall back to an uncounted bypass; round-4 REAL).
+      const nowSec = Math.floor(Date.now() / 1000);
+      const admSnap = budgetCoordinator?.getSnapshot()?.codex;
+      const admFiveHour = admSnap?.fiveHour?.resetEpoch ?? 0;
+      const admWeekly = admSnap?.weekly?.resetEpoch ?? 0;
+      const admissionWindowReset = admFiveHour > nowSec ? admFiveHour : (admWeekly > nowSec ? admWeekly : 0);
+      if (admissionWindowReset <= 0) {
+        // No fresh window to key the per-window quota on (probe outage while the
+        // gate is held, or all windows stale). FAIL CLOSED: reject — admitting an
+        // UNCOUNTED turn here would bypass the cap. Transient: recovers as soon as
+        // the next probe restores a fresh window.
+        log(`Injection rejected by admission gate: no fresh quota window (probe stale / snapshot lost)`);
+        sendClaudeToCodexResult(ws, message.requestId, {
+          success: false,
+          code: "budget_admission",
+          error: budgetAdmissionGateError(0, 0, true),
+        });
+        return;
+      }
+      // Only a turn that will actually INJECT consumes a wrap-up slot: a direct
+      // turn (no turn running) or an interrupt (which terminates then injects).
+      // A wrap-up while a turn is running on the default/reject busy policy is
+      // NOT consumed — it falls through to the busy guard (busy_reject) and Claude
+      // resends once Codex is idle.
+      const willInject = !codex.turnInProgress || message.onBusy === "interrupt";
+      if (message.wrapUp === true && willInject) {
+        // PRE-CHECK availability here, but DEFER the actual consume to the pre-inject
+        // commit below — a wrapUp+interrupt whose interrupt fails (5 non-injecting
+        // exits) must NOT burn a slot (round-1 REAL); the commit is FAIL CLOSED
+        // (round-2 REAL). admissionWindowReset is guaranteed > 0 (checked above).
+        const peek = currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log);
+        if (peek.wrapUpUsed >= BUDGET_CONFIG.maximize.wrapUpQuota) {
+          log(`Injection rejected by admission gate: wrap-up quota exhausted`);
+          sendClaudeToCodexResult(ws, message.requestId, {
+            success: false,
+            code: "budget_admission",
+            error: budgetAdmissionGateError(admissionWindowReset, 0, true),
+          });
+          return;
+        }
+        pendingWrapUpReset = admissionWindowReset; // committed only after a confirmed inject
+        log(`Admission-closed: wrap-up permitted (${peek.wrapUpUsed}/${BUDGET_CONFIG.maximize.wrapUpQuota} used; slot committed on inject)`);
+        // fall through to inject the wrap-up turn normally.
+      } else if (message.wrapUp === true && !willInject) {
+        // Turn running + reject policy: let the busy guard answer; do not consume.
+        // (fall through)
+      } else {
+        // A new task while admission-closed → reject.
+        const left = Math.max(
+          0,
+          BUDGET_CONFIG.maximize.wrapUpQuota - currentWindowState(stateDir.admissionQuotaFile, admissionWindowReset, log).wrapUpUsed,
+        );
+        log(`Injection rejected by admission gate: new task (set wrap_up to finish the current work)`);
+        sendClaudeToCodexResult(ws, message.requestId, {
+          success: false,
+          code: "budget_admission",
+          error: budgetAdmissionGateError(admissionWindowReset, left, false),
+        });
+        return;
+      }
+    }
   }
 
   const requireReply = !!message.requireReply;
@@ -1406,6 +1519,31 @@ async function handleClaudeToCodex(
   }
 
   const injectThreadId = codex.activeThreadId;
+  // v3 P3: commit the admission wrap-up slot HERE — after the interrupt block
+  // (every interrupt-failure exit already returned above, so no slot is burned on
+  // a non-injecting path) and JUST BEFORE the inject. FAIL CLOSED: if the slot
+  // cannot be durably recorded (write failure) or another request raced it to the
+  // cap, REJECT rather than inject an uncounted turn (which would silently bypass
+  // the cap — M3a round-2 REAL). The only residual is the safe over-protect
+  // direction: a rare injectMessage===null right after this burns one slot.
+  if (pendingWrapUpReset !== null) {
+    const committed = consumeWrapUp(
+      stateDir.admissionQuotaFile,
+      pendingWrapUpReset,
+      BUDGET_CONFIG.maximize.wrapUpQuota,
+      log,
+    );
+    if (!committed.allowed) {
+      log(`Injection rejected by admission gate: wrap-up slot not durably recorded (write failure or raced to cap)`);
+      sendClaudeToCodexResult(ws, message.requestId, {
+        success: false,
+        code: "budget_admission",
+        error: budgetAdmissionGateError(pendingWrapUpReset, 0, true),
+      });
+      return;
+    }
+    log(`Admission wrap-up slot committed (${committed.used}/${BUDGET_CONFIG.maximize.wrapUpQuota})`);
+  }
   const injectionId = codex.injectMessage(contentToSend, tierOverrides);
   if (injectionId === null) {
     // No wire attempt happened — any upfront interrupt-path accept() must not

--- a/src/integration-test/daemon-wiring.test.ts
+++ b/src/integration-test/daemon-wiring.test.ts
@@ -445,14 +445,19 @@ describe("daemon wiring", () => {
       );
 
       writeUsage("codex", 5);
+      // While the gate was CLOSED + Codex idle, the v3 P3 checkpoint baton (M3b)
+      // legitimately injects one turn before recovery — so the resume turn is no
+      // longer guaranteed to be turn-start [0]. Match the RESUME turn explicitly.
+      const findResume = () =>
+        readTurnStarts().find((p) => typeof p.input?.[0]?.text === "string" && p.input[0].text.includes(RESUME_PROMPT));
       await waitFor(
-        () => readTurnStarts().length >= 1,
+        () => findResume() !== undefined,
         "resume turn/start after budget recovery",
         400,
         50,
       );
 
-      const injected = readTurnStarts()[0]!;
+      const injected = findResume()!;
       expect(injected.threadId).toBe("thread-fake-1");
       expect(injected.input[0].text).toContain(RESUME_PROMPT);
       expect(injected.model).toBeUndefined();
@@ -909,6 +914,15 @@ describe("daemon wiring", () => {
       await waitFor(() => existsSync(quotaFile), "admission-quota.json persisted", 100, 100);
       const quota = JSON.parse(readFileSync(quotaFile, "utf-8"));
       expect(quota.wrapUpUsed).toBe(1);
+      // The checkpoint baton is a CLOSED-state action only; admission-closed must
+      // never fire it (M3b). The single turn-start so far is the wrap-up, not a baton.
+      expect(quota.checkpointBatonUsed).toBe(false);
+      expect(
+        readTurnStarts().some((p) => {
+          const input = (p.input as Array<{ text?: string }> | undefined) ?? [];
+          return input.some((i) => typeof i.text === "string" && i.text.includes("系统发起"));
+        }),
+      ).toBe(false);
 
       // 3. FAIL CLOSED (M3a round-2 REAL): make the quota file unwritable (replace
       // it with a directory so atomicWriteJson's rename throws at commit) → a
@@ -1000,6 +1014,178 @@ describe("daemon wiring", () => {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
   }, 45000);
+
+  test("v3 P3 (M3b): closed gate fires the checkpoint baton ONCE per window when Codex is idle", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-budget-baton-fixture-"));
+    const probePath = join(fixtureRoot, "probe.sh");
+    const turnStartLog = join(fixtureRoot, "turn-starts.jsonl");
+    const now = Math.floor(Date.now() / 1000);
+    const readTurnStarts = (): Array<Record<string, unknown>> => {
+      if (!existsSync(turnStartLog)) return [];
+      return readFileSync(turnStartLog, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    };
+    // A baton turn carries the system-initiated marker in its input text.
+    const batonStarts = () =>
+      readTurnStarts().filter((p) => {
+        const input = (p.input as Array<{ text?: string }> | undefined) ?? [];
+        return input.some((i) => typeof i.text === "string" && i.text.includes("系统发起"));
+      });
+    writeFileSync(join(fixtureRoot, "usage-claude.json"), JSON.stringify({
+      ok: true, util: 10, warn_util: 10, fetched_at: now,
+      buckets: [{ id: "five_hour", util: 10, reset_epoch: now + 7200 }],
+    }));
+    // Codex 5h util 95 ≥ pauseAt(90) → fully CLOSED (not just admission-closed).
+    writeFileSync(join(fixtureRoot, "usage-codex.json"), JSON.stringify({
+      ok: true, util: 95, warn_util: 95, fetched_at: now,
+      buckets: [{ id: "five_hour", util: 95, reset_epoch: now + 7200 }],
+    }));
+    writeFileSync(probePath, `#!/bin/sh\ncat "${fixtureRoot}/usage-$2.json"\n`, "utf-8");
+    chmodSync(probePath, 0o755);
+
+    try {
+      const harness = await startHarness({
+        pairId: "main-budgetbaton",
+        pairName: "main",
+        extraEnv: {
+          AGENTBRIDGE_BUDGET_ENABLED: "1",
+          AGENTBRIDGE_QUOTA_PROBE: probePath,
+          // 5s poll (the config minimum) so the once-per-window assertion below can
+          // OBSERVE a SECOND poll cycle (onSnapshot → maybeFireCheckpointBaton) — the
+          // poll where a regressed dedup would re-fire the baton.
+          AGENTBRIDGE_BUDGET_POLL_SECONDS: "5",
+          FAKE_APP_TURNSTART_LOG: turnStartLog,
+        },
+      });
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      // Gate closes on the first poll; the onSnapshot edge fires the baton while
+      // Codex is idle (the fake app-server never emits turn/started, so the baton's
+      // turn/start cannot re-arm a turn or re-trigger the listener).
+      await waitFor(() => batonStarts().length >= 1, "checkpoint baton injected once", 200, 100);
+      const quotaFile = join(harness.stateDir, "admission-quota.json");
+      await waitFor(() => existsSync(quotaFile), "admission-quota.json persisted (baton)", 100, 100);
+      const quota = JSON.parse(readFileSync(quotaFile, "utf-8"));
+      expect(quota.checkpointBatonUsed).toBe(true);
+      expect(quota.fiveHourResetEpoch).toBe(now + 7200);
+
+      // ONCE per window across MULTIPLE polls: require the coordinator to have polled
+      // (each onSnapshot calls maybeFireCheckpointBaton) at least 2 MORE times after
+      // the baton fired — distinct budget.updatedAt values prove distinct poll cycles.
+      // If the once-per-window dedup regressed (consumeCheckpointBaton always-true),
+      // the baton would re-fire on those polls and the count would exceed 1. (The
+      // earlier 5s-poll version returned before a 2nd poll and was vacuous on this axis.)
+      const seenUpdatedAt = new Set<number>();
+      await waitFor(async () => {
+        const res = await fetch(`http://127.0.0.1:${harness.controlPort}/healthz`);
+        if (!res.ok) return false;
+        const status = (await res.json()) as DaemonStatus;
+        if (status.budget?.gateState !== "closed") return false;
+        if (typeof status.budget.updatedAt === "number") seenUpdatedAt.add(status.budget.updatedAt);
+        return seenUpdatedAt.size >= 2; // the firing poll + ≥1 further poll cycle
+      }, "≥2 closed-gate budget poll cycles observed", 200, 100);
+      expect(batonStarts().length).toBe(1);
+      // The baton instructs Codex to write .agent/checkpoint.md.
+      const input = (batonStarts()[0]!.input as Array<{ text?: string }>);
+      expect(input[0]!.text).toContain(".agent/checkpoint.md");
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 45000);
+
+  test("v3 P3 (round-4): interrupt RE-CHECKS the gate after the await — a flip to admission-closed during the wait rejects the injection", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-int-gateflip-"));
+    const probePath = join(fixtureRoot, "probe.sh");
+    const turnStartLog = join(fixtureRoot, "turn-starts.jsonl");
+    const interruptLog = join(fixtureRoot, "turninterrupt.jsonl");
+    const writeUsage = (agent: "claude" | "codex", util: number) => {
+      writeFileSync(
+        join(fixtureRoot, `usage-${agent}.json`),
+        JSON.stringify({
+          ok: true,
+          util,
+          warn_util: util,
+          fetched_at: Math.floor(Date.now() / 1000),
+          buckets: [{ id: "five_hour", util, reset_epoch: Math.floor(Date.now() / 1000) + 7200 }],
+        }),
+      );
+    };
+    const readTurnStarts = () =>
+      existsSync(turnStartLog)
+        ? readFileSync(turnStartLog, "utf-8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l))
+        : [];
+    writeUsage("claude", 10);
+    writeUsage("codex", 20); // gate OPEN initially → interrupt is admitted into the await
+    writeFileSync(probePath, `#!/bin/sh\ncat "${fixtureRoot}/usage-$2.json"\n`, "utf-8");
+    chmodSync(probePath, 0o755);
+
+    try {
+      const harness = await startHarness({
+        pairId: "main-gateflip",
+        pairName: "main",
+        extraEnv: {
+          AGENTBRIDGE_BUDGET_ENABLED: "1",
+          AGENTBRIDGE_QUOTA_PROBE: probePath,
+          AGENTBRIDGE_BUDGET_POLL_SECONDS: "5",
+          // Raise the interrupt terminal-boundary timeout to its 13s ceiling so the
+          // fake's deferred boundary (9s, below) is NOT pre-empted by interrupt_timeout.
+          AGENTBRIDGE_INTERRUPT_TIMEOUT_MS: "13000",
+          FAKE_APP_TURNSTART_LOG: turnStartLog,
+          FAKE_APP_TURNINTERRUPT_LOG: interruptLog,
+          // Defer the interrupt terminal boundary 9s: comfortably ABOVE the 5s budget
+          // poll (so the gate reliably flips to admission-closed mid-await, ~3s margin)
+          // and BELOW the 13s interrupt timeout (so the boundary fires normally rather
+          // than timing out, ~4s margin). gateState propagates to the coordinator's
+          // in-memory value that both /healthz and the post-await re-check read.
+          FAKE_APP_INTERRUPT_DELAY_MS: "9000",
+        },
+      });
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      const gateState = async () => {
+        const res = await fetch(`http://127.0.0.1:${harness.controlPort}/healthz`);
+        return res.ok ? (await res.json() as DaemonStatus).budget?.gateState : undefined;
+      };
+      await waitFor(async () => (await gateState()) === "open", "gateState=open initially", 200, 100);
+
+      // Drive a running turn so the interrupt path (not direct inject) activates.
+      harness.sendAppCommand("start-turn");
+      await waitForMessage(harness.messages, (m) => m.id.startsWith("system_turn_started"), "system_turn_started");
+
+      // Interrupt + inject a NEW task. Gate is OPEN at the top → admitted; the fake
+      // defers the terminal boundary, so the daemon now parks in waitForInterruptOutcome.
+      harness.sendClaudeToCodex("req-gateflip", "new task via interrupt", { onBusy: "interrupt" });
+      await waitFor(
+        () => existsSync(interruptLog) && readFileSync(interruptLog, "utf-8").trim() !== "",
+        "interrupt dispatched (daemon parked in the await)",
+        100,
+        100,
+      );
+
+      // FLIP the gate to admission-closed DURING the await, and confirm the poll landed.
+      writeUsage("codex", 86);
+      await waitFor(async () => (await gateState()) === "admission-closed", "gate flipped to admission-closed mid-await", 200, 100);
+
+      // When the terminal boundary fires, the post-await re-check must REJECT (the
+      // top-of-handler check ran against the now-stale OPEN gate). Without the re-check
+      // the new turn would inject past the gate.
+      await waitFor(
+        () => harness.statusMessages.some((m) => m.type === "claude_to_codex_result" && m.requestId === "req-gateflip"),
+        "result for req-gateflip after the terminal boundary",
+        250,
+        100,
+      );
+      const result = harness.statusMessages.find(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === "req-gateflip",
+      ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }>;
+      expect(result.success).toBe(false);
+      expect(result.code).toBe("budget_admission"); // gate re-checked AFTER the await
+      expect(readTurnStarts().length).toBe(0); // the new turn was NOT injected (no bypass)
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 60000);
 
   test("budget status broadcasts follow coordinator snapshot polls, not the daemon interval", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-budget-snapshot-fixture-"));

--- a/src/integration-test/daemon-wiring.test.ts
+++ b/src/integration-test/daemon-wiring.test.ts
@@ -49,7 +49,7 @@ interface Harness {
   sendClaudeToCodex: (
     requestId: string,
     text: string,
-    opts?: { onBusy?: "reject" | "steer" | "interrupt"; requireReply?: boolean; idempotencyKey?: string },
+    opts?: { onBusy?: "reject" | "steer" | "interrupt"; requireReply?: boolean; idempotencyKey?: string; wrapUp?: boolean },
   ) => void;
   /** Send an ack_resume control message over the attached control socket (PR4). */
   sendAckResume: (resumeId: string, status: string) => void;
@@ -746,7 +746,10 @@ describe("daemon wiring", () => {
       );
     };
     writeUsage("claude", 10);
-    writeUsage("codex", 85); // eco band (≥80) but below pauseAt=90 — no pause
+    // eco band (warnUtil ≥80) yet below pauseAt=90 (no pause) AND below
+    // admissionAt=85 (no v3 P3 admission-closed gate) — so the tier-override turn
+    // still injects. (85 would now trip admission-closed and block the turn.)
+    writeUsage("codex", 82);
     writeFileSync(probePath, `#!/bin/sh\ncat "${fixtureRoot}/usage-$2.json"\n`, "utf-8");
     chmodSync(probePath, 0o755);
 
@@ -826,6 +829,177 @@ describe("daemon wiring", () => {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
   }, 60000);
+
+  test("v3 P3 admission gate: new turns rejected with budget_admission; wrap-up allowed", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-budget-admission-fixture-"));
+    const probePath = join(fixtureRoot, "probe.sh");
+    const turnStartLog = join(fixtureRoot, "turn-starts.jsonl");
+    const writeUsage = (agent: "claude" | "codex", gateUtil: number) => {
+      writeFileSync(
+        join(fixtureRoot, `usage-${agent}.json`),
+        JSON.stringify({
+          ok: true,
+          util: gateUtil,
+          warn_util: gateUtil,
+          fetched_at: Math.floor(Date.now() / 1000),
+          buckets: [
+            { id: "five_hour", util: gateUtil, reset_epoch: Math.floor(Date.now() / 1000) + 7200 },
+          ],
+        }),
+      );
+    };
+    const readTurnStarts = (): Array<Record<string, unknown>> => {
+      if (!existsSync(turnStartLog)) return [];
+      return readFileSync(turnStartLog, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    };
+    writeUsage("claude", 10);
+    // 5h util 86 ≥ admissionAt(85) → admission-closed, yet < pauseAt(90) → NOT paused.
+    writeUsage("codex", 86);
+    writeFileSync(probePath, `#!/bin/sh\ncat "${fixtureRoot}/usage-$2.json"\n`, "utf-8");
+    chmodSync(probePath, 0o755);
+
+    try {
+      const harness = await startHarness({
+        pairId: "main-budgetadm",
+        pairName: "main",
+        extraEnv: {
+          AGENTBRIDGE_BUDGET_ENABLED: "1",
+          AGENTBRIDGE_QUOTA_PROBE: probePath,
+          AGENTBRIDGE_BUDGET_POLL_SECONDS: "5",
+          FAKE_APP_TURNSTART_LOG: turnStartLog,
+        },
+      });
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      // Wait until the coordinator's first poll computed gateState=admission-closed.
+      await waitFor(async () => {
+        try {
+          const res = await fetch(`http://127.0.0.1:${harness.controlPort}/healthz`);
+          if (!res.ok) return false;
+          const status = (await res.json()) as DaemonStatus;
+          return status.budget?.gateState === "admission-closed" && status.budget?.paused === false;
+        } catch {
+          return false;
+        }
+      }, "gateState=admission-closed on /healthz", 200, 100);
+
+      // 1. A normal new turn is rejected with budget_admission (NOT budget_paused).
+      harness.sendClaudeToCodex("req-adm-new", "start a new task");
+      await waitFor(
+        () => harness.statusMessages.some((m) => m.type === "claude_to_codex_result" && m.requestId === "req-adm-new"),
+        "claude_to_codex_result for req-adm-new",
+      );
+      const rejected = harness.statusMessages.find(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === "req-adm-new",
+      ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }>;
+      expect(rejected.success).toBe(false);
+      expect(rejected.code).toBe("budget_admission");
+      expect(rejected.error).toContain("收尾保护");
+      expect(readTurnStarts().length).toBe(0); // new task did NOT inject
+
+      // 2. A wrap-up reply is let through the admission gate → injects a turn.
+      harness.sendClaudeToCodex("req-adm-wrap", "wrap the current work to a checkpoint", { wrapUp: true });
+      await waitFor(() => readTurnStarts().length >= 1, "wrap-up turn injected past admission gate", 100, 100);
+
+      // The wrap-up slot is consumed ONLY on the confirmed injection (deferred from
+      // the gate). So after exactly one injected wrap-up the count is 1 — and the
+      // earlier rejected new-turn (step 1) consumed nothing.
+      const quotaFile = join(harness.stateDir, "admission-quota.json");
+      await waitFor(() => existsSync(quotaFile), "admission-quota.json persisted", 100, 100);
+      const quota = JSON.parse(readFileSync(quotaFile, "utf-8"));
+      expect(quota.wrapUpUsed).toBe(1);
+
+      // 3. FAIL CLOSED (M3a round-2 REAL): make the quota file unwritable (replace
+      // it with a directory so atomicWriteJson's rename throws at commit) → a
+      // further wrap-up is REJECTED with budget_admission and does NOT inject — the
+      // gate never lets an UNCOUNTED turn through on a write failure.
+      rmSync(quotaFile, { force: true });
+      mkdirSync(quotaFile);
+      const turnsBefore = readTurnStarts().length;
+      harness.sendClaudeToCodex("req-adm-wrapfail", "wrap up again (commit write fails)", { wrapUp: true });
+      await waitFor(
+        () => harness.statusMessages.some((m) => m.type === "claude_to_codex_result" && m.requestId === "req-adm-wrapfail"),
+        "result for req-adm-wrapfail",
+      );
+      const wrapFail = harness.statusMessages.find(
+        (m) => m.type === "claude_to_codex_result" && m.requestId === "req-adm-wrapfail",
+      ) as Extract<ControlServerMessage, { type: "claude_to_codex_result" }>;
+      expect(wrapFail.success).toBe(false);
+      expect(wrapFail.code).toBe("budget_admission");
+      expect(readTurnStarts().length).toBe(turnsBefore); // fail-closed: NOT injected
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 45000);
+
+  test("v3 P3 admission gate: weekly-runway trigger (no fresh 5h) still COUNTS wrap-ups (cap not bypassed)", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-budget-admweekly-fixture-"));
+    const probePath = join(fixtureRoot, "probe.sh");
+    const turnStartLog = join(fixtureRoot, "turn-starts.jsonl");
+    const now = Math.floor(Date.now() / 1000);
+    const readTurnStarts = (): Array<Record<string, unknown>> => {
+      if (!existsSync(turnStartLog)) return [];
+      return readFileSync(turnStartLog, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    };
+    // Claude idle. Codex: an EXPIRED 5h window (reset_epoch = now-100, > 0 yet past —
+    // the round-4 case: a 5h-only ">0" key would mis-key here) plus a fresh weekly
+    // that will-fill (util 70 + rate 30/h over 1h → 100 > targetUtil 98) with a short
+    // runway (3000s < finishingHorizon 30m × 2 = 3600s) → admission-closed via the
+    // weekly-runway trigger, while util 70 < pauseAt 90 keeps it OUT of pause. The
+    // daemon must key the wrap-up quota on the FRESH weekly window, not the expired 5h.
+    writeFileSync(join(fixtureRoot, "usage-claude.json"), JSON.stringify({
+      ok: true, util: 10, warn_util: 10, fetched_at: now,
+      buckets: [{ id: "five_hour", util: 10, reset_epoch: now + 7200 }],
+    }));
+    writeFileSync(join(fixtureRoot, "usage-codex.json"), JSON.stringify({
+      ok: true, util: 70, warn_util: 70, fetched_at: now,
+      buckets: [
+        { id: "five_hour", util: 70, reset_epoch: now - 100 },
+        { id: "seven_day", util: 70, reset_epoch: now + 3600, burn_rate_pct_per_hour: 30, burn_confident: true, runway_seconds: 3000 },
+      ],
+    }));
+    writeFileSync(probePath, `#!/bin/sh\ncat "${fixtureRoot}/usage-$2.json"\n`, "utf-8");
+    chmodSync(probePath, 0o755);
+
+    try {
+      const harness = await startHarness({
+        pairId: "main-budgetadmwk",
+        pairName: "main",
+        extraEnv: {
+          AGENTBRIDGE_BUDGET_ENABLED: "1",
+          AGENTBRIDGE_QUOTA_PROBE: probePath,
+          AGENTBRIDGE_BUDGET_POLL_SECONDS: "5",
+          FAKE_APP_TURNSTART_LOG: turnStartLog,
+        },
+      });
+      await harness.attachClaude();
+      await harness.connectTui();
+
+      await waitFor(async () => {
+        try {
+          const res = await fetch(`http://127.0.0.1:${harness.controlPort}/healthz`);
+          if (!res.ok) return false;
+          const status = (await res.json()) as DaemonStatus;
+          return status.budget?.gateState === "admission-closed" && status.budget?.paused === false;
+        } catch {
+          return false;
+        }
+      }, "gateState=admission-closed (weekly trigger) on /healthz", 200, 100);
+
+      // A wrap-up is let through AND counted on the weekly-window key (not uncounted):
+      // the 5h key would be 0 here, so the daemon must fall back to the weekly reset.
+      harness.sendClaudeToCodex("req-admwk-wrap", "wrap up under weekly-triggered admission", { wrapUp: true });
+      await waitFor(() => readTurnStarts().length >= 1, "wrap-up injected under weekly admission", 100, 100);
+      const quotaFile = join(harness.stateDir, "admission-quota.json");
+      await waitFor(() => existsSync(quotaFile), "admission-quota.json persisted on the weekly key", 100, 100);
+      const quota = JSON.parse(readFileSync(quotaFile, "utf-8"));
+      expect(quota.wrapUpUsed).toBe(1); // COUNTED (cap not bypassed)
+      expect(quota.fiveHourResetEpoch).toBe(now + 3600); // keyed on the weekly reset
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 45000);
 
   test("budget status broadcasts follow coordinator snapshot polls, not the daemon interval", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "agentbridge-budget-snapshot-fixture-"));
@@ -1761,7 +1935,7 @@ async function startHarness(opts: {
         }
       }, "bridge ready after TUI handshake", 100, 100);
     },
-    sendClaudeToCodex: (requestId: string, text: string, sendOpts?: { onBusy?: "reject" | "steer" | "interrupt"; requireReply?: boolean; idempotencyKey?: string }) => {
+    sendClaudeToCodex: (requestId: string, text: string, sendOpts?: { onBusy?: "reject" | "steer" | "interrupt"; requireReply?: boolean; idempotencyKey?: string; wrapUp?: boolean }) => {
       harness.controlWs?.send(JSON.stringify({
         type: "claude_to_codex",
         requestId,
@@ -1769,6 +1943,7 @@ async function startHarness(opts: {
         ...(sendOpts?.requireReply ? { requireReply: true } : {}),
         ...(sendOpts?.onBusy && sendOpts.onBusy !== "reject" ? { onBusy: sendOpts.onBusy } : {}),
         ...(sendOpts?.idempotencyKey ? { idempotencyKey: sendOpts.idempotencyKey } : {}),
+        ...(sendOpts?.wrapUp ? { wrapUp: true } : {}),
       }));
     },
     sendAckResume: (resumeId: string, status: string) => {

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -119,6 +119,16 @@ export class StateDirResolver {
   }
 
   /**
+   * v3 P3 (§3.2): per-5h-window admission-gate quota — wrap-up turn count and
+   * checkpoint-baton flag, keyed to the current 5h reset epoch so a window change
+   * zeroes them. Persisted here (the daemon's own state dir, not the guard's) so
+   * the counts survive a daemon restart within a window but never across one.
+   */
+  get admissionQuotaFile(): string {
+    return join(this.stateDir, "admission-quota.json");
+  }
+
+  /**
    * Cache for the update-notifier: `{ lastCheckMs, latest }`. Machine/user-global
    * (not per-project) so the daily npm check runs once per machine, not once per
    * project — see src/update-notifier.ts.

--- a/src/unit-test/admission-quota.test.ts
+++ b/src/unit-test/admission-quota.test.ts
@@ -1,0 +1,143 @@
+/**
+ * v3 P3 (§3.2) — per-5h-window admission quota persistence (admission-quota.ts).
+ *
+ * Covers: fresh-state on absent/malformed file; wrap-up consume under/at limit;
+ * persistence across re-read (daemon-restart simulation); window-change reset
+ * (Q9: counters never carry across a 5h window); checkpoint-baton once-per-window;
+ * limit 0 disables wrap-ups; the pure parser's shape rejection.
+ */
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  consumeCheckpointBaton,
+  consumeWrapUp,
+  currentWindowState,
+  parseAdmissionQuota,
+} from "../budget/admission-quota";
+
+const EPOCH_A = 2_000_000;
+const EPOCH_B = 2_018_000; // a later 5h window
+
+let dir: string;
+let file: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "abg-admission-"));
+  file = join(dir, "admission-quota.json");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("currentWindowState", () => {
+  test("absent file → fresh zero state for the requested window", () => {
+    const s = currentWindowState(file, EPOCH_A);
+    expect(s).toEqual({ version: 1, fiveHourResetEpoch: EPOCH_A, wrapUpUsed: 0, checkpointBatonUsed: false });
+  });
+
+  test("malformed file → fresh zero state (never throws)", () => {
+    writeFileSync(file, "{not json");
+    expect(currentWindowState(file, EPOCH_A).wrapUpUsed).toBe(0);
+  });
+
+  test("stored record for a DIFFERENT window → fresh zero state (window change resets)", () => {
+    writeFileSync(file, JSON.stringify({ version: 1, fiveHourResetEpoch: EPOCH_A, wrapUpUsed: 2, checkpointBatonUsed: true }));
+    const s = currentWindowState(file, EPOCH_B);
+    expect(s.wrapUpUsed).toBe(0);
+    expect(s.checkpointBatonUsed).toBe(false);
+    expect(s.fiveHourResetEpoch).toBe(EPOCH_B);
+  });
+});
+
+describe("consumeWrapUp", () => {
+  test("allows up to the limit, then rejects; persists each increment", () => {
+    const r1 = consumeWrapUp(file, EPOCH_A, 2);
+    expect(r1).toEqual({ allowed: true, used: 1, remaining: 1 });
+    const r2 = consumeWrapUp(file, EPOCH_A, 2);
+    expect(r2).toEqual({ allowed: true, used: 2, remaining: 0 });
+    const r3 = consumeWrapUp(file, EPOCH_A, 2);
+    expect(r3.allowed).toBe(false);
+    expect(r3.used).toBe(2);
+    // persisted: a fresh read sees the consumed count (daemon-restart safe).
+    expect(currentWindowState(file, EPOCH_A).wrapUpUsed).toBe(2);
+    expect(existsSync(file)).toBe(true);
+  });
+
+  test("window change resets the wrap-up count (Q9: no carry-over)", () => {
+    consumeWrapUp(file, EPOCH_A, 2);
+    consumeWrapUp(file, EPOCH_A, 2);
+    expect(consumeWrapUp(file, EPOCH_A, 2).allowed).toBe(false);
+    // new window → fresh quota
+    expect(consumeWrapUp(file, EPOCH_B, 2).allowed).toBe(true);
+  });
+
+  test("limit 0 disables wrap-ups entirely", () => {
+    expect(consumeWrapUp(file, EPOCH_A, 0).allowed).toBe(false);
+  });
+});
+
+describe("consumeCheckpointBaton", () => {
+  test("fires once per window, then rejects until the window resets", () => {
+    expect(consumeCheckpointBaton(file, EPOCH_A)).toBe(true);
+    expect(consumeCheckpointBaton(file, EPOCH_A)).toBe(false);
+    // new window → baton available again
+    expect(consumeCheckpointBaton(file, EPOCH_B)).toBe(true);
+  });
+
+  test("baton and wrap-up counters are independent within a window", () => {
+    consumeWrapUp(file, EPOCH_A, 2);
+    expect(consumeCheckpointBaton(file, EPOCH_A)).toBe(true);
+    // wrap-up count survives the baton write
+    expect(currentWindowState(file, EPOCH_A).wrapUpUsed).toBe(1);
+    expect(currentWindowState(file, EPOCH_A).checkpointBatonUsed).toBe(true);
+  });
+});
+
+describe("fail-closed on write failure (never throws, never over-grants)", () => {
+  // A path whose PARENT is a regular file makes atomicWriteJson's mkdirSync/openSync
+  // throw — simulating a non-writable target without monkey-patching fs.
+  function unwritablePath(): string {
+    const blocker = join(dir, "blocker-file");
+    writeFileSync(blocker, "x");
+    return join(blocker, "admission-quota.json");
+  }
+
+  test("consumeWrapUp DENIES the grant when the write fails (no over-grant, no throw)", () => {
+    const bad = unwritablePath();
+    expect(consumeWrapUp(bad, EPOCH_A, 2).allowed).toBe(false);
+    // a swallowed write must NOT let the next read re-allow (the over-grant bug)
+    expect(consumeWrapUp(bad, EPOCH_A, 2).allowed).toBe(false);
+  });
+
+  test("consumeCheckpointBaton WITHHOLDS the baton when the write fails (no re-fire)", () => {
+    const bad = unwritablePath();
+    expect(consumeCheckpointBaton(bad, EPOCH_A)).toBe(false);
+    expect(consumeCheckpointBaton(bad, EPOCH_A)).toBe(false);
+  });
+});
+
+describe("non-finite epoch guard (I2 self-enforced)", () => {
+  test("NaN epoch never grants and never fires", () => {
+    expect(consumeWrapUp(file, NaN, 2).allowed).toBe(false);
+    expect(consumeCheckpointBaton(file, NaN)).toBe(false);
+    expect(existsSync(file)).toBe(false); // never persists a poison record
+  });
+});
+
+describe("parseAdmissionQuota", () => {
+  test("rejects non-v1 / wrong-shape inputs", () => {
+    expect(parseAdmissionQuota(null)).toBeNull();
+    expect(parseAdmissionQuota([])).toBeNull();
+    expect(parseAdmissionQuota({ version: 2, fiveHourResetEpoch: 1, wrapUpUsed: 0 })).toBeNull();
+    expect(parseAdmissionQuota({ version: 1, fiveHourResetEpoch: "x", wrapUpUsed: 0 })).toBeNull();
+    expect(parseAdmissionQuota({ version: 1, fiveHourResetEpoch: 1, wrapUpUsed: -1 })).toBeNull();
+  });
+
+  test("accepts a valid record and coerces a missing baton flag to false", () => {
+    const s = parseAdmissionQuota({ version: 1, fiveHourResetEpoch: 5, wrapUpUsed: 1 });
+    expect(s).toEqual({ version: 1, fiveHourResetEpoch: 5, wrapUpUsed: 1, checkpointBatonUsed: false });
+  });
+});

--- a/src/unit-test/budget-admission.test.ts
+++ b/src/unit-test/budget-admission.test.ts
@@ -1,0 +1,222 @@
+/**
+ * v3 P3 (§3.2) — admission-gate decision predicates (budget-decision.ts).
+ *
+ * Covers agentShouldAdmitClose / agentCanAdmitOpen:
+ *   - the three independent CLOSE triggers (5h util ≥ admissionAt; §3.1 hard cap;
+ *     weekly runway < finishingHorizon×2), each in isolation + first-match order;
+ *   - the OPEN side with hysteresis (util admissionAt−resumeHysteresisPct; the
+ *     2×/3× weekly-runway enter/exit hold band);
+ *   - I2: non-decision-grade (null / stale / all-reset) never closes AND never
+ *     opens (the predicates return false for canAdmitOpen on stale — phantom-hold
+ *     in the fingerprint keeps a closed gate closed).
+ */
+import { describe, expect, test } from "bun:test";
+import { agentCanAdmitOpen, agentShouldAdmitClose } from "../budget/budget-decision";
+import type { AgentUsage, BudgetConfig, BudgetWindow } from "../budget/types";
+
+const NOW = 1_000_000;
+
+const CFG: BudgetConfig = {
+  enabled: true,
+  pollSeconds: 300,
+  pauseAt: 90,
+  resumeBelow: 30,
+  syncDriftPct: 10,
+  parallel: { minRemainingPct: 60, timeWindowSec: 3600 },
+  codexTierControl: false,
+  codexTiers: { full: null, balanced: { effort: "medium" }, eco: { effort: "low" } },
+  maximize: {
+    targetUtil: 98,
+    reserveSlopePctPerHour: 0.4,
+    reserveMaxPct: 7,
+    finishingHorizonMinutes: 30, // floor: enter < 2×30m=3600s, exit ≥ 3×30m=5400s
+    resumeHysteresisPct: 5, // admission util exit line: admissionAt − 5 = 80
+    admissionAt: 85,
+    wrapUpQuota: 2,
+  },
+  allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
+};
+
+interface WinOpts {
+  rate?: number;
+  confident?: boolean;
+  runwaySeconds?: number;
+}
+
+/** Build a window resetting `tHours` from NOW with optional burn rate + runway. */
+function win(util: number, tHours: number, opts: WinOpts = {}): BudgetWindow {
+  const w: BudgetWindow = { util, resetEpoch: NOW + Math.round(tHours * 3600) };
+  if (opts.rate !== undefined) {
+    w.burnRate = opts.rate;
+    w.burnConfident = opts.confident ?? true;
+  }
+  if (opts.runwaySeconds !== undefined) w.runwaySeconds = opts.runwaySeconds;
+  return w;
+}
+
+function usage(opts: {
+  fiveHour?: BudgetWindow | null;
+  weekly?: BudgetWindow | null;
+  fetchedAt?: number;
+}): AgentUsage {
+  const fiveHour = opts.fiveHour ?? null;
+  const weekly = opts.weekly ?? null;
+  const gateUtil = Math.max(fiveHour?.util ?? 0, weekly?.util ?? 0);
+  return {
+    ok: true,
+    stale: false,
+    gateUtil,
+    warnUtil: gateUtil,
+    fiveHour,
+    weekly,
+    remaining: Math.max(0, 100 - gateUtil),
+    rateLimitedUntil: 0,
+    fetchedAt: opts.fetchedAt ?? NOW,
+    parsedVia: "id-match",
+  };
+}
+
+describe("agentShouldAdmitClose — close triggers", () => {
+  test("(1) 5h util ≥ admissionAt closes, attributes fiveHour", () => {
+    const d = agentShouldAdmitClose("codex", usage({ fiveHour: win(85, 3) }), CFG, NOW);
+    expect(d.admitClose).toBe(true);
+    expect(d.window).toBe("fiveHour");
+    expect(d.reason).toContain("admissionAt");
+  });
+
+  test("(1) 5h util just below admissionAt does NOT close (no other trigger)", () => {
+    const d = agentShouldAdmitClose("codex", usage({ fiveHour: win(84, 3) }), CFG, NOW);
+    expect(d.admitClose).toBe(false);
+  });
+
+  test("(2) §3.1 hard cap (5h util ≥ targetUtil) closes via the hard-cap branch", () => {
+    // util 98 ≥ admissionAt too, but the reason should mention the util line first
+    // (condition 1 wins). Use a weekly hard cap with 5h below admissionAt to hit (2).
+    // rate 0 keeps projected (= util) at target, so the `util ≥ targetUtil`
+    // hard cap fires (a positive rate would project past target → will-fill →
+    // a numeric line, not admission-closed).
+    const d = agentShouldAdmitClose(
+      "codex",
+      usage({ fiveHour: win(50, 3, { rate: 1, confident: true }), weekly: win(98, 5, { rate: 0, confident: true }) }),
+      CFG,
+      NOW,
+    );
+    expect(d.admitClose).toBe(true);
+    expect(d.window).toBe("weekly");
+    expect(d.reason).toContain("收尾保护硬线");
+  });
+
+  test("(3) weekly will-fill + runway < 2×finishingHorizon closes, attributes weekly", () => {
+    // weekly: util 70, rate 20/h, 2h to reset → projected 110 > target 98 (will-fill);
+    // runwaySeconds 3000 < 3600 floor. 5h clean (util 50 < admissionAt, no hard cap).
+    const d = agentShouldAdmitClose(
+      "codex",
+      usage({
+        fiveHour: win(50, 4, { rate: 1, confident: true }),
+        weekly: win(70, 2, { rate: 20, confident: true, runwaySeconds: 3000 }),
+      }),
+      CFG,
+      NOW,
+    );
+    expect(d.admitClose).toBe(true);
+    expect(d.window).toBe("weekly");
+    expect(d.reason).toContain("runway");
+  });
+
+  test("(3) weekly runway above the enter floor does NOT close", () => {
+    const d = agentShouldAdmitClose(
+      "codex",
+      usage({
+        fiveHour: win(50, 4, { rate: 1, confident: true }),
+        weekly: win(70, 2, { rate: 20, confident: true, runwaySeconds: 4000 }), // > 3600
+      }),
+      CFG,
+      NOW,
+    );
+    expect(d.admitClose).toBe(false);
+  });
+
+  test("will-not-fill weekly with short runway does NOT close (reset-truncation guard)", () => {
+    // Low burn → won't fill before reset; a short runwaySeconds here is reset-bound,
+    // not depletion-bound, so it must not trigger the weekly guard.
+    const d = agentShouldAdmitClose(
+      "codex",
+      usage({ weekly: win(50, 0.5, { rate: 0.1, confident: true, runwaySeconds: 1000 }) }),
+      CFG,
+      NOW,
+    );
+    expect(d.admitClose).toBe(false);
+  });
+
+  test("non-confident weekly (no burn rate) does not trigger the runway guard", () => {
+    // burnConfident:false → confidentRate null → dynamicWindowVerdict degraded →
+    // weeklyRunwayShort returns false even with a short runwaySeconds.
+    const w = win(70, 2, { rate: 20, confident: false, runwaySeconds: 1000 });
+    expect(agentShouldAdmitClose("codex", usage({ weekly: w }), CFG, NOW).admitClose).toBe(false);
+  });
+
+  test("weekly absent → no runway trigger, only 5h drives close", () => {
+    expect(agentShouldAdmitClose("codex", usage({ fiveHour: win(70, 3) }), CFG, NOW).admitClose).toBe(false);
+    expect(agentShouldAdmitClose("codex", usage({ fiveHour: win(86, 3) }), CFG, NOW).admitClose).toBe(true);
+  });
+
+  test("null / non-decision-grade usage never closes (I2)", () => {
+    expect(agentShouldAdmitClose("codex", null, CFG, NOW).admitClose).toBe(false);
+    // stale: fetchedAt far in the past
+    const stale = usage({ fiveHour: win(95, 3), fetchedAt: NOW - 10_000 });
+    expect(agentShouldAdmitClose("codex", stale, CFG, NOW).admitClose).toBe(false);
+    // all windows already reset
+    const past = usage({ fiveHour: win(95, -1) });
+    expect(agentShouldAdmitClose("codex", past, CFG, NOW).admitClose).toBe(false);
+  });
+});
+
+describe("agentCanAdmitOpen — open with hysteresis", () => {
+  test("all clear → can open", () => {
+    expect(agentCanAdmitOpen(usage({ fiveHour: win(70, 3) }), CFG, NOW)).toBe(true);
+  });
+
+  test("5h util in hysteresis band [admissionAt−5, admissionAt) blocks open", () => {
+    // 82 ≥ 80 (= 85 − 5) → still blocks open even though < admissionAt (no new entry).
+    expect(agentCanAdmitOpen(usage({ fiveHour: win(82, 3) }), CFG, NOW)).toBe(false);
+  });
+
+  test("5h util below the relaxed line opens", () => {
+    expect(agentCanAdmitOpen(usage({ fiveHour: win(79, 3) }), CFG, NOW)).toBe(true);
+  });
+
+  test("hard cap still firing blocks open", () => {
+    expect(
+      agentCanAdmitOpen(usage({ fiveHour: win(50, 3), weekly: win(98, 5, { rate: 0, confident: true }) }), CFG, NOW),
+    ).toBe(false);
+  });
+
+  test("weekly runway in the hold band [2×, 3×) blocks open (hysteresis)", () => {
+    // runway 4000s: ≥ 3600 (won't newly enter) but < 5400 (exit floor) → holds closed.
+    const u = usage({
+      fiveHour: win(50, 4, { rate: 1, confident: true }),
+      weekly: win(70, 2, { rate: 20, confident: true, runwaySeconds: 4000 }),
+    });
+    expect(agentCanAdmitOpen(u, CFG, NOW)).toBe(false);
+  });
+
+  test("weekly runway above the exit floor opens", () => {
+    const u = usage({
+      fiveHour: win(50, 4, { rate: 1, confident: true }),
+      weekly: win(70, 2, { rate: 20, confident: true, runwaySeconds: 6000 }), // > 5400
+    });
+    expect(agentCanAdmitOpen(u, CFG, NOW)).toBe(true);
+  });
+
+  test("non-decision-grade never opens (I2: stale must not release a closed gate)", () => {
+    expect(agentCanAdmitOpen(null, CFG, NOW)).toBe(false);
+    const stale = usage({ fiveHour: win(70, 3), fetchedAt: NOW - 10_000 });
+    expect(agentCanAdmitOpen(stale, CFG, NOW)).toBe(false);
+  });
+
+  test("a live rate-limit blocks open even when util has receded (parity with agentCanResume)", () => {
+    const u = usage({ fiveHour: win(70, 3) });
+    u.rateLimitedUntil = NOW + 600;
+    expect(agentCanAdmitOpen(u, CFG, NOW)).toBe(false);
+  });
+});

--- a/src/unit-test/budget-admission.test.ts
+++ b/src/unit-test/budget-admission.test.ts
@@ -12,6 +12,8 @@
  */
 import { describe, expect, test } from "bun:test";
 import { agentCanAdmitOpen, agentShouldAdmitClose } from "../budget/budget-decision";
+import { classifyAdmission, INITIAL_ADMISSION_STATE } from "../budget/budget-fingerprint";
+import { computeBudgetState } from "../budget/budget-state";
 import type { AgentUsage, BudgetConfig, BudgetWindow } from "../budget/types";
 
 const NOW = 1_000_000;
@@ -218,5 +220,87 @@ describe("agentCanAdmitOpen — open with hysteresis", () => {
     const u = usage({ fiveHour: win(70, 3) });
     u.rateLimitedUntil = NOW + 600;
     expect(agentCanAdmitOpen(u, CFG, NOW)).toBe(false);
+  });
+});
+
+describe("classifyAdmission — admission lane reducer (v3 P3 M2)", () => {
+  function stateFor(claudeU: AgentUsage | null, codexU: AgentUsage | null) {
+    return computeBudgetState(claudeU, codexU, CFG, NOW);
+  }
+
+  test("enters admission-closed for codex when 5h util >= admissionAt", () => {
+    const state = stateFor(null, usage({ fiveHour: win(86, 3) }));
+    const r = classifyAdmission(INITIAL_ADMISSION_STATE, state, CFG);
+    expect(r.next.side).toBe("codex");
+    expect(r.effect.kind).toBe("enter");
+    if (r.effect.kind === "enter") expect(r.effect.emit).toBe(true);
+  });
+
+  test("does NOT re-emit on an identical follow-up poll (fingerprint dedup)", () => {
+    const state = stateFor(null, usage({ fiveHour: win(86, 3) }));
+    const r1 = classifyAdmission(INITIAL_ADMISSION_STATE, state, CFG);
+    const r2 = classifyAdmission(r1.next, state, CFG);
+    expect(r2.next.side).toBe("codex");
+    expect(r2.effect.kind).toBe("enter");
+    if (r2.effect.kind === "enter") expect(r2.effect.emit).toBe(false);
+  });
+
+  test("exits when util recedes below admissionAt - resumeHysteresisPct", () => {
+    const entered = classifyAdmission(INITIAL_ADMISSION_STATE, stateFor(null, usage({ fiveHour: win(86, 3) })), CFG);
+    const r = classifyAdmission(entered.next, stateFor(null, usage({ fiveHour: win(79, 3) })), CFG); // < 85-5=80
+    expect(r.next.side).toBe(null);
+    expect(r.effect.kind).toBe("exit");
+  });
+
+  test("phantom-hold: a non-decision-grade probe HOLDS the closed side (I2)", () => {
+    const entered = classifyAdmission(INITIAL_ADMISSION_STATE, stateFor(null, usage({ fiveHour: win(86, 3) })), CFG);
+    const stale = stateFor(null, usage({ fiveHour: win(50, 3), fetchedAt: NOW - 10_000 }));
+    const r = classifyAdmission(entered.next, stale, CFG);
+    expect(r.next.side).toBe("codex"); // held closed, NOT opened on stale data
+    expect(r.effect.kind).toBe("hold-uncertain");
+  });
+
+  test("both sides 5h util >= admissionAt → side 'both'", () => {
+    const state = stateFor(usage({ fiveHour: win(90, 3) }), usage({ fiveHour: win(90, 3) }));
+    expect(classifyAdmission(INITIAL_ADMISSION_STATE, state, CFG).next.side).toBe("both");
+  });
+
+  test("open stays open / 'none' when nothing trips", () => {
+    const r = classifyAdmission(INITIAL_ADMISSION_STATE, stateFor(null, usage({ fiveHour: win(50, 3) })), CFG);
+    expect(r.next.side).toBe(null);
+    expect(r.effect.kind).toBe("none");
+  });
+});
+
+describe("classifyAdmission — M2 round-1 fixes", () => {
+  function stateFor2(claudeU: AgentUsage | null, codexU: AgentUsage | null) {
+    return computeBudgetState(claudeU, codexU, CFG, NOW);
+  }
+
+  test("a rate-limit-held admission side reports the 限流 reason, not the hysteresis-band reason", () => {
+    const r1 = classifyAdmission(INITIAL_ADMISSION_STATE, stateFor2(null, usage({ fiveHour: win(86, 3) })), CFG);
+    expect(r1.next.side).toBe("codex");
+    // util dropped below admissionAt − hysteresis BUT rate-limited → held closed.
+    const rl = usage({ fiveHour: win(70, 3) });
+    rl.rateLimitedUntil = NOW + 600;
+    const r2 = classifyAdmission(r1.next, stateFor2(null, rl), CFG);
+    expect(r2.next.side).toBe("codex"); // held
+    expect(r2.next.reason).toContain("限流");
+    expect(r2.next.reason).not.toContain("出闸滞回带");
+  });
+
+  test("dedup keys on the gate-explaining window: a weekly-trigger close survives a 5h reset (no re-emit)", () => {
+    // weekly hard cap (util 98, rate 0 → admission-closed) AND weekly is the
+    // gateUtil winner (98 > 5h 50) → matchingGateReset → weekly reset.
+    const close1 = usage({ fiveHour: win(50, 1, { rate: 1, confident: true }), weekly: win(98, 5, { rate: 0, confident: true }) });
+    const r1 = classifyAdmission(INITIAL_ADMISSION_STATE, stateFor2(null, close1), CFG);
+    expect(r1.next.side).toBe("codex");
+    // 5h window RESET to a new epoch (util dropped) but weekly unchanged → the
+    // gate-explaining (weekly) reset is stable → fingerprint stable → no re-emit.
+    const close2 = usage({ fiveHour: win(10, 4, { rate: 1, confident: true }), weekly: win(98, 5, { rate: 0, confident: true }) });
+    const r2 = classifyAdmission(r1.next, stateFor2(null, close2), CFG);
+    expect(r2.next.side).toBe("codex");
+    expect(r2.effect.kind).toBe("enter");
+    if (r2.effect.kind === "enter") expect(r2.effect.emit).toBe(false);
   });
 });

--- a/src/unit-test/budget-allocation.test.ts
+++ b/src/unit-test/budget-allocation.test.ts
@@ -21,6 +21,8 @@ const CONFIG: BudgetConfig = {
     reserveMaxPct: 7,
     finishingHorizonMinutes: 30,
     resumeHysteresisPct: 5,
+    admissionAt: 85,
+    wrapUpQuota: 2,
   },
   allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
 };

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -1349,3 +1349,38 @@ describe("BudgetCoordinator — v3 P4 underutilization cooldown gate", () => {
     expect(emitted.some((e) => e.id.startsWith("system_budget_underutilized"))).toBe(false);
   });
 });
+
+describe("gateState — v3 P3 three-state gate (M2)", () => {
+  async function gateAfterPoll(claudeU: AgentUsage | null, codexU: AgentUsage | null) {
+    const source = new FakeSource([{ claude: claudeU, codex: codexU }]);
+    const { coordinator } = makeCoordinator(source);
+    await coordinator.start();
+    return coordinator;
+  }
+
+  test("open when neither side is admission-closed or paused", async () => {
+    const c = await gateAfterPoll(usage({ gateUtil: 20 }), usage({ gateUtil: 20 }));
+    expect(c.gateState()).toBe("open");
+    expect(c.getSnapshot()?.gateState).toBe("open");
+  });
+
+  test("admission-closed when Codex 5h util >= admissionAt but below the pause line", async () => {
+    const c = await gateAfterPoll(usage({ gateUtil: 20 }), usage({ gateUtil: 86 }));
+    expect(c.isGateClosed()).toBe(false); // not the pause gate
+    expect(c.gateState()).toBe("admission-closed");
+    expect(c.getSnapshot()?.gateState).toBe("admission-closed");
+  });
+
+  test("closed (pause) takes precedence over admission-closed", async () => {
+    // Codex util 95 → pause (>= pauseAt 90) AND admission (>= 85); closed wins.
+    const c = await gateAfterPoll(usage({ gateUtil: 20 }), usage({ gateUtil: 95 }));
+    expect(c.isGateClosed()).toBe(true);
+    expect(c.gateState()).toBe("closed");
+    expect(c.getSnapshot()?.gateState).toBe("closed");
+  });
+
+  test("Claude-side admission does NOT close the daemon gate (gates Codex turns only)", async () => {
+    const c = await gateAfterPoll(usage({ gateUtil: 86 }), usage({ gateUtil: 20 }));
+    expect(c.gateState()).toBe("open");
+  });
+});

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -25,7 +25,7 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
   allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
 };
 

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { BudgetCoordinator, nextBudgetPollDelayMs } from "../budget/budget-coordinator";
 import { AdviceCooldown } from "../budget/advice-cooldown";
 import type { ResumeSignals } from "../budget/budget-fingerprint";
-import type { AgentUsage, BudgetConfig } from "../budget/types";
+import type { AgentName, AgentUsage, BudgetConfig } from "../budget/types";
 
 const NOW = 1_700_000_000;
 
@@ -572,7 +572,12 @@ describe("BudgetCoordinator", () => {
     });
     const source = new FakeSource([
       { claude: usage(), codex: codexUsage(96) }, // 96 ≥ line 95.6 → pause (confident b-branch)
-      { claude: usage(), codex: codexUsage(88) }, // 88 → projected 89.2 ≤ 97 → won't-fill → resume
+      // 78 < line−hysteresis (90.6) → pause resumes, AND < admissionAt−hysteresis
+      // (80) → admission lane also opens, so gateState() is fully "open" and the
+      // codex recovery directive fires. (v3 P3 M3b: a value in [80,90.6) would
+      // clear pause but HOLD admission-closed, so the recovery is correctly held —
+      // see the de-escalation regression test below.)
+      { claude: usage(), codex: codexUsage(78) },
     ]);
     const { coordinator, emitted, pauseChanges } = makeCoordinator(source, maximizeConfig);
 
@@ -1382,5 +1387,270 @@ describe("gateState — v3 P3 three-state gate (M2)", () => {
   test("Claude-side admission does NOT close the daemon gate (gates Codex turns only)", async () => {
     const c = await gateAfterPoll(usage({ gateUtil: 86 }), usage({ gateUtil: 20 }));
     expect(c.gateState()).toBe("open");
+  });
+});
+
+describe("admission directive emission — v3 P3 (M3b, turnPhase-aware)", () => {
+  function makeAdmissionCoordinator(results: FetchResult[], turnActive: { value: boolean }) {
+    const emitted: Array<{ id: string; content: string }> = [];
+    const logs: string[] = [];
+    const scheduler = new FakeScheduler();
+    const source = new FakeSource(results);
+    const coordinator = new BudgetCoordinator({
+      source,
+      config: CONFIG,
+      emit: (id, content) => emitted.push({ id, content }),
+      onPauseChange: () => {},
+      now: () => NOW,
+      scheduler,
+      log: (m) => logs.push(m),
+      isCodexTurnActive: () => turnActive.value,
+    });
+    return { coordinator, emitted, logs, scheduler };
+  }
+
+  const admissionEmits = (emitted: Array<{ id: string; content: string }>) =>
+    emitted.filter((e) => e.id.startsWith("system_budget_admission"));
+
+  test("emits system_budget_admission when Codex idle and admission closes", async () => {
+    const { coordinator, emitted } = makeAdmissionCoordinator(
+      [{ claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 86 }) }],
+      { value: false },
+    );
+    await coordinator.start();
+    expect(coordinator.gateState()).toBe("admission-closed");
+    const ads = admissionEmits(emitted);
+    expect(ads).toHaveLength(1);
+    expect(ads[0]!.content).toContain("收尾保护");
+    expect(ads[0]!.content).toContain("budget_admission");
+    expect(ads[0]!.content).toContain("wrap_up");
+  });
+
+  test("defers the directive while a Codex turn runs, flushes on idle", async () => {
+    const turnActive = { value: true };
+    const { coordinator, emitted } = makeAdmissionCoordinator(
+      [{ claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 86 }) }],
+      turnActive,
+    );
+    await coordinator.start();
+    expect(coordinator.gateState()).toBe("admission-closed");
+    expect(admissionEmits(emitted)).toHaveLength(0); // deferred while the turn runs
+    turnActive.value = false;
+    coordinator.onCodexTurnIdle(); // turn ended → flush
+    expect(admissionEmits(emitted)).toHaveLength(1);
+  });
+
+  test("does not double-emit after a deferred flush (dedup across later polls)", async () => {
+    const turnActive = { value: true };
+    const { coordinator, emitted, scheduler } = makeAdmissionCoordinator(
+      [
+        { claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 86 }) },
+        { claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 86 }) },
+      ],
+      turnActive,
+    );
+    await coordinator.start(); // poll 1 → deferred
+    turnActive.value = false;
+    coordinator.onCodexTurnIdle(); // emit #1
+    await scheduler.runNext(); // poll 2: same admission fingerprint → no re-emit
+    expect(admissionEmits(emitted)).toHaveLength(1);
+  });
+
+  test("drops the deferred directive if admission exits during the turn", async () => {
+    const { coordinator, emitted, scheduler } = makeAdmissionCoordinator(
+      [
+        { claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 86 }) }, // admission-closed
+        { claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 20 }) }, // reopened
+      ],
+      { value: true },
+    );
+    await coordinator.start(); // deferred
+    await scheduler.runNext(); // exit clears the pending directive
+    coordinator.onCodexTurnIdle(); // nothing to flush
+    expect(admissionEmits(emitted)).toHaveLength(0);
+    expect(coordinator.gateState()).toBe("open");
+  });
+
+  test("suppresses the admission directive while a pause (handoff) is active", async () => {
+    // Claude paused (handoff) + Codex admission-closed: pause takes display
+    // priority, so no admission directive — but the handoff directive still fires.
+    const { coordinator, emitted } = makeAdmissionCoordinator(
+      [{ claude: usage({ gateUtil: 95 }), codex: usage({ gateUtil: 86 }) }],
+      { value: false },
+    );
+    await coordinator.start();
+    expect(coordinator.gateState()).toBe("admission-closed");
+    expect(admissionEmits(emitted)).toHaveLength(0);
+    expect(emitted.some((e) => e.id.startsWith("system_budget_handoff"))).toBe(true);
+  });
+
+  test("claude-only admission close emits no directive (daemon gate is codex-scoped)", async () => {
+    const { coordinator, emitted } = makeAdmissionCoordinator(
+      [{ claude: usage({ gateUtil: 86 }), codex: usage({ gateUtil: 20 }) }],
+      { value: false },
+    );
+    await coordinator.start();
+    expect(coordinator.gateState()).toBe("open");
+    expect(admissionEmits(emitted)).toHaveLength(0);
+  });
+
+  test("onCodexTurnIdle is a no-op when nothing is pending", async () => {
+    const { coordinator, emitted } = makeAdmissionCoordinator(
+      [{ claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 20 }) }],
+      { value: false },
+    );
+    await coordinator.start();
+    coordinator.onCodexTurnIdle();
+    expect(emitted).toHaveLength(0);
+  });
+
+  // Confident-burn-data codex usage: the 5h dynamic pause line is 90, so pause
+  // resumes at util < 85 (line − resumeHysteresisPct) while admission holds until
+  // util < 80 (admissionAt − hysteresis) — the de-escalation band [80,85). The
+  // weekly window MUST sit below resumeBelow(30): a degraded weekly at util ≥ 30
+  // would block resume on its own (maximizeWindowBlocksResume fallback) and the
+  // 5h-only de-escalation could never surface.
+  const burnCodex = (util: number): AgentUsage =>
+    usage({
+      gateUtil: util,
+      warnUtil: util,
+      fiveHour: { util, resetEpoch: NOW + 3600, burnRate: 20, burnConfident: true },
+      weekly: { util: 20, resetEpoch: NOW + 500_000 },
+    });
+
+  test("re-emits when a pause de-escalates to admission-only (REAL: missed-emit on de-escalation)", async () => {
+    // Burn regime: dynamic line ≈90, so pause clears at util < 85 (line−hysteresis)
+    // while admission holds until util < 80. poll1 util 96 → pause+admission (admission
+    // suppressed by pause display priority); poll2 util 82 ∈ [80,85) → pause clears,
+    // admission holds. The one-shot reducer emit flag is false on poll2 (same
+    // fingerprint), so this ONLY emits because applyAdmissionDirective drives off
+    // lastEmittedAdmissionFingerprint — the regression guard for the missed-emit fix.
+    const { coordinator, emitted, scheduler } = makeAdmissionCoordinator(
+      [
+        { claude: usage({ gateUtil: 20 }), codex: burnCodex(96) },
+        { claude: usage({ gateUtil: 20 }), codex: burnCodex(82) },
+      ],
+      { value: false },
+    );
+    await coordinator.start();
+    expect(coordinator.gateState()).toBe("closed"); // paused
+    expect(admissionEmits(emitted)).toHaveLength(0); // admission suppressed by pause
+    await scheduler.runNext();
+    expect(coordinator.gateState()).toBe("admission-closed"); // pause cleared, admission holds
+    expect(admissionEmits(emitted)).toHaveLength(1); // NOW emitted (regression guard)
+  });
+
+  test("drops a deferred admission directive when the gate escalates to a full pause", async () => {
+    // defer at admission-closed (turn running) → escalate to closed → the escalation
+    // poll clears pending, so onCodexTurnIdle emits no stale admission directive; the
+    // pause directive fires instead. (workflow REAL: previously-untested transition.)
+    const turnActive = { value: true };
+    const { coordinator, emitted, scheduler } = makeAdmissionCoordinator(
+      [
+        { claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 86 }) }, // admission-closed → defer
+        { claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 95 }) }, // escalate → closed (pause)
+      ],
+      turnActive,
+    );
+    await coordinator.start();
+    expect(admissionEmits(emitted)).toHaveLength(0); // deferred
+    await scheduler.runNext();
+    expect(coordinator.gateState()).toBe("closed");
+    turnActive.value = false;
+    coordinator.onCodexTurnIdle();
+    expect(admissionEmits(emitted)).toHaveLength(0); // no stale admission directive
+    expect(emitted.some((e) => e.id.startsWith("system_budget_pause"))).toBe(true);
+  });
+
+  test("emit-path dedup: a second poll on the same admission episode does not re-emit", async () => {
+    // Drives the lastEmittedAdmissionFingerprint guard directly (idle path, no defer):
+    // emit on poll1, identical state on poll2 → exactly one emit. Removing the guard
+    // makes poll2 re-emit (the dedup is no longer vacuous under the idempotent rewrite).
+    const { coordinator, emitted, scheduler } = makeAdmissionCoordinator(
+      [
+        { claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 86 }) },
+        { claude: usage({ gateUtil: 20 }), codex: usage({ gateUtil: 86 }) },
+      ],
+      { value: false },
+    );
+    await coordinator.start();
+    expect(admissionEmits(emitted)).toHaveLength(1);
+    await scheduler.runNext();
+    expect(admissionEmits(emitted)).toHaveLength(1);
+  });
+
+  test("holds the Codex pause-recovery while still admission-closed (R2-1: no resume bypass)", async () => {
+    // closed→admission-closed de-escalation: pause clears (burn band) but admission
+    // holds. The pause-lane recovery must NOT fire emitRecovery/onResume for codex —
+    // onResume routes enqueueCodexBudgetResume → the resume queue → codex.injectMessage,
+    // which BYPASSES the admission gate and would inject an unbounded continuation.
+    const emitted: Array<{ id: string; content: string }> = [];
+    const resumeCalls: AgentName[] = [];
+    const scheduler = new FakeScheduler();
+    const source = new FakeSource([
+      { claude: usage({ gateUtil: 20 }), codex: burnCodex(96) }, // pause + admission
+      { claude: usage({ gateUtil: 20 }), codex: burnCodex(82) }, // pause clears, admission holds
+    ]);
+    const coordinator = new BudgetCoordinator({
+      source,
+      config: CONFIG,
+      emit: (id, content) => emitted.push({ id, content }),
+      onPauseChange: () => {},
+      now: () => NOW,
+      scheduler,
+      log: () => {},
+      onResume: (side) => resumeCalls.push(side),
+      resumeSignals: () => readySignals(), // ready → without the fix, onResume(codex) WOULD route a resume
+    });
+    await coordinator.start();
+    expect(coordinator.gateState()).toBe("closed");
+    await scheduler.runNext();
+    expect(coordinator.gateState()).toBe("admission-closed");
+    // Recovery HELD: no resume directive, no resume routing (no bypass).
+    expect(emitted.some((e) => e.id.startsWith("system_budget_resume"))).toBe(false);
+    expect(resumeCalls).not.toContain("codex");
+    // The correct signal fires instead.
+    expect(emitted.some((e) => e.id.startsWith("system_budget_admission"))).toBe(true);
+  });
+
+  test("re-emits suppressed balance advice once the admission gate opens (R2-2)", async () => {
+    // codex 86→82→78 with a persistent drift vs a low Claude. 86: layer-1 suppresses
+    // (admit-close → phase normal). 82: hold band — phase=balance but gate
+    // admission-closed → layer-2 suppresses AND re-arms the fingerprint. 78: gate
+    // opens → balance emits exactly once. Without the re-arm, the committed-but-
+    // suppressed fingerprint would dedup poll-3 to silence (permanent miss).
+    const { coordinator, emitted, scheduler } = makeAdmissionCoordinator(
+      [
+        { claude: usage({ gateUtil: 20, warnUtil: 20 }), codex: usage({ gateUtil: 86, warnUtil: 86 }) },
+        { claude: usage({ gateUtil: 20, warnUtil: 20 }), codex: usage({ gateUtil: 82, warnUtil: 82 }) },
+        { claude: usage({ gateUtil: 20, warnUtil: 20 }), codex: usage({ gateUtil: 78, warnUtil: 78 }) },
+      ],
+      { value: false },
+    );
+    const balanceEmits = () => emitted.filter((e) => e.id.startsWith("system_budget_balance"));
+    await coordinator.start();
+    expect(balanceEmits()).toHaveLength(0); // admit-close: layer-1 suppressed
+    await scheduler.runNext();
+    expect(coordinator.gateState()).toBe("admission-closed");
+    expect(balanceEmits()).toHaveLength(0); // hold band: layer-2 suppressed (re-armed, not lost)
+    await scheduler.runNext();
+    expect(coordinator.gateState()).toBe("open");
+    expect(balanceEmits()).toHaveLength(1); // re-emitted on gate open (regression guard)
+  });
+
+  test("admission directive reset shows the CODEX window even for side=both (R2-3)", async () => {
+    // Both sides admission-closed; Claude's 5h window resets LATER than Codex's. The
+    // directive's "对应窗口约 X 刷新" line must show CODEX's reset (the codex-scoped gate
+    // the daemon actually keys on), not max(claude,codex) — else Claude waits too long.
+    const claude = usage({ gateUtil: 86, warnUtil: 86, fiveHour: { util: 86, resetEpoch: NOW + 20_000 } });
+    const codex = usage({ gateUtil: 86, warnUtil: 86, fiveHour: { util: 86, resetEpoch: NOW + 3_600 } });
+    const { coordinator, emitted } = makeAdmissionCoordinator([{ claude, codex }], { value: false });
+    await coordinator.start();
+    expect(coordinator.gateState()).toBe("admission-closed");
+    const ad = emitted.find((e) => e.id.startsWith("system_budget_admission"));
+    expect(ad).toBeDefined();
+    const fmt = (epoch: number) => new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+    expect(ad!.content).toContain(`对应窗口约 ${fmt(NOW + 3_600)} 刷新`); // codex window
+    expect(ad!.content).not.toContain(`对应窗口约 ${fmt(NOW + 20_000)} 刷新`); // not claude's later window
   });
 });

--- a/src/unit-test/budget-fingerprint.test.ts
+++ b/src/unit-test/budget-fingerprint.test.ts
@@ -24,7 +24,7 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
   allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
 };
 

--- a/src/unit-test/budget-maximize.test.ts
+++ b/src/unit-test/budget-maximize.test.ts
@@ -42,6 +42,8 @@ const MAXIMIZE: BudgetConfig = {
     reserveMaxPct: 7,
     finishingHorizonMinutes: 30,
     resumeHysteresisPct: 5,
+    admissionAt: 85,
+    wrapUpQuota: 2,
   },
   allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
 };
@@ -210,6 +212,8 @@ describe("invariant I1 — the dynamic line never pauses below pauseAt (property
           reserveMaxPct: i % 20,
           finishingHorizonMinutes: 5 + (i % 170),
           resumeHysteresisPct: 1 + (i % 29),
+          admissionAt: 50,
+          wrapUpQuota: 2,
         },
       };
       const rate = (i % 25) * 0.5;
@@ -244,6 +248,8 @@ describe("invariant I1 — the dynamic line never pauses below pauseAt (property
           reserveMaxPct: i % 20,
           finishingHorizonMinutes: 5 + (i % 170),
           resumeHysteresisPct: 1 + (i % 29),
+          admissionAt: 50,
+          wrapUpQuota: 2,
         },
       };
       const u = usage({

--- a/src/unit-test/budget-state.test.ts
+++ b/src/unit-test/budget-state.test.ts
@@ -186,6 +186,30 @@ describe("computeBudgetState", () => {
     expect(codexHeavy.directiveToClaude).toContain("Claude");
   });
 
+  test("v3 P3 (M3b): routing advice is suppressed when a side is admission-closing", () => {
+    // REAL (cross-engine): balance/underutilization advice moves work DENSITY between
+    // sides and directly contradicts the admission gate ("no new Codex tasks"). A side
+    // at 5h util ≥ admissionAt(85) but < pauseAt(90) is admission-closed yet NOT paused,
+    // so without this guard adviceEligible stayed true and phase=balance fired alongside
+    // the admission directive. Contrast: util 84 (not admit-closing) still balances.
+    const notClosing = computeBudgetState(
+      usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }),
+      usage({ gateUtil: 84, warnUtil: 84, remaining: 16 }),
+      CONFIG,
+      NOW,
+    );
+    expect(notClosing.phase).toBe("balance"); // baseline: drift would route to Claude
+
+    const admissionClosing = computeBudgetState(
+      usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }),
+      usage({ gateUtil: 86, warnUtil: 86, remaining: 14 }), // codex 5h util 86 ≥ admissionAt
+      CONFIG,
+      NOW,
+    );
+    expect(admissionClosing.phase).toBe("normal"); // advice suppressed
+    expect(admissionClosing.directiveToClaude).toBeNull();
+  });
+
   test("balances reverse 20/40 drift toward Claude", () => {
     const state = computeBudgetState(
       usage({ gateUtil: 20, warnUtil: 20, remaining: 80 }),

--- a/src/unit-test/budget-state.test.ts
+++ b/src/unit-test/budget-state.test.ts
@@ -20,7 +20,7 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
   allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
 };
 

--- a/src/unit-test/codex-adapter.test.ts
+++ b/src/unit-test/codex-adapter.test.ts
@@ -401,6 +401,26 @@ describe("CodexAdapter turn state machine", () => {
     expect(injectionId).toBeLessThan(0);
   });
 
+  test("canInject mirrors injectMessage's three synchronous pre-send guards (P3 baton precheck)", () => {
+    const adapter = createAdapter();
+    // No thread → not injectable.
+    expect(adapter.canInject()).toBe(false);
+    adapter.threadId = "thread-1";
+    // Thread but no open socket → not injectable.
+    expect(adapter.canInject()).toBe(false);
+    adapter.appServerWs = { readyState: WebSocket.OPEN, send: () => {} } as any;
+    // Thread + open socket + idle → injectable.
+    expect(adapter.canInject()).toBe(true);
+    // A turn in progress → not injectable (injectMessage would reject too).
+    adapter.handleServerNotification({ method: "turn/started", params: { turn: { id: "t1" } } });
+    expect(adapter.canInject()).toBe(false);
+    // Closed socket → not injectable.
+    adapter.activeTurnIds.clear();
+    adapter.turnInProgress = false;
+    adapter.appServerWs = { readyState: WebSocket.CLOSED, send: () => {} } as any;
+    expect(adapter.canInject()).toBe(false);
+  });
+
   test("clearResponseTrackingState + turn reset simulates onclose behavior", () => {
     const adapter = createAdapter();
     // Start a turn and track a response

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -391,7 +391,7 @@ describe("ConfigService — budget section", () => {
         balanced: { effort: "medium" },
         eco: { effort: "low" },
       },
-      maximize: { targetUtil: 98, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+      maximize: { targetUtil: 98, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
       allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
     });
   });
@@ -445,7 +445,7 @@ describe("ConfigService — budget section", () => {
         eco: { effort: "minimal" },
       },
       // v3 P1 keys absent in the raw file normalize to defaults.
-      maximize: { targetUtil: 98, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+      maximize: { targetUtil: 98, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
       allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
     });
   });
@@ -608,7 +608,7 @@ describe("applyBudgetEnvOverrides", () => {
       balanced: { effort: "medium" },
       eco: { effort: "low" },
     },
-    maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+    maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
     allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
   };
 
@@ -664,7 +664,7 @@ describe("applyBudgetEnvOverrides — boolean spellings", () => {
       balanced: { effort: "medium" },
       eco: { effort: "low" },
     },
-    maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+    maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
     allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
   };
 
@@ -760,7 +760,7 @@ describe("applyBudgetEnvOverrides — v3 P1 keys", () => {
       balanced: { effort: "medium" },
       eco: { effort: "low" },
     },
-    maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+    maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
     allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
   };
 
@@ -815,7 +815,41 @@ describe("normalizeBudgetConfig — v3 P2 maximize block", () => {
       reserveMaxPct: 10,
       finishingHorizonMinutes: 45,
       resumeHysteresisPct: 8,
+      admissionAt: 85,
+      wrapUpQuota: 2,
     });
+  });
+
+  test("valid custom admissionAt / wrapUpQuota pass through", () => {
+    writeRawConfig({
+      budget: { maximize: { admissionAt: 80, wrapUpQuota: 3 } },
+    });
+    const m = loadBudget().maximize;
+    expect(m.admissionAt).toBe(80);
+    expect(m.wrapUpQuota).toBe(3);
+  });
+
+  test("out-of-range admissionAt / wrapUpQuota fall back per field", () => {
+    writeRawConfig({
+      budget: { maximize: { admissionAt: 30, wrapUpQuota: 99 } }, // 30 < 50, 99 > 10
+    });
+    const m = loadBudget().maximize;
+    expect(m.admissionAt).toBe(85);
+    expect(m.wrapUpQuota).toBe(2);
+  });
+
+  test("admissionAt >= targetUtil resets the WHOLE maximize block to defaults", () => {
+    writeRawConfig({
+      budget: { maximize: { targetUtil: 96, admissionAt: 96 } }, // 96 >= 96 → unsatisfiable
+    });
+    expect(loadBudget().maximize).toEqual(DEFAULT_CONFIG.budget.maximize);
+  });
+
+  test("garbage admissionAt fails loud as corrupt (not silent default)", () => {
+    writeRawConfig({ budget: { maximize: { admissionAt: "eighty-five" } } });
+    const result = new ConfigService(tempDir).load();
+    expect(result.state).toBe("corrupt");
+    if (result.state === "corrupt") expect(result.reason).toContain("budget.maximize.admissionAt");
   });
 
   test("out-of-range fields fall back per field (others preserved)", () => {
@@ -853,6 +887,29 @@ describe("normalizeBudgetConfig — v3 P2 maximize block", () => {
     expect(overridden.maximize.targetUtil).toBe(96);
     expect(overridden.maximize.reserveSlopePctPerHour).toBe(0.9);
     expect(overridden.maximize.finishingHorizonMinutes).toBe(60);
+  });
+
+  test("env overrides land on the P3 admission keys", () => {
+    const overridden = applyBudgetEnvOverrides(DEFAULT_CONFIG.budget, {
+      AGENTBRIDGE_BUDGET_ADMISSION_AT: "80",
+      AGENTBRIDGE_BUDGET_WRAP_UP_QUOTA: "4",
+    });
+    expect(overridden.maximize.admissionAt).toBe(80);
+    expect(overridden.maximize.wrapUpQuota).toBe(4);
+  });
+
+  test("out-of-range admission env values are ignored (normalize bounds apply)", () => {
+    const overridden = applyBudgetEnvOverrides(DEFAULT_CONFIG.budget, {
+      AGENTBRIDGE_BUDGET_ADMISSION_AT: "30", // < 50 → fallback 85
+      AGENTBRIDGE_BUDGET_WRAP_UP_QUOTA: "99", // > 10 → fallback 2
+    });
+    expect(overridden.maximize.admissionAt).toBe(85);
+    expect(overridden.maximize.wrapUpQuota).toBe(2);
+  });
+
+  test("fractional wrapUpQuota is floored to an integer", () => {
+    writeRawConfig({ budget: { maximize: { wrapUpQuota: 1.9 } } });
+    expect(loadBudget().maximize.wrapUpQuota).toBe(1);
   });
 
   test("describeConfig reports custom values when maximize is tuned", () => {

--- a/src/unit-test/resume-candidate-e2e.test.ts
+++ b/src/unit-test/resume-candidate-e2e.test.ts
@@ -47,7 +47,7 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
   allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
 };
 

--- a/src/unit-test/resume-candidate.test.ts
+++ b/src/unit-test/resume-candidate.test.ts
@@ -25,7 +25,7 @@ const CONFIG: BudgetConfig = {
     balanced: { effort: "medium" },
     eco: { effort: "low" },
   },
-  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5 },
+  maximize: { targetUtil: 97, reserveSlopePctPerHour: 0.4, reserveMaxPct: 7, finishingHorizonMinutes: 30, resumeHysteresisPct: 5, admissionAt: 85, wrapUpQuota: 2 },
   allocation: { minRunwayRatio: 50, minRunwayGapHours: 2 },
 };
 


### PR DESCRIPTION
## v3 P3 — 三态 admission 闸门 (M1–M3b) / Three-state admission gate

把预算闸门从二态（paused / 否）升级为三态 `open | admission-closed | closed`，实现"额度收尾保护"：临近额度耗尽时**拒新任务、放收尾**，而不是非黑即白地全停。设计稿：`docs/design/budget-strategy-v3.md` §3.2 / §6 P3，实施计划：`docs/design/budget-v3-p3-implementation-plan.md`。

Upgrades the budget gate from two-state to three-state `open | admission-closed | closed` — a "finishing-protection" tier that **rejects new tasks but allows wrap-up** as quota nears exhaustion, instead of an all-or-nothing pause.

### 闸门语义 / Gate semantics
- `open`：照常放行 / forward normally.
- `admission-closed`（codex/both 侧，5h util ≥ `admissionAt`(默认 85) 或 §3.1 硬线 或 weekly runway < `finishingHorizon×2`）：拒新 `turn/start`（新错误码 `budget_admission`）、放行 `steer`、放行 `wrap_up:true` 的 reply（每额度窗口至多 `wrapUpQuota`(默认 2) 个、**配额持久化 fail-closed**）。
- `closed`（既有 pause 闸，codex/both 侧耗尽）：维持全拒；外加每额度窗口一次的**系统 checkpoint baton**（让 Codex 在熄火前写 `.agent/checkpoint.md`）。
- 优先级 `closed > admission-closed > open`。不变量 **I2**：曾关闭的窗口在数据 stale 期维持原态，绝不因数据缺失开闸。

### 里程碑 / Milestones（4 commits）
- **M1** (`ec7f9db`)：配置 + 谓词 + 配额持久化（`admissionAt`/`wrapUpQuota`、`agentShouldAdmitClose`/`agentCanAdmitOpen`、`admission-quota.ts` per-窗口 fail-closed + Q9 跨窗清零）。
- **M2** (`02064f0`)：状态机（`budget-fingerprint.ts` admission 车道、`gateState()`、snapshot.gateState；observability-only）。
- **M3a** (`ca19f6a`)：daemon live 强制（三态闸 + `wrapUp` 协议透传 + 配额 peek/consume fail-closed）。**5 轮 cross-review**。
- **M3b** (`739ebae`)：admission directive（turnPhase-aware、幂等、pause 抑制+降级补发、codex-scoped）+ closed 态 checkpoint baton（canInject 预检 + once-per-window）+ advice 抑制（admission-closing 时）+ pause-recovery hold（防 resume 绕闸）+ **interrupt await 后闸复检**（提取 `evaluateInjectionBudgetGate`）。**6 轮 cross-review**。

### Cross-review / 交叉评审
M3a 5 轮 + M3b 6 轮跨引擎评审（Claude 多维 adversarial workflow + Codex `adversarial-reviewer`，每轮全新 reviewer，循环至连续两轮 0-REAL）。M3b 累计修复 **10 个真实问题**，其中：
- interrupt-await gate-bypass（await 期间闸收紧仍注入新 turn）— Codex 跨引擎 catch、Claude workflow 漏；
- advice/admission 文案冲突（"别派 Codex" 与 "多派 Codex" 同时发）；
- baton injectability token-loss（TUI 断开时烧掉 once-per-window token）；
- 2 个 admission/balance missed-emit（hold band 指纹被吞）。
另有 4 项被实证 refuted（如 5h-reset 清零 = 既定 Q9 语义）。

### Test plan / 测试
- `bun run check`：**1610 pass / 0 fail**，typecheck 干净，plugin sync + 版本检查通过。
- 单测：`budget-coordinator.test.ts`（admission directive emit/defer/flush/dedup/suppress/de-escalation/resume-hold/reset）、`budget-state.test.ts`（advice 抑制）、`admission-quota.test.ts`（fail-closed/once-per-window/Q9）、`codex-adapter.test.ts`（canInject 四态）。
- 集成：`daemon-wiring.test.ts`（admission gate 拒新/放 wrapUp、baton once-per-window+canInject、interrupt await 闸复检、resume 路径）。
- E2E 手测计划：`docs/test-plans/p3-m3b-admission-directive-baton.md`（T1–T6）。

### Backlog（非阻塞 / non-blocking RECOMMEND）
- `getResumeCandidate().codex` 在 held-recovery 当 poll 残留 `true`（unconsumed，唯一消费者被跳过）；可同条件清除。
- `renderBudgetSnapshot()` 未渲染 `admission-closed`（hold band 中 `phase` 可显示 balance）；`gateState` 字段已权威，可补可观测性。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
