### PR TITLE
refactor(daemon): 拆配对单例为 AgentRegistry/RoomManager/ConnectionSession (PR1a)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14707,10 +14707,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.24", "0.0.0-source"),
-  commit: defineString("99d0f4a", "source"),
+  commit: defineString("39a46f1", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("aeb64ca4c8b6", "source")
+  codeHash: defineString("f2cb1899dc80", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.24", "0.0.0-source"),
-  commit: defineString("99d0f4a", "source"),
+  commit: defineString("39a46f1", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("aeb64ca4c8b6", "source")
+  codeHash: defineString("f2cb1899dc80", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -6519,34 +6519,6 @@ var PAIR_SLOT_STRIDE = 10;
 var RECLAIMABLE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 var MAX_PAIR_SLOT = Math.floor((65535 - 2 - PAIR_BASE_PORT) / PAIR_SLOT_STRIDE);
 
-// src/liveness-probe.ts
-var OPEN = 1;
-async function probeLiveness(target, options) {
-  const {
-    timeoutMs,
-    pollMs = 50,
-    now = Date.now,
-    sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-  } = options;
-  if (target.readyState !== OPEN)
-    return false;
-  const baseline = target.pongCount;
-  try {
-    target.ping();
-  } catch {
-    return false;
-  }
-  const deadline = now() + timeoutMs;
-  while (now() < deadline) {
-    if (target.pongCount > baseline)
-      return true;
-    if (target.readyState !== OPEN)
-      return false;
-    await sleep(pollMs);
-  }
-  return target.pongCount > baseline;
-}
-
 // src/delivery-buffer.ts
 class BoundedMessageBuffer {
   messages = [];
@@ -6588,6 +6560,256 @@ class BoundedMessageBuffer {
   }
 }
 
+// src/liveness-probe.ts
+var OPEN = 1;
+async function probeLiveness(target, options) {
+  const {
+    timeoutMs,
+    pollMs = 50,
+    now = Date.now,
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+  } = options;
+  if (target.readyState !== OPEN)
+    return false;
+  const baseline = target.pongCount;
+  try {
+    target.ping();
+  } catch {
+    return false;
+  }
+  const deadline = now() + timeoutMs;
+  while (now() < deadline) {
+    if (target.pongCount > baseline)
+      return true;
+    if (target.readyState !== OPEN)
+      return false;
+    await sleep(pollMs);
+  }
+  return target.pongCount > baseline;
+}
+
+// src/connection-session.ts
+var OPEN2 = 1;
+
+class ConnectionSession {
+  ws;
+  deps;
+  constructor(ws, deps) {
+    this.ws = ws;
+    this.deps = deps;
+  }
+  get clientId() {
+    return this.ws.data.clientId;
+  }
+  get identity() {
+    return this.ws.data.identity;
+  }
+  set identity(v) {
+    this.ws.data.identity = v;
+  }
+  get readyState() {
+    return this.ws.readyState;
+  }
+  get isOpen() {
+    return this.ws.readyState === OPEN2;
+  }
+  get attached() {
+    return this.ws.data.attached;
+  }
+  get lastPongAt() {
+    return this.ws.data.lastPongAt;
+  }
+  get pongCount() {
+    return this.ws.data.pongCount;
+  }
+  get pendingBackpressureSize() {
+    return this.ws.data.pendingBackpressure.length;
+  }
+  markAttached(value) {
+    this.ws.data.attached = value;
+  }
+  recordPong() {
+    this.ws.data.lastPongAt = Date.now();
+    this.ws.data.pongCount++;
+  }
+  send(message) {
+    try {
+      const result = this.ws.send(JSON.stringify({ type: "codex_to_claude", message }));
+      if (typeof result === "number" && result === 0) {
+        this.deps.log("Bridge message send returned 0 (dropped)");
+        return false;
+      }
+      if (typeof result === "number" && result === -1) {
+        this.ws.data.pendingBackpressure.push(message);
+      }
+      return true;
+    } catch (err) {
+      this.deps.log(`Failed to send bridge message: ${err.message}`);
+      return false;
+    }
+  }
+  sendProtocol(message) {
+    try {
+      const result = this.ws.send(JSON.stringify(message));
+      if (typeof result === "number" && result === 0) {
+        this.deps.log(`Control message dropped (socket closed): type=${message.type}`);
+      }
+    } catch (err) {
+      this.deps.log(`Failed to send control message: ${err.message}`);
+    }
+  }
+  ping() {
+    this.ws.ping();
+  }
+  probeLiveness(timeoutMs) {
+    const ws = this.ws;
+    return probeLiveness({
+      get readyState() {
+        return ws.readyState;
+      },
+      get pongCount() {
+        return ws.data.pongCount;
+      },
+      ping: () => {
+        ws.ping();
+      }
+    }, { timeoutMs, pollMs: this.deps.livenessPollMs });
+  }
+  close(code, reason) {
+    this.ws.close(code, reason);
+  }
+  drainPendingBackpressureInto(backlog) {
+    const reBuffered = this.ws.data.pendingBackpressure.drainAll();
+    backlog.unshiftMany(reBuffered);
+    return reBuffered.length;
+  }
+  confirmDrainIfFlushed() {
+    if (this.ws.data.pendingBackpressure.length > 0 && this.ws.getBufferedAmount() === 0) {
+      this.ws.data.pendingBackpressure.clear();
+    }
+  }
+}
+
+// src/agent-registry.ts
+class AgentRegistry {
+  claude = null;
+  _codexBootstrapped = false;
+  _challengeInProgress = false;
+  getClaude() {
+    return this.claude;
+  }
+  setClaude(session) {
+    this.claude = session;
+  }
+  clearClaude() {
+    this.claude = null;
+  }
+  isClaude(ws) {
+    return this.claude?.ws === ws;
+  }
+  get codexBootstrapped() {
+    return this._codexBootstrapped;
+  }
+  set codexBootstrapped(value) {
+    this._codexBootstrapped = value;
+  }
+  beginChallenge() {
+    if (this._challengeInProgress)
+      return false;
+    this._challengeInProgress = true;
+    return true;
+  }
+  endChallenge() {
+    this._challengeInProgress = false;
+  }
+  get challengeInProgress() {
+    return this._challengeInProgress;
+  }
+}
+
+// src/room-manager.ts
+class RoomManager {
+  deps;
+  backlog;
+  idleShutdownTimer = null;
+  claudeDisconnectTimer = null;
+  constructor(deps) {
+    this.deps = deps;
+    this.backlog = new BoundedMessageBuffer({
+      cap: deps.bufferedCap,
+      overflowLabel: "Message buffer overflow",
+      log: deps.log
+    });
+  }
+  get backlogSize() {
+    return this.backlog.length;
+  }
+  deliverToClaude(message) {
+    const claude = this.deps.getClaude();
+    if (claude && claude.isOpen) {
+      if (claude.send(message))
+        return;
+      this.deps.log("Send to Claude failed, buffering message for retry on reconnect");
+    }
+    this.backlog.push(message);
+  }
+  flushBacklog(session) {
+    const messages = this.backlog.drainAll();
+    for (let i = 0;i < messages.length; i++) {
+      if (!session.send(messages[i])) {
+        const remaining = messages.slice(i);
+        this.backlog.unshiftMany(remaining);
+        this.deps.log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
+        return;
+      }
+    }
+  }
+  rebufferOnDetach(session) {
+    return session.drainPendingBackpressureInto(this.backlog);
+  }
+  scheduleIdleShutdown() {
+    this.cancelIdleShutdown();
+    if (this.deps.getClaude())
+      return;
+    if (this.deps.isTuiConnected())
+      return;
+    this.deps.log(`No clients connected. Daemon will shut down in ${this.deps.idleShutdownMs}ms if no one reconnects.`);
+    this.idleShutdownTimer = setTimeout(() => {
+      if (this.deps.getClaude() || this.deps.isTuiConnected()) {
+        this.deps.log("Idle shutdown cancelled: client reconnected during grace period");
+        return;
+      }
+      this.deps.onIdleShutdown("idle \u2014 no clients connected");
+    }, this.deps.idleShutdownMs);
+  }
+  cancelIdleShutdown() {
+    if (this.idleShutdownTimer) {
+      clearTimeout(this.idleShutdownTimer);
+      this.idleShutdownTimer = null;
+    }
+  }
+  clearPendingClaudeDisconnect(reason) {
+    if (!this.claudeDisconnectTimer)
+      return;
+    clearTimeout(this.claudeDisconnectTimer);
+    this.claudeDisconnectTimer = null;
+    if (reason) {
+      this.deps.log(`Cleared pending Claude disconnect notification (${reason})`);
+    }
+  }
+  scheduleClaudeDisconnectNotification(clientId) {
+    this.clearPendingClaudeDisconnect("rescheduled");
+    this.claudeDisconnectTimer = setTimeout(() => {
+      this.claudeDisconnectTimer = null;
+      if (this.deps.getClaude()) {
+        this.deps.log(`Skipping Claude disconnect notification for client #${clientId} because Claude already reconnected`);
+        return;
+      }
+      this.deps.log(`Claude disconnect persisted past grace window (client #${clientId})`);
+    }, this.deps.claudeDisconnectGraceMs);
+  }
+}
+
 // src/daemon.ts
 var stateDir = new StateDirResolver;
 stateDir.ensure();
@@ -6623,11 +6845,10 @@ var codex = new CodexAdapter(CODEX_APP_PORT, CODEX_PROXY_PORT, stateDir.logFile)
 var attachCmd = `codex --enable tui_app_server --remote ${codex.proxyUrl}`;
 var controlServer = null;
 var boundControlPort = false;
-var attachedClaude = null;
+var agentRegistry = new AgentRegistry;
 var nextControlClientId = 0;
 var nextSystemMessageId = 0;
 var SYSTEM_MSG_SALT = randomUUID4().slice(0, 8);
-var codexBootstrapped = false;
 var attentionWindowTimer = null;
 var inAttentionWindow = false;
 var replyTracker = new ReplyRequiredTracker;
@@ -6683,18 +6904,10 @@ var pendingSteerDispatches = new Map;
 var BUSY_RETRY_ADVISORY_MS = 15000;
 var shuttingDown = false;
 var bootDeadlineTimer = null;
-var idleShutdownTimer = null;
-var claudeDisconnectTimer = null;
 var lastAttachStatusSentTs = 0;
 var ATTACH_STATUS_COOLDOWN_MS = 30000;
 var LIVENESS_PROBE_TIMEOUT_MS = parsePositiveIntEnv("AGENTBRIDGE_LIVENESS_PROBE_TIMEOUT_MS", 3000, log);
 var LIVENESS_PROBE_POLL_MS = 50;
-var challengeInProgress = false;
-var bufferedMessages = new BoundedMessageBuffer({
-  cap: MAX_BUFFERED_MESSAGES,
-  overflowLabel: "Message buffer overflow",
-  log
-});
 function createPendingBackpressureBuffer() {
   return new BoundedMessageBuffer({
     cap: MAX_BUFFERED_MESSAGES,
@@ -6731,7 +6944,7 @@ function readResumeSignals() {
     log(`resume signal: codex tuiReady failed: ${error instanceof Error ? error.message : String(error)}`);
   }
   try {
-    tuiReadyClaude = attachedClaude !== null;
+    tuiReadyClaude = agentRegistry.getClaude() !== null;
   } catch (error) {
     log(`resume signal: claude tuiReady failed: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -6928,6 +7141,15 @@ var tuiConnectionState = new TuiConnectionState({
   }
 });
 var statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
+var roomManager = new RoomManager({
+  bufferedCap: MAX_BUFFERED_MESSAGES,
+  idleShutdownMs: IDLE_SHUTDOWN_MS,
+  claudeDisconnectGraceMs: CLAUDE_DISCONNECT_GRACE_MS,
+  log,
+  getClaude: () => agentRegistry.getClaude(),
+  isTuiConnected: () => tuiConnectionState.snapshot().tuiConnected,
+  onIdleShutdown: (reason) => shutdown(reason)
+});
 function tryWriteStatusFile(reason) {
   try {
     writeStatusFile();
@@ -6982,8 +7204,9 @@ codex.on("bridgeTurnStarted", ({ requestId, turnId }) => {
   if (pending.idempotencyKey) {
     idempotencyTracker.markStarted(pending.threadId, pending.idempotencyKey, turnId);
   }
-  if (attachedClaude) {
-    sendProtocolMessage(attachedClaude, {
+  const claudeForTurnStarted = agentRegistry.getClaude();
+  if (claudeForTurnStarted) {
+    claudeForTurnStarted.sendProtocol({
       type: "turn_started",
       requestId: pending.requestId,
       ...pending.idempotencyKey ? { idempotencyKey: pending.idempotencyKey } : {},
@@ -7131,8 +7354,8 @@ codex.on("error", (err) => {
 });
 codex.on("exit", (code) => {
   log(`Codex process exited (code ${code})`);
-  const wasBootstrapped = codexBootstrapped;
-  codexBootstrapped = false;
+  const wasBootstrapped = agentRegistry.codexBootstrapped;
+  agentRegistry.codexBootstrapped = false;
   replyTracker.reset();
   idempotencyTracker.terminateAll("aborted");
   pendingTurnStarts.clear();
@@ -7162,7 +7385,7 @@ function startControlServer() {
           return Response.json(currentStatus());
         }
         if (url.pathname === "/readyz") {
-          return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
+          return Response.json(currentStatus(), { status: agentRegistry.codexBootstrapped ? 200 : 503 });
         }
         if (url.pathname === "/ws") {
           if (!isAllowedWsUpgrade(req)) {
@@ -7182,11 +7405,12 @@ function startControlServer() {
           ws.data.clientId = ++nextControlClientId;
           ws.data.lastPongAt = Date.now();
           ws.data.pendingBackpressure = createPendingBackpressureBuffer();
+          ws.data.session = new ConnectionSession(ws, { log, livenessPollMs: LIVENESS_PROBE_POLL_MS });
           log(`Frontend socket opened (#${ws.data.clientId})`);
         },
         close: (ws, code, reason) => {
-          log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
-          if (attachedClaude === ws) {
+          log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${agentRegistry.isClaude(ws)})`);
+          if (agentRegistry.isClaude(ws)) {
             detachClaude(ws, "frontend socket closed");
           }
         },
@@ -7194,14 +7418,11 @@ function startControlServer() {
           handleControlMessage(ws, raw);
         },
         pong: (ws) => {
-          ws.data.lastPongAt = Date.now();
-          ws.data.pongCount++;
+          ws.data.session.recordPong();
         },
         drain: (ws) => {
-          if (ws.data.pendingBackpressure.length > 0 && ws.getBufferedAmount() === 0) {
-            ws.data.pendingBackpressure.clear();
-          }
-          if (ws === attachedClaude && bufferedMessages.length > 0) {
+          ws.data.session.confirmDrainIfFlushed();
+          if (agentRegistry.isClaude(ws) && roomManager.backlogSize > 0) {
             flushBufferedMessages(ws);
           }
         }
@@ -7319,9 +7540,10 @@ function waitForInterruptOutcome(turnIds) {
   });
 }
 async function handleClaudeToCodex(ws, message) {
-  const attachGuard = evaluateInjectionAttachGuard(attachedClaude, ws);
+  const claudeSlot = agentRegistry.getClaude();
+  const attachGuard = evaluateInjectionAttachGuard(claudeSlot?.ws ?? null, ws);
   if (!attachGuard.allowed) {
-    log(`Rejecting claude_to_codex from non-attached socket #${ws.data.clientId} ` + `(request ${message.requestId}, attached=${attachedClaude ? "#" + attachedClaude.data.clientId : "none"})`);
+    log(`Rejecting claude_to_codex from non-attached socket #${ws.data.clientId} ` + `(request ${message.requestId}, attached=${claudeSlot ? "#" + claudeSlot.clientId : "none"})`);
     sendClaudeToCodexResult(ws, message.requestId, {
       success: false,
       code: attachGuard.code,
@@ -7447,10 +7669,11 @@ async function handleClaudeToCodex(ws, message) {
       return;
     }
     log("Interrupt reached terminal boundary \u2014 injecting the message as a new turn");
-    const postWaitAttachGuard = evaluateInjectionAttachGuard(attachedClaude, ws);
+    const postWaitSlot = agentRegistry.getClaude();
+    const postWaitAttachGuard = evaluateInjectionAttachGuard(postWaitSlot?.ws ?? null, ws);
     if (!postWaitAttachGuard.allowed) {
       releaseInterruptKey();
-      log(`Rejecting interrupt-path injection from socket #${ws.data.clientId} that lost the attach ` + `slot during the terminal-boundary wait (request ${message.requestId}, ` + `attached=${attachedClaude ? "#" + attachedClaude.data.clientId : "none"})`);
+      log(`Rejecting interrupt-path injection from socket #${ws.data.clientId} that lost the attach ` + `slot during the terminal-boundary wait (request ${message.requestId}, ` + `attached=${postWaitSlot ? "#" + postWaitSlot.clientId : "none"})`);
       sendClaudeToCodexResult(ws, message.requestId, {
         success: false,
         code: "not_attached",
@@ -7528,21 +7751,20 @@ async function handleClaudeToCodex(ws, message) {
   sendClaudeToCodexResult(ws, message.requestId, { success: true });
 }
 async function attachClaude(ws, identity) {
-  const occupant = attachedClaude;
-  if (occupant && occupant !== ws && occupant.readyState !== WebSocket.CLOSED) {
-    const msSincePong = Date.now() - occupant.data.lastPongAt;
-    log(`Claude frontend contest: new=#${ws.data.clientId}, incumbent=#${occupant.data.clientId} ` + `(readyState=${occupant.readyState}, msSincePong=${msSincePong})`);
-    if (challengeInProgress) {
+  const occupant = agentRegistry.getClaude();
+  if (occupant && occupant.ws !== ws && occupant.readyState !== WebSocket.CLOSED) {
+    const msSincePong = Date.now() - occupant.lastPongAt;
+    log(`Claude frontend contest: new=#${ws.data.clientId}, incumbent=#${occupant.clientId} ` + `(readyState=${occupant.readyState}, msSincePong=${msSincePong})`);
+    if (!agentRegistry.beginChallenge()) {
       log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 another liveness probe already in flight`);
       ws.close(CLOSE_CODE_PROBE_IN_PROGRESS, "liveness probe in progress, retry shortly");
       return;
     }
-    challengeInProgress = true;
     let incumbentAlive = false;
     try {
-      incumbentAlive = await probeLiveness2(occupant, LIVENESS_PROBE_TIMEOUT_MS);
+      incumbentAlive = await occupant.probeLiveness(LIVENESS_PROBE_TIMEOUT_MS);
     } finally {
-      challengeInProgress = false;
+      agentRegistry.endChallenge();
     }
     if (ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
       log(`Contestant #${ws.data.clientId} disappeared during probe \u2014 aborting`);
@@ -7552,24 +7774,25 @@ async function attachClaude(ws, identity) {
       return;
     }
     if (incumbentAlive) {
-      log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 incumbent #${occupant.data.clientId} responded to liveness probe`);
+      log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 incumbent #${occupant.clientId} responded to liveness probe`);
       ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
       return;
     }
     evictStale(occupant, `liveness probe timed out after ${LIVENESS_PROBE_TIMEOUT_MS}ms`);
   }
-  if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
-    log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 slot re-acquired by #${attachedClaude.data.clientId} after probe`);
+  const currentSlot = agentRegistry.getClaude();
+  if (currentSlot && currentSlot.ws !== ws && currentSlot.readyState !== WebSocket.CLOSED) {
+    log(`Rejecting Claude frontend #${ws.data.clientId} \u2014 slot re-acquired by #${currentSlot.clientId} after probe`);
     ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
     return;
   }
   clearPendingClaudeDisconnect("Claude frontend attached");
   ws.data.identity = identity;
-  attachedClaude = ws;
+  agentRegistry.setClaude(ws.data.session);
   ws.data.attached = true;
   cancelIdleShutdown();
   log(`Claude frontend attached (#${ws.data.clientId}, pair=${identity?.pairId ?? "<none>"}, cwd=${identity?.cwd ?? "<unknown>"})`);
-  const hadBacklog = bufferedMessages.length > 0;
+  const hadBacklog = roomManager.backlogSize > 0;
   if (hadBacklog) {
     flushBufferedMessages(ws);
   }
@@ -7580,39 +7803,38 @@ async function attachClaude(ws, identity) {
   if (!hadBacklog && !isRapidReattach) {
     if (tuiConnectionState.canReply()) {
       sendBridgeMessage(ws, systemMessage("system_ready", currentReadyMessage()));
-    } else if (codexBootstrapped) {
+    } else if (agentRegistry.codexBootstrapped) {
       sendBridgeMessage(ws, systemMessage("system_waiting", currentWaitingMessage()));
     }
   }
   lastAttachStatusSentTs = now;
 }
 function detachClaude(ws, reason) {
-  if (attachedClaude !== ws)
+  if (!agentRegistry.isClaude(ws))
     return;
-  attachedClaude = null;
+  agentRegistry.clearClaude();
   ws.data.attached = false;
   log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
-  if (ws.data.pendingBackpressure.length > 0) {
-    const reBuffered = ws.data.pendingBackpressure.drainAll();
-    log(`Re-buffered ${reBuffered.length} backpressured message(s) for redelivery on reconnect`);
-    bufferedMessages.unshiftMany(reBuffered);
+  if (ws.data.session.pendingBackpressureSize > 0) {
+    const reBufferedCount = roomManager.rebufferOnDetach(ws.data.session);
+    log(`Re-buffered ${reBufferedCount} backpressured message(s) for redelivery on reconnect`);
   }
   scheduleClaudeDisconnectNotification(ws.data.clientId);
   scheduleIdleShutdown();
 }
 async function handleProbeIncumbent(ws) {
-  const occupant = attachedClaude;
-  log(`probe_incumbent from #${ws.data.clientId}: occupant=${occupant ? "#" + occupant.data.clientId : "none"} readyState=${occupant?.readyState}`);
-  if (!occupant || occupant === ws || occupant.readyState !== WebSocket.OPEN) {
+  const occupant = agentRegistry.getClaude();
+  log(`probe_incumbent from #${ws.data.clientId}: occupant=${occupant ? "#" + occupant.clientId : "none"} readyState=${occupant?.readyState}`);
+  if (!occupant || occupant.ws === ws || occupant.readyState !== WebSocket.OPEN) {
     sendProtocolMessage(ws, { type: "incumbent_status", connected: false, alive: false });
     return;
   }
-  if (challengeInProgress) {
+  if (agentRegistry.challengeInProgress) {
     sendProtocolMessage(ws, { type: "incumbent_status", connected: true, alive: true });
     return;
   }
-  const alive = await probeLiveness2(occupant, LIVENESS_PROBE_TIMEOUT_MS);
-  const stillConnected = attachedClaude === occupant && occupant.readyState === WebSocket.OPEN;
+  const alive = await occupant.probeLiveness(LIVENESS_PROBE_TIMEOUT_MS);
+  const stillConnected = agentRegistry.getClaude() === occupant && occupant.readyState === WebSocket.OPEN;
   log(`probe_incumbent reply to #${ws.data.clientId}: connected=${stillConnected} alive=${stillConnected && alive}`);
   sendProtocolMessage(ws, {
     type: "incumbent_status",
@@ -7625,28 +7847,15 @@ async function handleRequestBudgetRefresh(ws, requestId) {
   log(`request_budget_refresh from #${ws.data.clientId}: ${snapshot ? "fresh" : "unavailable"}`);
   sendProtocolMessage(ws, { type: "budget_refresh", requestId, snapshot });
 }
-async function probeLiveness2(ws, timeoutMs) {
-  return probeLiveness({
-    get readyState() {
-      return ws.readyState;
-    },
-    get pongCount() {
-      return ws.data.pongCount;
-    },
-    ping: () => {
-      ws.ping();
-    }
-  }, { timeoutMs, pollMs: LIVENESS_PROBE_POLL_MS });
-}
-function evictStale(ws, reason) {
-  log(`Evicting stale Claude frontend #${ws.data.clientId}: ${reason}`);
-  if (attachedClaude === ws) {
-    detachClaude(ws, `evicted: ${reason}`);
+function evictStale(session, reason) {
+  log(`Evicting stale Claude frontend #${session.clientId}: ${reason}`);
+  if (agentRegistry.isClaude(session.ws)) {
+    detachClaude(session.ws, `evicted: ${reason}`);
   }
   try {
-    ws.close(CLOSE_CODE_EVICTED_STALE, "stale frontend evicted by newer session");
+    session.close(CLOSE_CODE_EVICTED_STALE, "stale frontend evicted by newer session");
   } catch (err) {
-    log(`Evict close threw on #${ws.data.clientId}: ${err.message}`);
+    log(`Evict close threw on #${session.clientId}: ${err.message}`);
   }
 }
 function startAttentionWindow() {
@@ -7675,81 +7884,25 @@ function clearAttentionWindow() {
   }
 }
 function scheduleIdleShutdown() {
-  cancelIdleShutdown();
-  if (attachedClaude)
-    return;
-  const snapshot = tuiConnectionState.snapshot();
-  if (snapshot.tuiConnected)
-    return;
-  log(`No clients connected. Daemon will shut down in ${IDLE_SHUTDOWN_MS}ms if no one reconnects.`);
-  idleShutdownTimer = setTimeout(() => {
-    if (attachedClaude || tuiConnectionState.snapshot().tuiConnected) {
-      log("Idle shutdown cancelled: client reconnected during grace period");
-      return;
-    }
-    shutdown("idle \u2014 no clients connected");
-  }, IDLE_SHUTDOWN_MS);
+  roomManager.scheduleIdleShutdown();
 }
 function cancelIdleShutdown() {
-  if (idleShutdownTimer) {
-    clearTimeout(idleShutdownTimer);
-    idleShutdownTimer = null;
-  }
+  roomManager.cancelIdleShutdown();
 }
 function clearPendingClaudeDisconnect(reason) {
-  if (!claudeDisconnectTimer)
-    return;
-  clearTimeout(claudeDisconnectTimer);
-  claudeDisconnectTimer = null;
-  if (reason) {
-    log(`Cleared pending Claude disconnect notification (${reason})`);
-  }
+  roomManager.clearPendingClaudeDisconnect(reason);
 }
 function scheduleClaudeDisconnectNotification(clientId) {
-  clearPendingClaudeDisconnect("rescheduled");
-  claudeDisconnectTimer = setTimeout(() => {
-    claudeDisconnectTimer = null;
-    if (attachedClaude) {
-      log(`Skipping Claude disconnect notification for client #${clientId} because Claude already reconnected`);
-      return;
-    }
-    log(`Claude disconnect persisted past grace window (client #${clientId})`);
-  }, CLAUDE_DISCONNECT_GRACE_MS);
+  roomManager.scheduleClaudeDisconnectNotification(clientId);
 }
 function emitToClaude(message) {
-  if (attachedClaude && attachedClaude.readyState === WebSocket.OPEN) {
-    if (trySendBridgeMessage(attachedClaude, message))
-      return;
-    log("Send to Claude failed, buffering message for retry on reconnect");
-  }
-  bufferedMessages.push(message);
+  roomManager.deliverToClaude(message);
 }
 function trySendBridgeMessage(ws, message) {
-  try {
-    const result = ws.send(JSON.stringify({ type: "codex_to_claude", message }));
-    if (typeof result === "number" && result === 0) {
-      log("Bridge message send returned 0 (dropped)");
-      return false;
-    }
-    if (typeof result === "number" && result === -1) {
-      ws.data.pendingBackpressure.push(message);
-    }
-    return true;
-  } catch (err) {
-    log(`Failed to send bridge message: ${err.message}`);
-    return false;
-  }
+  return ws.data.session.send(message);
 }
 function flushBufferedMessages(ws) {
-  const messages = bufferedMessages.drainAll();
-  for (let i = 0;i < messages.length; i++) {
-    if (!trySendBridgeMessage(ws, messages[i])) {
-      const remaining = messages.slice(i);
-      bufferedMessages.unshiftMany(remaining);
-      log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
-      return;
-    }
-  }
+  roomManager.flushBacklog(ws.data.session);
 }
 function sendBridgeMessage(ws, message) {
   trySendBridgeMessage(ws, message);
@@ -7758,19 +7911,13 @@ function sendStatus(ws) {
   sendProtocolMessage(ws, { type: "status", status: currentStatus() });
 }
 function broadcastStatus() {
-  if (!attachedClaude)
+  const claude = agentRegistry.getClaude();
+  if (!claude)
     return;
-  sendStatus(attachedClaude);
+  sendStatus(claude.ws);
 }
 function sendProtocolMessage(ws, message) {
-  try {
-    const result = ws.send(JSON.stringify(message));
-    if (typeof result === "number" && result === 0) {
-      log(`Control message dropped (socket closed): type=${message.type}`);
-    }
-  } catch (err) {
-    log(`Failed to send control message: ${err.message}`);
-  }
+  ws.data.session.sendProtocol(message);
 }
 function currentStatus() {
   const snapshot = tuiConnectionState.snapshot();
@@ -7778,7 +7925,7 @@ function currentStatus() {
     bridgeReady: tuiConnectionState.canReply(),
     tuiConnected: snapshot.tuiConnected,
     threadId: codex.activeThreadId,
-    queuedMessageCount: bufferedMessages.length + statusBuffer.size + (attachedClaude?.data.pendingBackpressure.length ?? 0),
+    queuedMessageCount: roomManager.backlogSize + statusBuffer.size + (agentRegistry.getClaude()?.pendingBackpressureSize ?? 0),
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
     pid: process.pid,
@@ -7889,12 +8036,12 @@ function armBootDeadline() {
     return;
   bootDeadlineTimer = setTimeout(() => {
     bootDeadlineTimer = null;
-    if (codexBootstrapped)
+    if (agentRegistry.codexBootstrapped)
       return;
     if (tuiConnectionState.snapshot().tuiConnected)
       return;
     log(`Codex not ready within bootstrap deadline (${BOOTSTRAP_TIMEOUT_MS}ms) \u2014 self-exiting to release control port`);
-    if (attachedClaude) {
+    if (agentRegistry.getClaude()) {
       emitToClaude(systemMessage("system_daemon_self_replace", "\u26A0\uFE0F Codex did not become ready within the bootstrap deadline \u2014 the AgentBridge daemon is restarting itself to release a clean slot. The bridge will reconnect automatically."));
     }
     shutdown("codex not ready within bootstrap deadline", 1);
@@ -7915,7 +8062,7 @@ async function bootCodex() {
   for (let attempt = 0;attempt <= CODEX_BOOT_RETRIES; attempt++) {
     try {
       await codex.start();
-      codexBootstrapped = true;
+      agentRegistry.codexBootstrapped = true;
       clearBootDeadline();
       writeStatusFile();
       emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -1,0 +1,62 @@
+import type { ServerWebSocket } from "bun";
+import type { ConnectionSession, ControlSocketData } from "./connection-session";
+
+/**
+ * §2.1 logical-agent layer.
+ *
+ * 1:1 today: one Claude slot plus Codex liveness flags. Consolidates the former
+ * daemon module singletons (`attachedClaude` / `codexBootstrapped` /
+ * `challengeInProgress`) into a single addressable owner, so room membership can
+ * later hold N members instead of one global slot. The Claude member is keyed
+ * implicitly today; real agentIds (§2.2, email/GitHub) plug in here later
+ * WITHOUT touching the call sites that go through these methods.
+ *
+ * Deliberately a pure state holder (no deps): `codex` and `tuiConnectionState`
+ * stay as daemon module consts — they are already well-encapsulated objects, and
+ * moving them in would add churn without making the slot more addressable.
+ */
+export class AgentRegistry {
+  private claude: ConnectionSession | null = null;
+  private _codexBootstrapped = false;
+  private _challengeInProgress = false;
+
+  /** The session currently holding the Claude slot, or null when detached. */
+  getClaude(): ConnectionSession | null {
+    return this.claude;
+  }
+  setClaude(session: ConnectionSession): void {
+    this.claude = session;
+  }
+  clearClaude(): void {
+    this.claude = null;
+  }
+  /** True iff `ws` is the socket currently holding the Claude slot. */
+  isClaude(ws: ServerWebSocket<ControlSocketData>): boolean {
+    return this.claude?.ws === ws;
+  }
+
+  get codexBootstrapped(): boolean {
+    return this._codexBootstrapped;
+  }
+  set codexBootstrapped(value: boolean) {
+    this._codexBootstrapped = value;
+  }
+
+  /**
+   * Single-flight admission gate for the one Claude slot (challenge-on-contest).
+   * Returns false if a liveness probe is already in flight, so a concurrent
+   * claude_connect is bounced instead of racing a second probe. Pair with
+   * {@link endChallenge} in a finally.
+   */
+  beginChallenge(): boolean {
+    if (this._challengeInProgress) return false;
+    this._challengeInProgress = true;
+    return true;
+  }
+  endChallenge(): void {
+    this._challengeInProgress = false;
+  }
+  get challengeInProgress(): boolean {
+    return this._challengeInProgress;
+  }
+}

--- a/src/connection-session.ts
+++ b/src/connection-session.ts
@@ -1,0 +1,198 @@
+import type { ServerWebSocket } from "bun";
+import type { BridgeMessage } from "./types";
+import type { ControlClientIdentity, ControlServerMessage } from "./control-protocol";
+import { BoundedMessageBuffer } from "./delivery-buffer";
+import { probeLiveness as probeLivenessImpl } from "./liveness-probe";
+
+/** WebSocket.OPEN. */
+const OPEN = 1;
+
+/**
+ * Per-socket state carried on `ws.data` for every control-WS connection.
+ *
+ * Lives here (not in daemon.ts) because it is intrinsically tied to
+ * {@link ConnectionSession}: the session wraps a `ServerWebSocket<ControlSocketData>`
+ * and `ControlSocketData.session` points back at it. Keeping both in one file
+ * avoids a daemon↔session circular type import. The shape is unchanged from the
+ * prior daemon-local interface.
+ */
+export interface ControlSocketData {
+  clientId: number;
+  attached: boolean;
+  /** Wall-clock of the last pong (used only for the contest diagnostic log). */
+  lastPongAt: number;
+  /** Monotonic pong counter — the liveness probe's source of truth (see liveness-probe.ts). */
+  pongCount: number;
+  identity?: ControlClientIdentity;
+  /**
+   * Bridge messages ws.send() returned -1 for: enqueued in Bun's socket buffer
+   * under backpressure, NOT yet on the wire. Bun discards that buffer if the
+   * socket closes before `drain` fires, so these are re-buffered at detach for
+   * redelivery on reconnect (at-least-once: a pre-close partial flush can
+   * produce a duplicate; silent loss cannot).
+   */
+  pendingBackpressure: BoundedMessageBuffer;
+  /** The behaviour wrapper over this socket. Set in the WS `open` handler. */
+  session?: ConnectionSession;
+}
+
+export interface ConnectionSessionDeps {
+  log: (msg: string) => void;
+  /** Poll interval for the liveness probe (LIVENESS_PROBE_POLL_MS). */
+  livenessPollMs: number;
+}
+
+/**
+ * §2.1 session layer: a thin behaviour wrapper over one live control socket.
+ *
+ * Owns only per-socket MECHANICS (send / protocol-send / liveness probe / pong
+ * bookkeeping / backpressure rebuffer). Holds no membership or pairing state —
+ * that is AgentRegistry/RoomManager's job. Bodies are moved verbatim from the
+ * prior daemon module functions so behaviour is bit-identical; the daemon keeps
+ * the old function names as one-line delegators to `ws.data.session`.
+ */
+export class ConnectionSession {
+  constructor(
+    readonly ws: ServerWebSocket<ControlSocketData>,
+    private readonly deps: ConnectionSessionDeps,
+  ) {}
+
+  get clientId(): number {
+    return this.ws.data.clientId;
+  }
+  get identity(): ControlClientIdentity | undefined {
+    return this.ws.data.identity;
+  }
+  set identity(v: ControlClientIdentity | undefined) {
+    this.ws.data.identity = v;
+  }
+  get readyState(): number {
+    return this.ws.readyState;
+  }
+  /** True iff the socket is OPEN (readyState === WebSocket.OPEN). */
+  get isOpen(): boolean {
+    return this.ws.readyState === OPEN;
+  }
+  get attached(): boolean {
+    return this.ws.data.attached;
+  }
+  /** Wall-clock of the last pong (contest diagnostic only). */
+  get lastPongAt(): number {
+    return this.ws.data.lastPongAt;
+  }
+  get pongCount(): number {
+    return this.ws.data.pongCount;
+  }
+  get pendingBackpressureSize(): number {
+    return this.ws.data.pendingBackpressure.length;
+  }
+
+  markAttached(value: boolean): void {
+    this.ws.data.attached = value;
+  }
+
+  /** Record a pong: refresh the diagnostic timestamp and advance the probe counter. */
+  recordPong(): void {
+    this.ws.data.lastPongAt = Date.now();
+    this.ws.data.pongCount++;
+  }
+
+  /**
+   * Send a bridge message to this socket. Returns false ONLY on a dropped send
+   * (result 0) or a throw; -1 (backpressure) is success — the message IS enqueued
+   * and is tracked in pendingBackpressure so detach can re-buffer it. (Treating
+   * -1 as failure would re-buffer an already-queued message and deliver twice.)
+   */
+  send(message: BridgeMessage): boolean {
+    try {
+      const result = this.ws.send(
+        JSON.stringify({ type: "codex_to_claude", message } satisfies ControlServerMessage),
+      );
+      if (typeof result === "number" && result === 0) {
+        this.deps.log("Bridge message send returned 0 (dropped)");
+        return false;
+      }
+      if (typeof result === "number" && result === -1) {
+        // Enqueued but not on the wire: Bun owns the bytes until `drain`
+        // confirms delivery, and drops them if the socket closes first. Track
+        // the message so detach can re-buffer it for the next attach.
+        this.ws.data.pendingBackpressure.push(message);
+      }
+      return true;
+    } catch (err: any) {
+      this.deps.log(`Failed to send bridge message: ${err.message}`);
+      return false;
+    }
+  }
+
+  /**
+   * Send a request-scoped control message. A dropped send (socket closed) is
+   * NOT retried — the client's pending request has already timed out — but it is
+   * logged so a dropped claude_to_codex_result leaves a trail.
+   */
+  sendProtocol(message: ControlServerMessage): void {
+    try {
+      const result = this.ws.send(JSON.stringify(message));
+      if (typeof result === "number" && result === 0) {
+        this.deps.log(`Control message dropped (socket closed): type=${message.type}`);
+      }
+    } catch (err: any) {
+      this.deps.log(`Failed to send control message: ${err.message}`);
+    }
+  }
+
+  /** Send a WS ping frame. May throw synchronously on a failed write. */
+  ping(): void {
+    this.ws.ping();
+  }
+
+  /**
+   * Probe this socket for liveness (challenge-on-contest / probe_incumbent).
+   * Resolves true iff a NEW pong is observed within `timeoutMs` (see
+   * liveness-probe.ts for the counter-not-timestamp rationale).
+   */
+  probeLiveness(timeoutMs: number): Promise<boolean> {
+    const ws = this.ws;
+    return probeLivenessImpl(
+      {
+        get readyState() {
+          return ws.readyState;
+        },
+        get pongCount() {
+          return ws.data.pongCount;
+        },
+        ping: () => {
+          ws.ping();
+        },
+      },
+      { timeoutMs, pollMs: this.deps.livenessPollMs },
+    );
+  }
+
+  close(code: number, reason: string): void {
+    this.ws.close(code, reason);
+  }
+
+  /**
+   * Move this socket's backpressured messages into the room backlog for
+   * redelivery on reconnect (detach path). Prepends (they predate everything
+   * already buffered) via BoundedMessageBuffer.unshiftMany. Returns the count
+   * moved (for the log line).
+   */
+  drainPendingBackpressureInto(backlog: BoundedMessageBuffer): number {
+    const reBuffered = this.ws.data.pendingBackpressure.drainAll();
+    backlog.unshiftMany(reBuffered);
+    return reBuffered.length;
+  }
+
+  /**
+   * Drain-handler confirmation: clear tracked backpressure ONLY when the socket
+   * buffer is fully empty. After a partial drain the tail can still be lost on
+   * close, and a duplicate beats silent loss, so we keep tracking until empty.
+   */
+  confirmDrainIfFlushed(): void {
+    if (this.ws.data.pendingBackpressure.length > 0 && this.ws.getBufferedAmount() === 0) {
+      this.ws.data.pendingBackpressure.clear();
+    }
+  }
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -58,26 +58,10 @@ import type {
   DaemonStatus,
 } from "./control-protocol";
 import type { BridgeMessage } from "./types";
-import { probeLiveness as probeLivenessImpl } from "./liveness-probe";
 import { BoundedMessageBuffer } from "./delivery-buffer";
-
-interface ControlSocketData {
-  clientId: number;
-  attached: boolean;
-  /** Wall-clock of the last pong (used only for the contest diagnostic log). */
-  lastPongAt: number;
-  /** Monotonic pong counter — the liveness probe's source of truth (see liveness-probe.ts). */
-  pongCount: number;
-  identity?: ControlClientIdentity;
-  /**
-   * Bridge messages ws.send() returned -1 for: enqueued in Bun's socket buffer
-   * under backpressure, NOT yet on the wire. Bun discards that buffer if the
-   * socket closes before `drain` fires, so these are re-buffered at detach for
-   * redelivery on reconnect (at-least-once: a pre-close partial flush can
-   * produce a duplicate; silent loss cannot).
-   */
-  pendingBackpressure: BoundedMessageBuffer;
-}
+import { ConnectionSession, type ControlSocketData } from "./connection-session";
+import { AgentRegistry } from "./agent-registry";
+import { RoomManager } from "./room-manager";
 
 const stateDir = new StateDirResolver();
 stateDir.ensure();
@@ -155,7 +139,10 @@ let controlServer: ReturnType<typeof Bun.serve> | null = null;
 // bind-race daemon (EADDRINUSE) never flips this, so its cleanup is a no-op and
 // the live incumbent's identity files survive (HIGH-1a).
 let boundControlPort = false;
-let attachedClaude: ServerWebSocket<ControlSocketData> | null = null;
+// §2.1 logical-agent layer: owns the Claude slot + Codex liveness flags
+// (formerly the attachedClaude / codexBootstrapped / challengeInProgress
+// module singletons). Pure state holder — see agent-registry.ts.
+const agentRegistry = new AgentRegistry();
 let nextControlClientId = 0;
 let nextSystemMessageId = 0;
 // Per-PROCESS salt for systemMessage ids (HIGH-2). The counter resets to 0 on
@@ -165,7 +152,6 @@ let nextSystemMessageId = 0;
 // ids unique ACROSS restarts, the counter keeps them unique WITHIN a process.
 // Same fix class as STATUS_SUMMARY_SALT in message-filter.ts (PR #139).
 const SYSTEM_MSG_SALT = randomUUID().slice(0, 8);
-let codexBootstrapped = false;
 let attentionWindowTimer: ReturnType<typeof setTimeout> | null = null;
 let inAttentionWindow = false;
 const replyTracker = new ReplyRequiredTracker();
@@ -249,8 +235,6 @@ const pendingSteerDispatches = new Map<number, PendingSteerDispatch>();
 const BUSY_RETRY_ADVISORY_MS = 15_000;
 let shuttingDown = false;
 let bootDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
-let idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
-let claudeDisconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let lastAttachStatusSentTs = 0;
 const ATTACH_STATUS_COOLDOWN_MS = 30_000; // Don't re-send status on rapid reattach
 
@@ -264,15 +248,6 @@ const LIVENESS_PROBE_TIMEOUT_MS = parsePositiveIntEnv(
   log,
 );
 const LIVENESS_PROBE_POLL_MS = 50;
-let challengeInProgress = false;
-
-// Module-level delivery backlog: messages that could not be sent while Claude
-// was detached / a send failed, awaiting the next attach or drain.
-const bufferedMessages = new BoundedMessageBuffer({
-  cap: MAX_BUFFERED_MESSAGES,
-  overflowLabel: "Message buffer overflow",
-  log,
-});
 
 // Per-socket backpressure tracker (ws.send returned -1): bounded the same way
 // so a never-draining socket can't accumulate unboundedly. Distinct overflow
@@ -328,7 +303,7 @@ function resumeClaimTtlSec(): number {
  * PR2 (detection only): gather the resume-readiness signals the coordinator's
  * pure reducer needs. ALL IO lives here so the reducer stays pure. Called once
  * per poll AFTER coordinator construction (first codex `ready`), so the
- * hoisted-but-later-`const` references (tuiConnectionState / attachedClaude) are
+ * hoisted-but-later-`const` references (tuiConnectionState / agentRegistry) are
  * fully initialized by the time this runs. Every probe is fault-isolated: a
  * transient fs/socket error degrades a SINGLE per-side signal to false rather
  * than throwing into the poll loop.
@@ -349,7 +324,7 @@ function readResumeSignals(): ResumeSignals {
     log(`resume signal: codex tuiReady failed: ${error instanceof Error ? error.message : String(error)}`);
   }
   try {
-    tuiReadyClaude = attachedClaude !== null;
+    tuiReadyClaude = agentRegistry.getClaude() !== null;
   } catch (error) {
     log(`resume signal: claude tuiReady failed: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -727,6 +702,20 @@ const tuiConnectionState = new TuiConnectionState({
 
 const statusBuffer = new StatusBuffer((summary) => emitToClaude(summary));
 
+// §2.3–2.4 room layer: owns the delivery backlog + the two "Claude slot empty"
+// lifecycle timers (formerly bufferedMessages / idleShutdownTimer /
+// claudeDisconnectTimer). Live state is injected via runtime getter closures so
+// timer callbacks read CURRENT state at fire time. See room-manager.ts.
+const roomManager = new RoomManager({
+  bufferedCap: MAX_BUFFERED_MESSAGES,
+  idleShutdownMs: IDLE_SHUTDOWN_MS,
+  claudeDisconnectGraceMs: CLAUDE_DISCONNECT_GRACE_MS,
+  log,
+  getClaude: () => agentRegistry.getClaude(),
+  isTuiConnected: () => tuiConnectionState.snapshot().tuiConnected,
+  onIdleShutdown: (reason) => shutdown(reason),
+});
+
 // Turn-transition status refreshes are OBSERVABILITY writes (issue #102) —
 // a disk/permission failure there must never break core turn handling, so
 // they go through this catcher (boot-path writes keep strict semantics).
@@ -834,8 +823,9 @@ codex.on("bridgeTurnStarted", ({ requestId, turnId }: { requestId: number; turnI
   if (pending.idempotencyKey) {
     idempotencyTracker.markStarted(pending.threadId, pending.idempotencyKey, turnId);
   }
-  if (attachedClaude) {
-    sendProtocolMessage(attachedClaude, {
+  const claudeForTurnStarted = agentRegistry.getClaude();
+  if (claudeForTurnStarted) {
+    claudeForTurnStarted.sendProtocol({
       type: "turn_started",
       requestId: pending.requestId,
       ...(pending.idempotencyKey ? { idempotencyKey: pending.idempotencyKey } : {}),
@@ -1076,8 +1066,8 @@ codex.on("exit", (code: number | null) => {
   // bootCodex() already govern recovery, and a retry may bring Codex up cleanly, so
   // telling the user to restart (and resetting the deadline each failed attempt) would
   // be misleading.
-  const wasBootstrapped = codexBootstrapped;
-  codexBootstrapped = false;
+  const wasBootstrapped = agentRegistry.codexBootstrapped;
+  agentRegistry.codexBootstrapped = false;
   replyTracker.reset(); // any in-flight require_reply turn is gone with the process
   // The process is gone — every pending/running idempotency key is terminal,
   // and per-injection correlation can never resolve (PR B).
@@ -1122,7 +1112,7 @@ function startControlServer() {
       }
 
       if (url.pathname === "/readyz") {
-        return Response.json(currentStatus(), { status: codexBootstrapped ? 200 : 503 });
+        return Response.json(currentStatus(), { status: agentRegistry.codexBootstrapped ? 200 : 503 });
       }
 
       if (url.pathname === "/ws") {
@@ -1148,11 +1138,12 @@ function startControlServer() {
         ws.data.clientId = ++nextControlClientId;
         ws.data.lastPongAt = Date.now();
         ws.data.pendingBackpressure = createPendingBackpressureBuffer();
+        ws.data.session = new ConnectionSession(ws, { log, livenessPollMs: LIVENESS_PROBE_POLL_MS });
         log(`Frontend socket opened (#${ws.data.clientId})`);
       },
       close: (ws: ServerWebSocket<ControlSocketData>, code: number, reason: string) => {
-        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${attachedClaude === ws})`);
-        if (attachedClaude === ws) {
+        log(`Frontend socket closed (#${ws.data.clientId}, code=${code}, reason=${reason || "none"}, wasAttached=${agentRegistry.isClaude(ws)})`);
+        if (agentRegistry.isClaude(ws)) {
           detachClaude(ws, "frontend socket closed");
         }
       },
@@ -1160,8 +1151,7 @@ function startControlServer() {
         handleControlMessage(ws, raw);
       },
       pong: (ws: ServerWebSocket<ControlSocketData>) => {
-        ws.data.lastPongAt = Date.now();
-        ws.data.pongCount++;
+        ws.data.session!.recordPong();
       },
       drain: (ws: ServerWebSocket<ControlSocketData>) => {
         // Backpressure released. Confirm tracked messages as delivered only
@@ -1173,12 +1163,10 @@ function startControlServer() {
         // so a detached socket is always empty here. A drain with an empty
         // OS buffer means the bytes reached the transport — the same
         // delivery guarantee a plain successful send has.
-        if (ws.data.pendingBackpressure.length > 0 && ws.getBufferedAmount() === 0) {
-          ws.data.pendingBackpressure.clear();
-        }
+        ws.data.session!.confirmDrainIfFlushed();
         // Deliver anything that buffered while the socket was congested
         // instead of waiting for the next reattach.
-        if (ws === attachedClaude && bufferedMessages.length > 0) {
+        if (agentRegistry.isClaude(ws) && roomManager.backlogSize > 0) {
           flushBufferedMessages(ws);
         }
       },
@@ -1367,11 +1355,12 @@ async function handleClaudeToCodex(
   // lifecycle: attachClaude sets attachedClaude=ws, detachClaude/eviction clear
   // it, and a replaced socket is closed). Decision extracted to a pure helper so
   // it is unit-testable without a live WebSocket.
-  const attachGuard = evaluateInjectionAttachGuard(attachedClaude, ws);
+  const claudeSlot = agentRegistry.getClaude();
+  const attachGuard = evaluateInjectionAttachGuard(claudeSlot?.ws ?? null, ws);
   if (!attachGuard.allowed) {
     log(
       `Rejecting claude_to_codex from non-attached socket #${ws.data.clientId} ` +
-      `(request ${message.requestId}, attached=${attachedClaude ? "#" + attachedClaude.data.clientId : "none"})`,
+      `(request ${message.requestId}, attached=${claudeSlot ? "#" + claudeSlot.clientId : "none"})`,
     );
     sendClaudeToCodexResult(ws, message.requestId, {
       success: false,
@@ -1600,7 +1589,8 @@ async function handleClaudeToCodex(
     // turn_started) if `ws` lost the slot during the wait. steer has no such
     // await and the normal reply/inject paths satisfy attachedClaude===ws by
     // construction, so neither is affected.
-    const postWaitAttachGuard = evaluateInjectionAttachGuard(attachedClaude, ws);
+    const postWaitSlot = agentRegistry.getClaude();
+    const postWaitAttachGuard = evaluateInjectionAttachGuard(postWaitSlot?.ws ?? null, ws);
     if (!postWaitAttachGuard.allowed) {
       // The upfront accept() (under interruptThreadId) must not strand. Release
       // it — releaseInterruptKey is scoped to interruptThreadId and is a no-op
@@ -1610,7 +1600,7 @@ async function handleClaudeToCodex(
       log(
         `Rejecting interrupt-path injection from socket #${ws.data.clientId} that lost the attach ` +
         `slot during the terminal-boundary wait (request ${message.requestId}, ` +
-        `attached=${attachedClaude ? "#" + attachedClaude.data.clientId : "none"})`,
+        `attached=${postWaitSlot ? "#" + postWaitSlot.clientId : "none"})`,
       );
       sendClaudeToCodexResult(ws, message.requestId, {
         success: false,
@@ -1731,18 +1721,18 @@ async function handleClaudeToCodex(
 }
 
 async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: ControlClientIdentity) {
-  const occupant = attachedClaude;
-  if (occupant && occupant !== ws && occupant.readyState !== WebSocket.CLOSED) {
+  const occupant = agentRegistry.getClaude();
+  if (occupant && occupant.ws !== ws && occupant.readyState !== WebSocket.CLOSED) {
     // Slot is occupied by another socket that hasn't yet shown us FIN.
     // Issue #68: OS may never surface a FIN for a crashed peer, so readyState
     // stays OPEN forever. Probe the incumbent with a ping before rejecting.
-    const msSincePong = Date.now() - occupant.data.lastPongAt;
+    const msSincePong = Date.now() - occupant.lastPongAt;
     log(
-      `Claude frontend contest: new=#${ws.data.clientId}, incumbent=#${occupant.data.clientId} ` +
+      `Claude frontend contest: new=#${ws.data.clientId}, incumbent=#${occupant.clientId} ` +
       `(readyState=${occupant.readyState}, msSincePong=${msSincePong})`,
     );
 
-    if (challengeInProgress) {
+    if (!agentRegistry.beginChallenge()) {
       log(
         `Rejecting Claude frontend #${ws.data.clientId} — another liveness probe already in flight`,
       );
@@ -1753,12 +1743,11 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: C
       return;
     }
 
-    challengeInProgress = true;
     let incumbentAlive = false;
     try {
-      incumbentAlive = await probeLiveness(occupant, LIVENESS_PROBE_TIMEOUT_MS);
+      incumbentAlive = await occupant.probeLiveness(LIVENESS_PROBE_TIMEOUT_MS);
     } finally {
-      challengeInProgress = false;
+      agentRegistry.endChallenge();
     }
 
     // Slot may have cleared during the probe (real close fired, or the new ws
@@ -1773,7 +1762,7 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: C
 
     if (incumbentAlive) {
       log(
-        `Rejecting Claude frontend #${ws.data.clientId} — incumbent #${occupant.data.clientId} responded to liveness probe`,
+        `Rejecting Claude frontend #${ws.data.clientId} — incumbent #${occupant.clientId} responded to liveness probe`,
       );
       ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
       return;
@@ -1783,10 +1772,11 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: C
     // Fall through to accept path below.
   }
 
-  if (attachedClaude && attachedClaude !== ws && attachedClaude.readyState !== WebSocket.CLOSED) {
+  const currentSlot = agentRegistry.getClaude();
+  if (currentSlot && currentSlot.ws !== ws && currentSlot.readyState !== WebSocket.CLOSED) {
     // Another contestant may have raced in between the probe and here. Reject.
     log(
-      `Rejecting Claude frontend #${ws.data.clientId} — slot re-acquired by #${attachedClaude.data.clientId} after probe`,
+      `Rejecting Claude frontend #${ws.data.clientId} — slot re-acquired by #${currentSlot.clientId} after probe`,
     );
     ws.close(CLOSE_CODE_REPLACED, "another Claude session is already connected");
     return;
@@ -1794,7 +1784,7 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: C
 
   clearPendingClaudeDisconnect("Claude frontend attached");
   ws.data.identity = identity;
-  attachedClaude = ws;
+  agentRegistry.setClaude(ws.data.session!);
   ws.data.attached = true;
   cancelIdleShutdown();
   log(
@@ -1804,7 +1794,7 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: C
   // Drain the older backlog BEFORE the status buffer's fresher summary — the
   // reverse order delivered events out of timeline (summary first, then the
   // pre-disconnect messages it summarizes).
-  const hadBacklog = bufferedMessages.length > 0;
+  const hadBacklog = roomManager.backlogSize > 0;
   if (hadBacklog) {
     flushBufferedMessages(ws);
   }
@@ -1818,7 +1808,7 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: C
     // Only send status messages if this is not a rapid reattach (avoid flooding Claude)
     if (tuiConnectionState.canReply()) {
       sendBridgeMessage(ws, systemMessage("system_ready", currentReadyMessage()));
-    } else if (codexBootstrapped) {
+    } else if (agentRegistry.codexBootstrapped) {
       sendBridgeMessage(ws, systemMessage("system_waiting", currentWaitingMessage()));
     }
   }
@@ -1827,9 +1817,9 @@ async function attachClaude(ws: ServerWebSocket<ControlSocketData>, identity?: C
 }
 
 function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
-  if (attachedClaude !== ws) return;
+  if (!agentRegistry.isClaude(ws)) return;
 
-  attachedClaude = null;
+  agentRegistry.clearClaude();
   ws.data.attached = false;
   log(`Claude frontend detached (#${ws.data.clientId}, ${reason})`);
 
@@ -1837,12 +1827,11 @@ function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
   // drops its socket buffer on close, so without this they would be lost.
   // Prepend (they predate anything buffered after the send started failing)
   // and re-apply the cap.
-  if (ws.data.pendingBackpressure.length > 0) {
-    const reBuffered = ws.data.pendingBackpressure.drainAll();
+  if (ws.data.session!.pendingBackpressureSize > 0) {
+    const reBufferedCount = roomManager.rebufferOnDetach(ws.data.session!);
     log(
-      `Re-buffered ${reBuffered.length} backpressured message(s) for redelivery on reconnect`,
+      `Re-buffered ${reBufferedCount} backpressured message(s) for redelivery on reconnect`,
     );
-    bufferedMessages.unshiftMany(reBuffered);
   }
 
   scheduleClaudeDisconnectNotification(ws.data.clientId);
@@ -1864,15 +1853,15 @@ function detachClaude(ws: ServerWebSocket<ControlSocketData>, reason: string) {
  * it is safe to launch and let admission evict the stale frontend.
  */
 async function handleProbeIncumbent(ws: ServerWebSocket<ControlSocketData>) {
-  const occupant = attachedClaude;
-  log(`probe_incumbent from #${ws.data.clientId}: occupant=${occupant ? "#" + occupant.data.clientId : "none"} readyState=${occupant?.readyState}`);
-  if (!occupant || occupant === ws || occupant.readyState !== WebSocket.OPEN) {
+  const occupant = agentRegistry.getClaude();
+  log(`probe_incumbent from #${ws.data.clientId}: occupant=${occupant ? "#" + occupant.clientId : "none"} readyState=${occupant?.readyState}`);
+  if (!occupant || occupant.ws === ws || occupant.readyState !== WebSocket.OPEN) {
     sendProtocolMessage(ws, { type: "incumbent_status", connected: false, alive: false });
     return;
   }
   // A real challenge-on-contest decision is already running — defer to it (report
   // live so the CLI guard errs on the safe side and does not race the admission).
-  if (challengeInProgress) {
+  if (agentRegistry.challengeInProgress) {
     sendProtocolMessage(ws, { type: "incumbent_status", connected: true, alive: true });
     return;
   }
@@ -1881,9 +1870,9 @@ async function handleProbeIncumbent(ws: ServerWebSocket<ControlSocketData>) {
   // bounced with CLOSE_CODE_PROBE_IN_PROGRESS (a ~3s reconnect delay) even though
   // the probing socket never intends to attach. A real contest that races this
   // probe just runs its own ping concurrently — harmless (ping is idempotent).
-  const alive = await probeLiveness(occupant, LIVENESS_PROBE_TIMEOUT_MS);
+  const alive = await occupant.probeLiveness(LIVENESS_PROBE_TIMEOUT_MS);
   // The probe awaited; re-read state in case the incumbent closed meanwhile.
-  const stillConnected = attachedClaude === occupant && occupant.readyState === WebSocket.OPEN;
+  const stillConnected = agentRegistry.getClaude() === occupant && occupant.readyState === WebSocket.OPEN;
   log(`probe_incumbent reply to #${ws.data.clientId}: connected=${stillConnected} alive=${stillConnected && alive}`);
   sendProtocolMessage(ws, {
     type: "incumbent_status",
@@ -1908,20 +1897,6 @@ async function handleRequestBudgetRefresh(ws: ServerWebSocket<ControlSocketData>
   sendProtocolMessage(ws, { type: "budget_refresh", requestId, snapshot });
 }
 
-async function probeLiveness(
-  ws: ServerWebSocket<ControlSocketData>,
-  timeoutMs: number,
-): Promise<boolean> {
-  return probeLivenessImpl(
-    {
-      get readyState() { return ws.readyState; },
-      get pongCount() { return ws.data.pongCount; },
-      ping: () => { ws.ping(); },
-    },
-    { timeoutMs, pollMs: LIVENESS_PROBE_POLL_MS },
-  );
-}
-
 /**
  * Evict the incumbent Claude frontend so a newer session can take over.
  * Sends CLOSE_CODE_EVICTED_STALE (4002) and releases the slot so the next
@@ -1935,15 +1910,15 @@ async function probeLiveness(
  * contestant disappeared mid-probe), letting the timer fire is the correct
  * behavior: Codex genuinely has no Claude attached.
  */
-function evictStale(ws: ServerWebSocket<ControlSocketData>, reason: string) {
-  log(`Evicting stale Claude frontend #${ws.data.clientId}: ${reason}`);
-  if (attachedClaude === ws) {
-    detachClaude(ws, `evicted: ${reason}`);
+function evictStale(session: ConnectionSession, reason: string) {
+  log(`Evicting stale Claude frontend #${session.clientId}: ${reason}`);
+  if (agentRegistry.isClaude(session.ws)) {
+    detachClaude(session.ws, `evicted: ${reason}`);
   }
   try {
-    ws.close(CLOSE_CODE_EVICTED_STALE, "stale frontend evicted by newer session");
+    session.close(CLOSE_CODE_EVICTED_STALE, "stale frontend evicted by newer session");
   } catch (err: any) {
-    log(`Evict close threw on #${ws.data.clientId}: ${err.message}`);
+    log(`Evict close threw on #${session.clientId}: ${err.message}`);
   }
 }
 
@@ -1975,109 +1950,31 @@ function clearAttentionWindow() {
 }
 
 function scheduleIdleShutdown() {
-  cancelIdleShutdown();
-  if (attachedClaude) return; // still has a client
-
-  const snapshot = tuiConnectionState.snapshot();
-  if (snapshot.tuiConnected) return; // TUI still connected
-
-  log(`No clients connected. Daemon will shut down in ${IDLE_SHUTDOWN_MS}ms if no one reconnects.`);
-  idleShutdownTimer = setTimeout(() => {
-    // Re-check before shutting down
-    if (attachedClaude || tuiConnectionState.snapshot().tuiConnected) {
-      log("Idle shutdown cancelled: client reconnected during grace period");
-      return;
-    }
-    shutdown("idle — no clients connected");
-  }, IDLE_SHUTDOWN_MS);
+  roomManager.scheduleIdleShutdown();
 }
 
 function cancelIdleShutdown() {
-  if (idleShutdownTimer) {
-    clearTimeout(idleShutdownTimer);
-    idleShutdownTimer = null;
-  }
+  roomManager.cancelIdleShutdown();
 }
 
 function clearPendingClaudeDisconnect(reason?: string) {
-  if (!claudeDisconnectTimer) return;
-  clearTimeout(claudeDisconnectTimer);
-  claudeDisconnectTimer = null;
-  if (reason) {
-    log(`Cleared pending Claude disconnect notification (${reason})`);
-  }
+  roomManager.clearPendingClaudeDisconnect(reason);
 }
 
 function scheduleClaudeDisconnectNotification(clientId: number) {
-  clearPendingClaudeDisconnect("rescheduled");
-  claudeDisconnectTimer = setTimeout(() => {
-    claudeDisconnectTimer = null;
-
-    if (attachedClaude) {
-      log(
-        `Skipping Claude disconnect notification for client #${clientId} because Claude already reconnected`,
-      );
-      return;
-    }
-
-    // Runtime offline events are no longer injected into Codex: the only channel
-    // (turn/start) pollutes the Codex thread/title and can trigger spurious
-    // responses. Logged for ops; Codex simply receives no further messages until
-    // Claude reconnects (the static collaboration context lives in AGENTS.md).
-    log(`Claude disconnect persisted past grace window (client #${clientId})`);
-  }, CLAUDE_DISCONNECT_GRACE_MS);
+  roomManager.scheduleClaudeDisconnectNotification(clientId);
 }
 
 function emitToClaude(message: BridgeMessage) {
-  if (attachedClaude && attachedClaude.readyState === WebSocket.OPEN) {
-    if (trySendBridgeMessage(attachedClaude, message)) return;
-    // Send failed — fall through to buffer
-    log("Send to Claude failed, buffering message for retry on reconnect");
-  }
-
-  bufferedMessages.push(message);
+  roomManager.deliverToClaude(message);
 }
 
 function trySendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: BridgeMessage): boolean {
-  try {
-    const result = ws.send(JSON.stringify({ type: "codex_to_claude", message } satisfies ControlServerMessage));
-    // Bun semantics: -1 = backpressure, the message IS enqueued and will be
-    // delivered once the socket drains — treating it as failure re-buffered an
-    // already-queued message and delivered it twice. Only 0 (dropped) fails.
-    if (typeof result === "number" && result === 0) {
-      log("Bridge message send returned 0 (dropped)");
-      return false;
-    }
-    if (typeof result === "number" && result === -1) {
-      // Enqueued but not on the wire: Bun owns the bytes until `drain`
-      // confirms delivery, and drops them if the socket closes first. Track
-      // the message so detachClaude can re-buffer it for the next attach.
-      // Same cap as bufferedMessages — a never-draining socket must not
-      // accumulate unboundedly (bounded, logged loss beats OOM).
-      ws.data.pendingBackpressure.push(message);
-    }
-    return true;
-  } catch (err: any) {
-    log(`Failed to send bridge message: ${err.message}`);
-    return false;
-  }
+  return ws.data.session!.send(message);
 }
 
 function flushBufferedMessages(ws: ServerWebSocket<ControlSocketData>) {
-  const messages = bufferedMessages.drainAll();
-  for (let i = 0; i < messages.length; i++) {
-    if (!trySendBridgeMessage(ws, messages[i]!)) {
-      // Re-buffer this and all remaining messages on failure. Positional index,
-      // not indexOf: identity lookup breaks the count if a message object is
-      // ever enqueued twice. The buffer is empty here (just drained, and
-      // trySend only touches pendingBackpressure), so re-applying the cap on
-      // prepend is a provable no-op — count is preserved bit-exactly.
-      const remaining = messages.slice(i);
-      bufferedMessages.unshiftMany(remaining);
-      log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
-      return;
-    }
-  }
+  roomManager.flushBacklog(ws.data.session!);
 }
 
 function sendBridgeMessage(ws: ServerWebSocket<ControlSocketData>, message: BridgeMessage) {
@@ -2089,24 +1986,13 @@ function sendStatus(ws: ServerWebSocket<ControlSocketData>) {
 }
 
 function broadcastStatus() {
-  if (!attachedClaude) return;
-  sendStatus(attachedClaude);
+  const claude = agentRegistry.getClaude();
+  if (!claude) return;
+  sendStatus(claude.ws);
 }
 
 function sendProtocolMessage(ws: ServerWebSocket<ControlSocketData>, message: ControlServerMessage) {
-  try {
-    const result = ws.send(JSON.stringify(message));
-    // Control responses are request-scoped: re-sending them to a future socket
-    // would be wrong (the client's pending request has already timed out), so
-    // a dropped send is not retried — but it must not be silent. A dropped
-    // `claude_to_codex_result` is the trail for "Claude saw a timeout but the
-    // turn WAS injected" reports.
-    if (typeof result === "number" && result === 0) {
-      log(`Control message dropped (socket closed): type=${message.type}`);
-    }
-  } catch (err: any) {
-    log(`Failed to send control message: ${err.message}`);
-  }
+  ws.data.session!.sendProtocol(message);
 }
 
 function currentStatus(): DaemonStatus {
@@ -2119,7 +2005,7 @@ function currentStatus(): DaemonStatus {
     // confirmation — without them a diagnosis can read "0 queued" while
     // unconfirmed messages still sit in the socket.
     queuedMessageCount:
-      bufferedMessages.length + statusBuffer.size + (attachedClaude?.data.pendingBackpressure.length ?? 0),
+      roomManager.backlogSize + statusBuffer.size + (agentRegistry.getClaude()?.pendingBackpressureSize ?? 0),
     proxyUrl: codex.proxyUrl,
     appServerUrl: codex.appServerUrl,
     pid: process.pid,
@@ -2307,13 +2193,13 @@ function armBootDeadline() {
   if (bootDeadlineTimer) return;
   bootDeadlineTimer = setTimeout(() => {
     bootDeadlineTimer = null;
-    if (codexBootstrapped) return; // became ready in time — nothing to do
+    if (agentRegistry.codexBootstrapped) return; // became ready in time — nothing to do
     if (tuiConnectionState.snapshot().tuiConnected) return; // a TUI is actively using it
     log(`Codex not ready within bootstrap deadline (${BOOTSTRAP_TIMEOUT_MS}ms) — self-exiting to release control port`);
     // An attached Claude frontend deserves a why before the socket drops: without
     // this notice the self-exit looks like a random daemon crash from its side
     // (it only sees "control connection lost" + a reconnect loop).
-    if (attachedClaude) {
+    if (agentRegistry.getClaude()) {
       emitToClaude(
         systemMessage(
           "system_daemon_self_replace",
@@ -2343,7 +2229,7 @@ async function bootCodex() {
   for (let attempt = 0; attempt <= CODEX_BOOT_RETRIES; attempt++) {
     try {
       await codex.start();
-      codexBootstrapped = true;
+      agentRegistry.codexBootstrapped = true;
       clearBootDeadline(); // codex up — cancel the self-exit watchdog
       writeStatusFile();
       emitToClaude(systemMessage("system_waiting", currentWaitingMessage()));

--- a/src/room-manager.ts
+++ b/src/room-manager.ts
@@ -1,0 +1,145 @@
+import type { BridgeMessage } from "./types";
+import type { ConnectionSession } from "./connection-session";
+import { BoundedMessageBuffer } from "./delivery-buffer";
+
+export interface RoomManagerDeps {
+  /** Max retained backlog messages (MAX_BUFFERED_MESSAGES). */
+  bufferedCap: number;
+  /** Idle-shutdown grace (IDLE_SHUTDOWN_MS). */
+  idleShutdownMs: number;
+  /** Claude-disconnect notification grace (CLAUDE_DISCONNECT_GRACE_MS). */
+  claudeDisconnectGraceMs: number;
+  log: (msg: string) => void;
+  /** The live Claude member, resolved at CALL time (never captured at schedule time). */
+  getClaude: () => ConnectionSession | null;
+  /** Whether the Codex TUI is connected, resolved at CALL time. */
+  isTuiConnected: () => boolean;
+  /** Self-shutdown trigger (daemon `shutdown(reason)`). */
+  onIdleShutdown: (reason: string) => void;
+}
+
+/**
+ * §2.3–2.4 room layer (1:1 today: a single room with members {claude?, codex}).
+ *
+ * Owns the room's delivery backlog + the two "Claude slot empty" lifecycle
+ * timers (idle-shutdown and disconnect-notification) — formerly the daemon
+ * `bufferedMessages` / `idleShutdownTimer` / `claudeDisconnectTimer` singletons.
+ * Holds no socket: it resolves the live Claude member through the injected
+ * `getClaude()` so timer callbacks always read CURRENT state at fire time, never
+ * a value captured when the timer was scheduled. Bodies are moved verbatim from
+ * the prior daemon module functions; the daemon keeps the old function names as
+ * one-line delegators.
+ */
+export class RoomManager {
+  private readonly backlog: BoundedMessageBuffer;
+  private idleShutdownTimer: ReturnType<typeof setTimeout> | null = null;
+  private claudeDisconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly deps: RoomManagerDeps) {
+    this.backlog = new BoundedMessageBuffer({
+      cap: deps.bufferedCap,
+      overflowLabel: "Message buffer overflow",
+      log: deps.log,
+    });
+  }
+
+  /** Current backlog depth (for status diagnostics). */
+  get backlogSize(): number {
+    return this.backlog.length;
+  }
+
+  /**
+   * Deliver to the live Claude member; on no-member / not-OPEN / failed send,
+   * buffer for redelivery on the next attach (formerly `emitToClaude`).
+   */
+  deliverToClaude(message: BridgeMessage): void {
+    const claude = this.deps.getClaude();
+    if (claude && claude.isOpen) {
+      if (claude.send(message)) return;
+      // Send failed — fall through to buffer
+      this.deps.log("Send to Claude failed, buffering message for retry on reconnect");
+    }
+    this.backlog.push(message);
+  }
+
+  /**
+   * Drain the backlog to a (re)attached session, re-buffering the tail on the
+   * first send failure (formerly `flushBufferedMessages`). Positional index, not
+   * indexOf: identity lookup would break the count if a message were enqueued
+   * twice. The buffer is empty here (just drained), so re-applying cap on the
+   * prepend is a provable no-op — count is preserved bit-exactly.
+   */
+  flushBacklog(session: ConnectionSession): void {
+    const messages = this.backlog.drainAll();
+    for (let i = 0; i < messages.length; i++) {
+      if (!session.send(messages[i]!)) {
+        const remaining = messages.slice(i);
+        this.backlog.unshiftMany(remaining);
+        this.deps.log(`Flush interrupted: re-buffered ${remaining.length} message(s) after send failure`);
+        return;
+      }
+    }
+  }
+
+  /**
+   * Detach: move the session's backpressured (un-drained) messages into the
+   * backlog so they are redelivered on reconnect. Returns the count moved.
+   */
+  rebufferOnDetach(session: ConnectionSession): number {
+    return session.drainPendingBackpressureInto(this.backlog);
+  }
+
+  scheduleIdleShutdown(): void {
+    this.cancelIdleShutdown();
+    if (this.deps.getClaude()) return; // still has a client
+    if (this.deps.isTuiConnected()) return; // TUI still connected
+
+    this.deps.log(
+      `No clients connected. Daemon will shut down in ${this.deps.idleShutdownMs}ms if no one reconnects.`,
+    );
+    this.idleShutdownTimer = setTimeout(() => {
+      // Re-check CURRENT state before shutting down (never the scheduled-time value).
+      if (this.deps.getClaude() || this.deps.isTuiConnected()) {
+        this.deps.log("Idle shutdown cancelled: client reconnected during grace period");
+        return;
+      }
+      this.deps.onIdleShutdown("idle — no clients connected");
+    }, this.deps.idleShutdownMs);
+  }
+
+  cancelIdleShutdown(): void {
+    if (this.idleShutdownTimer) {
+      clearTimeout(this.idleShutdownTimer);
+      this.idleShutdownTimer = null;
+    }
+  }
+
+  clearPendingClaudeDisconnect(reason?: string): void {
+    if (!this.claudeDisconnectTimer) return;
+    clearTimeout(this.claudeDisconnectTimer);
+    this.claudeDisconnectTimer = null;
+    if (reason) {
+      this.deps.log(`Cleared pending Claude disconnect notification (${reason})`);
+    }
+  }
+
+  scheduleClaudeDisconnectNotification(clientId: number): void {
+    this.clearPendingClaudeDisconnect("rescheduled");
+    this.claudeDisconnectTimer = setTimeout(() => {
+      this.claudeDisconnectTimer = null;
+
+      if (this.deps.getClaude()) {
+        this.deps.log(
+          `Skipping Claude disconnect notification for client #${clientId} because Claude already reconnected`,
+        );
+        return;
+      }
+
+      // Runtime offline events are no longer injected into Codex: the only channel
+      // (turn/start) pollutes the Codex thread/title and can trigger spurious
+      // responses. Logged for ops; Codex simply receives no further messages until
+      // Claude reconnects (the static collaboration context lives in AGENTS.md).
+      this.deps.log(`Claude disconnect persisted past grace window (client #${clientId})`);
+    }, this.deps.claudeDisconnectGraceMs);
+  }
+}

--- a/src/unit-test/agent-registry.test.ts
+++ b/src/unit-test/agent-registry.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { AgentRegistry } from "../agent-registry";
+import type { ConnectionSession } from "../connection-session";
+
+/** Minimal ConnectionSession stub — AgentRegistry only reads `.ws` (for isClaude). */
+function fakeSession(ws: object): ConnectionSession {
+  return { ws } as unknown as ConnectionSession;
+}
+
+describe("AgentRegistry — Claude slot single source of truth", () => {
+  let reg: AgentRegistry;
+  beforeEach(() => {
+    reg = new AgentRegistry();
+  });
+
+  test("starts empty", () => {
+    expect(reg.getClaude()).toBeNull();
+  });
+
+  test("setClaude / getClaude / clearClaude", () => {
+    const wsA = {};
+    const s = fakeSession(wsA);
+    reg.setClaude(s);
+    expect(reg.getClaude()).toBe(s);
+    reg.clearClaude();
+    expect(reg.getClaude()).toBeNull();
+  });
+
+  test("isClaude matches only the slot's underlying ws", () => {
+    const wsA = {};
+    const wsB = {};
+    expect(reg.isClaude(wsA as any)).toBe(false); // empty slot
+    reg.setClaude(fakeSession(wsA));
+    expect(reg.isClaude(wsA as any)).toBe(true);
+    expect(reg.isClaude(wsB as any)).toBe(false);
+    reg.clearClaude();
+    expect(reg.isClaude(wsA as any)).toBe(false);
+  });
+});
+
+describe("AgentRegistry — codexBootstrapped flag", () => {
+  test("defaults false, round-trips", () => {
+    const reg = new AgentRegistry();
+    expect(reg.codexBootstrapped).toBe(false);
+    reg.codexBootstrapped = true;
+    expect(reg.codexBootstrapped).toBe(true);
+    reg.codexBootstrapped = false;
+    expect(reg.codexBootstrapped).toBe(false);
+  });
+});
+
+describe("AgentRegistry — challenge single-flight gate", () => {
+  let reg: AgentRegistry;
+  beforeEach(() => {
+    reg = new AgentRegistry();
+  });
+
+  test("first beginChallenge wins, concurrent is rejected until endChallenge", () => {
+    expect(reg.challengeInProgress).toBe(false);
+    expect(reg.beginChallenge()).toBe(true);
+    expect(reg.challengeInProgress).toBe(true);
+    // A second contender while a probe is in flight is bounced.
+    expect(reg.beginChallenge()).toBe(false);
+    reg.endChallenge();
+    expect(reg.challengeInProgress).toBe(false);
+    // Gate is reusable after release.
+    expect(reg.beginChallenge()).toBe(true);
+    reg.endChallenge();
+  });
+});

--- a/src/unit-test/connection-session.test.ts
+++ b/src/unit-test/connection-session.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import type { ServerWebSocket } from "bun";
+import { ConnectionSession, type ControlSocketData } from "../connection-session";
+import { BoundedMessageBuffer } from "../delivery-buffer";
+import type { BridgeMessage } from "../types";
+
+const OPEN = 1;
+
+function msg(id: string): BridgeMessage {
+  return { id, source: "codex", content: id, timestamp: 0 };
+}
+
+/** Minimal fake of the ServerWebSocket surface ConnectionSession touches. */
+class FakeWs {
+  data: ControlSocketData;
+  readyState = OPEN;
+  sendResult: number = 42; // default: a normal byte count (success)
+  sendThrows = false;
+  bufferedAmount = 0;
+  sent: string[] = [];
+  pings = 0;
+  closed: { code: number; reason: string } | null = null;
+
+  constructor() {
+    this.data = {
+      clientId: 7,
+      attached: false,
+      lastPongAt: 0,
+      pongCount: 0,
+      pendingBackpressure: new BoundedMessageBuffer({ cap: 100, overflowLabel: "x", log: () => {} }),
+    };
+  }
+  send(payload: string): number {
+    if (this.sendThrows) throw new Error("boom");
+    this.sent.push(payload);
+    return this.sendResult;
+  }
+  ping(): void {
+    this.pings++;
+  }
+  close(code: number, reason: string): void {
+    this.closed = { code, reason };
+  }
+  getBufferedAmount(): number {
+    return this.bufferedAmount;
+  }
+}
+
+function makeSession(): { ws: FakeWs; session: ConnectionSession; logs: string[] } {
+  const ws = new FakeWs();
+  const logs: string[] = [];
+  const session = new ConnectionSession(ws as unknown as ServerWebSocket<ControlSocketData>, {
+    log: (m) => logs.push(m),
+    livenessPollMs: 1,
+  });
+  ws.data.session = session;
+  return { ws, session, logs };
+}
+
+describe("ConnectionSession.send — Bun -1/0/throw semantics", () => {
+  let ctx: ReturnType<typeof makeSession>;
+  beforeEach(() => {
+    ctx = makeSession();
+  });
+
+  test("normal send (>0) returns true and tracks no backpressure", () => {
+    ctx.ws.sendResult = 42;
+    expect(ctx.session.send(msg("a"))).toBe(true);
+    expect(ctx.session.pendingBackpressureSize).toBe(0);
+    expect(ctx.ws.sent.length).toBe(1);
+  });
+
+  test("backpressure (-1) returns TRUE and tracks the message for redelivery", () => {
+    ctx.ws.sendResult = -1;
+    expect(ctx.session.send(msg("a"))).toBe(true);
+    expect(ctx.session.pendingBackpressureSize).toBe(1);
+  });
+
+  test("dropped (0) returns false and tracks nothing", () => {
+    ctx.ws.sendResult = 0;
+    expect(ctx.session.send(msg("a"))).toBe(false);
+    expect(ctx.session.pendingBackpressureSize).toBe(0);
+    expect(ctx.logs.some((l) => l.includes("returned 0 (dropped)"))).toBe(true);
+  });
+
+  test("throw returns false and logs", () => {
+    ctx.ws.sendThrows = true;
+    expect(ctx.session.send(msg("a"))).toBe(false);
+    expect(ctx.logs.some((l) => l.includes("Failed to send bridge message"))).toBe(true);
+  });
+
+  test("send serialises as a codex_to_claude envelope", () => {
+    ctx.session.send(msg("hello"));
+    expect(JSON.parse(ctx.ws.sent[0]!)).toMatchObject({ type: "codex_to_claude", message: { id: "hello" } });
+  });
+});
+
+describe("ConnectionSession backpressure rebuffer + drain confirm", () => {
+  test("drainPendingBackpressureInto moves messages (prepended) and returns count", () => {
+    const { ws, session } = makeSession();
+    ws.sendResult = -1;
+    session.send(msg("p1"));
+    session.send(msg("p2"));
+    const backlog = new BoundedMessageBuffer({ cap: 100, overflowLabel: "backlog", log: () => {} });
+    backlog.push(msg("existing"));
+    const n = session.drainPendingBackpressureInto(backlog);
+    expect(n).toBe(2);
+    expect(session.pendingBackpressureSize).toBe(0);
+    // prepended: p1,p2 precede the pre-existing backlog entry
+    expect(backlog.drainAll().map((m) => m.id)).toEqual(["p1", "p2", "existing"]);
+  });
+
+  test("confirmDrainIfFlushed clears only when socket buffer is empty", () => {
+    const { ws, session } = makeSession();
+    ws.sendResult = -1;
+    session.send(msg("p1"));
+    ws.bufferedAmount = 5; // not yet flushed
+    session.confirmDrainIfFlushed();
+    expect(session.pendingBackpressureSize).toBe(1);
+    ws.bufferedAmount = 0; // fully drained
+    session.confirmDrainIfFlushed();
+    expect(session.pendingBackpressureSize).toBe(0);
+  });
+});
+
+describe("ConnectionSession misc mechanics", () => {
+  test("recordPong advances counter and timestamp", () => {
+    const { session } = makeSession();
+    expect(session.pongCount).toBe(0);
+    session.recordPong();
+    expect(session.pongCount).toBe(1);
+  });
+
+  test("markAttached + getters reflect ws.data", () => {
+    const { ws, session } = makeSession();
+    expect(session.clientId).toBe(7);
+    expect(session.attached).toBe(false);
+    session.markAttached(true);
+    expect(session.attached).toBe(true);
+    expect(ws.data.attached).toBe(true);
+  });
+
+  test("probeLiveness resolves true when a pong is observed", async () => {
+    const { ws, session } = makeSession();
+    // ping() simulates an immediate pong on this fake.
+    const origPing = ws.ping.bind(ws);
+    ws.ping = () => {
+      origPing();
+      ws.data.pongCount++;
+    };
+    expect(await session.probeLiveness(50)).toBe(true);
+  });
+
+  test("probeLiveness resolves false when socket is not OPEN", async () => {
+    const { ws, session } = makeSession();
+    ws.readyState = 3; // CLOSED
+    expect(await session.probeLiveness(50)).toBe(false);
+  });
+
+  test("close delegates code+reason", () => {
+    const { ws, session } = makeSession();
+    session.close(4002, "evicted");
+    expect(ws.closed).toEqual({ code: 4002, reason: "evicted" });
+  });
+});

--- a/src/unit-test/room-manager.test.ts
+++ b/src/unit-test/room-manager.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, expect } from "bun:test";
+import { RoomManager, type RoomManagerDeps } from "../room-manager";
+import type { ConnectionSession } from "../connection-session";
+import type { BoundedMessageBuffer } from "../delivery-buffer";
+import type { BridgeMessage } from "../types";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const msg = (id: string): BridgeMessage => ({ id, source: "codex", content: id, timestamp: 0 });
+
+/** Fake ConnectionSession: configurable send + backpressure drain. */
+class FakeSession {
+  isOpen = true;
+  sent: BridgeMessage[] = [];
+  /** ids for which send() should report failure (dropped). */
+  failIds = new Set<string>();
+  /** messages to hand back from drainPendingBackpressureInto. */
+  backpressured: BridgeMessage[] = [];
+
+  send(m: BridgeMessage): boolean {
+    if (this.failIds.has(m.id)) return false;
+    this.sent.push(m);
+    return true;
+  }
+  drainPendingBackpressureInto(backlog: BoundedMessageBuffer): number {
+    const n = this.backpressured.length;
+    backlog.unshiftMany(this.backpressured);
+    this.backpressured = [];
+    return n;
+  }
+}
+
+function makeRM(over: Partial<RoomManagerDeps> = {}): {
+  rm: RoomManager;
+  logs: string[];
+  shutdowns: string[];
+  state: { claude: ConnectionSession | null; tui: boolean };
+} {
+  const logs: string[] = [];
+  const shutdowns: string[] = [];
+  const state = { claude: null as ConnectionSession | null, tui: false };
+  const rm = new RoomManager({
+    bufferedCap: 100,
+    idleShutdownMs: 20,
+    claudeDisconnectGraceMs: 20,
+    log: (m) => logs.push(m),
+    getClaude: () => state.claude,
+    isTuiConnected: () => state.tui,
+    onIdleShutdown: (r) => shutdowns.push(r),
+    ...over,
+  });
+  return { rm, logs, shutdowns, state };
+}
+
+describe("RoomManager.deliverToClaude", () => {
+  test("open member + successful send → delivered, no backlog", () => {
+    const { rm, state } = makeRM();
+    const s = new FakeSession();
+    state.claude = s as unknown as ConnectionSession;
+    rm.deliverToClaude(msg("a"));
+    expect(s.sent.map((m) => m.id)).toEqual(["a"]);
+    expect(rm.backlogSize).toBe(0);
+  });
+
+  test("no member → buffered", () => {
+    const { rm } = makeRM();
+    rm.deliverToClaude(msg("a"));
+    expect(rm.backlogSize).toBe(1);
+  });
+
+  test("member not OPEN → buffered", () => {
+    const { rm, state } = makeRM();
+    const s = new FakeSession();
+    s.isOpen = false;
+    state.claude = s as unknown as ConnectionSession;
+    rm.deliverToClaude(msg("a"));
+    expect(s.sent.length).toBe(0);
+    expect(rm.backlogSize).toBe(1);
+  });
+
+  test("failed send → buffered + logged", () => {
+    const { rm, state, logs } = makeRM();
+    const s = new FakeSession();
+    s.failIds.add("a");
+    state.claude = s as unknown as ConnectionSession;
+    rm.deliverToClaude(msg("a"));
+    expect(rm.backlogSize).toBe(1);
+    expect(logs.some((l) => l.includes("buffering message for retry"))).toBe(true);
+  });
+});
+
+describe("RoomManager.flushBacklog", () => {
+  test("drains in order to the session", () => {
+    const { rm } = makeRM();
+    rm.deliverToClaude(msg("a"));
+    rm.deliverToClaude(msg("b"));
+    const s = new FakeSession();
+    rm.flushBacklog(s as unknown as ConnectionSession);
+    expect(s.sent.map((m) => m.id)).toEqual(["a", "b"]);
+    expect(rm.backlogSize).toBe(0);
+  });
+
+  test("re-buffers the tail (in order) on a mid-flush send failure", () => {
+    const { rm } = makeRM();
+    rm.deliverToClaude(msg("a"));
+    rm.deliverToClaude(msg("b"));
+    rm.deliverToClaude(msg("c"));
+    const s = new FakeSession();
+    s.failIds.add("b"); // a ok, b fails → b,c re-buffered
+    rm.flushBacklog(s as unknown as ConnectionSession);
+    expect(s.sent.map((m) => m.id)).toEqual(["a"]);
+    expect(rm.backlogSize).toBe(2);
+    // a good session then drains the preserved order b,c
+    const s2 = new FakeSession();
+    rm.flushBacklog(s2 as unknown as ConnectionSession);
+    expect(s2.sent.map((m) => m.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("RoomManager.rebufferOnDetach", () => {
+  test("moves the session's backpressured messages (prepended) into the backlog", () => {
+    const { rm } = makeRM();
+    rm.deliverToClaude(msg("tail")); // already in backlog
+    const s = new FakeSession();
+    s.backpressured = [msg("bp1"), msg("bp2")];
+    const n = rm.rebufferOnDetach(s as unknown as ConnectionSession);
+    expect(n).toBe(2);
+    // backpressured predate the existing backlog entry → prepended
+    const drain = new FakeSession();
+    rm.flushBacklog(drain as unknown as ConnectionSession);
+    expect(drain.sent.map((m) => m.id)).toEqual(["bp1", "bp2", "tail"]);
+  });
+});
+
+describe("RoomManager idle-shutdown timer — reads LIVE state at fire time", () => {
+  test("does not arm idle-shutdown when a client is present", async () => {
+    const { rm, shutdowns, logs, state } = makeRM();
+    state.claude = new FakeSession() as unknown as ConnectionSession;
+    rm.scheduleIdleShutdown();
+    await sleep(45);
+    // The present-client early-return (room-manager.ts: `if (getClaude()) return`)
+    // means no timer is armed, nothing shuts down, and the "will shut down" log
+    // is never emitted. Deleting that guard makes this test go red.
+    expect(shutdowns).toEqual([]);
+    expect(logs.some((l) => l.includes("will shut down"))).toBe(false);
+  });
+
+  test("fires shutdown when still idle at fire time", async () => {
+    const { rm, shutdowns } = makeRM();
+    rm.scheduleIdleShutdown();
+    await sleep(45);
+    expect(shutdowns).toEqual(["idle — no clients connected"]);
+  });
+
+  test("a reconnect BEFORE fire cancels the shutdown (live-state recheck)", async () => {
+    const { rm, shutdowns, state, logs } = makeRM();
+    rm.scheduleIdleShutdown(); // idle → armed
+    state.claude = new FakeSession() as unknown as ConnectionSession; // reconnect before fire
+    await sleep(45);
+    expect(shutdowns).toEqual([]);
+    expect(logs.some((l) => l.includes("Idle shutdown cancelled"))).toBe(true);
+  });
+
+  test("cancelIdleShutdown stops a pending fire", async () => {
+    const { rm, shutdowns } = makeRM();
+    rm.scheduleIdleShutdown();
+    rm.cancelIdleShutdown();
+    await sleep(45);
+    expect(shutdowns).toEqual([]);
+  });
+});
+
+describe("RoomManager claude-disconnect notification timer", () => {
+  test("persists past grace when no reconnect", async () => {
+    const { rm, logs } = makeRM();
+    rm.scheduleClaudeDisconnectNotification(7);
+    await sleep(45);
+    expect(logs.some((l) => l.includes("persisted past grace window (client #7)"))).toBe(true);
+  });
+
+  test("skips notification when reconnected before fire", async () => {
+    const { rm, logs, state } = makeRM();
+    rm.scheduleClaudeDisconnectNotification(7);
+    state.claude = new FakeSession() as unknown as ConnectionSession;
+    await sleep(45);
+    expect(logs.some((l) => l.includes("already reconnected"))).toBe(true);
+    expect(logs.some((l) => l.includes("persisted past grace window"))).toBe(false);
+  });
+
+  test("clearPendingClaudeDisconnect stops the pending notification", async () => {
+    const { rm, logs } = makeRM();
+    rm.scheduleClaudeDisconnectNotification(7);
+    rm.clearPendingClaudeDisconnect("test");
+    await sleep(45);
+    expect(logs.some((l) => l.includes("persisted past grace window"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要 / Summary

PR1a（v3 单团队协作 MVP 地基）：把 `daemon.ts` 的 5 个模块级配对单例重构进三个 concrete class，让状态「可按 id 寻址」，为后续多成员 room 铺路。**行为逐字节保持、对外零变化**（`control-protocol.ts` 未动，1:1 Claude↔Codex 流不受影响）。

Refactor daemon.ts's 5 module-level pairing singletons into three concrete classes so v3 multi-member rooms can later address state by id. **Behaviour bit-preserved, zero external change.**

## 改动 / Changes

| 类 | 层（spec §） | 收口的旧单例 |
|---|---|---|
| `ConnectionSession` | §2.1 session | `ws.data` 机制：send / -1 背压 / sendProtocol / probeLiveness / recordPong / drain 回灌（`ControlSocketData` 迁入本文件） |
| `AgentRegistry` | §2.1 logical-agent | `attachedClaude` 槽位单一真相源 + `codexBootstrapped` + challenge 单飞闸 |
| `RoomManager` | §2.3–2.4 room | `bufferedMessages` backlog + idle/disconnect timer + 投递；timer 回调经注入闭包在 **fire 时**读活状态 |

- `daemon.ts` 保留旧函数名作一行委托器，调用点不变（**net −114 行**）。
- 刻意保留在 daemon 模块作用域（非槽位中心、搬=纯风险）：`lastAttachStatusSentTs` / attentionWindow / bootDeadline / statusBuffer / `codex` / `tuiConnectionState`。

## 测试计划 / Test plan

- [x] `bun run typecheck` 干净
- [x] `bun test src` → **1666 pass / 0 fail**（含新增 3 单测 31 用例：connection-session 12 / agent-registry 5 / room-manager 14）
- [x] `bun run build:plugin` 重建；`bun run check` 全绿（bundle 同步、版本对齐 0.1.24）
- [x] 回归网：现有 `daemon-wiring` / `e2e-reconnect`（attach/detach/probe/contest/背压/重连补投）全绿

## Cross-review

3 轮跨维度对抗式 review（每轮 5 维 reviewer + 逐条 adversarial verify，由独立 subagent 执行）：
- 轮 1：抓出 1 个零断言测试（绿但无效）→ 已修 + **mutation 实证**（删被守护的守卫 → 测试变红）。
- 轮 2 / 轮 3：**连续两轮 0 真实 issue** → 收敛。其余 finding 均用旧新逐字节对照驳倒为非阻塞 RECOMMEND。

## Backlog（RECOMMEND，非阻塞）

- `ConnectionSession.markAttached()` / `ping()` 暂未接线（§2.2 多成员预留 API）——接线或删。
- `sendProtocol` drop/throw、`isOpen` getter、RoomManager TUI-connected idle 分支、`currentStatus` 聚合 可补直测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
