### PR TITLE
feat(budget): fresh-if-stale get_budget + activity-gated idle advice / 决策时实时额度 + 空闲降噪

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14161,6 +14161,7 @@ var DEFAULT_MAX_BUFFERED_MESSAGES = 100;
 var DEFAULT_MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
 var DEFAULT_DEDUPE_CAPACITY = 2048;
 var DEFAULT_DEDUPE_TTL_MS = 20 * 60 * 1000;
+var DEFAULT_BUDGET_FRESH_TTL_MS = 25 * 1000;
 var CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
   "",
@@ -14224,6 +14225,10 @@ class ClaudeAdapter extends EventEmitter {
   monotonicNow;
   deliveredMessageIds = new Map;
   budgetSnapshot = null;
+  budgetFreshTtlMs;
+  wallNow;
+  requestFreshSnapshot = null;
+  pendingBudgetRefresh = null;
   constructor(logFile = new StateDirResolver().logFile, options = {}) {
     super();
     this.logFile = logFile;
@@ -14240,6 +14245,8 @@ class ClaudeAdapter extends EventEmitter {
     this.dedupeCapacity = positiveIntegerOr(options.dedupeCapacity, DEFAULT_DEDUPE_CAPACITY);
     this.dedupeTtlMs = positiveIntegerOr(options.dedupeTtlMs, DEFAULT_DEDUPE_TTL_MS);
     this.monotonicNow = options.now ?? (() => performance.now());
+    this.budgetFreshTtlMs = positiveIntegerOr(options.budgetFreshTtlMs, parsePositiveIntegerEnv("AGENTBRIDGE_BUDGET_FRESH_TTL_SEC", DEFAULT_BUDGET_FRESH_TTL_MS / 1000) * 1000);
+    this.wallNow = options.wallNow ?? (() => Date.now());
     this.server = new Server({ name: "agentbridge", version: "0.1.0" }, {
       capabilities: {
         experimental: { "claude/channel": {} },
@@ -14266,6 +14273,9 @@ class ClaudeAdapter extends EventEmitter {
   }
   setBudgetSnapshot(snapshot) {
     this.budgetSnapshot = snapshot;
+  }
+  setRequestFreshSnapshot(fetcher) {
+    this.requestFreshSnapshot = fetcher;
   }
   async pushNotification(message) {
     this.log(`pushNotification (instance=${this.instanceId}, msgId=${message.id}, len=${message.content.length})`);
@@ -14543,12 +14553,41 @@ chat_id: ${this.sessionId}`);
       content: [{ type: "text", text: `Resume acknowledged (resume_id=${resumeIdRaw}, status=${status}).` }]
     };
   }
-  handleGetBudget() {
-    this.log(`get_budget called (instance=${this.instanceId}, hasSnapshot=${this.budgetSnapshot !== null})`);
-    const text = this.budgetSnapshot ? renderBudgetSnapshot(this.budgetSnapshot) : BUDGET_UNAVAILABLE_TEXT;
+  async handleGetBudget() {
+    let snapshot = this.budgetSnapshot;
+    const fresh = snapshot !== null && this.isBudgetSnapshotFresh(snapshot);
+    this.log(`get_budget called (instance=${this.instanceId}, hasSnapshot=${snapshot !== null}, fresh=${fresh})`);
+    if (!fresh && this.requestFreshSnapshot) {
+      const refreshed = await this.refreshBudgetSnapshot();
+      snapshot = refreshed ?? this.budgetSnapshot;
+    }
+    const text = snapshot ? renderBudgetSnapshot(snapshot) : BUDGET_UNAVAILABLE_TEXT;
     return {
       content: [{ type: "text", text }]
     };
+  }
+  isBudgetSnapshotFresh(snapshot) {
+    if (!snapshot.updatedAt || snapshot.updatedAt <= 0)
+      return false;
+    const ageMs = this.wallNow() - snapshot.updatedAt * 1000;
+    return ageMs < this.budgetFreshTtlMs;
+  }
+  refreshBudgetSnapshot() {
+    if (!this.requestFreshSnapshot)
+      return Promise.resolve(null);
+    if (!this.pendingBudgetRefresh) {
+      this.pendingBudgetRefresh = this.requestFreshSnapshot().then((snapshot) => {
+        if (snapshot)
+          this.budgetSnapshot = snapshot;
+        return snapshot;
+      }).catch((error2) => {
+        this.log(`get_budget refresh failed: ${error2 instanceof Error ? error2.message : String(error2)}`);
+        return null;
+      }).finally(() => {
+        this.pendingBudgetRefresh = null;
+      });
+    }
+    return this.pendingBudgetRefresh;
   }
   async handleReply(args) {
     const text = args?.text;
@@ -14668,10 +14707,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.21", "0.0.0-source"),
-  commit: defineString("d6034c6", "source"),
+  commit: defineString("99d0f4a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("8354efa9fcad", "source")
+  codeHash: defineString("58759085e3a3", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)
@@ -14875,9 +14914,26 @@ class DaemonClient extends EventEmitter2 {
       send: () => this.send({ type: "probe_incumbent" })
     });
   }
+  async requestBudgetRefresh(timeoutMs = 3000) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return null;
+    }
+    const requestId = `budget_${Date.now()}_${this.nextRequestId++}`;
+    return this.awaitTypedResponse({
+      key: "budget_refresh",
+      successEvent: "budgetRefresh",
+      match: (payload) => payload.requestId === requestId,
+      successValue: (payload) => payload.snapshot,
+      failValue: null,
+      timeoutMs,
+      send: () => this.send({ type: "request_budget_refresh", requestId })
+    });
+  }
   awaitTypedResponse(opts) {
-    const { key, successEvent, successValue, failValue, timeoutMs, send } = opts;
+    const { key, successEvent, successValue, failValue, timeoutMs, send, match } = opts;
     const onSuccess = (payload) => {
+      if (match && !match(payload))
+        return;
       this.pendingEventWaiters.settle(key, successValue(payload));
     };
     const onRejected = () => {
@@ -14977,6 +15033,9 @@ class DaemonClient extends EventEmitter2 {
           return;
         case "incumbent_status":
           this.emit("incumbentStatus", { connected: message.connected, alive: message.alive });
+          return;
+        case "budget_refresh":
+          this.emit("budgetRefresh", { requestId: message.requestId, snapshot: message.snapshot });
           return;
       }
     };
@@ -15694,6 +15753,8 @@ import { join as join2 } from "path";
 var DEFAULT_BUDGET_CONFIG = {
   enabled: true,
   pollSeconds: 300,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,
@@ -15755,7 +15816,7 @@ function findShapeViolation(raw) {
     if (!isRecord(budget)) {
       return "budget is present but not an object";
     }
-    const numericKeys = ["pauseAt", "resumeBelow", "pollSeconds", "syncDriftPct"];
+    const numericKeys = ["pauseAt", "resumeBelow", "pollSeconds", "syncDriftPct", "budgetFreshTtlSec", "idleAdviceActivityWindowSec"];
     for (const key of numericKeys) {
       if (key in budget && !isCoercibleNumber(budget[key])) {
         return `budget.${key} is present but not a number`;
@@ -15809,7 +15870,7 @@ function hasCustomDecisionValues(config2) {
   const d = DEFAULT_CONFIG;
   const b = config2.budget;
   const db = d.budget;
-  return config2.idleShutdownSeconds !== d.idleShutdownSeconds || config2.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config2.codex.appPort !== d.codex.appPort || config2.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct || b.maximize.admissionAt !== db.maximize.admissionAt || b.maximize.wrapUpQuota !== db.maximize.wrapUpQuota || b.allocation.minRunwayRatio !== db.allocation.minRunwayRatio || b.allocation.minRunwayGapHours !== db.allocation.minRunwayGapHours;
+  return config2.idleShutdownSeconds !== d.idleShutdownSeconds || config2.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config2.codex.appPort !== d.codex.appPort || config2.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.budgetFreshTtlSec !== db.budgetFreshTtlSec || b.idleAdviceActivityWindowSec !== db.idleAdviceActivityWindowSec || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct || b.maximize.admissionAt !== db.maximize.admissionAt || b.maximize.wrapUpQuota !== db.maximize.wrapUpQuota || b.allocation.minRunwayRatio !== db.allocation.minRunwayRatio || b.allocation.minRunwayGapHours !== db.allocation.minRunwayGapHours;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -15905,6 +15966,8 @@ function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
   return {
     enabled: normalizeBoolean(budget.enabled, fallback.enabled),
     pollSeconds: normalizeBoundedInteger(budget.pollSeconds, fallback.pollSeconds, 5, 3600),
+    budgetFreshTtlSec: normalizeBoundedInteger(budget.budgetFreshTtlSec, fallback.budgetFreshTtlSec, 1, 300),
+    idleAdviceActivityWindowSec: normalizeBoundedInteger(budget.idleAdviceActivityWindowSec, fallback.idleAdviceActivityWindowSec, 0, 86400),
     pauseAt,
     resumeBelow,
     syncDriftPct: normalizeBoundedInteger(budget.syncDriftPct, fallback.syncDriftPct, 1, 100),
@@ -15917,6 +15980,37 @@ function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
     maximize: normalizeMaximizeConfig(budget.maximize, pauseAt, fallback.maximize),
     allocation: normalizeAllocationConfig(budget.allocation, fallback.allocation)
   };
+}
+function applyBudgetEnvOverrides(budget, env = process.env) {
+  const overlay = {
+    enabled: env.AGENTBRIDGE_BUDGET_ENABLED ?? budget.enabled,
+    pollSeconds: env.AGENTBRIDGE_BUDGET_POLL_SECONDS ?? budget.pollSeconds,
+    budgetFreshTtlSec: env.AGENTBRIDGE_BUDGET_FRESH_TTL_SEC ?? budget.budgetFreshTtlSec,
+    idleAdviceActivityWindowSec: env.AGENTBRIDGE_BUDGET_IDLE_ADVICE_ACTIVITY_WINDOW_SEC ?? budget.idleAdviceActivityWindowSec,
+    pauseAt: env.AGENTBRIDGE_BUDGET_PAUSE_AT ?? budget.pauseAt,
+    resumeBelow: env.AGENTBRIDGE_BUDGET_RESUME_BELOW ?? budget.resumeBelow,
+    syncDriftPct: env.AGENTBRIDGE_BUDGET_SYNC_DRIFT_PCT ?? budget.syncDriftPct,
+    parallel: {
+      minRemainingPct: env.AGENTBRIDGE_BUDGET_PARALLEL_MIN_REMAINING_PCT ?? budget.parallel.minRemainingPct,
+      timeWindowSec: env.AGENTBRIDGE_BUDGET_PARALLEL_TIME_WINDOW_SEC ?? budget.parallel.timeWindowSec
+    },
+    codexTierControl: env.AGENTBRIDGE_BUDGET_CODEX_TIER_CONTROL ?? budget.codexTierControl,
+    codexTiers: budget.codexTiers,
+    maximize: {
+      targetUtil: env.AGENTBRIDGE_BUDGET_TARGET_UTIL ?? budget.maximize.targetUtil,
+      reserveSlopePctPerHour: env.AGENTBRIDGE_BUDGET_RESERVE_SLOPE_PCT_PER_HOUR ?? budget.maximize.reserveSlopePctPerHour,
+      reserveMaxPct: env.AGENTBRIDGE_BUDGET_RESERVE_MAX_PCT ?? budget.maximize.reserveMaxPct,
+      finishingHorizonMinutes: env.AGENTBRIDGE_BUDGET_FINISHING_HORIZON_MINUTES ?? budget.maximize.finishingHorizonMinutes,
+      resumeHysteresisPct: env.AGENTBRIDGE_BUDGET_RESUME_HYSTERESIS_PCT ?? budget.maximize.resumeHysteresisPct,
+      admissionAt: env.AGENTBRIDGE_BUDGET_ADMISSION_AT ?? budget.maximize.admissionAt,
+      wrapUpQuota: env.AGENTBRIDGE_BUDGET_WRAP_UP_QUOTA ?? budget.maximize.wrapUpQuota
+    },
+    allocation: {
+      minRunwayRatio: env.AGENTBRIDGE_BUDGET_MIN_RUNWAY_RATIO ?? budget.allocation.minRunwayRatio,
+      minRunwayGapHours: env.AGENTBRIDGE_BUDGET_MIN_RUNWAY_GAP_HOURS ?? budget.allocation.minRunwayGapHours
+    }
+  };
+  return normalizeBudgetConfig(overlay, budget);
 }
 function normalizeConfig(raw) {
   if (!isRecord(raw))
@@ -16397,8 +16491,12 @@ var config2 = configService.loadOrDefault(processLogger.log);
 var CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10);
 var daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 var CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
-var claude = new ClaudeAdapter(stateDir.logFile);
+var effectiveBudget = applyBudgetEnvOverrides(config2.budget);
+var claude = new ClaudeAdapter(stateDir.logFile, {
+  budgetFreshTtlMs: effectiveBudget.budgetFreshTtlSec * 1000
+});
 var daemonClient = new DaemonClient(CONTROL_WS_URL, { identity: currentClientIdentity });
+claude.setRequestFreshSnapshot(() => daemonClient.requestBudgetRefresh());
 var shuttingDown = false;
 var daemonDisabled = false;
 var daemonDisabledReason = null;

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.21", "0.0.0-source"),
-  commit: defineString("d6034c6", "source"),
+  commit: defineString("99d0f4a", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("8354efa9fcad", "source")
+  codeHash: defineString("58759085e3a3", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -3478,6 +3478,8 @@ import { join as join4 } from "path";
 var DEFAULT_BUDGET_CONFIG = {
   enabled: true,
   pollSeconds: 300,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,
@@ -3539,7 +3541,7 @@ function findShapeViolation(raw) {
     if (!isRecord(budget)) {
       return "budget is present but not an object";
     }
-    const numericKeys = ["pauseAt", "resumeBelow", "pollSeconds", "syncDriftPct"];
+    const numericKeys = ["pauseAt", "resumeBelow", "pollSeconds", "syncDriftPct", "budgetFreshTtlSec", "idleAdviceActivityWindowSec"];
     for (const key of numericKeys) {
       if (key in budget && !isCoercibleNumber(budget[key])) {
         return `budget.${key} is present but not a number`;
@@ -3593,7 +3595,7 @@ function hasCustomDecisionValues(config) {
   const d = DEFAULT_CONFIG;
   const b = config.budget;
   const db = d.budget;
-  return config.idleShutdownSeconds !== d.idleShutdownSeconds || config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config.codex.appPort !== d.codex.appPort || config.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct || b.maximize.admissionAt !== db.maximize.admissionAt || b.maximize.wrapUpQuota !== db.maximize.wrapUpQuota || b.allocation.minRunwayRatio !== db.allocation.minRunwayRatio || b.allocation.minRunwayGapHours !== db.allocation.minRunwayGapHours;
+  return config.idleShutdownSeconds !== d.idleShutdownSeconds || config.turnCoordination.attentionWindowSeconds !== d.turnCoordination.attentionWindowSeconds || config.codex.appPort !== d.codex.appPort || config.codex.proxyPort !== d.codex.proxyPort || b.enabled !== db.enabled || b.pollSeconds !== db.pollSeconds || b.budgetFreshTtlSec !== db.budgetFreshTtlSec || b.idleAdviceActivityWindowSec !== db.idleAdviceActivityWindowSec || b.pauseAt !== db.pauseAt || b.resumeBelow !== db.resumeBelow || b.syncDriftPct !== db.syncDriftPct || b.parallel.minRemainingPct !== db.parallel.minRemainingPct || b.parallel.timeWindowSec !== db.parallel.timeWindowSec || b.codexTierControl !== db.codexTierControl || b.maximize.targetUtil !== db.maximize.targetUtil || b.maximize.reserveSlopePctPerHour !== db.maximize.reserveSlopePctPerHour || b.maximize.reserveMaxPct !== db.maximize.reserveMaxPct || b.maximize.finishingHorizonMinutes !== db.maximize.finishingHorizonMinutes || b.maximize.resumeHysteresisPct !== db.maximize.resumeHysteresisPct || b.maximize.admissionAt !== db.maximize.admissionAt || b.maximize.wrapUpQuota !== db.maximize.wrapUpQuota || b.allocation.minRunwayRatio !== db.allocation.minRunwayRatio || b.allocation.minRunwayGapHours !== db.allocation.minRunwayGapHours;
 }
 function normalizeInteger(value, fallback) {
   if (typeof value === "number" && Number.isFinite(value))
@@ -3689,6 +3691,8 @@ function normalizeBudgetConfig(raw, fallback = DEFAULT_BUDGET_CONFIG) {
   return {
     enabled: normalizeBoolean(budget.enabled, fallback.enabled),
     pollSeconds: normalizeBoundedInteger(budget.pollSeconds, fallback.pollSeconds, 5, 3600),
+    budgetFreshTtlSec: normalizeBoundedInteger(budget.budgetFreshTtlSec, fallback.budgetFreshTtlSec, 1, 300),
+    idleAdviceActivityWindowSec: normalizeBoundedInteger(budget.idleAdviceActivityWindowSec, fallback.idleAdviceActivityWindowSec, 0, 86400),
     pauseAt,
     resumeBelow,
     syncDriftPct: normalizeBoundedInteger(budget.syncDriftPct, fallback.syncDriftPct, 1, 100),
@@ -3706,6 +3710,8 @@ function applyBudgetEnvOverrides(budget, env = process.env) {
   const overlay = {
     enabled: env.AGENTBRIDGE_BUDGET_ENABLED ?? budget.enabled,
     pollSeconds: env.AGENTBRIDGE_BUDGET_POLL_SECONDS ?? budget.pollSeconds,
+    budgetFreshTtlSec: env.AGENTBRIDGE_BUDGET_FRESH_TTL_SEC ?? budget.budgetFreshTtlSec,
+    idleAdviceActivityWindowSec: env.AGENTBRIDGE_BUDGET_IDLE_ADVICE_ACTIVITY_WINDOW_SEC ?? budget.idleAdviceActivityWindowSec,
     pauseAt: env.AGENTBRIDGE_BUDGET_PAUSE_AT ?? budget.pauseAt,
     resumeBelow: env.AGENTBRIDGE_BUDGET_RESUME_BELOW ?? budget.resumeBelow,
     syncDriftPct: env.AGENTBRIDGE_BUDGET_SYNC_DRIFT_PCT ?? budget.syncDriftPct,
@@ -4846,6 +4852,7 @@ class BudgetCoordinator {
   resumeSignals;
   adviceCooldown;
   isCodexTurnActive;
+  hasRecentActivity;
   timer = null;
   running = false;
   fpState = INITIAL_FINGERPRINT_STATE;
@@ -4876,6 +4883,7 @@ class BudgetCoordinator {
       log: this.log
     });
     this.isCodexTurnActive = options.isCodexTurnActive ?? (() => false);
+    this.hasRecentActivity = options.hasRecentActivity ?? (() => true);
   }
   async start() {
     if (this.running || !this.config.enabled)
@@ -4907,6 +4915,24 @@ class BudgetCoordinator {
   }
   getSnapshot() {
     return this.latestSnapshot;
+  }
+  async refreshSnapshotReadonly() {
+    let usage;
+    try {
+      usage = await this.source.fetchBoth();
+    } catch (error) {
+      this.log(`budget readonly refresh failed: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+    if (!usage)
+      return null;
+    const now = this.now();
+    const runway = {
+      claude: agentRunway(usage.claude, now),
+      codex: agentRunway(usage.codex, now)
+    };
+    const state = computeBudgetState(usage.claude, usage.codex, this.config, now, runway);
+    return this.toSnapshot(state, runway);
   }
   getResumeCandidate() {
     const { detail, ...rest } = this.resumeCandidate;
@@ -5022,6 +5048,12 @@ class BudgetCoordinator {
       }
       case "advise": {
         if (this.gateState() !== "open") {
+          this.fpState = { ...this.fpState, fingerprint: null };
+          return;
+        }
+        const activityWindowSec = this.config.idleAdviceActivityWindowSec;
+        if (activityWindowSec > 0 && !this.hasRecentActivity(activityWindowSec)) {
+          this.log(`budget advise suppressed: no agent activity in last ${activityWindowSec}s`);
           this.fpState = { ...this.fpState, fingerprint: null };
           return;
         }
@@ -6795,7 +6827,8 @@ function ensureBudgetCoordinatorStarted() {
         });
       },
       resumeSignals: readResumeSignals,
-      isCodexTurnActive: () => codex.turnInProgress
+      isCodexTurnActive: () => codex.turnInProgress,
+      hasRecentActivity: (windowSec) => codex.turnInProgress || Date.now() - lastActivityEpochMs <= windowSec * 1000
     });
   }
   budgetCoordinator.start();
@@ -6924,6 +6957,7 @@ codex.on("steerFailed", ({ requestId, reason }) => {
 });
 codex.on("steerAccepted", ({ requestId }) => {
   log("Steer accepted by app-server");
+  recordAgentActivity();
   const dispatch = pendingSteerDispatches.get(requestId);
   pendingSteerDispatches.delete(requestId);
   if (dispatch?.requireReply) {
@@ -6993,13 +7027,19 @@ codex.on("turnTrackingReset", (reason) => {
   pendingSteerDispatches.clear();
   resumeInjectionQueue.onTurnTrackingReset();
 });
+var lastActivityEpochMs = 0;
+function recordAgentActivity() {
+  lastActivityEpochMs = Date.now();
+}
 codex.on("turnStarted", () => {
   log("Codex turn started");
+  recordAgentActivity();
   emitToClaude(systemMessage("system_turn_started", "\u23F3 Codex is working on the current task. Wait for completion before sending a reply."));
 });
 codex.on("agentMessage", (msg) => {
   if (msg.source !== "codex")
     return;
+  recordAgentActivity();
   const route = routeCodexMessage(msg.content, {
     mode: FILTER_MODE,
     replyArmed: replyTracker.isArmed,
@@ -7215,6 +7255,11 @@ function handleControlMessage(ws, raw) {
     case "probe_incumbent":
       handleProbeIncumbent(ws).catch((err) => {
         log(`handleProbeIncumbent threw for #${ws.data.clientId}: ${err?.message ?? err}`);
+      });
+      return;
+    case "request_budget_refresh":
+      handleRequestBudgetRefresh(ws, message.requestId).catch((err) => {
+        log(`handleRequestBudgetRefresh threw for #${ws.data.clientId}: ${err?.message ?? err}`);
       });
       return;
     case "claude_to_codex": {
@@ -7574,6 +7619,11 @@ async function handleProbeIncumbent(ws) {
     connected: stillConnected,
     alive: stillConnected && alive
   });
+}
+async function handleRequestBudgetRefresh(ws, requestId) {
+  const snapshot = budgetCoordinator ? await budgetCoordinator.refreshSnapshotReadonly() : null;
+  log(`request_budget_refresh from #${ws.data.clientId}: ${snapshot ? "fresh" : "unavailable"}`);
+  sendProtocolMessage(ws, { type: "budget_refresh", requestId, snapshot });
 }
 async function probeLiveness2(ws, timeoutMs) {
   return probeLiveness({

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -6,7 +6,7 @@ import { BUILD_INFO } from "./build-info";
 import { DaemonClient } from "./daemon-client";
 import { DaemonLifecycle } from "./daemon-lifecycle";
 import { StateDirResolver } from "./state-dir";
-import { ConfigService } from "./config-service";
+import { ConfigService, applyBudgetEnvOverrides } from "./config-service";
 import { disabledReplyError, shouldEmitReconnectSuccess, type BridgeDisabledReason } from "./bridge-disabled-state";
 import { guardAgentBridgeEnv, normalizeEnvGuardMode } from "./env-guard";
 import { pairScopedCommand } from "./pair-command";
@@ -45,11 +45,24 @@ const CONTROL_PORT = parseInt(process.env.AGENTBRIDGE_CONTROL_PORT ?? "4502", 10
 const daemonLifecycle = new DaemonLifecycle({ stateDir, controlPort: CONTROL_PORT, log });
 const CONTROL_WS_URL = daemonLifecycle.controlWsUrl;
 
-const claude = new ClaudeAdapter(stateDir.logFile);
+// Thread the budget-freshness TTL from config → frontend so a config.json
+// `budget.budgetFreshTtlSec` actually governs get_budget (the daemon/coordinator
+// never read it — it is a frontend-only knob). applyBudgetEnvOverrides keeps the
+// env > config > default precedence consistent with the daemon side.
+const effectiveBudget = applyBudgetEnvOverrides(config.budget);
+const claude = new ClaudeAdapter(stateDir.logFile, {
+  budgetFreshTtlMs: effectiveBudget.budgetFreshTtlSec * 1000,
+});
 // Pass the identity RESOLVER (not a snapshot) so the control token is read from
 // disk on each attach: the daemon may not have written it when bridge.ts starts,
 // and a daemon restart rotates the token (arch-review P1 #283).
 const daemonClient = new DaemonClient(CONTROL_WS_URL, { identity: currentClientIdentity });
+
+// Fresh-if-stale budget (v3 P5): get_budget asks the daemon for a near-live
+// read-only snapshot when its broadcast cache is older than budgetFreshTtlMs.
+// requestBudgetRefresh is fail-open (null on timeout / closed socket / older
+// daemon), so get_budget degrades to its cached snapshot instead of hanging.
+claude.setRequestFreshSnapshot(() => daemonClient.requestBudgetRefresh());
 
 let shuttingDown = false;
 let daemonDisabled = false;

--- a/src/budget/budget-coordinator.ts
+++ b/src/budget/budget-coordinator.ts
@@ -101,6 +101,16 @@ export interface BudgetCoordinatorOptions {
    * emits immediately on entry — the safe default for unit tests.
    */
   isCodexTurnActive?: () => boolean;
+  /**
+   * Idle-noise gate: returns whether the pair had agent activity (a Codex turn,
+   * an agentMessage, or a Claude→Codex forward) within `windowSec`. Used to
+   * SUPPRESS the routine advise directives (balance / underutilization) when both
+   * agents have been idle — those are pacing nudges that only matter while work is
+   * happening. Pause / handoff / resume / admission directives are NEVER gated by
+   * this. Absent (tests / no wiring) → treated as always-active, so advice emits
+   * immediately — the backward-compatible default.
+   */
+  hasRecentActivity?: (windowSec: number) => boolean;
 }
 
 const AGENT_LABEL: Record<AgentName, string> = {
@@ -190,6 +200,7 @@ export class BudgetCoordinator {
   private readonly resumeSignals: (() => ResumeSignals) | null;
   private readonly adviceCooldown: AdviceCooldown;
   private readonly isCodexTurnActive: () => boolean;
+  private readonly hasRecentActivity: (windowSec: number) => boolean;
 
   private timer: BudgetPollTimer | null = null;
   private running = false;
@@ -240,6 +251,9 @@ export class BudgetCoordinator {
         log: this.log,
       });
     this.isCodexTurnActive = options.isCodexTurnActive ?? (() => false);
+    // Default always-active → advice never suppressed when no activity signal is
+    // wired (tests / standalone), preserving prior behavior.
+    this.hasRecentActivity = options.hasRecentActivity ?? (() => true);
   }
 
   async start(): Promise<void> {
@@ -280,6 +294,35 @@ export class BudgetCoordinator {
 
   getSnapshot(): BudgetSnapshot | null {
     return this.latestSnapshot;
+  }
+
+  /**
+   * Fresh, read-only budget snapshot for an on-demand get_budget call
+   * (fresh-if-stale at a task-allocation decision). Does a single fetch + compute
+   * and returns the snapshot, but NEVER advances coordinator state: no directive
+   * emit, no onPauseChange, no fingerprint/admission/sequence mutation, no
+   * setSnapshot/onSnapshot, no pending-override update. Mirrors pollOnce's
+   * fetch+compute (runway computed ONCE, same as the poll) minus every side
+   * effect, so it is safe to call repeatedly and even while polling is stopped.
+   * Returns null when the fetch fails or yields no usage.
+   */
+  async refreshSnapshotReadonly(): Promise<BudgetSnapshot | null> {
+    let usage: Awaited<ReturnType<QuotaSourceLike["fetchBoth"]>>;
+    try {
+      usage = await this.source.fetchBoth();
+    } catch (error) {
+      this.log(`budget readonly refresh failed: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+    if (!usage) return null;
+
+    const now = this.now();
+    const runway: RunwayInput = {
+      claude: agentRunway(usage.claude, now),
+      codex: agentRunway(usage.codex, now),
+    };
+    const state = computeBudgetState(usage.claude, usage.codex, this.config, now, runway);
+    return this.toSnapshot(state, runway);
   }
 
   /**
@@ -495,6 +538,22 @@ export class BudgetCoordinator {
           // returns kind:"none" → the legitimate balance/underutilization advice is
           // permanently lost for the episode (round-2 REAL, both review engines).
           // Nulling it makes the next OPEN-gate poll recompute and emit exactly once.
+          this.fpState = { ...this.fpState, fingerprint: null };
+          return;
+        }
+        // Idle-noise gate (v3 P5): balance / underutilization are pacing NUDGES
+        // that only matter while the pair is working. When both agents have been
+        // idle longer than idleAdviceActivityWindowSec, suppress the advice and
+        // RE-ARM the fingerprint (null) — same reasoning as the gate-closed branch:
+        // a bare return burns the dedup key so the advice never re-emits once
+        // activity resumes. Checked BEFORE the underutilization cooldown acquire so
+        // an idle poll never burns the cross-pair cooldown slot either. windowSec
+        // <= 0 disables the gate entirely (always emit — prior behavior). Only the
+        // advise lane is gated; pause / handoff / resume / admission are never
+        // suppressed by idleness (they are handled by their own effect branches).
+        const activityWindowSec = this.config.idleAdviceActivityWindowSec;
+        if (activityWindowSec > 0 && !this.hasRecentActivity(activityWindowSec)) {
+          this.log(`budget advise suppressed: no agent activity in last ${activityWindowSec}s`);
           this.fpState = { ...this.fpState, fingerprint: null };
           return;
         }

--- a/src/budget/types.ts
+++ b/src/budget/types.ts
@@ -179,6 +179,22 @@ export interface BudgetConfig {
   enabled: boolean;
   /** Coordinator poll interval in seconds (first poll fires immediately on start()). */
   pollSeconds: number;
+  /**
+   * Freshness TTL (seconds) for the get_budget tool. When the cached snapshot is
+   * older than this at a get_budget call, the frontend asks the daemon for a
+   * read-only on-demand refresh so a task-allocation decision reads near-live
+   * quota instead of the last poll. Default 25; range [1, 300].
+   */
+  budgetFreshTtlSec: number;
+  /**
+   * Idle-noise window (seconds) for the routine advise directives (balance /
+   * underutilization). They are suppressed when the pair has had no agent
+   * activity (a Codex turn in progress, an agentMessage, or an accepted
+   * Claude→Codex forward) within this window. Pause / handoff / resume /
+   * admission are never gated. Default 600; 0 disables the gate (always emit);
+   * range [0, 86400].
+   */
+  idleAdviceActivityWindowSec: number;
   /** Dynamic-line floor + no-burn-data fallback entry threshold on gateUtil; below guard's hard=99. */
   pauseAt: number;
   /** Joint-pause exit threshold; BOTH sides must drop below this on gateUtil. */

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -42,12 +42,21 @@ export interface ClaudeAdapterOptions {
   dedupeTtlMs?: number;
   /** Monotonic milliseconds for internal dedupe TTL; defaults to performance.now(). */
   now?: () => number;
+  /**
+   * Freshness TTL (ms) for the get_budget tool: when the cached snapshot is older
+   * than this, get_budget asks the daemon for a fresh read-only refresh before
+   * rendering. Defaults to AGENTBRIDGE_BUDGET_FRESH_TTL_SEC×1000 or 25000.
+   */
+  budgetFreshTtlMs?: number;
+  /** Wall-clock milliseconds for the budget-freshness check; defaults to Date.now(). */
+  wallNow?: () => number;
 }
 
 const DEFAULT_MAX_BUFFERED_MESSAGES = 100;
 const DEFAULT_MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
 const DEFAULT_DEDUPE_CAPACITY = 2048;
 const DEFAULT_DEDUPE_TTL_MS = 20 * 60 * 1000;
+const DEFAULT_BUDGET_FRESH_TTL_MS = 25 * 1000;
 
 export const CLAUDE_INSTRUCTIONS = [
   "Codex is an AI coding agent (OpenAI) running in a separate session on the same machine.",
@@ -120,6 +129,14 @@ export class ClaudeAdapter extends EventEmitter {
 
   // Latest budget snapshot, fed by bridge from DaemonStatus.budget broadcasts.
   private budgetSnapshot: BudgetSnapshot | null = null;
+  private readonly budgetFreshTtlMs: number;
+  private readonly wallNow: () => number;
+  // On-demand fresh-snapshot fetch (fresh-if-stale at get_budget). Wired by bridge
+  // to daemonClient.requestBudgetRefresh; absent → get_budget renders the cache.
+  private requestFreshSnapshot: (() => Promise<BudgetSnapshot | null>) | null = null;
+  // Single-flight guard: concurrent get_budget calls share ONE in-flight refresh
+  // (the no-requestId budget_refresh waiter cannot disambiguate parallel requests).
+  private pendingBudgetRefresh: Promise<BudgetSnapshot | null> | null = null;
 
   constructor(logFile = new StateDirResolver().logFile, options: ClaudeAdapterOptions = {}) {
     super();
@@ -149,6 +166,11 @@ export class ClaudeAdapter extends EventEmitter {
     this.dedupeCapacity = positiveIntegerOr(options.dedupeCapacity, DEFAULT_DEDUPE_CAPACITY);
     this.dedupeTtlMs = positiveIntegerOr(options.dedupeTtlMs, DEFAULT_DEDUPE_TTL_MS);
     this.monotonicNow = options.now ?? (() => performance.now());
+    this.budgetFreshTtlMs = positiveIntegerOr(
+      options.budgetFreshTtlMs,
+      parsePositiveIntegerEnv("AGENTBRIDGE_BUDGET_FRESH_TTL_SEC", DEFAULT_BUDGET_FRESH_TTL_MS / 1000) * 1000,
+    );
+    this.wallNow = options.wallNow ?? (() => Date.now());
 
     this.server = new Server(
       { name: "agentbridge", version: "0.1.0" },
@@ -196,6 +218,15 @@ export class ClaudeAdapter extends EventEmitter {
   /** Cache the latest budget snapshot from the daemon (null clears it). */
   setBudgetSnapshot(snapshot: BudgetSnapshot | null) {
     this.budgetSnapshot = snapshot;
+  }
+
+  /**
+   * Register the on-demand budget refresh fetcher (fresh-if-stale at get_budget).
+   * Wired by bridge.ts to daemonClient.requestBudgetRefresh. Absent → get_budget
+   * always renders the broadcast cache (prior behavior).
+   */
+  setRequestFreshSnapshot(fetcher: () => Promise<BudgetSnapshot | null>) {
+    this.requestFreshSnapshot = fetcher;
   }
 
   // ── Message Delivery ───────────────────────────────────────
@@ -548,14 +579,58 @@ export class ClaudeAdapter extends EventEmitter {
     };
   }
 
-  private handleGetBudget() {
-    this.log(`get_budget called (instance=${this.instanceId}, hasSnapshot=${this.budgetSnapshot !== null})`);
-    const text = this.budgetSnapshot
-      ? renderBudgetSnapshot(this.budgetSnapshot)
-      : BUDGET_UNAVAILABLE_TEXT;
+  private async handleGetBudget() {
+    // Fresh-if-stale: a get_budget call is an explicit task-allocation decision
+    // point, so when the broadcast cache is older than budgetFreshTtlMs ask the
+    // daemon for a read-only on-demand refresh. Fresh cache (or no fetcher wired)
+    // → render the cache directly. Refresh failure/timeout → fall back to the
+    // (stale) cache, else the unavailable text.
+    let snapshot = this.budgetSnapshot;
+    const fresh = snapshot !== null && this.isBudgetSnapshotFresh(snapshot);
+    this.log(
+      `get_budget called (instance=${this.instanceId}, hasSnapshot=${snapshot !== null}, fresh=${fresh})`,
+    );
+    if (!fresh && this.requestFreshSnapshot) {
+      const refreshed = await this.refreshBudgetSnapshot();
+      snapshot = refreshed ?? this.budgetSnapshot;
+    }
+    const text = snapshot ? renderBudgetSnapshot(snapshot) : BUDGET_UNAVAILABLE_TEXT;
     return {
       content: [{ type: "text" as const, text }],
     };
+  }
+
+  private isBudgetSnapshotFresh(snapshot: BudgetSnapshot): boolean {
+    if (!snapshot.updatedAt || snapshot.updatedAt <= 0) return false;
+    const ageMs = this.wallNow() - snapshot.updatedAt * 1000;
+    // Negative age (clock skew between daemon poll time and this process) is
+    // treated as fresh — never trigger a refresh on a future-stamped snapshot.
+    return ageMs < this.budgetFreshTtlMs;
+  }
+
+  /**
+   * Single-flight on-demand refresh: concurrent get_budget calls await ONE
+   * in-flight daemon round-trip. A successful refresh updates the cache; a null
+   * result (timeout / unavailable) leaves the existing cache untouched so the
+   * caller can fall back to it.
+   */
+  private refreshBudgetSnapshot(): Promise<BudgetSnapshot | null> {
+    if (!this.requestFreshSnapshot) return Promise.resolve(null);
+    if (!this.pendingBudgetRefresh) {
+      this.pendingBudgetRefresh = this.requestFreshSnapshot()
+        .then((snapshot) => {
+          if (snapshot) this.budgetSnapshot = snapshot;
+          return snapshot;
+        })
+        .catch((error) => {
+          this.log(`get_budget refresh failed: ${error instanceof Error ? error.message : String(error)}`);
+          return null;
+        })
+        .finally(() => {
+          this.pendingBudgetRefresh = null;
+        });
+    }
+    return this.pendingBudgetRefresh;
   }
 
   private async handleReply(args: Record<string, unknown>) {

--- a/src/config-service.ts
+++ b/src/config-service.ts
@@ -20,6 +20,8 @@ export interface AgentBridgeConfig {
 const DEFAULT_BUDGET_CONFIG: BudgetConfig = {
   enabled: true,
   pollSeconds: 300,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   // v3.2: pauseAt/resumeBelow are the no-burn-data FALLBACK line (the dynamic
   // line is primary). pauseAt also floors the dynamic line (I1). Kept well below
   // the outer quota-guard hard line (99) so the bridge pauses first and leaves
@@ -171,7 +173,7 @@ function findShapeViolation(raw: Record<string, unknown>): string | null {
     if (!isRecord(budget)) {
       return "budget is present but not an object";
     }
-    const numericKeys = ["pauseAt", "resumeBelow", "pollSeconds", "syncDriftPct"] as const;
+    const numericKeys = ["pauseAt", "resumeBelow", "pollSeconds", "syncDriftPct", "budgetFreshTtlSec", "idleAdviceActivityWindowSec"] as const;
     for (const key of numericKeys) {
       if (key in budget && !isCoercibleNumber(budget[key])) {
         return `budget.${key} is present but not a number`;
@@ -243,6 +245,8 @@ function hasCustomDecisionValues(config: AgentBridgeConfig): boolean {
     config.codex.proxyPort !== d.codex.proxyPort ||
     b.enabled !== db.enabled ||
     b.pollSeconds !== db.pollSeconds ||
+    b.budgetFreshTtlSec !== db.budgetFreshTtlSec ||
+    b.idleAdviceActivityWindowSec !== db.idleAdviceActivityWindowSec ||
     b.pauseAt !== db.pauseAt ||
     b.resumeBelow !== db.resumeBelow ||
     b.syncDriftPct !== db.syncDriftPct ||
@@ -451,6 +455,18 @@ function normalizeBudgetConfig(
       5,
       3600,
     ),
+    budgetFreshTtlSec: normalizeBoundedInteger(
+      budget.budgetFreshTtlSec,
+      fallback.budgetFreshTtlSec,
+      1,
+      300,
+    ),
+    idleAdviceActivityWindowSec: normalizeBoundedInteger(
+      budget.idleAdviceActivityWindowSec,
+      fallback.idleAdviceActivityWindowSec,
+      0,
+      86400,
+    ),
     pauseAt,
     resumeBelow,
     syncDriftPct: normalizeBoundedInteger(
@@ -495,6 +511,9 @@ export function applyBudgetEnvOverrides(
   const overlay: Record<string, unknown> = {
     enabled: env.AGENTBRIDGE_BUDGET_ENABLED ?? budget.enabled,
     pollSeconds: env.AGENTBRIDGE_BUDGET_POLL_SECONDS ?? budget.pollSeconds,
+    budgetFreshTtlSec: env.AGENTBRIDGE_BUDGET_FRESH_TTL_SEC ?? budget.budgetFreshTtlSec,
+    idleAdviceActivityWindowSec:
+      env.AGENTBRIDGE_BUDGET_IDLE_ADVICE_ACTIVITY_WINDOW_SEC ?? budget.idleAdviceActivityWindowSec,
     pauseAt: env.AGENTBRIDGE_BUDGET_PAUSE_AT ?? budget.pauseAt,
     resumeBelow: env.AGENTBRIDGE_BUDGET_RESUME_BELOW ?? budget.resumeBelow,
     syncDriftPct: env.AGENTBRIDGE_BUDGET_SYNC_DRIFT_PCT ?? budget.syncDriftPct,

--- a/src/control-protocol.ts
+++ b/src/control-protocol.ts
@@ -124,7 +124,15 @@ export type ControlClientMessage =
   // `abg claude` CLI conflict guard so a second session in the same pair errors
   // out up front instead of evicting a live incumbent (issue #68 admission still
   // arbitrates the authoritative live/stale decision at actual attach time).
-  | { type: "probe_incumbent" };
+  | { type: "probe_incumbent" }
+  /**
+   * On-demand budget refresh (fresh-if-stale). The frontend sends this when its
+   * cached snapshot is older than `budgetFreshTtlSec` at a get_budget call, so a
+   * task-allocation decision reads near-live quota rather than the last poll.
+   * The daemon replies with `budget_refresh` carrying a freshly fetched snapshot
+   * (read-only: no directive emission, no coordinator state advance).
+   */
+  | { type: "request_budget_refresh"; requestId: string };
 
 export type ControlServerMessage =
   | { type: "codex_to_claude"; message: BridgeMessage }
@@ -164,7 +172,13 @@ export type ControlServerMessage =
   // Reply to `probe_incumbent`. `connected` = a Claude frontend socket is
   // currently attached; `alive` = it responded to a liveness ping (a half-open
   // dead incumbent reports connected:true, alive:false → safe to take over).
-  | { type: "incumbent_status"; connected: boolean; alive: boolean };
+  | { type: "incumbent_status"; connected: boolean; alive: boolean }
+  // Reply to `request_budget_refresh`. `snapshot` is a freshly fetched, read-only
+  // budget snapshot (null when budget coordination is unavailable, e.g. no Codex
+  // attached or the fetch failed). The frontend renders it and refreshes its cache.
+  // `requestId` echoes the request so a straggler reply from a timed-out request
+  // never settles a LATER waiter on the long-lived control socket.
+  | { type: "budget_refresh"; requestId: string; snapshot: BudgetSnapshot | null };
 
 /** WebSocket close code sent by the daemon when a newer Claude session replaces the current one. */
 export const CLOSE_CODE_REPLACED = 4001;

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import type { BridgeMessage } from "./types";
+import type { BudgetSnapshot } from "./budget/types";
 import {
   CLOSE_CODE_REPLACED,
   CLOSE_CODE_EVICTED_STALE,
@@ -31,6 +32,8 @@ interface DaemonClientEvents {
   rejected: [number];
   status: [DaemonStatus];
   incumbentStatus: [{ connected: boolean; alive: boolean }];
+  /** Reply to request_budget_refresh: the echoed requestId + a fresh read-only snapshot (null if unavailable). */
+  budgetRefresh: [{ requestId: string; snapshot: BudgetSnapshot | null }];
   /** turn_started ACK (protocol v2 PR B): a bridge-injected turn was confirmed started. */
   turnStarted: [{ requestId: string; idempotencyKey?: string; threadId: string; turnId: string }];
 }
@@ -186,6 +189,35 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   }
 
   /**
+   * Ask the daemon for a FRESH read-only budget snapshot (fresh-if-stale at a
+   * get_budget call). Fail-OPEN: on timeout, a closed socket, a send throw, or an
+   * older daemon that stays silent, this resolves to `null` so get_budget can
+   * fall back to its cached snapshot (or the unavailable text) instead of hanging.
+   */
+  async requestBudgetRefresh(timeoutMs = 3000): Promise<BudgetSnapshot | null> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return null;
+    }
+    const requestId = `budget_${Date.now()}_${this.nextRequestId++}`;
+    return this.awaitTypedResponse<BudgetSnapshot | null>({
+      key: "budget_refresh",
+      successEvent: "budgetRefresh",
+      // Drop a straggler reply from a TIMED-OUT earlier request: only the matching
+      // requestId settles THIS waiter. Without it, a late reply from request #1
+      // (whose 3s wait already timed out while a slow daemon probe ran up to ~10s)
+      // would settle a subsequent #2 with #1's snapshot on this long-lived socket
+      // (review MEDIUM). A non-match is ignored — this waiter keeps waiting for its
+      // own reply or its own timeout.
+      match: (payload: { requestId: string; snapshot: BudgetSnapshot | null }) =>
+        payload.requestId === requestId,
+      successValue: (payload: { requestId: string; snapshot: BudgetSnapshot | null }) => payload.snapshot,
+      failValue: null,
+      timeoutMs,
+      send: () => this.send({ type: "request_budget_refresh", requestId }),
+    });
+  }
+
+  /**
    * Shared skeleton for the two event-style request/response waiters
    * (attach-status, probe-incumbent). Each waiter sends a control message and
    * awaits a single typed response, with RESOLVE-ONLY fail-open semantics on
@@ -206,15 +238,24 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
    */
   private awaitTypedResponse<T>(opts: {
     key: string;
-    successEvent: "status" | "incumbentStatus";
+    successEvent: "status" | "incumbentStatus" | "budgetRefresh";
     successValue: (payload: any) => T;
     failValue: T;
     timeoutMs: number;
     send: () => void;
+    /**
+     * Optional correlation filter. When present, a success-event payload that
+     * does NOT match is IGNORED (not settled) — used by requestBudgetRefresh so a
+     * straggler reply from a timed-out earlier request cannot settle a later
+     * waiter sharing the same message-type key. Absent → any payload settles
+     * (the original probe_incumbent / attach behavior).
+     */
+    match?: (payload: any) => boolean;
   }): Promise<T> {
-    const { key, successEvent, successValue, failValue, timeoutMs, send } = opts;
+    const { key, successEvent, successValue, failValue, timeoutMs, send, match } = opts;
 
     const onSuccess = (payload: any) => {
+      if (match && !match(payload)) return;
       this.pendingEventWaiters.settle(key, successValue(payload));
     };
     const onRejected = () => {
@@ -358,6 +399,9 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
           return;
         case "incumbent_status":
           this.emit("incumbentStatus", { connected: message.connected, alive: message.alive });
+          return;
+        case "budget_refresh":
+          this.emit("budgetRefresh", { requestId: message.requestId, snapshot: message.snapshot });
           return;
       }
     };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -494,6 +494,13 @@ function ensureBudgetCoordinatorStarted() {
       // v3 P3 (§3.2, M3b): turnPhase-aware admission directive — defer while a
       // Codex turn runs, flush on idle (see turnPhaseChanged → onCodexTurnIdle).
       isCodexTurnActive: () => codex.turnInProgress,
+      // v3 P5 idle-noise gate: routine balance/underutilization advice is
+      // suppressed when the pair has been idle. Active = an in-progress Codex turn
+      // (a long silent turn must NOT read as idle — Codex review REAL #2) OR agent
+      // activity within windowSec. The coordinator only calls this when the
+      // configured window > 0 (window = 0 disables the gate entirely).
+      hasRecentActivity: (windowSec: number) =>
+        codex.turnInProgress || Date.now() - lastActivityEpochMs <= windowSec * 1000,
     });
   }
   void budgetCoordinator.start();
@@ -788,6 +795,7 @@ codex.on("steerFailed", ({ requestId, reason }: { requestId: number; reason: str
 
 codex.on("steerAccepted", ({ requestId }: { requestId: number }) => {
   log("Steer accepted by app-server");
+  recordAgentActivity();
   // require_reply × steer (PR B): the expectation arms only NOW — "a NEW
   // forwarded agentMessage after steer-accept and before the turn's terminal
   // counts as the reply". Arming at dispatch would mis-attribute pre-steer
@@ -889,8 +897,22 @@ codex.on("turnTrackingReset", (reason: string) => {
   resumeInjectionQueue.onTurnTrackingReset();
 });
 
+// Idle-noise gate (v3 P5): last wall-clock ms at which the pair showed agent
+// activity — a Codex turn start, a Codex agentMessage, or an accepted
+// Claude→Codex steer. The budget coordinator reads hasRecentActivity() to
+// suppress the routine balance/underutilization advice while both agents are
+// idle (pause/handoff/resume/admission are never gated). Rejected injections do
+// NOT count (no recordAgentActivity on busy/budget reject) so failed retries
+// cannot keep the pair "active". A long silent Codex turn is still covered by
+// the `codex.turnInProgress` OR in hasRecentActivity below.
+let lastActivityEpochMs = 0;
+function recordAgentActivity(): void {
+  lastActivityEpochMs = Date.now();
+}
+
 codex.on("turnStarted", () => {
   log("Codex turn started");
+  recordAgentActivity();
   emitToClaude(
     systemMessage(
       "system_turn_started",
@@ -901,6 +923,7 @@ codex.on("turnStarted", () => {
 
 codex.on("agentMessage", (msg: BridgeMessage) => {
   if (msg.source !== "codex") return;
+  recordAgentActivity();
   const route = routeCodexMessage(msg.content, {
     mode: FILTER_MODE,
     replyArmed: replyTracker.isArmed,
@@ -1228,6 +1251,11 @@ function handleControlMessage(ws: ServerWebSocket<ControlSocketData>, raw: strin
     case "probe_incumbent":
       handleProbeIncumbent(ws).catch((err) => {
         log(`handleProbeIncumbent threw for #${ws.data.clientId}: ${err?.message ?? err}`);
+      });
+      return;
+    case "request_budget_refresh":
+      handleRequestBudgetRefresh(ws, message.requestId).catch((err) => {
+        log(`handleRequestBudgetRefresh threw for #${ws.data.clientId}: ${err?.message ?? err}`);
       });
       return;
     case "claude_to_codex": {
@@ -1862,6 +1890,22 @@ async function handleProbeIncumbent(ws: ServerWebSocket<ControlSocketData>) {
     connected: stillConnected,
     alive: stillConnected && alive,
   });
+}
+
+/**
+ * Answer an on-demand `request_budget_refresh` (fresh-if-stale): the frontend
+ * asks for a near-live snapshot at a get_budget call. refreshSnapshotReadonly
+ * does a single fetch + compute with NO coordinator state advance (no emit /
+ * pause / admission / setSnapshot / broadcast), so reading the budget never
+ * moves the gate. Null when no coordinator (Codex not attached yet) or the fetch
+ * failed — the frontend then falls back to its cached snapshot (or the
+ * unavailable text). `requestId` is echoed so a slow straggler reply can never
+ * settle a later waiter on the long-lived control socket (review MEDIUM).
+ */
+async function handleRequestBudgetRefresh(ws: ServerWebSocket<ControlSocketData>, requestId: string) {
+  const snapshot = budgetCoordinator ? await budgetCoordinator.refreshSnapshotReadonly() : null;
+  log(`request_budget_refresh from #${ws.data.clientId}: ${snapshot ? "fresh" : "unavailable"}`);
+  sendProtocolMessage(ws, { type: "budget_refresh", requestId, snapshot });
 }
 
 async function probeLiveness(

--- a/src/unit-test/budget-admission.test.ts
+++ b/src/unit-test/budget-admission.test.ts
@@ -21,6 +21,8 @@ const NOW = 1_000_000;
 const CFG: BudgetConfig = {
   enabled: true,
   pollSeconds: 300,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,

--- a/src/unit-test/budget-allocation.test.ts
+++ b/src/unit-test/budget-allocation.test.ts
@@ -9,6 +9,8 @@ const NOW = 1_700_000_000;
 const CONFIG: BudgetConfig = {
   enabled: true,
   pollSeconds: 60,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,

--- a/src/unit-test/budget-coordinator.test.ts
+++ b/src/unit-test/budget-coordinator.test.ts
@@ -13,6 +13,8 @@ const NOW = 1_700_000_000;
 const CONFIG: BudgetConfig = {
   enabled: true,
   pollSeconds: 0.01,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,
@@ -1655,5 +1657,77 @@ describe("admission directive emission — v3 P3 (M3b, turnPhase-aware)", () => 
     expect(ad).toBeDefined();
     expect(ad!.content).toContain(`对应窗口约 ${formatBeijing(NOW + 3_600)} 刷新`); // codex window
     expect(ad!.content).not.toContain(`对应窗口约 ${formatBeijing(NOW + 20_000)} 刷新`); // not claude's later window
+  });
+});
+
+describe("v3 P5: readonly refresh + idle advise gate", () => {
+  function makeWithActivity(
+    source: FakeSource,
+    hasRecentActivity: (windowSec: number) => boolean,
+    config: BudgetConfig = CONFIG,
+  ) {
+    const emitted: Array<{ id: string; content: string }> = [];
+    const coordinator = new BudgetCoordinator({
+      source,
+      config,
+      emit: (id, content) => emitted.push({ id, content }),
+      onPauseChange: () => {},
+      now: () => NOW,
+      log: () => {},
+      hasRecentActivity,
+    });
+    return { coordinator, emitted };
+  }
+
+  // Same shape as the working "deduplicates ... balance" test: warnUtil drift
+  // (45 vs 20 = 25 > syncDriftPct 10) → balance phase, no burn data needed.
+  const driftPair = (): FetchResult => ({
+    claude: usage({ warnUtil: 45 }),
+    codex: usage({ gateUtil: 20, warnUtil: 20 }),
+  });
+
+  test("refreshSnapshotReadonly returns a fresh snapshot WITHOUT emitting or advancing state", async () => {
+    // A pause-side codex (util 92) would emit a pause directive + pauseChange on a
+    // real poll; the read-only refresh must do neither and must not cache.
+    const source = new FakeSource([
+      { claude: usage(), codex: usage({ gateUtil: 92, warnUtil: 92, remaining: 8 }) },
+    ]);
+    const { coordinator, emitted, pauseChanges } = makeCoordinator(source);
+    const snap = await coordinator.refreshSnapshotReadonly();
+    expect(snap).not.toBeNull();
+    expect(source.calls).toBe(1);
+    expect(emitted).toEqual([]);
+    expect(pauseChanges).toEqual([]);
+    expect(coordinator.getSnapshot()).toBeNull(); // poll never ran → cache untouched
+  });
+
+  test("refreshSnapshotReadonly returns null when the fetch yields no usage", async () => {
+    const { coordinator } = makeCoordinator(new FakeSource([null]));
+    expect(await coordinator.refreshSnapshotReadonly()).toBeNull();
+  });
+
+  test("balance advice is SUPPRESSED when idle (window > 0, no recent activity)", async () => {
+    const { coordinator, emitted } = makeWithActivity(new FakeSource([driftPair()]), () => false);
+    await coordinator.start();
+    coordinator.stop();
+    expect(emitted.find((e) => e.id.startsWith("system_budget_balance"))).toBeUndefined();
+  });
+
+  test("balance advice EMITS when there is recent activity", async () => {
+    const { coordinator, emitted } = makeWithActivity(new FakeSource([driftPair()]), () => true);
+    await coordinator.start();
+    coordinator.stop();
+    expect(emitted.find((e) => e.id.startsWith("system_budget_balance"))).toBeDefined();
+  });
+
+  test("idleAdviceActivityWindowSec = 0 disables the gate — advice emits even when idle", async () => {
+    const { coordinator, emitted } = makeWithActivity(
+      new FakeSource([driftPair()]),
+      () => false,
+      { ...CONFIG, idleAdviceActivityWindowSec: 0 },
+    );
+    await coordinator.start();
+    coordinator.stop();
+    expect(emitted.find((e) => e.id.startsWith("system_budget_balance"))).toBeDefined();
   });
 });

--- a/src/unit-test/budget-fingerprint.test.ts
+++ b/src/unit-test/budget-fingerprint.test.ts
@@ -15,6 +15,8 @@ const NOW = 1_700_000_000;
 const CONFIG: BudgetConfig = {
   enabled: true,
   pollSeconds: 60,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,

--- a/src/unit-test/budget-maximize.test.ts
+++ b/src/unit-test/budget-maximize.test.ts
@@ -30,6 +30,8 @@ const NOW = 1_000_000;
 const MAXIMIZE: BudgetConfig = {
   enabled: true,
   pollSeconds: 300,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,

--- a/src/unit-test/budget-state.test.ts
+++ b/src/unit-test/budget-state.test.ts
@@ -8,6 +8,8 @@ const NOW = 1_700_000_000;
 const CONFIG: BudgetConfig = {
   enabled: true,
   pollSeconds: 60,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,

--- a/src/unit-test/config-service.test.ts
+++ b/src/unit-test/config-service.test.ts
@@ -381,6 +381,8 @@ describe("ConfigService — budget section", () => {
     expect(config.budget).toEqual({
       enabled: true,
       pollSeconds: 300,
+      budgetFreshTtlSec: 25,
+      idleAdviceActivityWindowSec: 600,
       pauseAt: 90,
       resumeBelow: 30,
       syncDriftPct: 10,
@@ -434,6 +436,8 @@ describe("ConfigService — budget section", () => {
     expect(budget).toEqual({
       enabled: false,
       pollSeconds: 120,
+      budgetFreshTtlSec: 25,
+      idleAdviceActivityWindowSec: 600,
       pauseAt: 85,
       resumeBelow: 20,
       syncDriftPct: 8,
@@ -598,6 +602,8 @@ describe("applyBudgetEnvOverrides", () => {
   const base = {
     enabled: true,
     pollSeconds: 60,
+    budgetFreshTtlSec: 25,
+    idleAdviceActivityWindowSec: 600,
     pauseAt: 90,
     resumeBelow: 30,
     syncDriftPct: 10,
@@ -648,12 +654,32 @@ describe("applyBudgetEnvOverrides", () => {
   test("empty env returns the base config unchanged", () => {
     expect(applyBudgetEnvOverrides(base, {})).toEqual(base);
   });
+
+  test("env overrides budgetFreshTtlSec and idleAdviceActivityWindowSec", () => {
+    const result = applyBudgetEnvOverrides(base, {
+      AGENTBRIDGE_BUDGET_FRESH_TTL_SEC: "10",
+      AGENTBRIDGE_BUDGET_IDLE_ADVICE_ACTIVITY_WINDOW_SEC: "0",
+    });
+    expect(result.budgetFreshTtlSec).toBe(10);
+    expect(result.idleAdviceActivityWindowSec).toBe(0); // 0 = gate disabled, a valid value
+  });
+
+  test("out-of-range fresh-TTL / idle-window env values fall back to base (boundary rules)", () => {
+    const result = applyBudgetEnvOverrides(base, {
+      AGENTBRIDGE_BUDGET_FRESH_TTL_SEC: "9000", // > 300 max
+      AGENTBRIDGE_BUDGET_IDLE_ADVICE_ACTIVITY_WINDOW_SEC: "-5", // < 0 min
+    });
+    expect(result.budgetFreshTtlSec).toBe(25);
+    expect(result.idleAdviceActivityWindowSec).toBe(600);
+  });
 });
 
 describe("applyBudgetEnvOverrides — boolean spellings", () => {
   const base = {
     enabled: true,
     pollSeconds: 60,
+    budgetFreshTtlSec: 25,
+    idleAdviceActivityWindowSec: 600,
     pauseAt: 90,
     resumeBelow: 30,
     syncDriftPct: 10,
@@ -750,6 +776,8 @@ describe("applyBudgetEnvOverrides — v3 P1 keys", () => {
   const base = {
     enabled: true,
     pollSeconds: 60,
+    budgetFreshTtlSec: 25,
+    idleAdviceActivityWindowSec: 600,
     pauseAt: 90,
     resumeBelow: 30,
     syncDriftPct: 10,

--- a/src/unit-test/daemon-client-budget.test.ts
+++ b/src/unit-test/daemon-client-budget.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { DaemonClient } from "../daemon-client";
+
+/**
+ * Unit coverage for the on-demand budget refresh round-trip
+ * (DaemonClient.requestBudgetRefresh ↔ daemon `request_budget_refresh` /
+ * `budget_refresh`). Drives the client against a fake control WS so the
+ * requestId-correlation (straggler-drop) and fail-open paths are exercised
+ * without a real daemon.
+ */
+
+interface FakeServerOptions {
+  /**
+   * "reply": echo the request's requestId. "wrong-id": answer with a DIFFERENT
+   * requestId (simulating a straggler reply from a timed-out earlier request).
+   * "silent": never answer.
+   */
+  mode: "reply" | "wrong-id" | "silent";
+  snapshot?: unknown;
+}
+
+let server: ReturnType<typeof Bun.serve> | null = null;
+
+function startFakeDaemon(opts: FakeServerOptions): string {
+  server = Bun.serve({
+    port: 0,
+    fetch(req, srv) {
+      if (srv.upgrade(req, { data: undefined })) return;
+      return new Response("expected a websocket upgrade", { status: 426 });
+    },
+    websocket: {
+      message(ws, raw) {
+        const text = typeof raw === "string" ? raw : raw.toString();
+        let msg: { type?: string; requestId?: string };
+        try {
+          msg = JSON.parse(text);
+        } catch {
+          return;
+        }
+        if (msg.type !== "request_budget_refresh") return;
+        if (opts.mode === "silent") return;
+        const requestId = opts.mode === "wrong-id" ? "stale-straggler-id" : (msg.requestId ?? "");
+        ws.send(JSON.stringify({ type: "budget_refresh", requestId, snapshot: opts.snapshot ?? null }));
+      },
+    },
+  });
+  return `ws://127.0.0.1:${server.port}/ws`;
+}
+
+afterEach(() => {
+  if (server) {
+    server.stop(true);
+    server = null;
+  }
+});
+
+// A full BudgetSnapshot stand-in; the client passes it through verbatim.
+const SNAP = {
+  phase: "normal" as const,
+  updatedAt: 1_780_000_000,
+  claude: null,
+  codex: null,
+  driftPct: 0,
+  paused: false,
+  gateClosed: false,
+  pauseSide: null,
+  pauseReason: null,
+  resumeAfterEpoch: null,
+  parallelRecommended: false,
+  codexTier: "full" as const,
+  claudeAdvice: null,
+};
+
+describe("DaemonClient.requestBudgetRefresh", () => {
+  test("returns the snapshot when the daemon echoes the matching requestId", async () => {
+    const url = startFakeDaemon({ mode: "reply", snapshot: SNAP });
+    const client = new DaemonClient(url);
+    await client.connect();
+    expect(await client.requestBudgetRefresh(1000)).toEqual(SNAP);
+    await client.disconnect();
+  });
+
+  test("returns null when the daemon reports no snapshot (coordinator unavailable)", async () => {
+    const url = startFakeDaemon({ mode: "reply", snapshot: null });
+    const client = new DaemonClient(url);
+    await client.connect();
+    expect(await client.requestBudgetRefresh(1000)).toBeNull();
+    await client.disconnect();
+  });
+
+  test("IGNORES a reply whose requestId does not match (straggler) → fails open via timeout", async () => {
+    const url = startFakeDaemon({ mode: "wrong-id", snapshot: SNAP });
+    const client = new DaemonClient(url);
+    await client.connect();
+    const start = performance.now();
+    const result = await client.requestBudgetRefresh(150);
+    expect(result).toBeNull(); // mismatched reply ignored → waiter times out, never mis-settled
+    expect(performance.now() - start).toBeGreaterThanOrEqual(140);
+    await client.disconnect();
+  });
+
+  test("fails OPEN (null) on a silent daemon that never answers", async () => {
+    const url = startFakeDaemon({ mode: "silent" });
+    const client = new DaemonClient(url);
+    await client.connect();
+    expect(await client.requestBudgetRefresh(150)).toBeNull();
+    await client.disconnect();
+  });
+});

--- a/src/unit-test/message-delivery.test.ts
+++ b/src/unit-test/message-delivery.test.ts
@@ -675,27 +675,80 @@ describe("get_budget tool (handleGetBudget)", () => {
     claudeAdvice: null,
   };
 
-  test("returns unavailable text when no snapshot is cached", () => {
+  test("returns unavailable text when no snapshot is cached", async () => {
     const adapter = new ClaudeAdapter() as any;
-    const result = adapter.handleGetBudget();
+    const result = await adapter.handleGetBudget();
     expect(result.content[0].text).toContain("预算感知不可用");
     expect(result.isError).toBeUndefined();
   });
 
-  test("renders the shared renderer output when a snapshot is cached", () => {
+  test("renders the shared renderer output when a snapshot is cached", async () => {
     const adapter = new ClaudeAdapter() as any;
     adapter.setBudgetSnapshot(snapshot);
-    const result = adapter.handleGetBudget();
+    const result = await adapter.handleGetBudget();
     expect(result.content[0].text).toContain("【预算快照 · 账号级】");
     expect(result.content[0].text).toContain("Claude：");
     expect(result.content[0].text).toContain("Codex：未知（探测不可用）");
   });
 
-  test("clearing the snapshot reverts to unavailable text", () => {
+  test("clearing the snapshot reverts to unavailable text", async () => {
     const adapter = new ClaudeAdapter() as any;
     adapter.setBudgetSnapshot(snapshot);
     adapter.setBudgetSnapshot(null);
-    const result = adapter.handleGetBudget();
+    const result = await adapter.handleGetBudget();
     expect(result.content[0].text).toContain("预算感知不可用");
+  });
+
+  // Fresh-if-stale + single-flight (v3 P5). wallNow + budgetFreshTtlMs are
+  // injected so freshness is deterministic regardless of wall-clock.
+  const NOW_MS = 1_780_711_710_000;
+  const NOW_SEC = Math.floor(NOW_MS / 1000);
+  function freshAdapter() {
+    return new ClaudeAdapter(undefined, { wallNow: () => NOW_MS, budgetFreshTtlMs: 25_000 }) as any;
+  }
+
+  test("fresh cache (within TTL) renders the cache WITHOUT calling the refresh fetcher", async () => {
+    const adapter = freshAdapter();
+    let calls = 0;
+    adapter.setRequestFreshSnapshot(async () => { calls++; return null; });
+    adapter.setBudgetSnapshot({ ...snapshot, updatedAt: NOW_SEC - 10 }); // 10s old < 25s TTL
+    const result = await adapter.handleGetBudget();
+    expect(calls).toBe(0);
+    expect(result.content[0].text).toContain("【预算快照 · 账号级】");
+  });
+
+  test("stale cache triggers an on-demand refresh and renders + caches the fresh snapshot", async () => {
+    const adapter = freshAdapter();
+    const fresh = { ...snapshot, updatedAt: NOW_SEC, claude: { ...snapshot.claude, gateUtil: 77 } };
+    let calls = 0;
+    adapter.setRequestFreshSnapshot(async () => { calls++; return fresh; });
+    adapter.setBudgetSnapshot({ ...snapshot, updatedAt: NOW_SEC - 60 }); // 60s old > 25s TTL
+    await adapter.handleGetBudget();
+    expect(calls).toBe(1);
+    expect(adapter.budgetSnapshot.claude.gateUtil).toBe(77); // cache updated to fresh
+  });
+
+  test("refresh returning null falls back to the (stale) cached snapshot", async () => {
+    const adapter = freshAdapter();
+    adapter.setRequestFreshSnapshot(async () => null); // daemon unavailable / timeout
+    adapter.setBudgetSnapshot({ ...snapshot, updatedAt: NOW_SEC - 60 });
+    const result = await adapter.handleGetBudget();
+    expect(result.content[0].text).toContain("【预算快照 · 账号级】"); // rendered from cache, not unavailable
+  });
+
+  test("concurrent stale get_budget calls share ONE in-flight refresh (single-flight)", async () => {
+    const adapter = freshAdapter();
+    let calls = 0;
+    let resolveFetch: (s: unknown) => void = () => {};
+    adapter.setRequestFreshSnapshot(() => {
+      calls++;
+      return new Promise((resolve) => { resolveFetch = resolve; });
+    });
+    adapter.setBudgetSnapshot({ ...snapshot, updatedAt: NOW_SEC - 60 });
+    const p1 = adapter.handleGetBudget();
+    const p2 = adapter.handleGetBudget();
+    resolveFetch({ ...snapshot, updatedAt: NOW_SEC });
+    await Promise.all([p1, p2]);
+    expect(calls).toBe(1);
   });
 });

--- a/src/unit-test/resume-candidate-e2e.test.ts
+++ b/src/unit-test/resume-candidate-e2e.test.ts
@@ -37,6 +37,8 @@ const CONFIG: BudgetConfig = {
   // Long poll so start() does NOT auto-fire a second poll while we drive each
   // poll explicitly; we advance the loop via pollOnce() to assert per-poll.
   pollSeconds: 300,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,

--- a/src/unit-test/resume-candidate.test.ts
+++ b/src/unit-test/resume-candidate.test.ts
@@ -15,6 +15,8 @@ const NOW = 1_700_000_000;
 const CONFIG: BudgetConfig = {
   enabled: true,
   pollSeconds: 60,
+  budgetFreshTtlSec: 25,
+  idleAdviceActivityWindowSec: 600,
   pauseAt: 90,
   resumeBelow: 30,
   syncDriftPct: 10,


### PR DESCRIPTION
> #182（北京时区）已合并到 master；本 PR 现 base=master，只含本期 budget-realtime 改动。

## 问题 / Problem

两个用户痛点：
1. **空闲也刷屏**：Claude/Codex 即使都没在跑任务，账号额度一变化 bridge 就不停推 `system_budget_balance`/欠载建议。
2. **决策时拿不到实时额度**：真正做任务分配时 `get_budget` 只返回**上一次后台轮询**的缓存（默认 pollSeconds=300s，最旧差 5 分钟），不触发实时探测。

## 修法 / Fix

**A — get_budget 过期即刷**
- 新增控制协议往返 `request_budget_refresh` ↔ `budget_refresh`（带 `requestId`，使超时请求的迟到 reply 不会在长连接上错误 settle 后续 waiter）。
- `BudgetCoordinator.refreshSnapshotReadonly()`：单次 fetch+compute，**绝不**推进状态机（不 emit/pause/admission/setSnapshot/broadcast）——读额度永不动闸门。
- `ClaudeAdapter.handleGetBudget` 改 async：缓存比 `budgetFreshTtlSec` 新就直接渲染；过期则向 daemon 请求只读刷新；single-flight（并发 get_budget 共享一次刷新）；超时/断连 fail-open 回退缓存。

**B — 空闲降噪（活动门控）**
- daemon 记 `lastActivityEpoch`（Codex turn 开始 / agentMessage / 接受的 steer 时打点）；`hasRecentActivity = codex.turnInProgress || 窗口内有活动`。
- 仅门控 advise 分支（balance/欠载）：空闲超过 `idleAdviceActivityWindowSec` 时抑制（清 fingerprint 以便活动恢复后重发；在跨对 cooldown 之前）。**暂停/接力/恢复/admission 从不门控**。`window=0` 关闭门控。

**配置**：`budgetFreshTtlSec`(25,[1,300]) + `idleAdviceActivityWindowSec`(600,[0,86400])——default/numericKeys/normalize bounds/env override/doctor 全链路。`budgetFreshTtlSec` 是前台-only 开关，经 bridge `applyBudgetEnvOverrides` 注入（env>config>default）。

## 测试 / Tests

- `bun run check` 全绿（typecheck + 测试 + plugin sync + 版本对齐）。
- 新增/更新 16 个测试：含 `daemon-client-budget.test.ts`（往返 + **straggler-drop**：daemon 回错 requestId → 客户端忽略 → fail-open）、get_budget single-flight/TTL/null 回退、活动门控 suppress/emit/window=0、`refreshSnapshotReadonly` 无副作用、config env+bounds。

## Review

- **Codex 独立设计评审** → 4 点反馈全并入（single-flight、`turnInProgress` OR、reject 不打点、`window=0` 语义）。
- **3 轮 Claude 跨引擎 review**（find→对抗性 verify）：round-1 修 2 个 MEDIUM REAL（配置未穿透前台 + straggler 竞态）；round-2/round-3 连续 0 REAL（仅一个已修的 cosmetic JSDoc 错位）。

## 部署 / Deploy

bundle 已随源码重建提交（plugin sync 已验证）。**本 PR 不含部署**——install-global / 重启 daemon 由用户在无运行中任务时手动触发。

## Backlog (非阻塞 RECOMMEND)
- `DaemonClient.requestBudgetRefresh` 仍用固定 registry key，依赖上层 single-flight；若未来有第二个直接调用点，再 key by requestId。
- 可选补 `updatedAt=0` stale 触发路径的单测。