### PR TITLE
fix(budget): v3 P3 backlog — hide held Codex from resume candidate + render admission-closed / P3 backlog 收尾

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14102,6 +14102,8 @@ function renderBudgetSnapshot(snapshot, options = {}) {
     } else {
       lines.push(`\u6682\u505C\uFF1A\u53CC\u4FA7\u8054\u5408\u6682\u505C\uFF08\u95F8\u95E8\u5173\u95ED\uFF09 \u2014 ${reason}${resume}`);
     }
+  } else if (snapshot.gateState === "admission-closed") {
+    lines.push("\u6682\u505C\uFF1A\u5426 \xB7 \u6536\u5C3E\u4FDD\u62A4\uFF1Aadmission-closed\uFF08Codex \u4FA7\u4EC5\u653E\u884C wrap-up/steer\uFF0C\u65B0\u4EFB\u52A1\u4F1A\u88AB\u62D2 budget_admission\uFF09");
   } else {
     lines.push("\u6682\u505C\uFF1A\u5426");
   }
@@ -14632,10 +14634,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.18", "0.0.0-source"),
-  commit: defineString("44137b8", "source"),
+  commit: defineString("5c9f7d0", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("36e830f077b2", "source")
+  codeHash: defineString("f85e311a26c7", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.18", "0.0.0-source"),
-  commit: defineString("44137b8", "source"),
+  commit: defineString("5c9f7d0", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("36e830f077b2", "source")
+  codeHash: defineString("f85e311a26c7", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -4967,9 +4967,11 @@ class BudgetCoordinator {
     this.fpState = next;
     this.admissionState = classifyAdmission(this.admissionState, state, this.config).next;
     this.applyAdmissionDirective(state);
-    this.resumeCandidate = this.resumeSignals ? computeResumeCandidate(resumeCandidateSides(effect), state, this.config, this.resumeSignals()) : {};
+    const codexAdmissionHeld = this.admissionState.side === "codex" || this.admissionState.side === "both";
+    const candidateSides = resumeCandidateSides(effect).filter((side) => !(side === "codex" && codexAdmissionHeld));
+    this.resumeCandidate = this.resumeSignals ? computeResumeCandidate(candidateSides, state, this.config, this.resumeSignals()) : {};
     for (const side of effect.recoveredSides) {
-      if (side === "codex" && (this.admissionState.side === "codex" || this.admissionState.side === "both")) {
+      if (side === "codex" && codexAdmissionHeld) {
         this.log(`Budget recovery for Codex held: pause cleared but still admission-closed`);
         continue;
       }

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -425,27 +425,36 @@ export class BudgetCoordinator {
     // side. When no signal provider is wired the candidate stays empty — nothing
     // can be a candidate without the readiness signals. This populates state
     // only; committed recovered sides emit below, but injection remains PR3/PR4.
+    // v3 P3 (M3b round-2 REAL + backlog): codex is HELD when it recovers from PAUSE
+    // but the admission lane still gates it (the closed→admission-closed
+    // de-escalation: codex util crosses below the pause-resume line into the
+    // admission hold band). A held codex is neither emitted as recovered (loop
+    // below) NOR exposed as a resume candidate here — otherwise getResumeCandidate()
+    // .codex would briefly read true on the de-escalation poll even though the
+    // recovery is suppressed. (Today the only consumer, enqueueCodexBudgetResume, is
+    // reached via the skipped onResume, so it is unconsumed; filtering keeps the
+    // read-only exposure honest so a future consumer cannot mis-read it.)
+    const codexAdmissionHeld = this.admissionState.side === "codex" || this.admissionState.side === "both";
+    const candidateSides = resumeCandidateSides(effect).filter(
+      (side) => !(side === "codex" && codexAdmissionHeld),
+    );
     this.resumeCandidate = this.resumeSignals
-      ? computeResumeCandidate(resumeCandidateSides(effect), state, this.config, this.resumeSignals())
+      ? computeResumeCandidate(candidateSides, state, this.config, this.resumeSignals())
       : {};
 
     for (const side of effect.recoveredSides) {
-      // v3 P3 (M3b, round-2 REAL): a side recovering from PAUSE may still be
-      // ADMISSION-closed — the closed→admission-closed de-escalation (codex util
-      // crosses below the pause-resume line into the admission hold band). Firing
-      // the codex recovery here would (a) tell Claude codex is fully recovered and
-      // (b) route an auto-resume turn through enqueueCodexBudgetResume → the resume
-      // queue → codex.injectMessage, which BYPASSES the codex_to_codex admission
-      // gate and would inject an unbounded continuation that never consumes a wrap-up
-      // slot — both wrong while codex is still in finishing protection. HOLD the
-      // codex recovery until the admission lane also opens. (admission is
-      // codex-scoped, so a claude recovery is never gated by it.) Trade-off: in a
-      // monotonic recovery (pause → admission-closed → open with no re-pause) the
-      // codex auto-resume is skipped for this episode; it re-fires on the next
-      // genuine pause-recovery cycle, and once the gate is open Claude can resume
-      // Codex manually via reply. The SAFE direction — no gate bypass. (follow-up:
-      // optionally re-fire the held resume on the admission-exit transition.)
-      if (side === "codex" && (this.admissionState.side === "codex" || this.admissionState.side === "both")) {
+      // Firing the codex recovery while HELD would (a) tell Claude codex is fully
+      // recovered and (b) route an auto-resume turn through enqueueCodexBudgetResume
+      // → the resume queue → codex.injectMessage, which BYPASSES the admission gate
+      // and would inject an unbounded continuation that never consumes a wrap-up slot
+      // — both wrong while codex is still in finishing protection. HOLD the codex
+      // recovery until the admission lane also opens. (admission is codex-scoped, so
+      // a claude recovery is never gated by it.) Trade-off: in a monotonic recovery
+      // (pause → admission-closed → open with no re-pause) the codex auto-resume is
+      // skipped for this episode; it re-fires on the next genuine pause-recovery cycle,
+      // and once the gate is open Claude can resume Codex manually via reply. The SAFE
+      // direction — no gate bypass. (follow-up: optionally re-fire on admission-exit.)
+      if (side === "codex" && codexAdmissionHeld) {
         this.log(`Budget recovery for Codex held: pause cleared but still admission-closed`);
         continue;
       }

--- a/src/budget/render.ts
+++ b/src/budget/render.ts
@@ -329,6 +329,13 @@ export function renderBudgetSnapshot(
     } else {
       lines.push(`暂停：双侧联合暂停（闸门关闭） — ${reason}${resume}`);
     }
+  } else if (snapshot.gateState === "admission-closed") {
+    // v3 P3 backlog: the gate can be admission-closed WITHOUT being paused (5h
+    // finishing protection on the Codex side). A bare "暂停：否" would hide that new
+    // Codex tasks are being declined, so surface the finishing-protection state.
+    // `gateState` is optional (back-compat): an old snapshot without it falls
+    // through to the plain "暂停：否" below.
+    lines.push("暂停：否 · 收尾保护：admission-closed（Codex 侧仅放行 wrap-up/steer，新任务会被拒 budget_admission）");
   } else {
     lines.push("暂停：否");
   }

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -1609,6 +1609,9 @@ describe("admission directive emission — v3 P3 (M3b, turnPhase-aware)", () => 
     // Recovery HELD: no resume directive, no resume routing (no bypass).
     expect(emitted.some((e) => e.id.startsWith("system_budget_resume"))).toBe(false);
     expect(resumeCalls).not.toContain("codex");
+    // Backlog: the read-only resume candidate must NOT expose codex while held —
+    // the de-escalation poll filters codex out of the candidate sides.
+    expect(coordinator.getResumeCandidate().codex).not.toBe(true);
     // The correct signal fires instead.
     expect(emitted.some((e) => e.id.startsWith("system_budget_admission"))).toBe(true);
   });

--- a/src/unit-test/budget-render.test.ts
+++ b/src/unit-test/budget-render.test.ts
@@ -54,6 +54,20 @@ describe("renderBudgetSnapshot", () => {
     expect(text).toContain("预警 45%");
   });
 
+  test("surfaces admission-closed (5h finishing protection) when not paused", () => {
+    const text = renderBudgetSnapshot(snapshot({ gateState: "admission-closed", paused: false }));
+    expect(text).toContain("收尾保护：admission-closed");
+    expect(text).toContain("budget_admission");
+  });
+
+  test("plain '暂停：否' when gate is open or gateState is absent (back-compat)", () => {
+    expect(renderBudgetSnapshot(snapshot({ gateState: "open" }))).toContain("暂停：否");
+    expect(renderBudgetSnapshot(snapshot({ gateState: "open" }))).not.toContain("收尾保护");
+    // Old snapshot without gateState → unchanged plain line.
+    expect(renderBudgetSnapshot(snapshot())).toContain("暂停：否");
+    expect(renderBudgetSnapshot(snapshot())).not.toContain("收尾保护");
+  });
+
   test("renders the dynamic line with per-agent headroom", () => {
     const text = renderBudgetSnapshot(
       snapshot({ dynamicPauseLine: { claude: 93.4, codex: 95.6 } }),


### PR DESCRIPTION
## v3 P3 backlog — 两个非阻塞可观测性收尾 / two non-blocking observability follow-ups

收尾 PR #180 (v3 P3 三态 admission 闸门) review 中记录的两个非阻塞 RECOMMEND backlog。纯收窄/可观测性，无闸门语义改动。

Closes the two non-blocking RECOMMEND items recorded in PR #180's review. Pure narrowing / observability — no gate-semantics change.

### 改动 / Changes
1. **resume candidate held-filter** (`src/budget/render.ts` 无关；`src/budget/budget-coordinator.ts`)
   - codex 从 pause 恢复但仍被 admission 闸住（`closed→admission-closed` 降级）时，除跳过 `onResume(codex)` 外，也把 codex 从 `resumeCandidate` 候选过滤掉（共享 `codexAdmissionHeld`，与 recovery-skip 同条件）。
   - 效果：`getResumeCandidate().codex` 不再在 de-escalation 当 poll 残留 `true`。仅过滤 held codex，不动 claude / unheld codex / open gate。held+paused 时 codex 候选从 `false` 收窄成 `undefined`——保守方向，唯一 live consumer `enqueueCodexBudgetResume` 只认 `=== true && detail.ready === true`，不受影响。
2. **snapshot 渲染收尾保护态** (`src/budget/render.ts`)
   - 未 paused 但 `gateState === "admission-closed"` 时显式渲染 `收尾保护：admission-closed（仅放 wrap-up/steer，新任务拒 budget_admission）`，不再裸显 `暂停：否`。
   - `gateState` 可选字段：旧 snapshot 无该字段 → 回退裸 `暂停：否`（back-compat）。分支序 `paused → admission-closed → 裸 else`，不与 closed/pause 文案重叠。

### Test plan
- 新增：`budget-coordinator.test.ts`（held-recovery 时 `getResumeCandidate().codex !== true`）、`budget-render.test.ts`（admission-closed 渲染 + back-compat 裸 `暂停：否`）。
- `bun run check`：**1614 pass / 0 fail**，typecheck 干净，plugin bundle 同步，版本对齐。

### Cross-review
2 轮跨引擎 cross-review（Claude adversarial workflow + Codex），连续两轮 **0 REAL / 0 SUSPECT / 0 RECOMMEND**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
