### PR TITLE
fix(budget): render all user-facing budget times in Beijing time / 额度时间统一北京时区

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -13866,6 +13866,45 @@ class StateDirResolver {
   }
 }
 
+// src/budget/format-time.ts
+var BEIJING_TZ = "Asia/Shanghai";
+function parts(epochSeconds, options) {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: BEIJING_TZ,
+    hour12: false,
+    ...options
+  });
+  const out = {};
+  for (const part of fmt.formatToParts(new Date(epochSeconds * 1000))) {
+    out[part.type] = part.value;
+  }
+  return out;
+}
+function formatBeijing(epochSeconds) {
+  if (!epochSeconds || epochSeconds <= 0)
+    return "\u672A\u77E5";
+  const d = new Date(epochSeconds * 1000);
+  if (Number.isNaN(d.getTime()))
+    return "\u672A\u77E5";
+  const p = parts(epochSeconds, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+  return `${p.year}-${p.month}-${p.day} ${p.hour}:${p.minute}`;
+}
+function formatBeijingClock(epochSeconds) {
+  if (!epochSeconds || epochSeconds <= 0)
+    return "\u672A\u77E5";
+  const d = new Date(epochSeconds * 1000);
+  if (Number.isNaN(d.getTime()))
+    return "\u672A\u77E5";
+  const p = parts(epochSeconds, { hour: "2-digit", minute: "2-digit" });
+  return `${p.hour}:${p.minute}`;
+}
+
 // src/budget/types.ts
 var STALE_MAX_AGE_SEC = 600;
 
@@ -13909,9 +13948,7 @@ function resolveGuardHardHint(env = process.env) {
   return parsed;
 }
 function formatEpoch(epochSeconds) {
-  if (!epochSeconds || epochSeconds <= 0)
-    return "\u672A\u77E5";
-  return new Date(epochSeconds * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+  return formatBeijing(epochSeconds);
 }
 function formatWindow(window, label) {
   if (!window)
@@ -13921,25 +13958,25 @@ function formatWindow(window, label) {
 function formatAgent(name, usage, snapshotAt) {
   if (!usage)
     return `${name}\uFF1A\u672A\u77E5\uFF08\u63A2\u6D4B\u4E0D\u53EF\u7528\uFF09`;
-  const parts = [
+  const parts2 = [
     formatWindow(usage.fiveHour, "5h"),
     formatWindow(usage.weekly, "\u5468"),
     `\u95E8\u63A7 ${usage.gateUtil}%`,
     `\u9884\u8B66 ${usage.warnUtil}%`
   ];
   if (usage.rateLimitedUntil > 0) {
-    parts.push(`\u9650\u6D41\u81F3 ${formatEpoch(usage.rateLimitedUntil)}`);
+    parts2.push(`\u9650\u6D41\u81F3 ${formatEpoch(usage.rateLimitedUntil)}`);
   }
   if (usage.parsedVia === "positional") {
-    parts.push("\u26A0\uFE0F \u7A97\u53E3\u8BC6\u522B\u4F7F\u7528\u4F4D\u7F6E\u515C\u5E95");
+    parts2.push("\u26A0\uFE0F \u7A97\u53E3\u8BC6\u522B\u4F7F\u7528\u4F4D\u7F6E\u515C\u5E95");
   }
   const ageSec = usage.fetchedAt > 0 ? snapshotAt - usage.fetchedAt : 0;
   if (ageSec > 300) {
-    parts.push(`\u26A0\uFE0F \u6570\u636E\u91C7\u96C6\u4E8E ${Math.round(ageSec / 60)} \u5206\u949F\u524D`);
+    parts2.push(`\u26A0\uFE0F \u6570\u636E\u91C7\u96C6\u4E8E ${Math.round(ageSec / 60)} \u5206\u949F\u524D`);
   } else if (usage.stale) {
-    parts.push("\uFF08\u7F13\u5B58\u6570\u636E\uFF09");
+    parts2.push("\uFF08\u7F13\u5B58\u6570\u636E\uFF09");
   }
-  return `${name}\uFF1A${parts.join(" \xB7 ")}`;
+  return `${name}\uFF1A${parts2.join(" \xB7 ")}`;
 }
 var WINDOW_LABELS = {
   fiveHour: "5h \u7A97\u53E3",
@@ -13955,10 +13992,7 @@ function formatDuration(seconds) {
   return `${hours}\u5C0F\u65F6${minutes}\u5206\u949F`;
 }
 function formatClockTime(epochSeconds) {
-  const date4 = new Date(epochSeconds * 1000);
-  const hh = String(date4.getHours()).padStart(2, "0");
-  const mm = String(date4.getMinutes()).padStart(2, "0");
-  return `${hh}:${mm}`;
+  return formatBeijingClock(epochSeconds);
 }
 function formatWindowRate(label, rate) {
   if (!rate)
@@ -13979,20 +14013,20 @@ function formatRunwaySegment(runway, basisWindow, snapshotAt) {
   return `\u7EA6\u53EF\u518D\u5DE5\u4F5C ${formatDuration(runway.seconds)}\uFF08${clockNote}${WINDOW_LABELS[runway.basis]}\u4E3A\u7EA6\u675F\uFF09`;
 }
 function formatBurnRateLine(name, usage, rates, runway, snapshotAt, guardHardPct) {
-  const parts = [
+  const parts2 = [
     formatWindowRate("5h", rates.fiveHour),
     formatWindowRate("\u5468", rates.weekly)
   ].filter((part) => part !== null);
-  if (parts.length === 0 && !runway)
+  if (parts2.length === 0 && !runway)
     return null;
   if (runway) {
     const basisWindow = usage ? usage[runway.basis] : null;
-    parts.push(formatRunwaySegment(runway, basisWindow, snapshotAt));
+    parts2.push(formatRunwaySegment(runway, basisWindow, snapshotAt));
   }
   if (guardHardPct !== null) {
-    parts.push(`\u5916\u5C42 guard \u786C\u7EBF ${guardHardPct}%\uFF08v3 \u4E0D\u53EF\u8D8A\u8FC7\uFF1Brunway \u4E3A\u4E2D\u6027\u53E3\u5F84\uFF0CClaude \u4F1A\u5148\u5728\u786C\u7EBF\u88AB\u5916\u5C42\u505C\u4F4F\uFF09`);
+    parts2.push(`\u5916\u5C42 guard \u786C\u7EBF ${guardHardPct}%\uFF08v3 \u4E0D\u53EF\u8D8A\u8FC7\uFF1Brunway \u4E3A\u4E2D\u6027\u53E3\u5F84\uFF0CClaude \u4F1A\u5148\u5728\u786C\u7EBF\u88AB\u5916\u5C42\u505C\u4F4F\uFF09`);
   }
-  return `${name} \u71C3\u5C3D\u7387\uFF1A${parts.join(" \xB7 ")}`;
+  return `${name} \u71C3\u5C3D\u7387\uFF1A${parts2.join(" \xB7 ")}`;
 }
 function formatFiveHourWindowsLeftLine(snapshot) {
   const values = [];
@@ -14037,7 +14071,7 @@ function formatDynamicLineLine(snapshot) {
   const lines = snapshot.dynamicPauseLine;
   if (!lines)
     return null;
-  const parts = [];
+  const parts2 = [];
   const entries = [
     ["Claude", lines.claude, snapshot.claude],
     ["Codex", lines.codex, snapshot.codex]
@@ -14046,11 +14080,11 @@ function formatDynamicLineLine(snapshot) {
     if (line === null)
       continue;
     const headroom = usage ? `\uFF08util ${usage.gateUtil}%\uFF0C\u4F59\u91CF ${(line - usage.gateUtil).toFixed(1)}\uFF09` : "";
-    parts.push(`${name} ${line.toFixed(1)}%${headroom}`);
+    parts2.push(`${name} ${line.toFixed(1)}%${headroom}`);
   }
-  if (parts.length === 0)
+  if (parts2.length === 0)
     return null;
-  return `\u52A8\u6001\u6682\u505C\u7EBF\uFF1A${parts.join(" \xB7 ")}`;
+  return `\u52A8\u6001\u6682\u505C\u7EBF\uFF1A${parts2.join(" \xB7 ")}`;
 }
 var PHASE_LABELS = {
   normal: "normal\uFF08\u6B63\u5E38\uFF09",
@@ -14062,7 +14096,7 @@ var PHASE_LABELS = {
 function renderBudgetSnapshot(snapshot, options = {}) {
   const guardHardPct = options.guardHardPct ?? resolveGuardHardHint();
   const lines = [];
-  lines.push(`\u3010\u9884\u7B97\u5FEB\u7167 \xB7 \u8D26\u53F7\u7EA7\u3011\u9636\u6BB5\uFF1A${PHASE_LABELS[snapshot.phase] ?? snapshot.phase} \xB7 \u66F4\u65B0\u4E8E ${formatEpoch(snapshot.updatedAt)}`);
+  lines.push(`\u3010\u9884\u7B97\u5FEB\u7167 \xB7 \u8D26\u53F7\u7EA7\u3011\u9636\u6BB5\uFF1A${PHASE_LABELS[snapshot.phase] ?? snapshot.phase} \xB7 \u66F4\u65B0\u4E8E ${formatEpoch(snapshot.updatedAt)}\uFF08\u65F6\u95F4\u5747\u4E3A\u5317\u4EAC\u65F6\u95F4 UTC+8\uFF09`);
   lines.push(formatAgent("Claude", snapshot.claude, snapshot.updatedAt));
   lines.push(formatAgent("Codex", snapshot.codex, snapshot.updatedAt));
   if (snapshot.burnRate) {
@@ -14356,21 +14390,21 @@ Codex: ${msg.content}`;
 `);
     const noticeText = notices.map((notice) => `WARNING: ${notice}`).join(`
 `);
-    const parts = [];
+    const parts2 = [];
     if (count > 0) {
-      parts.push(`[${count} new message${count > 1 ? "s" : ""} from Codex]
+      parts2.push(`[${count} new message${count > 1 ? "s" : ""} from Codex]
 chat_id: ${this.sessionId}`);
     }
     if (noticeText)
-      parts.push(noticeText);
+      parts2.push(noticeText);
     if (formatted)
-      parts.push(formatted);
+      parts2.push(formatted);
     this.log(`get_messages returning ${count} message(s) ` + `(instance=${this.instanceId}, dropped=${dropped}, oversized=${oversized}, oversizedBytes=${oversizedBytes})`);
     return {
       content: [
         {
           type: "text",
-          text: parts.join(`
+          text: parts2.join(`
 
 `)
         }
@@ -14634,10 +14668,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.20", "0.0.0-source"),
-  commit: defineString("2c84947", "source"),
+  commit: defineString("d6034c6", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("d2425ba159fe", "source")
+  codeHash: defineString("efb5b785c5f9", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.20", "0.0.0-source"),
-  commit: defineString("2c84947", "source"),
+  commit: defineString("d6034c6", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("d2425ba159fe", "source")
+  codeHash: defineString("efb5b785c5f9", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -3861,6 +3861,36 @@ function retryAfterMsForResume(resumeAfterEpoch, nowMs) {
   return remainingMs > 0 ? remainingMs : undefined;
 }
 
+// src/budget/format-time.ts
+var BEIJING_TZ = "Asia/Shanghai";
+function parts(epochSeconds, options) {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: BEIJING_TZ,
+    hour12: false,
+    ...options
+  });
+  const out = {};
+  for (const part of fmt.formatToParts(new Date(epochSeconds * 1000))) {
+    out[part.type] = part.value;
+  }
+  return out;
+}
+function formatBeijing(epochSeconds) {
+  if (!epochSeconds || epochSeconds <= 0)
+    return "\u672A\u77E5";
+  const d = new Date(epochSeconds * 1000);
+  if (Number.isNaN(d.getTime()))
+    return "\u672A\u77E5";
+  const p = parts(epochSeconds, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+  return `${p.year}-${p.month}-${p.day} ${p.hour}:${p.minute}`;
+}
+
 // src/budget/types.ts
 var STALE_MAX_AGE_SEC = 600;
 
@@ -4149,14 +4179,12 @@ function pct2(value) {
   return `${Math.round(value * 10) / 10}%`;
 }
 function formatEpoch(epoch) {
-  if (!epoch || epoch <= 0)
-    return "\u672A\u77E5";
-  return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+  return formatBeijing(epoch);
 }
 function usageSummary(name, usage) {
   if (!usage)
     return `${AGENT_LABEL2[name]} \u672A\u77E5`;
-  return `${AGENT_LABEL2[name]} gate=${pct2(usage.gateUtil)} warn=${pct2(usage.warnUtil)} 5h\u91CD\u7F6E=${formatEpoch(usage.fiveHour?.resetEpoch ?? 0)}`;
+  return `${AGENT_LABEL2[name]} gate=${pct2(usage.gateUtil)} warn=${pct2(usage.warnUtil)} 5h\u91CD\u7F6E=${formatEpoch(usage.fiveHour?.resetEpoch ?? 0)}\uFF08\u5317\u4EAC\u65F6\u95F4\uFF09`;
 }
 function resumeAfterEpoch(claude, codex, cfg, now) {
   const epochs = [
@@ -4452,7 +4480,7 @@ function pct3(value) {
   return `${Math.round(value * 10) / 10}%`;
 }
 function formatEpoch2(epoch) {
-  return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+  return formatBeijing(epoch);
 }
 var INITIAL_FINGERPRINT_STATE = {
   side: null,
@@ -4500,7 +4528,7 @@ function activeSideReason(agent, usage, cfg, now) {
   if (!usage)
     return `${AGENT_LABEL3[agent]} \u63A2\u6D4B\u6682\u65F6\u4E0D\u53EF\u7528\uFF0C\u4FDD\u6301\u4E0A\u4E00\u8F6E\u9884\u7B97\u5E72\u9884`;
   if (usage.rateLimitedUntil > now) {
-    return `${AGENT_LABEL3[agent]} \u63A2\u9488\u88AB\u9650\u6D41\u81F3 ${formatEpoch2(usage.rateLimitedUntil)}`;
+    return `${AGENT_LABEL3[agent]} \u63A2\u9488\u88AB\u9650\u6D41\u81F3 ${formatEpoch2(usage.rateLimitedUntil)}\uFF08\u5317\u4EAC\u65F6\u95F4\uFF09`;
   }
   const decision = agentShouldPause(agent, usage, cfg, now);
   if (decision.pause)
@@ -4643,7 +4671,7 @@ function admissionReason(side, state, cfg) {
     if (!usage)
       return `${AGENT_LABEL3[agent]} \u63A2\u6D4B\u6682\u65F6\u4E0D\u53EF\u7528\uFF0C\u4FDD\u6301\u4E0A\u4E00\u8F6E\u6536\u5C3E\u4FDD\u62A4`;
     if (usage.rateLimitedUntil > state.now) {
-      return `${AGENT_LABEL3[agent]} \u63A2\u9488\u88AB\u9650\u6D41\u81F3 ${formatEpoch2(usage.rateLimitedUntil)}\uFF0C\u4FDD\u6301\u6536\u5C3E\u4FDD\u62A4`;
+      return `${AGENT_LABEL3[agent]} \u63A2\u9488\u88AB\u9650\u6D41\u81F3 ${formatEpoch2(usage.rateLimitedUntil)}\uFF08\u5317\u4EAC\u65F6\u95F4\uFF09\uFF0C\u4FDD\u6301\u6536\u5C3E\u4FDD\u62A4`;
     }
     const decision = agentShouldAdmitClose(agent, usage, cfg, state.now);
     if (decision.admitClose)
@@ -6778,13 +6806,13 @@ function stopBudgetCoordinator() {
 function budgetPauseGateError() {
   const snapshot = budgetCoordinator?.getSnapshot() ?? null;
   const reason = snapshot?.pauseReason ?? "Codex \u4FA7\u989D\u5EA6\u63A5\u8FD1\u8017\u5C3D";
-  const resumeAt = snapshot?.resumeAfterEpoch ? new Date(snapshot.resumeAfterEpoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z") : null;
+  const resumeAt = snapshot?.resumeAfterEpoch ? `${formatBeijing(snapshot.resumeAfterEpoch)}\uFF08\u5317\u4EAC\u65F6\u95F4\uFF09` : null;
   const sideHint = snapshot?.pauseSide === "both" ? "\u53CC\u4FA7\u989D\u5EA6\u5747\u5DF2\u8017\u5C3D\uFF0C\u8BF7\u5199 checkpoint \u7B49\u5F85\u5237\u65B0" : "\u4F60\u53EF\u7EE7\u7EED solo \u63A8\u8FDB\u53EF\u72EC\u7ACB\u90E8\u5206\uFF0C\u5E76\u5199 checkpoint \u6807\u6CE8\u5206\u5DE5\u65AD\u70B9";
   const reopenText = `Codex \u4FA7\u5404\u7A97\u53E3 util \u56DE\u843D\u81F3\u52A8\u6001\u6682\u505C\u7EBF \u2212 ${BUDGET_CONFIG.maximize.resumeHysteresisPct}% \u4EE5\u4E0B\u6216\u5BF9\u5E94\u7A97\u53E3\u5237\u65B0\u540E\u95F8\u95E8\u81EA\u52A8\u653E\u5F00`;
   return `\u9884\u7B97\u6682\u505C\uFF08\u95F8\u95E8\u5173\u95ED\uFF09\uFF0C\u5DF2\u62D2\u7EDD\u8F6C\u53D1\uFF1A${reason}\u3002` + reopenText + (resumeAt ? `\uFF08\u9884\u8BA1\u6062\u590D ${resumeAt}\uFF0C\u4EE5\u5B9E\u6D4B\u4E3A\u51C6\uFF1B\u63D0\u524D\u5237\u65B0\u4F1A\u66F4\u65E9\u89E3\u9664\uFF09` : "") + `\u3002\u6536\u5230 RESUME \u901A\u77E5\u524D\u8BF7\u52FF\u91CD\u8BD5\u5411 Codex \u53D1\u9001 reply\uFF1B${sideHint}\u3002`;
 }
 function budgetAdmissionGateError(windowResetEpoch, wrapUpLeft, quotaExhausted) {
-  const resetAt = windowResetEpoch > 0 ? new Date(windowResetEpoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z") : "\u672A\u77E5";
+  const resetAt = windowResetEpoch > 0 ? `${formatBeijing(windowResetEpoch)}\uFF08\u5317\u4EAC\u65F6\u95F4\uFF09` : "\u672A\u77E5";
   const quota = BUDGET_CONFIG.maximize.wrapUpQuota;
   if (quotaExhausted) {
     return `\u989D\u5EA6\u7A97\u53E3\u6536\u5C3E\u4FDD\u62A4\u4E2D\uFF08admission-closed\uFF09\uFF1A\u672C\u7A97\u53E3 wrap-up \u914D\u989D\uFF08\u6BCF\u7A97\u53E3 ${quota} \u4E2A\uFF09\u5DF2\u7528\u5C3D\uFF0C\u5DF2\u62D2\u7EDD\u8F6C\u53D1\u3002` + `\u8BF7\u52FF\u518D\u6D3E\u65B0\u4EFB\u52A1\uFF1B\u5199 checkpoint\uFF0C\u7B49\u989D\u5EA6\u7A97\u53E3\u5237\u65B0\uFF08\u7EA6 ${resetAt}\uFF09\u540E\u518D\u7EE7\u7EED\u3002`;

--- a/src/budget/budget-fingerprint.ts
+++ b/src/budget/budget-fingerprint.ts
@@ -34,6 +34,7 @@ import {
   resumeBlockingEpochFor,
 } from "./budget-decision";
 import type { PendingEntry } from "./pending-reader";
+import { formatBeijing } from "./format-time";
 import type { AgentName, AgentUsage, BudgetConfig, BudgetState } from "./types";
 
 /** Active side, identical to the old pauseSide() bijection over activeSides. */
@@ -54,7 +55,7 @@ function pct(value: number): string {
 }
 
 function formatEpoch(epoch: number): string {
-  return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+  return formatBeijing(epoch);
 }
 
 /**
@@ -224,7 +225,7 @@ function removedAgents(prevSide: PauseSide, currentSide: PauseSide): AgentName[]
 function activeSideReason(agent: AgentName, usage: AgentUsage | null, cfg: BudgetConfig, now: number): string {
   if (!usage) return `${AGENT_LABEL[agent]} 探测暂时不可用，保持上一轮预算干预`;
   if (usage.rateLimitedUntil > now) {
-    return `${AGENT_LABEL[agent]} 探针被限流至 ${formatEpoch(usage.rateLimitedUntil)}`;
+    return `${AGENT_LABEL[agent]} 探针被限流至 ${formatEpoch(usage.rateLimitedUntil)}（北京时间）`;
   }
   // Delegate the "why paused" text to the decision layer (dynamic-line string,
   // or the gateUtil fallback string when burn data is absent).
@@ -548,7 +549,7 @@ function admissionReason(side: PauseSide, state: BudgetState, cfg: BudgetConfig)
       // rateLimitedUntil > now) even though agentShouldAdmitClose no longer trips
       // — without this branch that hold would mislabel as the hysteresis band.
       if (usage.rateLimitedUntil > state.now) {
-        return `${AGENT_LABEL[agent]} 探针被限流至 ${formatEpoch(usage.rateLimitedUntil)}，保持收尾保护`;
+        return `${AGENT_LABEL[agent]} 探针被限流至 ${formatEpoch(usage.rateLimitedUntil)}（北京时间），保持收尾保护`;
       }
       const decision = agentShouldAdmitClose(agent, usage, cfg, state.now);
       if (decision.admitClose) return decision.reason;

--- a/src/budget/budget-state.ts
+++ b/src/budget/budget-state.ts
@@ -1,4 +1,5 @@
 import { matchingGateReset } from "./budget-gate";
+import { formatBeijing } from "./format-time";
 import {
   agentShouldAdmitClose,
   agentShouldPause,
@@ -62,13 +63,12 @@ function pct(value: number): string {
 }
 
 function formatEpoch(epoch: number | null): string {
-  if (!epoch || epoch <= 0) return "未知";
-  return new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+  return formatBeijing(epoch);
 }
 
 function usageSummary(name: AgentName, usage: AgentUsage | null): string {
   if (!usage) return `${AGENT_LABEL[name]} 未知`;
-  return `${AGENT_LABEL[name]} gate=${pct(usage.gateUtil)} warn=${pct(usage.warnUtil)} 5h重置=${formatEpoch(usage.fiveHour?.resetEpoch ?? 0)}`;
+  return `${AGENT_LABEL[name]} gate=${pct(usage.gateUtil)} warn=${pct(usage.warnUtil)} 5h重置=${formatEpoch(usage.fiveHour?.resetEpoch ?? 0)}（北京时间）`;
 }
 
 function resumeAfterEpoch(

--- a/src/budget/format-time.ts
+++ b/src/budget/format-time.ts
@@ -1,0 +1,60 @@
+/**
+ * Beijing-time (UTC+8 / Asia/Shanghai) formatting for ALL user-facing budget
+ * timestamps.
+ *
+ * The user reads budget output in Beijing time, so every reset/resume timestamp
+ * the bridge renders (get_budget text, budget coordination notices, pause /
+ * admission gate errors) MUST go through here — never `toISOString()` (UTC) or
+ * `getHours()` (host-local, wrong on a non-Beijing host). This is enforced in
+ * code, not by per-session memory, so it holds in every project.
+ */
+
+const BEIJING_TZ = "Asia/Shanghai";
+
+/** Short label callers can append once per surface to disambiguate. */
+export const BEIJING_TZ_LABEL = "北京时间";
+
+function parts(
+  epochSeconds: number,
+  options: Intl.DateTimeFormatOptions,
+): Record<string, string> {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: BEIJING_TZ,
+    hour12: false,
+    ...options,
+  });
+  const out: Record<string, string> = {};
+  for (const part of fmt.formatToParts(new Date(epochSeconds * 1000))) {
+    out[part.type] = part.value;
+  }
+  return out;
+}
+
+/**
+ * Format an epoch (seconds) as 「YYYY-MM-DD HH:MM」 in Beijing time. Returns
+ * 「未知」 for missing/invalid input. No timezone suffix — callers add the
+ * `北京时间` label once per surface so repeated timestamps stay readable.
+ */
+export function formatBeijing(epochSeconds: number | null | undefined): string {
+  if (!epochSeconds || epochSeconds <= 0) return "未知";
+  const d = new Date(epochSeconds * 1000);
+  if (Number.isNaN(d.getTime())) return "未知";
+  const p = parts(epochSeconds, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  // en-CA yields ISO-ish 「2026-06-18」 for the date part; recompose explicitly.
+  return `${p.year}-${p.month}-${p.day} ${p.hour}:${p.minute}`;
+}
+
+/** Format an epoch (seconds) as a Beijing-time wall clock 「HH:MM」. */
+export function formatBeijingClock(epochSeconds: number | null | undefined): string {
+  if (!epochSeconds || epochSeconds <= 0) return "未知";
+  const d = new Date(epochSeconds * 1000);
+  if (Number.isNaN(d.getTime())) return "未知";
+  const p = parts(epochSeconds, { hour: "2-digit", minute: "2-digit" });
+  return `${p.hour}:${p.minute}`;
+}

--- a/src/budget/render.ts
+++ b/src/budget/render.ts
@@ -7,6 +7,7 @@
  */
 
 import { agentWeeklyFiveHourWindowsLeft } from "./burn-view";
+import { formatBeijing, formatBeijingClock } from "./format-time";
 import type {
   AgentBurnRates,
   AgentUsage,
@@ -40,8 +41,7 @@ export function resolveGuardHardHint(
 }
 
 function formatEpoch(epochSeconds: number | null | undefined): string {
-  if (!epochSeconds || epochSeconds <= 0) return "未知";
-  return new Date(epochSeconds * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+  return formatBeijing(epochSeconds);
 }
 
 function formatWindow(window: { util: number; resetEpoch: number } | null, label: string): string {
@@ -97,12 +97,9 @@ export function formatDuration(seconds: number): string {
   return `${hours}小时${minutes}分钟`;
 }
 
-/** Format an epoch as a LOCAL-timezone wall-clock 「HH:MM」. */
+/** Format an epoch as a Beijing-time wall-clock 「HH:MM」. */
 export function formatClockTime(epochSeconds: number): string {
-  const date = new Date(epochSeconds * 1000);
-  const hh = String(date.getHours()).padStart(2, "0");
-  const mm = String(date.getMinutes()).padStart(2, "0");
-  return `${hh}:${mm}`;
+  return formatBeijingClock(epochSeconds);
 }
 
 function formatWindowRate(label: string, rate: BurnRate | null): string | null {
@@ -115,7 +112,7 @@ function formatWindowRate(label: string, rate: BurnRate | null): string | null {
  * The runway display segment. All numbers are the guard's verbatim fields
  * (constraint #2: the bridge never recomputes) — this function only formats:
  *  - duration from runway_seconds;
- *  - 「至 HH:MM」 from depleted_at_epoch (local clock; omitted when absent);
+ *  - 「至 HH:MM」 from depleted_at_epoch (Beijing clock; omitted when absent);
  *  - the reset-truncation note when runway_seconds ends at the basis
  *    window's reset (refresh un-blocks before depletion would).
  */
@@ -268,7 +265,7 @@ export function renderBudgetSnapshot(
   // `?? snapshot.phase` degrades an unknown phase (cross-version skew / a future
   // phase a stale bundle has not learned) to its raw string instead of rendering
   // "undefined".
-  lines.push(`【预算快照 · 账号级】阶段：${PHASE_LABELS[snapshot.phase] ?? snapshot.phase} · 更新于 ${formatEpoch(snapshot.updatedAt)}`);
+  lines.push(`【预算快照 · 账号级】阶段：${PHASE_LABELS[snapshot.phase] ?? snapshot.phase} · 更新于 ${formatEpoch(snapshot.updatedAt)}（时间均为北京时间 UTC+8）`);
   lines.push(formatAgent("Claude", snapshot.claude, snapshot.updatedAt));
   lines.push(formatAgent("Codex", snapshot.codex, snapshot.updatedAt));
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -22,6 +22,7 @@ import { consumeCheckpointBaton, consumeWrapUp, currentWindowState } from "./bud
 import { ConfigService, applyBudgetEnvOverrides } from "./config-service";
 import { BudgetCoordinator } from "./budget/budget-coordinator";
 import { createQuotaSource } from "./budget/quota-source";
+import { formatBeijing } from "./budget/format-time";
 import { retryAfterMsForResume } from "./budget/budget-gate";
 import { readGuardPending } from "./budget/pending-reader";
 import type { ResumeSignals } from "./budget/budget-fingerprint";
@@ -509,7 +510,7 @@ function budgetPauseGateError(): string {
   const snapshot = budgetCoordinator?.getSnapshot() ?? null;
   const reason = snapshot?.pauseReason ?? "Codex 侧额度接近耗尽";
   const resumeAt = snapshot?.resumeAfterEpoch
-    ? new Date(snapshot.resumeAfterEpoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z")
+    ? `${formatBeijing(snapshot.resumeAfterEpoch)}（北京时间）`
     : null;
   const sideHint = snapshot?.pauseSide === "both"
     ? "双侧额度均已耗尽，请写 checkpoint 等待刷新"
@@ -540,7 +541,7 @@ function budgetAdmissionGateError(
   quotaExhausted: boolean,
 ): string {
   const resetAt = windowResetEpoch > 0
-    ? new Date(windowResetEpoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z")
+    ? `${formatBeijing(windowResetEpoch)}（北京时间）`
     : "未知";
   const quota = BUDGET_CONFIG.maximize.wrapUpQuota;
   if (quotaExhausted) {

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BudgetCoordinator, nextBudgetPollDelayMs } from "../budget/budget-coordinator";
+import { formatBeijing } from "../budget/format-time";
 import { AdviceCooldown } from "../budget/advice-cooldown";
 import type { ResumeSignals } from "../budget/budget-fingerprint";
 import type { AgentName, AgentUsage, BudgetConfig } from "../budget/types";
@@ -1652,8 +1653,7 @@ describe("admission directive emission — v3 P3 (M3b, turnPhase-aware)", () => 
     expect(coordinator.gateState()).toBe("admission-closed");
     const ad = emitted.find((e) => e.id.startsWith("system_budget_admission"));
     expect(ad).toBeDefined();
-    const fmt = (epoch: number) => new Date(epoch * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
-    expect(ad!.content).toContain(`对应窗口约 ${fmt(NOW + 3_600)} 刷新`); // codex window
-    expect(ad!.content).not.toContain(`对应窗口约 ${fmt(NOW + 20_000)} 刷新`); // not claude's later window
+    expect(ad!.content).toContain(`对应窗口约 ${formatBeijing(NOW + 3_600)} 刷新`); // codex window
+    expect(ad!.content).not.toContain(`对应窗口约 ${formatBeijing(NOW + 20_000)} 刷新`); // not claude's later window
   });
 });

--- a/src/unit-test/budget-fingerprint.test.ts
+++ b/src/unit-test/budget-fingerprint.test.ts
@@ -7,6 +7,7 @@ import {
   resumeCandidateSides,
   type FingerprintState,
 } from "../budget/budget-fingerprint";
+import { formatBeijing } from "../budget/format-time";
 import type { AgentUsage, BudgetConfig, BudgetState } from "../budget/types";
 
 const NOW = 1_700_000_000;
@@ -366,6 +367,16 @@ describe("classifyPoll reducer — hysteresis side transitions", () => {
     const r2 = classifyPoll(r1.next, s2, CONFIG);
     expect(r2.next.side).toBe("codex");
     expect(r2.next.resumeEpoch).toBe(NOW + 3600);
+  });
+
+  test("rate-limit pause reason renders the limit time in Beijing time, not UTC", () => {
+    const s = state(usage(), usage({ gateUtil: 92, warnUtil: 92, remaining: 8, rateLimitedUntil: NOW + 900 }));
+    const { effect } = classifyPoll(INITIAL_FINGERPRINT_STATE, s, CONFIG);
+    const reason = "reason" in effect ? (effect.reason ?? "") : "";
+    expect(reason).toContain("探针被限流至");
+    expect(reason).toContain(formatBeijing(NOW + 900));
+    expect(reason).toContain("（北京时间）");
+    expect(reason).not.toContain("Z");
   });
 });
 

--- a/src/unit-test/budget-render.test.ts
+++ b/src/unit-test/budget-render.test.ts
@@ -215,15 +215,17 @@ describe("formatDuration（分钟取整，<1 小时只显分钟）", () => {
   });
 });
 
-describe("formatClockTime（本地时区 HH:MM）", () => {
-  test("formats a local wall-clock time with zero padding", () => {
-    // Construct the epoch FROM local components so the test is TZ-agnostic.
-    const epoch = Math.floor(new Date(2026, 5, 11, 8, 5).getTime() / 1000);
+describe("formatClockTime（北京时区 HH:MM）", () => {
+  test("formats a Beijing wall-clock time with zero padding", () => {
+    // Construct the epoch from UTC so the test is TZ-agnostic; +8h = Beijing.
+    // 2026-06-11 00:05 UTC = 2026-06-11 08:05 北京时间.
+    const epoch = Math.floor(Date.UTC(2026, 5, 11, 0, 5) / 1000);
     expect(formatClockTime(epoch)).toBe("08:05");
   });
 
-  test("crosses midnight into the next local day", () => {
-    const epoch = Math.floor(new Date(2026, 5, 12, 0, 7).getTime() / 1000);
+  test("crosses midnight into the next Beijing day", () => {
+    // 2026-06-11 16:07 UTC = 2026-06-12 00:07 北京时间.
+    const epoch = Math.floor(Date.UTC(2026, 5, 11, 16, 7) / 1000);
     expect(formatClockTime(epoch)).toBe("00:07");
   });
 });

--- a/src/unit-test/budget-state.test.ts
+++ b/src/unit-test/budget-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { computeBudgetState } from "../budget/budget-state";
+import { formatBeijing } from "../budget/format-time";
 import type { AgentUsage, BudgetConfig } from "../budget/types";
 
 const NOW = 1_700_000_000;
@@ -158,8 +159,8 @@ describe("computeBudgetState", () => {
     expect(state.phase).toBe("paused");
     expect(state.pause.side).toBe("codex");
     expect(state.pause.resumeAfterEpoch).toBe(NOW + 600);
-    const codexResume = new Date((NOW + 600) * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
-    const claudeReset = new Date((NOW + 7200) * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+    const codexResume = formatBeijing(NOW + 600);
+    const claudeReset = formatBeijing(NOW + 7200);
     expect(state.directiveToClaude).toContain(`预计恢复时间（以实测为准；提前刷新会更早解除）：${codexResume}`);
     expect(state.directiveToClaude).not.toContain(`预计恢复时间（以实测为准；提前刷新会更早解除）：${claudeReset}`);
   });

--- a/src/unit-test/format-time.test.ts
+++ b/src/unit-test/format-time.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { formatBeijing, formatBeijingClock } from "../budget/format-time";
+
+// Epochs are built with Date.UTC so these assertions are independent of the
+// host timezone — they verify the +8h Beijing (Asia/Shanghai) conversion.
+describe("formatBeijing", () => {
+  test("renders an epoch as Beijing-time YYYY-MM-DD HH:MM (UTC+8)", () => {
+    // 2026-06-17 16:00 UTC = 2026-06-18 00:00 北京时间 (next day).
+    const epoch = Date.UTC(2026, 5, 17, 16, 0, 0) / 1000;
+    expect(formatBeijing(epoch)).toBe("2026-06-18 00:00");
+  });
+
+  test("does not carry a UTC 'Z' suffix", () => {
+    const epoch = Date.UTC(2026, 5, 17, 16, 0, 0) / 1000;
+    expect(formatBeijing(epoch)).not.toContain("Z");
+  });
+
+  test("returns 未知 for missing / non-positive / invalid input", () => {
+    expect(formatBeijing(0)).toBe("未知");
+    expect(formatBeijing(null)).toBe("未知");
+    expect(formatBeijing(undefined)).toBe("未知");
+    expect(formatBeijing(-5)).toBe("未知");
+  });
+});
+
+describe("formatBeijingClock", () => {
+  test("renders a Beijing-time HH:MM wall clock (UTC+8)", () => {
+    // 2026-06-17 16:05 UTC = 2026-06-18 00:05 北京时间.
+    const epoch = Date.UTC(2026, 5, 17, 16, 5, 0) / 1000;
+    expect(formatBeijingClock(epoch)).toBe("00:05");
+  });
+
+  test("returns 未知 for invalid input", () => {
+    expect(formatBeijingClock(0)).toBe("未知");
+    expect(formatBeijingClock(null)).toBe("未知");
+  });
+});


### PR DESCRIPTION
## 问题 / Problem

面向用户的额度/预算时间戳一律渲染成 **UTC（带 `Z`）**——`get_budget` 文本、预算协调通知（`5h重置=2026-06-17 16:00:00Z`）、暂停/admission 闸门错误、探针限流原因。用户在北京，每次都要自己 +8 心算。

## 修法 / Fix

统一渲染成**北京时间（UTC+8 / Asia/Shanghai）**，并由**共享格式化器在代码层保证**（不依赖 per-session memory，换任何项目都生效）。

- 新增 `src/budget/format-time.ts`：`formatBeijing` / `formatBeijingClock`，基于 `Intl.DateTimeFormat` + `timeZone: "Asia/Shanghai"`（中国无 DST → 恒 +8）；非法/缺失输入返回「未知」。
- `render.ts`（get_budget）：`formatEpoch`/`formatClockTime` 委托北京格式化器；快照头部加「（时间均为北京时间 UTC+8）」。
- `budget-state.ts`（协调通知）：`formatEpoch` → 北京；`usageSummary` 加「（北京时间）」。
- `budget-fingerprint.ts`：探针限流原因「探针被限流至 …」（经 directive content 面向用户——**不是** dedup key）→ 北京 + 标注。
- `daemon.ts`：暂停闸门 / admission 闸门错误时间戳 → 北京 + 标注。
- 非额度时间戳（日志、MCP channel meta、文件 createdAt、dedup fingerprint bucket）**刻意保留 ISO/UTC**。

## 测试 / Tests

- 新增 `src/unit-test/format-time.test.ts`：用 `Date.UTC` 锚定 +8 转换（TZ 无关，独立 oracle）。
- 更新 budget render/state/coordinator/fingerprint 测试；新增探针限流原因断言（北京值 + 「（北京时间）」+ 不含 `Z`）。
- `bun run check` 全绿：**1620 测试 + plugin sync + 版本对齐 0.1.20**。

## Review

3 轮跨引擎 review：round-1 抓到并修复 1 个 HIGH（探针限流原因漏改、仍 UTC，经实证会渲染给用户）；round-2 / round-3 连续两轮 0 REAL（含对抗性实测 Bun `Intl` 午夜/跨年/极值边界）。

## 部署说明

bundle 已随源码重建并提交（`plugins/agentbridge/server/*`，plugin sync 已验证）。**部署（install-global / 重启 daemon）需用户在无运行中任务时手动触发**，本 PR 不含自动部署。
