### PR TITLE
feat(backbone): 三接口+双实现+生产skeleton+契约测试 (PR1b)

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14707,10 +14707,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.24", "0.0.0-source"),
-  commit: defineString("39a46f1", "source"),
+  commit: defineString("c5b4172", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("f2cb1899dc80", "source")
+  codeHash: defineString("3705b611c554", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.24", "0.0.0-source"),
-  commit: defineString("39a46f1", "source"),
+  commit: defineString("c5b4172", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("f2cb1899dc80", "source")
+  codeHash: defineString("3705b611c554", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };

--- a/src/backbone/envelope.ts
+++ b/src/backbone/envelope.ts
@@ -1,0 +1,48 @@
+/**
+ * v3 message envelope (spec §3.1 + Appendix A).
+ *
+ * The control-plane unit the broker routes. Coexists with the legacy 2-party
+ * `BridgeMessage` (src/types.ts) — v3 routing uses THIS envelope; the single-
+ * machine Claude↔Codex flow keeps `BridgeMessage`. Carries only structured
+ * signals (a few hundred bytes); NEVER file/code content (data plane = git, §2.6).
+ */
+
+export type DeliveryMode = "online_only" | "store_if_offline";
+
+export interface EnvelopeSender {
+  /** Logical agent id — events are signed precisely to this (§2.1). */
+  agentId: string;
+  /** Ephemeral current session (§2.1); never a membership key. */
+  sessionId?: string;
+  agentType: string;
+  /** Display name, for UI only; routing never uses it (§2.2). */
+  name?: string;
+}
+
+export interface Envelope {
+  /** Room scope (§2.3). */
+  roomId: string;
+  /** Stable per-message id. */
+  messageId: string;
+  /**
+   * Stable trace id for loop prevention across multi-hop forwarding (§3.2) —
+   * the generalisation of the v1 binary-source guard.
+   */
+  traceId: string;
+  /** Dedup key for at-least-once redelivery (§3.2 offline replay). */
+  idempotencyKey: string;
+  from: EnvelopeSender;
+  /** Event-type discriminator, e.g. "task_completed" | "dm" | "member_joined". */
+  kind: string;
+  /** Event-specific body. Kept small; the ledger stores summaries, not blobs (§4.1). */
+  payload?: unknown;
+  timestamp: number;
+  deliveryMode: DeliveryMode;
+  /** Present ⇒ DM (only the listed agents receive it, §3.2). Absent ⇒ room broadcast. */
+  to?: string[];
+  /** @-mentions: delivered to the room, highlighted for these agents (§3.2). */
+  mentions?: string[];
+  /** Remaining forward hops; dropped at 0 (multi-party loop prevention, §3.2). */
+  hop?: number;
+  ack?: { requested: boolean };
+}

--- a/src/backbone/identity.ts
+++ b/src/backbone/identity.ts
@@ -1,0 +1,25 @@
+/**
+ * IdentityProvider interface (spec §6.1, §6.3).
+ *
+ * Authentication here is ROUTING data, not abstract security: event signing, DM
+ * targeting, room membership and presence all need a stable identity. The core
+ * depends only on this interface and only ever uses `Identity.id` — never the
+ * token, never the display name (§6.4). Battery impl = broker-signed PSK; the
+ * production impl (OIDC/SAML) must produce the SAME `Identity` shape so swapping
+ * the driver is a one-line config change with zero core change.
+ */
+
+export interface Identity {
+  /** Globally unique, machine-generated/derived (email or GitHub name, §2.2). */
+  id: string;
+  /** Display only; may collide; routing never uses it. */
+  displayName: string;
+}
+
+export interface IdentityProvider {
+  /**
+   * Resolve a credential (PSK token / OIDC code / …) to a collaboration identity.
+   * Rejects (throws) on an invalid credential.
+   */
+  authenticate(credential: string): Promise<Identity>;
+}

--- a/src/backbone/identity/fake-identity-provider.ts
+++ b/src/backbone/identity/fake-identity-provider.ts
@@ -1,0 +1,26 @@
+/**
+ * Fake IdentityProvider — a test double (§6.4 contract conformance).
+ *
+ * Maps a credential string directly to an Identity, producing the SAME
+ * `{ id, displayName }` shape as the PSK and OIDC drivers so the core sees no
+ * difference. No crypto: lookups are plain map hits.
+ */
+
+import type { Identity, IdentityProvider } from "../identity";
+
+export class FakeIdentityProvider implements IdentityProvider {
+  private readonly mapping: Map<string, Identity>;
+
+  constructor(mapping: Record<string, Identity> | Map<string, Identity>) {
+    this.mapping =
+      mapping instanceof Map ? new Map(mapping) : new Map(Object.entries(mapping));
+  }
+
+  async authenticate(credential: string): Promise<Identity> {
+    const identity = this.mapping.get(credential);
+    if (!identity) {
+      throw new Error("invalid fake credential");
+    }
+    return identity;
+  }
+}

--- a/src/backbone/identity/oidc-identity-provider.ts
+++ b/src/backbone/identity/oidc-identity-provider.ts
@@ -1,0 +1,18 @@
+/**
+ * OIDC IdentityProvider — production SSO skeleton (§11.3).
+ *
+ * Intentionally unimplemented: it exists so the production driver slots into the
+ * same IdentityProvider interface, making the swap a one-line config change with
+ * zero core change (§6.4). The real implementation exchanges an OIDC code for an
+ * id_token and derives `Identity` from verified claims.
+ */
+
+import type { Identity, IdentityProvider } from "../identity";
+
+export class OidcIdentityProvider implements IdentityProvider {
+  async authenticate(_credential: string): Promise<Identity> {
+    throw new Error(
+      "OidcIdentityProvider: not implemented — production SSO skeleton (§11.3)",
+    );
+  }
+}

--- a/src/backbone/identity/psk-identity-provider.ts
+++ b/src/backbone/identity/psk-identity-provider.ts
@@ -1,0 +1,45 @@
+/**
+ * PSK (pre-shared key) IdentityProvider — the §6.2 "battery" driver.
+ *
+ * A PSK token is broker-signed and bound to ONE identity at issue time. This
+ * provider holds the issued (token -> identity) list and resolves a presented
+ * credential by constant-time comparison against each issued token.
+ *
+ * control-token.ts has an equivalent `constantTimeEquals`, but it is module-
+ * private (not exported), so we use node:crypto's `timingSafeEqual` directly.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import type { Identity, IdentityProvider } from "../identity";
+
+/**
+ * Length-independent constant-time string compare. `timingSafeEqual` throws on
+ * unequal-length buffers, so on a length mismatch we still run an equal-length
+ * compare (a vs a) to keep timing uniform, then fail.
+ */
+function constantTimeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) {
+    timingSafeEqual(ab, ab);
+    return false;
+  }
+  return timingSafeEqual(ab, bb);
+}
+
+export class PskIdentityProvider implements IdentityProvider {
+  private readonly issued: ReadonlyArray<{ token: string; identity: Identity }>;
+
+  constructor(issued: Array<{ token: string; identity: Identity }>) {
+    this.issued = [...issued];
+  }
+
+  async authenticate(credential: string): Promise<Identity> {
+    for (const { token, identity } of this.issued) {
+      if (constantTimeEquals(credential, token)) {
+        return identity;
+      }
+    }
+    throw new Error("invalid PSK token");
+  }
+}

--- a/src/backbone/store.ts
+++ b/src/backbone/store.ts
@@ -1,0 +1,92 @@
+import type { Envelope } from "./envelope";
+
+/**
+ * Store interface (spec §6.1, §12 data model).
+ *
+ * The persistence seam. Battery impl = SQLite (WAL); production impl = Postgres
+ * behind the same interface. Methods are async to anticipate the networked
+ * production backend (§6.4: swapping the driver must not change the core), even
+ * though the SQLite/in-memory battery impls do synchronous work under the hood.
+ *
+ * Holds only control-plane state (§12) — identities, rooms, membership, session
+ * accounting, the event ledger, the whiteboard, pending deliveries. Never code.
+ */
+
+export interface IdentityRecord {
+  id: string;
+  displayName: string;
+}
+
+export interface AgentRecord {
+  agentId: string;
+  personId: string;
+  type: string;
+}
+
+export interface RoomRecord {
+  roomId: string;
+  name: string;
+  createdBy: string;
+}
+
+/** A whiteboard slot item — flexible shape filled by the mechanical merge (§4.2). */
+export type WhiteboardItem = Record<string, unknown>;
+
+/** The four structured whiteboard slots (Appendix B). */
+export interface WhiteboardRecord {
+  roomId: string;
+  contractsReady: WhiteboardItem[];
+  inProgress: WhiteboardItem[];
+  blockers: WhiteboardItem[];
+  recentMilestones: WhiteboardItem[];
+  updatedAt: number;
+}
+
+export interface Store {
+  // --- identities (§2.2): UNIQUE id; same id re-registering REUSES the row ---
+  upsertIdentity(id: string, displayName: string): Promise<IdentityRecord>;
+  getIdentity(id: string): Promise<IdentityRecord | null>;
+
+  // --- agents / logical agent (§2.1) ---
+  upsertAgent(agentId: string, personId: string, type: string): Promise<void>;
+  getAgent(agentId: string): Promise<AgentRecord | null>;
+
+  // --- sessions (§2.5): current/historical session rows ---
+  recordSession(sessionId: string, agentId: string, startedAt: number): Promise<void>;
+
+  // --- workspace session accounting (§2.5): (workspace, agentType) → lastSessionId ---
+  getLastSession(workspacePath: string, agentType: string): Promise<string | null>;
+  setLastSession(workspacePath: string, agentType: string, sessionId: string): Promise<void>;
+
+  // --- rooms (§2.3): anyone can create, others join ---
+  createRoom(roomId: string, name: string, createdBy: string): Promise<void>;
+  getRoom(roomId: string): Promise<RoomRecord | null>;
+  listRooms(): Promise<RoomRecord[]>;
+
+  // --- room members (§2.3): bound to logical agent id, persistent (survives restart) ---
+  addMember(roomId: string, agentId: string): Promise<void>;
+  removeMember(roomId: string, agentId: string): Promise<void>;
+  getMembers(roomId: string): Promise<string[]>;
+  getRoomsForAgent(agentId: string): Promise<string[]>;
+
+  // --- cwd → room map (§2.4): auto-join by workspace path ---
+  mapCwd(workspacePath: string, roomId: string): Promise<void>;
+  getRoomForCwd(workspacePath: string): Promise<string | null>;
+
+  // --- room_events: append-only ledger (§4.1); store envelopes (summaries, not blobs) ---
+  appendEvent(roomId: string, envelope: Envelope): Promise<void>;
+  /** Most-recent-first, capped at `limit` (rolling retention, §4.3). */
+  getRecentEvents(roomId: string, limit: number): Promise<Envelope[]>;
+
+  // --- room_whiteboard: one overwriting row per room (§4.2) ---
+  getWhiteboard(roomId: string): Promise<WhiteboardRecord | null>;
+  saveWhiteboard(roomId: string, whiteboard: WhiteboardRecord): Promise<void>;
+
+  // --- pending_deliveries: offline replay queue (§3.2), dedup by idempotencyKey ---
+  enqueuePending(targetAgentId: string, envelope: Envelope): Promise<void>;
+  /** Remove and return the target's pending envelopes (deduped by idempotencyKey). */
+  drainPending(targetAgentId: string): Promise<Envelope[]>;
+
+  /** Release resources (close the DB handle). Idempotent. */
+  close(): Promise<void>;
+}

--- a/src/backbone/store/memory-store.ts
+++ b/src/backbone/store/memory-store.ts
@@ -1,0 +1,154 @@
+import type { Envelope } from "../envelope";
+import type {
+  AgentRecord,
+  IdentityRecord,
+  RoomRecord,
+  Store,
+  WhiteboardRecord,
+} from "../store";
+
+/**
+ * In-memory Store impl — same contract as SqliteStore (§6.4), zero persistence.
+ * Used for fast unit tests and ephemeral runs. Maps mirror the SQLite schema.
+ */
+export class InMemoryStore implements Store {
+  private identities = new Map<string, IdentityRecord>();
+  private agents = new Map<string, AgentRecord>();
+  private sessions = new Map<string, { agentId: string; startedAt: number }>();
+  private workspaceSessions = new Map<string, string>(); // `${path}\0${type}` → sessionId
+  private rooms = new Map<string, RoomRecord>();
+  private members = new Map<string, Set<string>>(); // roomId → agentIds
+  private cwdRoom = new Map<string, string>();
+  private events = new Map<string, Envelope[]>(); // roomId → append-ordered ledger
+  private whiteboards = new Map<string, WhiteboardRecord>();
+  // targetAgentId → (idempotencyKey → envelope); Map preserves insertion order
+  private pending = new Map<string, Map<string, Envelope>>();
+
+  async upsertIdentity(id: string, displayName: string): Promise<IdentityRecord> {
+    const record = { id, displayName };
+    this.identities.set(id, record);
+    return record;
+  }
+
+  async getIdentity(id: string): Promise<IdentityRecord | null> {
+    return this.identities.get(id) ?? null;
+  }
+
+  async upsertAgent(agentId: string, personId: string, type: string): Promise<void> {
+    this.agents.set(agentId, { agentId, personId, type });
+  }
+
+  async getAgent(agentId: string): Promise<AgentRecord | null> {
+    return this.agents.get(agentId) ?? null;
+  }
+
+  async recordSession(sessionId: string, agentId: string, startedAt: number): Promise<void> {
+    this.sessions.set(sessionId, { agentId, startedAt });
+  }
+
+  async getLastSession(workspacePath: string, agentType: string): Promise<string | null> {
+    return this.workspaceSessions.get(`${workspacePath}\0${agentType}`) ?? null;
+  }
+
+  async setLastSession(
+    workspacePath: string,
+    agentType: string,
+    sessionId: string,
+  ): Promise<void> {
+    this.workspaceSessions.set(`${workspacePath}\0${agentType}`, sessionId);
+  }
+
+  async createRoom(roomId: string, name: string, createdBy: string): Promise<void> {
+    if (this.rooms.has(roomId)) return; // INSERT OR IGNORE — first create wins
+    this.rooms.set(roomId, { roomId, name, createdBy });
+  }
+
+  async getRoom(roomId: string): Promise<RoomRecord | null> {
+    return this.rooms.get(roomId) ?? null;
+  }
+
+  async listRooms(): Promise<RoomRecord[]> {
+    return [...this.rooms.values()];
+  }
+
+  async addMember(roomId: string, agentId: string): Promise<void> {
+    let set = this.members.get(roomId);
+    if (!set) {
+      set = new Set();
+      this.members.set(roomId, set);
+    }
+    set.add(agentId); // Set membership is naturally idempotent
+  }
+
+  async removeMember(roomId: string, agentId: string): Promise<void> {
+    this.members.get(roomId)?.delete(agentId);
+  }
+
+  async getMembers(roomId: string): Promise<string[]> {
+    return [...(this.members.get(roomId) ?? [])];
+  }
+
+  async getRoomsForAgent(agentId: string): Promise<string[]> {
+    // ponytail: O(rooms) scan; fine for control-plane sizes
+    const out: string[] = [];
+    for (const [roomId, set] of this.members) {
+      if (set.has(agentId)) out.push(roomId);
+    }
+    return out;
+  }
+
+  async mapCwd(workspacePath: string, roomId: string): Promise<void> {
+    this.cwdRoom.set(workspacePath, roomId); // remap overwrites
+  }
+
+  async getRoomForCwd(workspacePath: string): Promise<string | null> {
+    return this.cwdRoom.get(workspacePath) ?? null;
+  }
+
+  async appendEvent(roomId: string, envelope: Envelope): Promise<void> {
+    let list = this.events.get(roomId);
+    if (!list) {
+      list = [];
+      this.events.set(roomId, list);
+    }
+    list.push(envelope);
+  }
+
+  async getRecentEvents(roomId: string, limit: number): Promise<Envelope[]> {
+    // Non-positive limit → empty (matches SqliteStore). Without this, slice(-0)
+    // === slice(0) would return the WHOLE ledger for limit=0.
+    if (limit <= 0) return [];
+    const list = this.events.get(roomId) ?? [];
+    return list.slice(-limit).reverse(); // last N, most-recent-first
+  }
+
+  async getWhiteboard(roomId: string): Promise<WhiteboardRecord | null> {
+    return this.whiteboards.get(roomId) ?? null;
+  }
+
+  async saveWhiteboard(roomId: string, whiteboard: WhiteboardRecord): Promise<void> {
+    this.whiteboards.set(roomId, whiteboard); // overwrite
+  }
+
+  async enqueuePending(targetAgentId: string, envelope: Envelope): Promise<void> {
+    let byKey = this.pending.get(targetAgentId);
+    if (!byKey) {
+      byKey = new Map();
+      this.pending.set(targetAgentId, byKey);
+    }
+    if (!byKey.has(envelope.idempotencyKey)) {
+      byKey.set(envelope.idempotencyKey, envelope); // dedup: first wins
+    }
+  }
+
+  async drainPending(targetAgentId: string): Promise<Envelope[]> {
+    const byKey = this.pending.get(targetAgentId);
+    if (!byKey) return [];
+    this.pending.delete(targetAgentId);
+    return [...byKey.values()];
+  }
+
+  async close(): Promise<void> {
+    // No handle to release; idempotent no-op.
+  }
+}

--- a/src/backbone/store/postgres-store.ts
+++ b/src/backbone/store/postgres-store.ts
@@ -1,0 +1,114 @@
+import type { Envelope } from "../envelope";
+import type {
+  AgentRecord,
+  IdentityRecord,
+  RoomRecord,
+  Store,
+  WhiteboardRecord,
+} from "../store";
+
+const NOT_IMPLEMENTED =
+  "PostgresStore: not implemented — production backend skeleton (§11.3)";
+
+/**
+ * Production backend skeleton (§6.4, §11.3). Proves the Store seam admits a
+ * networked Postgres driver without touching the core; every method throws
+ * until the real driver lands.
+ */
+export class PostgresStore implements Store {
+  async upsertIdentity(_id: string, _displayName: string): Promise<IdentityRecord> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getIdentity(_id: string): Promise<IdentityRecord | null> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async upsertAgent(_agentId: string, _personId: string, _type: string): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getAgent(_agentId: string): Promise<AgentRecord | null> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async recordSession(_sessionId: string, _agentId: string, _startedAt: number): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getLastSession(_workspacePath: string, _agentType: string): Promise<string | null> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async setLastSession(
+    _workspacePath: string,
+    _agentType: string,
+    _sessionId: string,
+  ): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async createRoom(_roomId: string, _name: string, _createdBy: string): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getRoom(_roomId: string): Promise<RoomRecord | null> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async listRooms(): Promise<RoomRecord[]> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async addMember(_roomId: string, _agentId: string): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async removeMember(_roomId: string, _agentId: string): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getMembers(_roomId: string): Promise<string[]> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getRoomsForAgent(_agentId: string): Promise<string[]> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async mapCwd(_workspacePath: string, _roomId: string): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getRoomForCwd(_workspacePath: string): Promise<string | null> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async appendEvent(_roomId: string, _envelope: Envelope): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getRecentEvents(_roomId: string, _limit: number): Promise<Envelope[]> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getWhiteboard(_roomId: string): Promise<WhiteboardRecord | null> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async saveWhiteboard(_roomId: string, _whiteboard: WhiteboardRecord): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async enqueuePending(_targetAgentId: string, _envelope: Envelope): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async drainPending(_targetAgentId: string): Promise<Envelope[]> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async close(): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+}

--- a/src/backbone/store/sqlite-store.ts
+++ b/src/backbone/store/sqlite-store.ts
@@ -1,0 +1,258 @@
+import { Database } from "bun:sqlite";
+import type { Envelope } from "../envelope";
+import type {
+  AgentRecord,
+  IdentityRecord,
+  RoomRecord,
+  Store,
+  WhiteboardRecord,
+} from "../store";
+
+/**
+ * Battery-grade Store impl (§6.4): SQLite (WAL) behind the async interface.
+ * The same contract suite passes here and against InMemoryStore / Postgres.
+ */
+export class SqliteStore implements Store {
+  private db: Database;
+  private closed = false;
+
+  constructor(path: string) {
+    this.db = new Database(path);
+    this.db.exec("PRAGMA journal_mode=WAL");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS identities (
+        id TEXT PRIMARY KEY,
+        display_name TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS agents (
+        agent_id TEXT PRIMARY KEY,
+        person_id TEXT NOT NULL,
+        type TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS sessions (
+        session_id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        started_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS workspace_sessions (
+        workspace_path TEXT,
+        agent_type TEXT,
+        last_session_id TEXT NOT NULL,
+        PRIMARY KEY (workspace_path, agent_type)
+      );
+      CREATE TABLE IF NOT EXISTS rooms (
+        room_id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        created_by TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS room_members (
+        room_id TEXT,
+        agent_id TEXT,
+        PRIMARY KEY (room_id, agent_id)
+      );
+      CREATE TABLE IF NOT EXISTS cwd_room_map (
+        workspace_path TEXT PRIMARY KEY,
+        room_id TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS room_events (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        room_id TEXT NOT NULL,
+        envelope TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS room_whiteboard (
+        room_id TEXT PRIMARY KEY,
+        data TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS pending_deliveries (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        target_agent_id TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        envelope TEXT NOT NULL,
+        UNIQUE (target_agent_id, idempotency_key)
+      );
+    `);
+  }
+
+  // --- identities ---
+  async upsertIdentity(id: string, displayName: string): Promise<IdentityRecord> {
+    this.db
+      .query(
+        "INSERT INTO identities(id, display_name) VALUES(?, ?) ON CONFLICT(id) DO UPDATE SET display_name=excluded.display_name",
+      )
+      .run(id, displayName);
+    return { id, displayName };
+  }
+
+  async getIdentity(id: string): Promise<IdentityRecord | null> {
+    const row = this.db
+      .query("SELECT id, display_name FROM identities WHERE id=?")
+      .get(id) as { id: string; display_name: string } | null;
+    return row ? { id: row.id, displayName: row.display_name } : null;
+  }
+
+  // --- agents ---
+  async upsertAgent(agentId: string, personId: string, type: string): Promise<void> {
+    this.db
+      .query(
+        "INSERT INTO agents(agent_id, person_id, type) VALUES(?, ?, ?) ON CONFLICT(agent_id) DO UPDATE SET person_id=excluded.person_id, type=excluded.type",
+      )
+      .run(agentId, personId, type);
+  }
+
+  async getAgent(agentId: string): Promise<AgentRecord | null> {
+    const row = this.db
+      .query("SELECT agent_id, person_id, type FROM agents WHERE agent_id=?")
+      .get(agentId) as { agent_id: string; person_id: string; type: string } | null;
+    return row ? { agentId: row.agent_id, personId: row.person_id, type: row.type } : null;
+  }
+
+  // --- sessions ---
+  async recordSession(sessionId: string, agentId: string, startedAt: number): Promise<void> {
+    this.db
+      .query("INSERT OR REPLACE INTO sessions(session_id, agent_id, started_at) VALUES(?, ?, ?)")
+      .run(sessionId, agentId, startedAt);
+  }
+
+  async getLastSession(workspacePath: string, agentType: string): Promise<string | null> {
+    const row = this.db
+      .query(
+        "SELECT last_session_id FROM workspace_sessions WHERE workspace_path=? AND agent_type=?",
+      )
+      .get(workspacePath, agentType) as { last_session_id: string } | null;
+    return row ? row.last_session_id : null;
+  }
+
+  async setLastSession(
+    workspacePath: string,
+    agentType: string,
+    sessionId: string,
+  ): Promise<void> {
+    this.db
+      .query(
+        "INSERT INTO workspace_sessions(workspace_path, agent_type, last_session_id) VALUES(?, ?, ?) ON CONFLICT(workspace_path, agent_type) DO UPDATE SET last_session_id=excluded.last_session_id",
+      )
+      .run(workspacePath, agentType, sessionId);
+  }
+
+  // --- rooms ---
+  async createRoom(roomId: string, name: string, createdBy: string): Promise<void> {
+    this.db
+      .query("INSERT OR IGNORE INTO rooms(room_id, name, created_by) VALUES(?, ?, ?)")
+      .run(roomId, name, createdBy);
+  }
+
+  async getRoom(roomId: string): Promise<RoomRecord | null> {
+    const row = this.db
+      .query("SELECT room_id, name, created_by FROM rooms WHERE room_id=?")
+      .get(roomId) as { room_id: string; name: string; created_by: string } | null;
+    return row ? { roomId: row.room_id, name: row.name, createdBy: row.created_by } : null;
+  }
+
+  async listRooms(): Promise<RoomRecord[]> {
+    const rows = this.db
+      .query("SELECT room_id, name, created_by FROM rooms")
+      .all() as { room_id: string; name: string; created_by: string }[];
+    return rows.map((r) => ({ roomId: r.room_id, name: r.name, createdBy: r.created_by }));
+  }
+
+  // --- room members ---
+  async addMember(roomId: string, agentId: string): Promise<void> {
+    this.db
+      .query("INSERT OR IGNORE INTO room_members(room_id, agent_id) VALUES(?, ?)")
+      .run(roomId, agentId);
+  }
+
+  async removeMember(roomId: string, agentId: string): Promise<void> {
+    this.db
+      .query("DELETE FROM room_members WHERE room_id=? AND agent_id=?")
+      .run(roomId, agentId);
+  }
+
+  async getMembers(roomId: string): Promise<string[]> {
+    const rows = this.db
+      .query("SELECT agent_id FROM room_members WHERE room_id=?")
+      .all(roomId) as { agent_id: string }[];
+    return rows.map((r) => r.agent_id);
+  }
+
+  async getRoomsForAgent(agentId: string): Promise<string[]> {
+    const rows = this.db
+      .query("SELECT room_id FROM room_members WHERE agent_id=?")
+      .all(agentId) as { room_id: string }[];
+    return rows.map((r) => r.room_id);
+  }
+
+  // --- cwd → room map ---
+  async mapCwd(workspacePath: string, roomId: string): Promise<void> {
+    this.db
+      .query(
+        "INSERT INTO cwd_room_map(workspace_path, room_id) VALUES(?, ?) ON CONFLICT(workspace_path) DO UPDATE SET room_id=excluded.room_id",
+      )
+      .run(workspacePath, roomId);
+  }
+
+  async getRoomForCwd(workspacePath: string): Promise<string | null> {
+    const row = this.db
+      .query("SELECT room_id FROM cwd_room_map WHERE workspace_path=?")
+      .get(workspacePath) as { room_id: string } | null;
+    return row ? row.room_id : null;
+  }
+
+  // --- event ledger ---
+  async appendEvent(roomId: string, envelope: Envelope): Promise<void> {
+    this.db
+      .query("INSERT INTO room_events(room_id, envelope) VALUES(?, ?)")
+      .run(roomId, JSON.stringify(envelope));
+  }
+
+  async getRecentEvents(roomId: string, limit: number): Promise<Envelope[]> {
+    // Non-positive limit → empty (SQLite treats `LIMIT -1` as "unlimited"; keep
+    // the semantics crisp and identical to InMemoryStore).
+    if (limit <= 0) return [];
+    const rows = this.db
+      .query("SELECT envelope FROM room_events WHERE room_id=? ORDER BY seq DESC LIMIT ?")
+      .all(roomId, limit) as { envelope: string }[];
+    return rows.map((r) => JSON.parse(r.envelope) as Envelope);
+  }
+
+  // --- whiteboard ---
+  async getWhiteboard(roomId: string): Promise<WhiteboardRecord | null> {
+    const row = this.db
+      .query("SELECT data FROM room_whiteboard WHERE room_id=?")
+      .get(roomId) as { data: string } | null;
+    return row ? (JSON.parse(row.data) as WhiteboardRecord) : null;
+  }
+
+  async saveWhiteboard(roomId: string, whiteboard: WhiteboardRecord): Promise<void> {
+    this.db
+      .query(
+        "INSERT INTO room_whiteboard(room_id, data) VALUES(?, ?) ON CONFLICT(room_id) DO UPDATE SET data=excluded.data",
+      )
+      .run(roomId, JSON.stringify(whiteboard));
+  }
+
+  // --- pending deliveries ---
+  async enqueuePending(targetAgentId: string, envelope: Envelope): Promise<void> {
+    this.db
+      .query(
+        "INSERT OR IGNORE INTO pending_deliveries(target_agent_id, idempotency_key, envelope) VALUES(?, ?, ?)",
+      )
+      .run(targetAgentId, envelope.idempotencyKey, JSON.stringify(envelope));
+  }
+
+  async drainPending(targetAgentId: string): Promise<Envelope[]> {
+    const rows = this.db
+      .query("SELECT envelope FROM pending_deliveries WHERE target_agent_id=? ORDER BY seq")
+      .all(targetAgentId) as { envelope: string }[];
+    this.db
+      .query("DELETE FROM pending_deliveries WHERE target_agent_id=?")
+      .run(targetAgentId);
+    return rows.map((r) => JSON.parse(r.envelope) as Envelope);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.db.close();
+  }
+}

--- a/src/backbone/transport.ts
+++ b/src/backbone/transport.ts
@@ -1,0 +1,22 @@
+import type { Envelope } from "./envelope";
+
+/**
+ * MessageTransport interface (spec §6.1, §6.2).
+ *
+ * The pub/sub seam the broker routes envelopes through. Battery impl = in-process
+ * event bus (+ WSS fan-out, wired in the broker PR); production impl = NATS /
+ * Redis Streams / Kafka behind the same interface. The core depends only on this
+ * interface — swapping the driver is a one-line config change.
+ */
+
+export type Unsubscribe = () => void;
+
+export interface MessageTransport {
+  /** Publish an envelope to a topic (e.g. a room id). */
+  publish(topic: string, msg: Envelope): Promise<void>;
+  /**
+   * Subscribe to a topic. Returns an unsubscribe handle. The handler MUST NOT be
+   * invoked after unsubscribe.
+   */
+  subscribe(topic: string, handler: (msg: Envelope) => void): Unsubscribe;
+}

--- a/src/backbone/transport/in-memory-transport.ts
+++ b/src/backbone/transport/in-memory-transport.ts
@@ -1,0 +1,35 @@
+import type { Envelope } from "../envelope";
+import type { MessageTransport, Unsubscribe } from "../transport";
+
+/**
+ * In-memory transport test double. Same contract as InProcTransport, plus a
+ * `published` log every publish appends to — the introspection point for tests
+ * that assert what was emitted.
+ */
+export class InMemoryTransport implements MessageTransport {
+  private readonly topics = new Map<string, Set<(m: Envelope) => void>>();
+  readonly published: Envelope[] = [];
+
+  subscribe(topic: string, handler: (msg: Envelope) => void): Unsubscribe {
+    let set = this.topics.get(topic);
+    if (!set) {
+      set = new Set();
+      this.topics.set(topic, set);
+    }
+    set.add(handler);
+    return () => {
+      set!.delete(handler);
+    };
+  }
+
+  publish(topic: string, msg: Envelope): Promise<void> {
+    this.published.push(msg);
+    const set = this.topics.get(topic);
+    if (set) {
+      for (const handler of [...set]) {
+        handler(msg);
+      }
+    }
+    return Promise.resolve();
+  }
+}

--- a/src/backbone/transport/inproc-transport.ts
+++ b/src/backbone/transport/inproc-transport.ts
@@ -1,0 +1,33 @@
+import type { Envelope } from "../envelope";
+import type { MessageTransport, Unsubscribe } from "../transport";
+
+/**
+ * In-process pub/sub transport (spec §6.1 battery impl). Topic → handler set;
+ * publish snapshots the set before fanning out so a handler that (un)subscribes
+ * during delivery cannot corrupt the iteration.
+ */
+export class InProcTransport implements MessageTransport {
+  private readonly topics = new Map<string, Set<(m: Envelope) => void>>();
+
+  subscribe(topic: string, handler: (msg: Envelope) => void): Unsubscribe {
+    let set = this.topics.get(topic);
+    if (!set) {
+      set = new Set();
+      this.topics.set(topic, set);
+    }
+    set.add(handler);
+    return () => {
+      set!.delete(handler);
+    };
+  }
+
+  publish(topic: string, msg: Envelope): Promise<void> {
+    const set = this.topics.get(topic);
+    if (set) {
+      for (const handler of [...set]) {
+        handler(msg);
+      }
+    }
+    return Promise.resolve();
+  }
+}

--- a/src/backbone/transport/nats-transport.ts
+++ b/src/backbone/transport/nats-transport.ts
@@ -1,0 +1,17 @@
+import type { Envelope } from "../envelope";
+import type { MessageTransport, Unsubscribe } from "../transport";
+
+/**
+ * Production transport skeleton (spec §11.3). NATS / Redis Streams / Kafka would
+ * implement the same MessageTransport interface; this placeholder throws until
+ * the driver is wired, so an accidental production swap fails loudly.
+ */
+export class NatsTransport implements MessageTransport {
+  async publish(_topic: string, _msg: Envelope): Promise<void> {
+    throw new Error("NatsTransport: not implemented — production transport skeleton (§11.3)");
+  }
+
+  subscribe(_topic: string, _handler: (msg: Envelope) => void): Unsubscribe {
+    throw new Error("NatsTransport: not implemented — production transport skeleton (§11.3)");
+  }
+}

--- a/src/unit-test/backbone-fixtures.ts
+++ b/src/unit-test/backbone-fixtures.ts
@@ -1,0 +1,16 @@
+import type { Envelope } from "../backbone/envelope";
+
+/** Build a v3 Envelope with sensible defaults for contract tests. */
+export function makeEnvelope(over: Partial<Envelope> = {}): Envelope {
+  return {
+    roomId: "room-1",
+    messageId: "m1",
+    traceId: "t1",
+    idempotencyKey: "k1",
+    from: { agentId: "ag-1", agentType: "claude" },
+    kind: "task_completed",
+    timestamp: 1,
+    deliveryMode: "store_if_offline",
+    ...over,
+  };
+}

--- a/src/unit-test/identity-contract.ts
+++ b/src/unit-test/identity-contract.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "bun:test";
+import type { Identity, IdentityProvider } from "../backbone/identity";
+
+/**
+ * Shared IdentityProvider contract (NOT a *.test.ts).
+ *
+ * The §6.4 guarantee: every provider — PSK battery, OIDC production, test fake —
+ * resolves a valid credential to the SAME `Identity` shape `{ id, displayName }`,
+ * and rejects an invalid one. Each driver supplies its own valid/invalid
+ * credentials and the expected identity (since the credential format differs per
+ * provider), but the asserted shape is identical.
+ */
+export function runIdentityProviderContract(
+  label: string,
+  opts: {
+    makeProvider: () => IdentityProvider;
+    validCredential: string;
+    expected: Identity;
+    invalidCredential: string;
+  },
+) {
+  describe(`IdentityProvider contract — ${label}`, () => {
+    test("resolves a valid credential to the expected {id, displayName}", async () => {
+      const id = await opts.makeProvider().authenticate(opts.validCredential);
+      expect(id).toEqual(opts.expected);
+      // shape invariants the core depends on
+      expect(typeof id.id).toBe("string");
+      expect(id.id.length).toBeGreaterThan(0);
+      expect(typeof id.displayName).toBe("string");
+    });
+
+    test("rejects an invalid credential", async () => {
+      await expect(opts.makeProvider().authenticate(opts.invalidCredential)).rejects.toThrow();
+    });
+  });
+}

--- a/src/unit-test/identity-fake.test.ts
+++ b/src/unit-test/identity-fake.test.ts
@@ -1,0 +1,12 @@
+import { runIdentityProviderContract } from "./identity-contract";
+import { FakeIdentityProvider } from "../backbone/identity/fake-identity-provider";
+
+runIdentityProviderContract("fake", {
+  makeProvider: () =>
+    new FakeIdentityProvider({
+      "cred-bob": { id: "bob@x.com", displayName: "Bob" },
+    }),
+  validCredential: "cred-bob",
+  expected: { id: "bob@x.com", displayName: "Bob" },
+  invalidCredential: "nope",
+});

--- a/src/unit-test/identity-oidc-skeleton.test.ts
+++ b/src/unit-test/identity-oidc-skeleton.test.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "bun:test";
+import { OidcIdentityProvider } from "../backbone/identity/oidc-identity-provider";
+
+test("OidcIdentityProvider.authenticate rejects (production skeleton, §11.3)", async () => {
+  await expect(new OidcIdentityProvider().authenticate("x")).rejects.toThrow();
+});

--- a/src/unit-test/identity-psk.test.ts
+++ b/src/unit-test/identity-psk.test.ts
@@ -1,0 +1,12 @@
+import { runIdentityProviderContract } from "./identity-contract";
+import { PskIdentityProvider } from "../backbone/identity/psk-identity-provider";
+
+runIdentityProviderContract("psk", {
+  makeProvider: () =>
+    new PskIdentityProvider([
+      { token: "tok-123", identity: { id: "alice@x.com", displayName: "Alice" } },
+    ]),
+  validCredential: "tok-123",
+  expected: { id: "alice@x.com", displayName: "Alice" },
+  invalidCredential: "wrong-token",
+});

--- a/src/unit-test/store-contract.ts
+++ b/src/unit-test/store-contract.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import type { Store } from "../backbone/store";
+import { makeEnvelope } from "./backbone-fixtures";
+
+/**
+ * Shared Store contract (NOT a *.test.ts — imported by per-impl driver tests).
+ * Every Store implementation MUST pass this identical suite (§6.4: "one contract,
+ * both implementations pass" — proves the interface isn't polluted by impl detail).
+ */
+export function runStoreContract(label: string, makeStore: () => Store) {
+  describe(`Store contract — ${label}`, () => {
+    let store: Store;
+    beforeEach(() => {
+      store = makeStore();
+    });
+    afterEach(async () => {
+      await store.close();
+    });
+
+    test("upsertIdentity is idempotent on id (same email reuses the row)", async () => {
+      const a = await store.upsertIdentity("alice@x.com", "Alice");
+      expect(a).toEqual({ id: "alice@x.com", displayName: "Alice" });
+      // Re-register the same id (a second device) → still one row, id stable, name updated.
+      await store.upsertIdentity("alice@x.com", "Alice (laptop)");
+      expect(await store.getIdentity("alice@x.com")).toEqual({
+        id: "alice@x.com",
+        displayName: "Alice (laptop)",
+      });
+      expect(await store.getIdentity("nobody")).toBeNull();
+    });
+
+    test("agents round-trip", async () => {
+      await store.upsertAgent("ag-1", "alice@x.com", "claude");
+      expect(await store.getAgent("ag-1")).toEqual({
+        agentId: "ag-1",
+        personId: "alice@x.com",
+        type: "claude",
+      });
+      expect(await store.getAgent("ag-x")).toBeNull();
+    });
+
+    test("workspace session accounting (overwrite, distinct per agentType)", async () => {
+      expect(await store.getLastSession("/repo", "claude")).toBeNull();
+      await store.setLastSession("/repo", "claude", "sess-1");
+      expect(await store.getLastSession("/repo", "claude")).toBe("sess-1");
+      await store.setLastSession("/repo", "claude", "sess-2");
+      expect(await store.getLastSession("/repo", "claude")).toBe("sess-2");
+      expect(await store.getLastSession("/repo", "codex")).toBeNull();
+    });
+
+    test("rooms create / get / list", async () => {
+      await store.createRoom("room-checkout", "checkout", "ag-1");
+      expect(await store.getRoom("room-checkout")).toEqual({
+        roomId: "room-checkout",
+        name: "checkout",
+        createdBy: "ag-1",
+      });
+      await store.createRoom("room-auth", "auth", "ag-2");
+      const ids = (await store.listRooms()).map((r) => r.roomId).sort();
+      expect(ids).toEqual(["room-auth", "room-checkout"]);
+      expect(await store.getRoom("nope")).toBeNull();
+    });
+
+    test("membership persists, queryable both directions, idempotent add, remove works", async () => {
+      await store.createRoom("r1", "r1", "ag-1");
+      await store.addMember("r1", "ag-1");
+      await store.addMember("r1", "ag-2");
+      await store.addMember("r1", "ag-1"); // idempotent — no duplicate
+      expect((await store.getMembers("r1")).sort()).toEqual(["ag-1", "ag-2"]);
+      expect(await store.getRoomsForAgent("ag-1")).toEqual(["r1"]);
+      await store.removeMember("r1", "ag-2");
+      expect(await store.getMembers("r1")).toEqual(["ag-1"]);
+    });
+
+    test("cwd → room map (remap overwrites)", async () => {
+      expect(await store.getRoomForCwd("/repo/a")).toBeNull();
+      await store.mapCwd("/repo/a", "r1");
+      expect(await store.getRoomForCwd("/repo/a")).toBe("r1");
+      await store.mapCwd("/repo/a", "r2");
+      expect(await store.getRoomForCwd("/repo/a")).toBe("r2");
+    });
+
+    test("event ledger appends, returns most-recent-first within limit, scoped per room", async () => {
+      await store.appendEvent("r1", makeEnvelope({ messageId: "m1", timestamp: 1 }));
+      await store.appendEvent("r1", makeEnvelope({ messageId: "m2", timestamp: 2 }));
+      await store.appendEvent("r1", makeEnvelope({ messageId: "m3", timestamp: 3 }));
+      await store.appendEvent("r2", makeEnvelope({ roomId: "r2", messageId: "x", timestamp: 9 }));
+      const recent = await store.getRecentEvents("r1", 2);
+      expect(recent.map((e) => e.messageId)).toEqual(["m3", "m2"]);
+      expect((await store.getRecentEvents("r1", 10)).length).toBe(3);
+      // round-trips the full envelope, not just the id
+      expect(recent[0]!.from.agentId).toBe("ag-1");
+      // §6.4: a non-positive limit returns empty, IDENTICALLY across impls
+      // (guards InMemoryStore's slice(-0)=slice(0) and SQLite's LIMIT -1=unlimited).
+      expect(await store.getRecentEvents("r1", 0)).toEqual([]);
+      expect(await store.getRecentEvents("r1", -1)).toEqual([]);
+    });
+
+    test("whiteboard save / get round-trip (overwrite)", async () => {
+      expect(await store.getWhiteboard("r1")).toBeNull();
+      const wb = {
+        roomId: "r1",
+        contractsReady: [{ contract: "auth/v1", by: "ag-7" }],
+        inProgress: [],
+        blockers: [],
+        recentMilestones: [],
+        updatedAt: 5,
+      };
+      await store.saveWhiteboard("r1", wb);
+      expect(await store.getWhiteboard("r1")).toEqual(wb);
+      const wb2 = { ...wb, updatedAt: 6, blockers: [{ what: "waiting on payment" }] };
+      await store.saveWhiteboard("r1", wb2);
+      expect(await store.getWhiteboard("r1")).toEqual(wb2);
+    });
+
+    test("pending deliveries enqueue/drain, dedup by idempotencyKey, clear on drain, per-target", async () => {
+      await store.enqueuePending("ag-2", makeEnvelope({ idempotencyKey: "k1", messageId: "m1" }));
+      await store.enqueuePending("ag-2", makeEnvelope({ idempotencyKey: "k2", messageId: "m2" }));
+      await store.enqueuePending("ag-2", makeEnvelope({ idempotencyKey: "k1", messageId: "m1-dup" }));
+      await store.enqueuePending("ag-3", makeEnvelope({ idempotencyKey: "k9", messageId: "z" }));
+      const drained = await store.drainPending("ag-2");
+      expect(drained.map((e) => e.idempotencyKey).sort()).toEqual(["k1", "k2"]);
+      expect(await store.drainPending("ag-2")).toEqual([]); // cleared
+      expect((await store.drainPending("ag-3")).length).toBe(1); // other target intact
+    });
+  });
+}

--- a/src/unit-test/store-memory.test.ts
+++ b/src/unit-test/store-memory.test.ts
@@ -1,0 +1,4 @@
+import { runStoreContract } from "./store-contract";
+import { InMemoryStore } from "../backbone/store/memory-store";
+
+runStoreContract("memory", () => new InMemoryStore());

--- a/src/unit-test/store-postgres-skeleton.test.ts
+++ b/src/unit-test/store-postgres-skeleton.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "bun:test";
+import { PostgresStore } from "../backbone/store/postgres-store";
+import { makeEnvelope } from "./backbone-fixtures";
+
+/**
+ * PostgresStore is a §11.3 skeleton: every method must reject until the real
+ * driver lands. Spot-check a representative slice across the surface.
+ */
+describe("PostgresStore skeleton — every method rejects (not implemented)", () => {
+  const s = new PostgresStore();
+
+  test("identity/agent methods reject", async () => {
+    await expect(s.upsertIdentity("x", "X")).rejects.toThrow(/not implemented/);
+    await expect(s.getIdentity("x")).rejects.toThrow(/not implemented/);
+    await expect(s.upsertAgent("ag", "p", "claude")).rejects.toThrow(/not implemented/);
+    await expect(s.getAgent("ag")).rejects.toThrow(/not implemented/);
+  });
+
+  test("session/workspace methods reject", async () => {
+    await expect(s.recordSession("sess", "ag", 1)).rejects.toThrow(/not implemented/);
+    await expect(s.getLastSession("/repo", "claude")).rejects.toThrow(/not implemented/);
+    await expect(s.setLastSession("/repo", "claude", "sess")).rejects.toThrow(/not implemented/);
+  });
+
+  test("room/member/cwd methods reject", async () => {
+    await expect(s.createRoom("r", "r", "ag")).rejects.toThrow(/not implemented/);
+    await expect(s.getRoom("r")).rejects.toThrow(/not implemented/);
+    await expect(s.listRooms()).rejects.toThrow(/not implemented/);
+    await expect(s.addMember("r", "ag")).rejects.toThrow(/not implemented/);
+    await expect(s.removeMember("r", "ag")).rejects.toThrow(/not implemented/);
+    await expect(s.getMembers("r")).rejects.toThrow(/not implemented/);
+    await expect(s.getRoomsForAgent("ag")).rejects.toThrow(/not implemented/);
+    await expect(s.mapCwd("/repo", "r")).rejects.toThrow(/not implemented/);
+    await expect(s.getRoomForCwd("/repo")).rejects.toThrow(/not implemented/);
+  });
+
+  test("ledger/whiteboard/pending/close methods reject", async () => {
+    await expect(s.appendEvent("r", makeEnvelope())).rejects.toThrow(/not implemented/);
+    await expect(s.getRecentEvents("r", 10)).rejects.toThrow(/not implemented/);
+    await expect(s.getWhiteboard("r")).rejects.toThrow(/not implemented/);
+    await expect(
+      s.saveWhiteboard("r", {
+        roomId: "r",
+        contractsReady: [],
+        inProgress: [],
+        blockers: [],
+        recentMilestones: [],
+        updatedAt: 0,
+      }),
+    ).rejects.toThrow(/not implemented/);
+    await expect(s.enqueuePending("ag", makeEnvelope())).rejects.toThrow(/not implemented/);
+    await expect(s.drainPending("ag")).rejects.toThrow(/not implemented/);
+    await expect(s.close()).rejects.toThrow(/not implemented/);
+  });
+});

--- a/src/unit-test/store-sqlite.test.ts
+++ b/src/unit-test/store-sqlite.test.ts
@@ -1,0 +1,4 @@
+import { runStoreContract } from "./store-contract";
+import { SqliteStore } from "../backbone/store/sqlite-store";
+
+runStoreContract("sqlite", () => new SqliteStore(":memory:"));

--- a/src/unit-test/transport-contract.ts
+++ b/src/unit-test/transport-contract.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "bun:test";
+import type { MessageTransport } from "../backbone/transport";
+import { makeEnvelope } from "./backbone-fixtures";
+
+/**
+ * Shared MessageTransport contract (NOT a *.test.ts). Every transport impl passes
+ * the identical suite: topic-scoped delivery, unsubscribe stops delivery, and
+ * multiple subscribers on a topic all receive.
+ */
+export function runTransportContract(label: string, makeTransport: () => MessageTransport) {
+  describe(`MessageTransport contract — ${label}`, () => {
+    test("subscribe receives published envelopes on its topic only", async () => {
+      const t = makeTransport();
+      const got: string[] = [];
+      const unsub = t.subscribe("room-1", (m) => got.push(m.messageId));
+      await t.publish("room-1", makeEnvelope({ messageId: "m1" }));
+      await t.publish("room-2", makeEnvelope({ roomId: "room-2", messageId: "x" }));
+      expect(got).toEqual(["m1"]);
+      unsub();
+    });
+
+    test("unsubscribe stops delivery", async () => {
+      const t = makeTransport();
+      const got: string[] = [];
+      const unsub = t.subscribe("r", (m) => got.push(m.messageId));
+      unsub();
+      await t.publish("r", makeEnvelope());
+      expect(got).toEqual([]);
+    });
+
+    test("multiple subscribers on a topic all receive", async () => {
+      const t = makeTransport();
+      const a: string[] = [];
+      const b: string[] = [];
+      t.subscribe("r", (m) => a.push(m.messageId));
+      t.subscribe("r", (m) => b.push(m.messageId));
+      await t.publish("r", makeEnvelope({ messageId: "z" }));
+      expect(a).toEqual(["z"]);
+      expect(b).toEqual(["z"]);
+    });
+
+    test("one subscriber's unsubscribe does not affect the other", async () => {
+      const t = makeTransport();
+      const a: string[] = [];
+      const b: string[] = [];
+      const unsubA = t.subscribe("r", (m) => a.push(m.messageId));
+      t.subscribe("r", (m) => b.push(m.messageId));
+      unsubA();
+      await t.publish("r", makeEnvelope({ messageId: "z" }));
+      expect(a).toEqual([]);
+      expect(b).toEqual(["z"]);
+    });
+  });
+}

--- a/src/unit-test/transport-inmemory.test.ts
+++ b/src/unit-test/transport-inmemory.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test";
+import { runTransportContract } from "./transport-contract";
+import { InMemoryTransport } from "../backbone/transport/in-memory-transport";
+import { makeEnvelope } from "./backbone-fixtures";
+
+runTransportContract("in-memory", () => new InMemoryTransport());
+
+test("publish records the envelope in the published log", async () => {
+  const t = new InMemoryTransport();
+  const env = makeEnvelope({ messageId: "rec-1" });
+  await t.publish("r", env);
+  expect(t.published).toEqual([env]);
+});

--- a/src/unit-test/transport-inproc.test.ts
+++ b/src/unit-test/transport-inproc.test.ts
@@ -1,0 +1,4 @@
+import { runTransportContract } from "./transport-contract";
+import { InProcTransport } from "../backbone/transport/inproc-transport";
+
+runTransportContract("inproc", () => new InProcTransport());

--- a/src/unit-test/transport-nats-skeleton.test.ts
+++ b/src/unit-test/transport-nats-skeleton.test.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "bun:test";
+import { NatsTransport } from "../backbone/transport/nats-transport";
+import { makeEnvelope } from "./backbone-fixtures";
+
+test("subscribe throws (skeleton)", () => {
+  expect(() => new NatsTransport().subscribe("r", () => {})).toThrow();
+});
+
+test("publish rejects (skeleton)", async () => {
+  await expect(new NatsTransport().publish("r", makeEnvelope())).rejects.toThrow();
+});


### PR DESCRIPTION
> **Stacked on #187 (PR1a)** — base 是 `feat/v3-pr1a-daemon-refactor`。PR1a 合并后会自动 retarget 到 master。

## 概要 / Summary

PR1b：按 spec §6 落地 v3 backbone 的**三可替换接口 + 双实现并行 + 一套契约两实现都过**（用户选 §6.4 字面全做）。core 只依赖接口，换 driver = 一行配置、core 零改。新增 `src/backbone/`，**零新增 npm 依赖**（bun:sqlite / node:crypto / Bun 内置）。

## 三接口 × 三实现 / Interfaces × impls

| 接口 | 电池实现 | 第二实现（契约对照/测试 double） | 生产 skeleton（§11.3，throw） |
|---|---|---|---|
| `MessageTransport` | `InProcTransport`（进程内 pub/sub） | `InMemoryTransport`（+`published` 内省） | `NatsTransport` |
| `Store`（§12 十表面） | `SqliteStore`（bun:sqlite + WAL） | `InMemoryStore` | `PostgresStore` |
| `IdentityProvider` | `PskIdentityProvider`（node:crypto timingSafeEqual 常量时间比较） | `FakeIdentityProvider` | `OidcIdentityProvider` |

- 接口：`envelope.ts`（v3 信封 Appendix A，与旧 `BridgeMessage` 双轨并存）、`identity.ts`、`transport.ts`、`store.ts`（**方法 async** 前瞻生产 Postgres）。
- 契约：`runStoreContract` / `runIdentityProviderContract` / `runTransportContract`——一套 suite，两实现各跑一遍 + skeleton 断言 throw（§6.4「两实现都过」的可执行证明）。

## 测试计划 / Test plan

- [x] 实现由 **3 个并行 subagent** 编写（Store/Identity/Transport 各一）
- [x] 新增 38 用例（Store 22 / Identity 5 / Transport 11）
- [x] `bun run check` exit 0 → **1704 pass / 0 fail**、typecheck 干净、plugin bundle 同步（仅 build stamp）、版本对齐 0.1.24

## Cross-review

- **轮 1（thorough，5 维 + 逐条对抗式 verify）**：16 findings → 2 confirmed（同一 issue）：`getRecentEvents(limit<=0)` 两实现语义分叉（InMemory `slice(-0)`=全表 / SQLite `LIMIT 0`=空，§6.4 违背）。→ **根因修复**：两实现各加 `if (limit<=0) return []` + 契约补 limit=0/-1 断言锁死。
- **轮 2 / 轮 3（lean，2 broad reviewer + verify）**：连续两轮 **0 真实 issue** → 收敛。

## Backlog（RECOMMEND，非阻塞，已对抗式驳倒）

- `InMemoryStore` 返回活引用 vs `SqliteStore` JSON 快照——可加防御性拷贝。
- `InProcTransport` throwing-subscriber 应 try-catch 隔离（broker PR 前补）。
- 出契约域边界（小数 limit / close 后调用 / getMembers 顺序）两实现可进一步对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
