### PR TITLE
feat(v3): 房间口令自助加入 — room --password + join --password（§11.2）

### DIFF
--- a/plugins/agentbridge/server/bridge-server.js
+++ b/plugins/agentbridge/server/bridge-server.js
@@ -14707,10 +14707,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.24", "0.0.0-source"),
-  commit: defineString("2d64afa", "source"),
+  commit: defineString("2869fdd", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("e9f689afd6b6", "source")
+  codeHash: defineString("66df1aadf54e", "source")
 });
 function sameRuntimeContract(a, b) {
   if (!a || !b)

--- a/plugins/agentbridge/server/daemon.js
+++ b/plugins/agentbridge/server/daemon.js
@@ -30,10 +30,10 @@ function defineNumber(value, fallback) {
 }
 var BUILD_INFO = Object.freeze({
   version: defineString("0.1.24", "0.0.0-source"),
-  commit: defineString("2d64afa", "source"),
+  commit: defineString("2869fdd", "source"),
   bundle: defineBundle("plugin"),
   contractVersion: defineNumber(1, CONTRACT_VERSION),
-  codeHash: defineString("e9f689afd6b6", "source")
+  codeHash: defineString("66df1aadf54e", "source")
 });
 function daemonStatusBuildInfo() {
   return { ...BUILD_INFO };
@@ -6824,6 +6824,7 @@ class BrokerClient {
   outbox = [];
   eventHandlers = [];
   whiteboardHandlers = [];
+  pendingJoins = new Map;
   closed = false;
   authFailed = false;
   reconnectAttempt = 0;
@@ -6877,6 +6878,15 @@ class BrokerClient {
     if (this.connected)
       this.sendRaw({ type: "unsubscribe", topic });
   }
+  joinWithPassword(topic, password) {
+    if (!this.connected)
+      return Promise.reject(new Error("not connected"));
+    return new Promise((resolve, reject) => {
+      this.pendingJoins.get(topic)?.reject(new Error("superseded by a newer join"));
+      this.pendingJoins.set(topic, { resolve, reject });
+      this.sendRaw({ type: "join", topic, password });
+    });
+  }
   publish(topic, envelope) {
     if (this.connected) {
       this.sendRaw({ type: "publish", topic, envelope });
@@ -6898,6 +6908,7 @@ class BrokerClient {
     this.closed = true;
     this.clearReconnectTimer();
     this.teardownSocket();
+    this.failPendingJoins("client closed");
     if (this.rejectConnect) {
       const reject = this.rejectConnect;
       this.resolveConnect = null;
@@ -6959,6 +6970,18 @@ class BrokerClient {
             this.log(`whiteboard handler threw: ${String(e)}`);
           }
         }
+      } else if (msg.type === "joined") {
+        const p = this.pendingJoins.get(msg.topic);
+        if (p) {
+          this.pendingJoins.delete(msg.topic);
+          p.resolve();
+        }
+      } else if (msg.type === "join_error") {
+        const p = this.pendingJoins.get(msg.topic);
+        if (p) {
+          this.pendingJoins.delete(msg.topic);
+          p.reject(new Error(typeof msg.reason === "string" ? msg.reason : "join failed"));
+        }
       }
     };
     ws.onclose = () => {
@@ -6966,6 +6989,7 @@ class BrokerClient {
         return;
       this.ws = null;
       this.identity = null;
+      this.failPendingJoins("connection lost before the join completed");
       if (!this.closed && !this.authFailed)
         this.scheduleReconnect();
     };
@@ -6990,6 +7014,14 @@ class BrokerClient {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+  }
+  failPendingJoins(reason) {
+    if (this.pendingJoins.size === 0)
+      return;
+    const pend = [...this.pendingJoins.values()];
+    this.pendingJoins.clear();
+    for (const p of pend)
+      p.reject(new Error(reason));
   }
   flushOutbox() {
     if (this.outbox.length === 0)
@@ -7036,6 +7068,12 @@ class RoomService {
   }
   async listRooms() {
     return this.store.listRooms();
+  }
+  async setRoomPassword(roomId, passwordHash) {
+    await this.store.setRoomPassword(roomId, passwordHash);
+  }
+  async getRoomPasswordHash(roomId) {
+    return this.store.getRoomPasswordHash(roomId);
   }
   async join(roomId, agentId) {
     await this.store.addMember(roomId, agentId);
@@ -7117,7 +7155,8 @@ class SqliteStore {
       CREATE TABLE IF NOT EXISTS rooms (
         room_id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
-        created_by TEXT NOT NULL
+        created_by TEXT NOT NULL,
+        password_hash TEXT
       );
       CREATE TABLE IF NOT EXISTS room_members (
         room_id TEXT,
@@ -7149,6 +7188,9 @@ class SqliteStore {
         identity_id TEXT NOT NULL
       );
     `);
+    try {
+      this.db.exec("ALTER TABLE rooms ADD COLUMN password_hash TEXT");
+    } catch {}
   }
   async upsertIdentity(id, displayName) {
     this.db.query("INSERT INTO identities(id, display_name) VALUES(?, ?) ON CONFLICT(id) DO UPDATE SET display_name=excluded.display_name").run(id, displayName);
@@ -7185,6 +7227,13 @@ class SqliteStore {
   async listRooms() {
     const rows = this.db.query("SELECT room_id, name, created_by FROM rooms").all();
     return rows.map((r) => ({ roomId: r.room_id, name: r.name, createdBy: r.created_by }));
+  }
+  async setRoomPassword(roomId, passwordHash) {
+    this.db.query("UPDATE rooms SET password_hash=? WHERE room_id=?").run(passwordHash, roomId);
+  }
+  async getRoomPasswordHash(roomId) {
+    const row = this.db.query("SELECT password_hash FROM rooms WHERE room_id=?").get(roomId);
+    return row?.password_hash ?? null;
   }
   async addMember(roomId, agentId) {
     this.db.query("INSERT OR IGNORE INTO room_members(room_id, agent_id) VALUES(?, ?)").run(roomId, agentId);

--- a/src/backbone/password.ts
+++ b/src/backbone/password.ts
@@ -1,0 +1,55 @@
+/**
+ * Room-password hashing (§11.2 self-service join, §11.3 at-rest hardening).
+ *
+ * A room may carry an OPTIONAL password so an already-authenticated identity can add
+ * itself (`abg join --password`) without a member running `abg room add`. The password
+ * is a SHARED room secret, so it is never stored in plaintext — only a salted scrypt
+ * derivation lives in the broker's Store. scrypt is memory-hard (brute-force resistant);
+ * the broker additionally throttles attempts per connection.
+ *
+ * Format: `scrypt$<saltHex>$<hashHex>` — self-describing so the params can evolve.
+ */
+
+import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
+
+const SCHEME = "scrypt";
+const N = 16384; // CPU/memory cost 2^14 — interactive-login appropriate (~tens of ms), ~16MB < node's 32MB maxmem
+const R = 8;
+const P = 1;
+const KEYLEN = 32;
+const SALT_LEN = 16;
+
+/** Hash a room password for at-rest storage. Returns `scrypt$<saltHex>$<hashHex>`. */
+export function hashPassword(plain: string): string {
+  const salt = randomBytes(SALT_LEN);
+  const derived = scryptSync(plain, salt, KEYLEN, { N, r: R, p: P });
+  return `${SCHEME}$${salt.toString("hex")}$${derived.toString("hex")}`;
+}
+
+/**
+ * Constant-time verify `plain` against a stored `scrypt$salt$hash`. Returns false on ANY
+ * malformed/unparseable stored value or scheme mismatch (never throws) — a corrupt hash
+ * must read as "wrong password", not crash the broker's join handler.
+ */
+export function verifyPassword(plain: string, stored: string): boolean {
+  const parts = stored.split("$");
+  if (parts.length !== 3 || parts[0] !== SCHEME) return false;
+  let salt: Buffer;
+  let expected: Buffer;
+  try {
+    salt = Buffer.from(parts[1]!, "hex");
+    expected = Buffer.from(parts[2]!, "hex");
+  } catch {
+    return false;
+  }
+  // A truncated hex string yields a SHORTER buffer (Buffer.from is lenient), so length-check
+  // both halves before deriving — a wrong length is a malformed record, not a wrong password.
+  if (salt.length !== SALT_LEN || expected.length !== KEYLEN) return false;
+  let derived: Buffer;
+  try {
+    derived = scryptSync(plain, salt, KEYLEN, { N, r: R, p: P });
+  } catch {
+    return false;
+  }
+  return timingSafeEqual(derived, expected);
+}

--- a/src/backbone/store.ts
+++ b/src/backbone/store.ts
@@ -69,6 +69,10 @@ export interface Store {
   createRoom(roomId: string, name: string, createdBy: string): Promise<void>;
   getRoom(roomId: string): Promise<RoomRecord | null>;
   listRooms(): Promise<RoomRecord[]>;
+  /** Set (or clear, with null) a room's hashed self-service-join password (§11.2). */
+  setRoomPassword(roomId: string, passwordHash: string | null): Promise<void>;
+  /** The room's hashed self-service-join password, or null when invite-only (no self-join). */
+  getRoomPasswordHash(roomId: string): Promise<string | null>;
 
   // --- room members (§2.3): bound to logical agent id, persistent (survives restart) ---
   addMember(roomId: string, agentId: string): Promise<void>;

--- a/src/backbone/store/memory-store.ts
+++ b/src/backbone/store/memory-store.ts
@@ -18,6 +18,7 @@ export class InMemoryStore implements Store {
   private sessions = new Map<string, { agentId: string; startedAt: number }>();
   private workspaceSessions = new Map<string, string>(); // `${path}\0${type}` → sessionId
   private rooms = new Map<string, RoomRecord>();
+  private roomPasswords = new Map<string, string>(); // roomId → hashed self-service-join password
   private members = new Map<string, Set<string>>(); // roomId → agentIds
   private cwdRoom = new Map<string, string>();
   private events = new Map<string, Envelope[]>(); // roomId → append-ordered ledger
@@ -71,6 +72,15 @@ export class InMemoryStore implements Store {
 
   async listRooms(): Promise<RoomRecord[]> {
     return [...this.rooms.values()];
+  }
+
+  async setRoomPassword(roomId: string, passwordHash: string | null): Promise<void> {
+    if (passwordHash === null) this.roomPasswords.delete(roomId);
+    else this.roomPasswords.set(roomId, passwordHash);
+  }
+
+  async getRoomPasswordHash(roomId: string): Promise<string | null> {
+    return this.roomPasswords.get(roomId) ?? null;
   }
 
   async addMember(roomId: string, agentId: string): Promise<void> {

--- a/src/backbone/store/postgres-store.ts
+++ b/src/backbone/store/postgres-store.ts
@@ -60,6 +60,14 @@ export class PostgresStore implements Store {
     throw new Error(NOT_IMPLEMENTED);
   }
 
+  async setRoomPassword(_roomId: string, _passwordHash: string | null): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async getRoomPasswordHash(_roomId: string): Promise<string | null> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
   async addMember(_roomId: string, _agentId: string): Promise<void> {
     throw new Error(NOT_IMPLEMENTED);
   }

--- a/src/backbone/store/sqlite-store.ts
+++ b/src/backbone/store/sqlite-store.ts
@@ -44,7 +44,8 @@ export class SqliteStore implements Store {
       CREATE TABLE IF NOT EXISTS rooms (
         room_id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
-        created_by TEXT NOT NULL
+        created_by TEXT NOT NULL,
+        password_hash TEXT
       );
       CREATE TABLE IF NOT EXISTS room_members (
         room_id TEXT,
@@ -76,6 +77,13 @@ export class SqliteStore implements Store {
         identity_id TEXT NOT NULL
       );
     `);
+    // Migration: rooms.password_hash (§11.2 self-service join, added post-v3). The CREATE above
+    // carries it for fresh DBs; this idempotent ALTER backfills DBs created before the column existed.
+    try {
+      this.db.exec("ALTER TABLE rooms ADD COLUMN password_hash TEXT");
+    } catch {
+      /* column already present (fresh DB or already-migrated) — no-op */
+    }
   }
 
   // --- identities ---
@@ -158,6 +166,17 @@ export class SqliteStore implements Store {
       .query("SELECT room_id, name, created_by FROM rooms")
       .all() as { room_id: string; name: string; created_by: string }[];
     return rows.map((r) => ({ roomId: r.room_id, name: r.name, createdBy: r.created_by }));
+  }
+
+  async setRoomPassword(roomId: string, passwordHash: string | null): Promise<void> {
+    this.db.query("UPDATE rooms SET password_hash=? WHERE room_id=?").run(passwordHash, roomId);
+  }
+
+  async getRoomPasswordHash(roomId: string): Promise<string | null> {
+    const row = this.db
+      .query("SELECT password_hash FROM rooms WHERE room_id=?")
+      .get(roomId) as { password_hash: string | null } | null;
+    return row?.password_hash ?? null;
   }
 
   // --- room members ---

--- a/src/broker-client.ts
+++ b/src/broker-client.ts
@@ -58,6 +58,8 @@ export class BrokerClient {
   private readonly outbox: Array<{ topic: string; envelope: Envelope }> = [];
   private readonly eventHandlers: EventHandler[] = [];
   private readonly whiteboardHandlers: WhiteboardHandler[] = [];
+  /** topic → resolver for an in-flight joinWithPassword, settled by the broker's joined/join_error. */
+  private readonly pendingJoins = new Map<string, { resolve: () => void; reject: (e: Error) => void }>();
   private closed = false;
   /** Set on auth_error: a bad token must NOT trigger an infinite reconnect loop. */
   private authFailed = false;
@@ -120,6 +122,21 @@ export class BrokerClient {
     if (this.connected) this.sendRaw({ type: "unsubscribe", topic });
   }
 
+  /**
+   * Self-service join a password-protected room (§11.2): present the room password to the broker,
+   * which verifies it against the room's stored hash and grants PERSISTENT membership. Resolves on
+   * the broker's `joined`; rejects with the broker's reason (wrong password / throttled / no
+   * self-service join). Requires a live connection — call connect() first; subscribe() after it resolves.
+   */
+  joinWithPassword(topic: string, password: string): Promise<void> {
+    if (!this.connected) return Promise.reject(new Error("not connected"));
+    return new Promise<void>((resolve, reject) => {
+      this.pendingJoins.get(topic)?.reject(new Error("superseded by a newer join")); // one in-flight per topic
+      this.pendingJoins.set(topic, { resolve, reject });
+      this.sendRaw({ type: "join", topic, password });
+    });
+  }
+
   /** Publish an envelope; if offline, queue it (bounded) and flush on reconnect. */
   publish(topic: string, envelope: Envelope): void {
     if (this.connected) {
@@ -146,6 +163,7 @@ export class BrokerClient {
     this.closed = true;
     this.clearReconnectTimer();
     this.teardownSocket();
+    this.failPendingJoins("client closed");
     if (this.rejectConnect) {
       const reject = this.rejectConnect;
       this.resolveConnect = null;
@@ -211,12 +229,28 @@ export class BrokerClient {
             this.log(`whiteboard handler threw: ${String(e)}`);
           }
         }
+      } else if (msg.type === "joined") {
+        const p = this.pendingJoins.get(msg.topic);
+        if (p) {
+          this.pendingJoins.delete(msg.topic);
+          p.resolve();
+        }
+      } else if (msg.type === "join_error") {
+        const p = this.pendingJoins.get(msg.topic);
+        if (p) {
+          this.pendingJoins.delete(msg.topic);
+          p.reject(new Error(typeof msg.reason === "string" ? msg.reason : "join failed"));
+        }
       }
     };
     ws.onclose = () => {
       if (this.ws !== ws) return; // a stale/torn-down socket closing — ignore
       this.ws = null;
       this.identity = null;
+      // An in-flight password join can't be answered by a dead socket — reject it now so the
+      // caller errors out instead of hanging (the broker grants membership transactionally; a
+      // drop before `joined` means it did NOT complete).
+      this.failPendingJoins("connection lost before the join completed");
       // A transient drop does NOT reject connect() — reconnect retries and the
       // next welcome resolves the still-pending promise. Only auth failure / close()
       // settle it. Avoids the "reject-but-secretly-reconnect" contract that induced
@@ -250,6 +284,14 @@ export class BrokerClient {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+  }
+
+  /** Reject every in-flight joinWithPassword (the socket went away before the broker replied). */
+  private failPendingJoins(reason: string): void {
+    if (this.pendingJoins.size === 0) return;
+    const pend = [...this.pendingJoins.values()];
+    this.pendingJoins.clear();
+    for (const p of pend) p.reject(new Error(reason));
   }
 
   private flushOutbox(): void {

--- a/src/broker.ts
+++ b/src/broker.ts
@@ -6,6 +6,7 @@ import type { Envelope } from "./backbone/envelope";
 import { InProcTransport } from "./backbone/transport/inproc-transport";
 import { buildPresenceEnvelope, type PresenceMeta } from "./presence";
 import { mergeWhiteboard } from "./whiteboard";
+import { hashPassword, verifyPassword } from "./backbone/password";
 
 export const DEFAULT_BROKER_PORT = 4700; // outside the multi-pair 4500/4501/4502+stride range
 const CLOSE_AUTH_FAILED = 4401;
@@ -20,6 +21,19 @@ const MEMBER_CACHE_CAP = 2000;
 // the broker's fan-out bandwidth, so the cap is needed here too.)
 const PRESENCE_FIELD_CAP = 200;
 const PRESENCE_CAPS_CAP = 20;
+// Brute-force throttle for room-password self-join (§11.2): a room password is a guessable shared
+// secret. After MAX_JOIN_FAILS wrong attempts the IDENTITY (not the socket) is locked out of join for
+// JOIN_LOCKOUT_MS — keyed to the PSK-authenticated id, so reconnecting can't reset it. This bounds the
+// online attempt RATE; combined with the memory-hard scrypt verify it makes online guessing slow.
+// Offline guessing is impossible — the hash never leaves the broker.
+const MAX_JOIN_FAILS = 5;
+const JOIN_LOCKOUT_MS = 60_000;
+// Bound the per-identity throttle map (backstop — identities are already bounded by registration).
+const JOIN_THROTTLE_CAP = 10_000;
+// A constant dummy hash to verify against when a room has NO password set: the join handler then runs
+// the same memory-hard scrypt work whether the room is missing / invite-only or the password is simply
+// wrong, so response LATENCY can't be used to enumerate which slugs are password-protected rooms.
+const DUMMY_PW_HASH = hashPassword("agentbridge::no-such-password::sentinel");
 
 /** Validate the optional reserved presence blob from hello — best-effort, drop anything malformed. Exported for boundary tests. */
 export function sanitizePresence(raw: unknown): PresenceMeta | undefined {
@@ -61,6 +75,7 @@ type ClientMessage =
   | { type: "hello"; token: string; presence?: unknown }
   | { type: "subscribe"; topic: string }
   | { type: "unsubscribe"; topic: string }
+  | { type: "join"; topic: string; password: string }
   | { type: "publish"; topic: string; envelope: Envelope };
 
 export interface BrokerOptions {
@@ -73,6 +88,8 @@ export interface BrokerOptions {
   transport?: MessageTransport;
   /** TTL for the hot-path membership cache (§11.2 revocation latency). Default 3000ms; tests set it small. */
   memberCacheTtlMs?: number;
+  /** Lockout window after MAX_JOIN_FAILS wrong room-password attempts (§11.2). Default 60000ms; tests set it small. */
+  joinLockoutMs?: number;
   log?: (msg: string) => void;
 }
 
@@ -106,6 +123,8 @@ export class Broker {
   private readonly topicMembers = new Map<string, Map<string, number>>();
   /** Short-TTL membership cache (§11.2 revocation): bounds re-validation cost on the hot delivery path. */
   private readonly memberCache = new Map<string, { ok: boolean; exp: number }>();
+  /** Per-identity room-password brute-force throttle (§11.2): id → { consecutive fails, lockout-until epoch ms }. */
+  private readonly joinThrottle = new Map<string, { fails: number; until: number }>();
   private readonly transport: MessageTransport;
   private readonly log: (msg: string) => void;
 
@@ -338,6 +357,61 @@ export class Broker {
         }
         return;
       }
+      case "join": {
+        // Self-service join (§11.2): a room with a password lets an already-AUTHENTICATED identity
+        // add ITSELF to the room, sparing a member from running `abg room add` per person. The PSK
+        // hello already proved identity; the room password is a SECOND gate. PERSISTENT membership is
+        // granted (not just this socket), so a later subscribe / reconnect is authorized. Wrong
+        // attempts lock the IDENTITY out (not just the socket), so reconnecting can't reset the cap.
+        const topic = msg.topic;
+        if (typeof msg.password !== "string" || msg.password.length === 0) {
+          this.send(ws, { type: "join_error", topic, reason: "missing password" });
+          return;
+        }
+        const now = Date.now();
+        const throttle = this.joinThrottle.get(me);
+        if (throttle && throttle.until > now) {
+          // Locked out by too many recent wrong attempts — keyed to the identity, so a fresh socket
+          // (reconnect) is still locked. The real barrier is scrypt × password entropy; this just
+          // bounds the online attempt RATE per identity (offline guessing isn't possible — no hash leaves).
+          this.send(ws, { type: "join_error", topic, reason: "too many attempts" });
+          this.log(`DENY join ${me} → ${topic} (locked out ${Math.ceil((throttle.until - now) / 1000)}s)`);
+          return;
+        }
+        let hash: string | null;
+        try {
+          hash = await this.opts.store.getRoomPasswordHash(topic);
+        } catch (e) {
+          // Store unreadable → fail CLOSED (never grant), and don't burn the attempt counter.
+          this.send(ws, { type: "join_error", topic, reason: "join unavailable" });
+          this.log(`join store error ${me} → ${topic}: ${String(e)}`);
+          return;
+        }
+        // ALWAYS run a constant-time verify (against a dummy when no password is set), so latency
+        // can't distinguish "no such / invite-only room" from "wrong password". A null hash (room
+        // missing OR invite-only) and a wrong password collapse to the SAME generic rejection.
+        const ok = verifyPassword(msg.password, hash ?? DUMMY_PW_HASH);
+        if (!hash || !ok) {
+          this.recordJoinFail(me, now);
+          this.send(ws, { type: "join_error", topic, reason: "invalid room or password" });
+          this.log(`DENY join ${me} → ${topic} (bad room/password)`);
+          return;
+        }
+        try {
+          await this.opts.store.addMember(topic, me);
+        } catch (e) {
+          this.send(ws, { type: "join_error", topic, reason: "join unavailable" });
+          this.log(`join addMember error ${me} → ${topic}: ${String(e)}`);
+          return;
+        }
+        // Success clears the per-identity fail counter; drop stale cached membership so a subscribe
+        // immediately after this sees the grant.
+        this.joinThrottle.delete(me);
+        this.memberCache.delete(`${topic}|${me}`);
+        this.send(ws, { type: "joined", topic });
+        this.log(`JOIN ${me} → ${topic} (self-service via password)`);
+        return;
+      }
       case "publish": {
         // CONTROL PLANE ONLY: forward the structured Envelope. No filesystem,
         // no repo access — code sync is git's job (§2.6). The broker is a trust
@@ -526,6 +600,26 @@ export class Broker {
     }
     this.memberCache.set(key, { ok, exp: now + ttlMs });
     return ok;
+  }
+
+  /**
+   * Record a wrong room-password attempt for `id`, locking the identity out for JOIN_LOCKOUT_MS once it
+   * reaches MAX_JOIN_FAILS. Keyed by the PSK-authenticated identity (NOT the socket), so a reconnect
+   * can't reset the counter (§11.2 R1). The map is bounded as a backstop — identities are already
+   * bounded by registration, and a success / lockout expiry clears the entry.
+   */
+  private recordJoinFail(id: string, now: number): void {
+    const t = this.joinThrottle.get(id) ?? { fails: 0, until: 0 };
+    t.fails++;
+    if (t.fails >= MAX_JOIN_FAILS) {
+      t.until = now + (this.opts.joinLockoutMs ?? JOIN_LOCKOUT_MS); // lock out; the window now governs
+      t.fails = 0; // reset so a fresh window starts clean after the lockout expires
+    }
+    if (!this.joinThrottle.has(id) && this.joinThrottle.size >= JOIN_THROTTLE_CAP) {
+      const oldest = this.joinThrottle.keys().next().value;
+      if (oldest !== undefined) this.joinThrottle.delete(oldest);
+    }
+    this.joinThrottle.set(id, t);
   }
 
   /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -191,14 +191,21 @@ Commands:
                      On the edge: install a broker-issued token to <state>/auth-token (0600)
   auth login --id <email|github> --name <displayName>
                      Self-sign a token locally (single-machine case) and write it (0600)
-  room create <name> | room list
-                     Create a collaboration room (id = slugified name) or list rooms
+  room create <name> [--password <pw> | --password-stdin] | room list
+                     Create a collaboration room (id = slugified name) or list rooms. With a
+                     password, members can self-join via "abg join <id> --password <pw>"
   room invite <roomId> <identityId> [--name <displayName>] [--broker-url <ws://…>]
                      On the broker: issue a token + grant membership + print the invitee's
                      full join commands (one-shot cross-network onboarding). Pass the routable
                      --broker-url from "abg broker start"'s card so the invitee can actually reach you
-  join <roomId>      Join a room and auto-join this directory next time (§2.4). For a remote
-                     room (no local record) it maps the cwd; the broker enforces membership
+  room set-password <roomId> (--password <pw> | --password-stdin | --clear)
+                     On the broker: set/clear a room's self-service-join password (members only)
+  join <roomId> [--password <pw> | --password-stdin]
+                     Join a room and auto-join this directory next time (§2.4). For a remote
+                     room (no local record) it maps the cwd; the broker enforces membership.
+                     With a password, self-join a password-protected room (broker grants membership).
+                     Prefer --password-stdin (e.g. "echo pw | abg join r --password-stdin"): a
+                     password on argv leaks via ps / shell history
   broker start [--host <ip>] [--port <n>] [--db <path>] [--web-port <n>] [--no-web] [--no-open]
                      Run the always-on control-plane broker (§11.1) + a loopback-only
                      admin dashboard (view rooms/members/whiteboards + create a room)

--- a/src/cli/room.ts
+++ b/src/cli/room.ts
@@ -15,8 +15,21 @@ import { RoomService, slugify } from "../room-service";
 import { IdentityService } from "../backbone/identity-service";
 import { SqliteStore } from "../backbone/store/sqlite-store";
 import type { RoomRecord, Store } from "../backbone/store";
-import { resolveBrokerUrl } from "../collab-store";
+import { readAuthToken, resolveBrokerUrl } from "../collab-store";
+import { BrokerClient } from "../broker-client";
+import { hashPassword } from "../backbone/password";
 import { StateDirResolver } from "../state-dir";
+
+/**
+ * Read a single line (the password) from stdin — the non-leaky alternative to `--password <pw>` on the
+ * command line. argv lands in `ps` / `/proc/<pid>/cmdline` and the shell history; a piped/typed secret
+ * (`echo pw | abg join r --password-stdin`) does not. Mirrors `docker login --password-stdin`.
+ */
+async function readPasswordFromStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8").replace(/\r?\n$/, "");
+}
 
 /** Resolve the collab DB path: explicit > env override > `<state>/collab.db`. */
 function resolveDbPath(explicit?: string): string {
@@ -64,6 +77,8 @@ export async function createRoom(opts: {
   name: string;
   cwd?: string;
   dbPath?: string;
+  /** Optional self-service-join password (§11.2). Stored hashed; omit/empty for invite-only. */
+  password?: string;
 }): Promise<{ roomId: string; created: boolean }> {
   const dbPath = resolveDbPath(opts.dbPath);
   const store = openStore(dbPath);
@@ -80,6 +95,9 @@ export async function createRoom(opts: {
       // EXISTING room — that reopens the self-join hole `joinRoom` closed.
       throw new Error(`房间 ${roomId} 已存在且你（${createdBy}）不是成员；请让成员 abg room add ${createdBy}`);
     }
+    // Optional self-service-join password (§11.2): a member (incl. the just-created creator) may set it.
+    // Hashed at rest. An empty value is treated as "not provided" here — use `room set-password` to clear.
+    if (opts.password) await svc.setRoomPassword(roomId, hashPassword(opts.password));
     await svc.mapCwd(opts.cwd ?? process.cwd(), roomId);
     return { roomId, created: !existed };
   } finally {
@@ -210,8 +228,17 @@ export function isLoopbackBrokerUrl(url: string): boolean {
   return /:\/\/(127\.\d+\.\d+\.\d+|localhost|\[::1\]|::1)(:|\/|$)/.test(url);
 }
 
-/** Remove `identityId` from `roomId`. Caller must be a member (§11.2). */
-export async function removeRoomMember(opts: { roomId: string; identityId: string; dbPath?: string }): Promise<void> {
+/**
+ * Remove `identityId` from `roomId`. Caller must be a member (§11.2). Returns whether the room still
+ * has a self-service-join password — if so, removal alone does NOT revoke access (the removed party,
+ * still holding a valid PSK token + the password, can `abg join --password` straight back in), so the
+ * caller should warn the operator to rotate/clear the password too.
+ */
+export async function removeRoomMember(opts: {
+  roomId: string;
+  identityId: string;
+  dbPath?: string;
+}): Promise<{ roomHasPassword: boolean }> {
   const dbPath = resolveDbPath(opts.dbPath);
   const store = openStore(dbPath);
   try {
@@ -222,32 +249,141 @@ export async function removeRoomMember(opts: { roomId: string; identityId: strin
       throw new Error(`只有房间成员能移除成员；你（${caller}）不是 ${opts.roomId} 的成员`);
     }
     await svc.leave(opts.roomId, opts.identityId);
+    return { roomHasPassword: (await svc.getRoomPasswordHash(opts.roomId)) !== null };
   } finally {
     await store.close();
   }
 }
 
 const ROOM_USAGE =
-  "用法：abg room create <name> | abg room list | abg room invite <roomId> <identityId> [--name <displayName>] [--broker-url <ws://…>] | abg room add <roomId> <identityId> | abg room remove <roomId> <identityId>";
+  "用法：abg room create <name> [--password <口令>|--password-stdin] | abg room list | abg room invite <roomId> <identityId> [--name <displayName>] [--broker-url <ws://…>] | abg room set-password <roomId> --password <口令>|--password-stdin|--clear | abg room add <roomId> <identityId> | abg room remove <roomId> <identityId>";
 
 /** Dispatch `abg room <subcommand>`: `create <name>` / `list`. */
+/**
+ * Set or clear a room's self-service-join password (§11.2). Member-only: only an existing member may
+ * change the join secret. A null/empty password clears it (back to invite-only). Runs against the
+ * BROKER's collab DB (the broker machine), like `abg room add`.
+ */
+export async function setRoomPasswordCli(opts: {
+  roomId: string;
+  password: string | null;
+  dbPath?: string;
+}): Promise<void> {
+  const dbPath = resolveDbPath(opts.dbPath);
+  const store = openStore(dbPath);
+  try {
+    const caller = await currentIdentityId(store, dbPath);
+    const svc = new RoomService(store);
+    if ((await svc.getRoom(opts.roomId)) === null) throw new Error(`房间不存在：${opts.roomId}`);
+    if (!(await svc.isMember(opts.roomId, caller))) {
+      throw new Error(`只有房间成员能设置口令；你（${caller}）不是 ${opts.roomId} 的成员`);
+    }
+    await svc.setRoomPassword(opts.roomId, opts.password ? hashPassword(opts.password) : null);
+  } finally {
+    await store.close();
+  }
+}
+
+/**
+ * Self-service join a password-protected room (§11.2): connect to the broker as the logged-in identity
+ * and present the room password. The BROKER verifies it against the room's stored hash and grants
+ * PERSISTENT membership — no member needs to run `abg room add`. On success the cwd is mapped locally so
+ * the daemon's room-bridge picks up this room. Throws the broker's reason on a wrong/throttled password.
+ */
+export async function joinRoomWithPassword(opts: {
+  roomId: string;
+  password: string;
+  cwd?: string;
+  dbPath?: string;
+  brokerUrl?: string;
+}): Promise<{ roomId: string }> {
+  const dbPath = resolveDbPath(opts.dbPath);
+  const token = readAuthToken(dbPath);
+  if (!token) {
+    throw new Error("未登录：请先 abg auth login --token <broker 签发的令牌>，再用房间口令自助加入");
+  }
+  const client = new BrokerClient({ url: resolveBrokerUrl(opts.brokerUrl), token });
+  try {
+    await client.connect(); // PSK auth — proves identity to the broker
+    await client.joinWithPassword(opts.roomId, opts.password); // broker verifies password + grants membership
+  } finally {
+    client.close();
+  }
+  // Membership now lives broker-side; map the cwd locally so the daemon's room-bridge resolves it (§2.4).
+  const store = openStore(dbPath);
+  try {
+    await new RoomService(store).mapCwd(opts.cwd ?? process.cwd(), opts.roomId);
+  } finally {
+    await store.close();
+  }
+  return { roomId: opts.roomId };
+}
+
 export async function runRoom(args: string[]): Promise<void> {
   const sub = args[0];
   switch (sub) {
     case "create": {
-      const name = args.slice(1).join(" ").trim();
+      // name = all non-flag args joined; optional `--password <pw>` (space- or `=`-separated).
+      const rest = args.slice(1);
+      let password: string | undefined;
+      let stdin = false;
+      const nameParts: string[] = [];
+      for (let i = 0; i < rest.length; i++) {
+        const a = rest[i]!;
+        if (a === "--password") password = rest[++i] ?? "";
+        else if (a.startsWith("--password=")) password = a.slice("--password=".length);
+        else if (a === "--password-stdin") stdin = true;
+        else nameParts.push(a);
+      }
+      if (stdin) password = await readPasswordFromStdin();
+      const name = nameParts.join(" ").trim();
       if (!name) {
         console.error("缺少房间名称。");
         console.error(ROOM_USAGE);
         process.exit(1);
         return;
       }
-      const { roomId, created } = await createRoom({ name });
+      if (password === "") {
+        console.error("口令为空：--password <口令> / --password-stdin 需要非空口令（都省略则建无口令房）。");
+        process.exit(1);
+        return;
+      }
+      const { roomId, created } = await createRoom({ name, password });
       console.log(
         created
           ? `已创建房间 ${roomId}（${name}），你已加入；该目录今后会自动加入`
           : `房间 ${roomId} 已存在，已为你加入；该目录今后会自动加入`,
       );
+      if (password) {
+        console.log(`已设置自助加入口令：他人可 abg join ${roomId} --password <口令> 自助加入（口令请通过安全渠道带外发，勿随仓库提交）`);
+      }
+      break;
+    }
+    case "set-password": {
+      const roomId = args[1];
+      let password: string | null = null;
+      let provided = false;
+      let stdin = false;
+      for (let i = 2; i < args.length; i++) {
+        const a = args[i]!;
+        if (a === "--password") { password = args[++i] ?? ""; provided = true; }
+        else if (a.startsWith("--password=")) { password = a.slice("--password=".length); provided = true; }
+        else if (a === "--password-stdin") { stdin = true; provided = true; }
+        else if (a === "--clear") { password = null; provided = true; }
+      }
+      if (stdin) password = await readPasswordFromStdin();
+      if (!roomId || !provided) {
+        console.error("用法：abg room set-password <roomId> --password <口令>|--password-stdin   ｜   abg room set-password <roomId> --clear（移除口令，恢复仅邀请）");
+        process.exit(1);
+        return;
+      }
+      if (password === "") {
+        console.error("口令为空：--password <口令> / --password-stdin 需要非空口令；要移除口令请用 --clear。");
+        process.exit(1);
+        return;
+      }
+      await setRoomPasswordCli({ roomId, password });
+      console.log(password ? `已为房间 ${roomId} 设置自助加入口令` : `已移除房间 ${roomId} 的口令（恢复仅邀请加入）`);
       break;
     }
     case "list": {
@@ -310,8 +446,12 @@ export async function runRoom(args: string[]): Promise<void> {
         await addRoomMember({ roomId, identityId });
         console.log(`已把 ${identityId} 加入房间 ${roomId}（现在它可订阅/发布该房）`);
       } else {
-        await removeRoomMember({ roomId, identityId });
+        const { roomHasPassword } = await removeRoomMember({ roomId, identityId });
         console.log(`已把 ${identityId} 移出房间 ${roomId}（它将无法再订阅/发布该房）`);
+        if (roomHasPassword) {
+          console.log(`⚠️ 该房设有自助加入口令——仅 remove 挡不住知道口令的人：对方仍持有效 token 时可 abg join ${roomId} --password 自助加回。`);
+          console.log(`   要真正排除，请同时改/清口令：abg room set-password ${roomId} --password <新口令>  或  abg room set-password ${roomId} --clear`);
+        }
       }
       break;
     }
@@ -325,9 +465,29 @@ export async function runRoom(args: string[]): Promise<void> {
 /** Dispatch `abg join <roomId>`. */
 export async function runJoin(args: string[]): Promise<void> {
   const roomId = args[0];
+  // Optional `--password <pw>` / `--password-stdin` → self-service join via the broker.
+  let password: string | undefined;
+  let stdin = false;
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--password") password = args[++i] ?? "";
+    else if (a.startsWith("--password=")) password = a.slice("--password=".length);
+    else if (a === "--password-stdin") stdin = true;
+  }
+  if (stdin) password = await readPasswordFromStdin();
   if (!roomId) {
-    console.error("用法：abg join <roomId>");
+    console.error("用法：abg join <roomId> [--password <口令> | --password-stdin]");
     process.exit(1);
+    return;
+  }
+  if (password !== undefined) {
+    if (password === "") {
+      console.error("口令为空：abg join <roomId> --password <口令>");
+      process.exit(1);
+      return;
+    }
+    await joinRoomWithPassword({ roomId, password });
+    console.log(`已用房间口令自助加入 ${roomId}（broker 已校验口令并授予成员资格）；该目录今后会自动加入`);
     return;
   }
   const result = await joinRoom({ roomId });

--- a/src/integration-test/broker-password-join.test.ts
+++ b/src/integration-test/broker-password-join.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Room-password self-service join (§11.2): an already-AUTHENTICATED identity that is NOT a member
+ * can add itself to a room by presenting the room password, which the broker verifies against the
+ * stored hash. Covers the full path store → broker → BrokerClient.joinWithPassword end-to-end.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Broker } from "../broker";
+import { BrokerClient } from "../broker-client";
+import { InMemoryStore } from "../backbone/store/memory-store";
+import { SqliteStore } from "../backbone/store/sqlite-store";
+import { IdentityService } from "../backbone/identity-service";
+import { StorePskIdentityProvider } from "../backbone/identity/store-psk-identity-provider";
+import { RoomService } from "../room-service";
+import { hashPassword } from "../backbone/password";
+import { joinRoomWithPassword } from "../cli/room";
+import { makeEnvelope } from "../unit-test/backbone-fixtures";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Broker + store with alice (owner/member of `r` and `np`) and bob (a NON-member). `r` has a password. */
+async function startBroker() {
+  const store = new InMemoryStore();
+  const svc = new IdentityService(store);
+  await svc.registerIdentity("alice@x.com", "Alice");
+  await svc.registerIdentity("bob@x.com", "Bob");
+  const tokenA = await svc.issueToken("alice@x.com");
+  const tokenB = await svc.issueToken("bob@x.com");
+  const rooms = new RoomService(store);
+  await rooms.createRoom("r", "Room", "alice@x.com");
+  await rooms.join("r", "alice@x.com");
+  await store.setRoomPassword("r", hashPassword("secret"));
+  await rooms.createRoom("np", "NoPass", "alice@x.com"); // invite-only (no password)
+  await rooms.join("np", "alice@x.com");
+  const broker = new Broker({
+    store,
+    identityProvider: new StorePskIdentityProvider(store),
+    host: "127.0.0.1",
+    port: 0,
+    memberCacheTtlMs: 0,
+    log: () => {},
+  });
+  const { port } = broker.start();
+  return { store, broker, tokenA, tokenB, url: `ws://127.0.0.1:${port}/ws` };
+}
+
+describe("room-password self-service join (§11.2)", () => {
+  test("right password → broker grants membership; the joiner can then subscribe + receive", async () => {
+    const { store, broker, tokenA, tokenB, url } = await startBroker();
+    const alice = new BrokerClient({ url, token: tokenA, log: () => {} });
+    const bob = new BrokerClient({ url, token: tokenB, log: () => {} });
+    try {
+      await bob.connect();
+      expect(await store.getMembers("r")).not.toContain("bob@x.com"); // closed-by-default before join
+      await bob.joinWithPassword("r", "secret"); // resolves on the broker's `joined`
+      expect(await store.getMembers("r")).toContain("bob@x.com"); // broker granted PERSISTENT membership
+
+      const got: string[] = [];
+      bob.onEvent((_t, env) => got.push(env.messageId));
+      bob.subscribe("r");
+      await sleep(60);
+      await alice.connect();
+      alice.publish("r", makeEnvelope({ messageId: "e1", roomId: "r" }));
+      await sleep(60);
+      expect(got).toEqual(["e1"]); // the freshly self-joined member receives room events
+    } finally {
+      alice.close();
+      bob.close();
+      broker.stop();
+      await store.close();
+    }
+  });
+
+  test("wrong password → rejected, no membership granted", async () => {
+    const { store, broker, tokenB, url } = await startBroker();
+    const bob = new BrokerClient({ url, token: tokenB, log: () => {} });
+    try {
+      await bob.connect();
+      await expect(bob.joinWithPassword("r", "nope")).rejects.toThrow(/invalid room or password/);
+      expect(await store.getMembers("r")).not.toContain("bob@x.com");
+    } finally {
+      bob.close();
+      broker.stop();
+      await store.close();
+    }
+  });
+
+  test("a room with NO password rejects self-join (invite-only stays closed)", async () => {
+    const { store, broker, tokenB, url } = await startBroker();
+    const bob = new BrokerClient({ url, token: tokenB, log: () => {} });
+    try {
+      await bob.connect();
+      // Same generic reason as a wrong password — a prober can't tell "no such / invite-only room"
+      // from "wrong password".
+      await expect(bob.joinWithPassword("np", "anything")).rejects.toThrow(/invalid room or password/);
+      await expect(bob.joinWithPassword("does-not-exist", "anything")).rejects.toThrow(/invalid room or password/);
+      expect(await store.getMembers("np")).not.toContain("bob@x.com");
+    } finally {
+      bob.close();
+      broker.stop();
+      await store.close();
+    }
+  });
+
+  test("throttles after MAX_JOIN_FAILS wrong attempts — even the RIGHT password is then refused", async () => {
+    const { store, broker, tokenB, url } = await startBroker();
+    const bob = new BrokerClient({ url, token: tokenB, log: () => {} });
+    try {
+      await bob.connect();
+      for (let i = 0; i < 5; i++) {
+        await expect(bob.joinWithPassword("r", "wrong")).rejects.toThrow(/invalid room or password/);
+      }
+      // 6th attempt is throttled regardless of correctness — online brute force is rate-capped.
+      await expect(bob.joinWithPassword("r", "secret")).rejects.toThrow(/too many attempts/);
+      expect(await store.getMembers("r")).not.toContain("bob@x.com");
+    } finally {
+      bob.close();
+      broker.stop();
+      await store.close();
+    }
+  });
+
+  test("throttle is per-IDENTITY — reconnecting on a fresh socket does NOT reset the lockout (R1)", async () => {
+    const { store, broker, tokenB, url } = await startBroker();
+    let bob = new BrokerClient({ url, token: tokenB, log: () => {} });
+    try {
+      await bob.connect();
+      for (let i = 0; i < 5; i++) {
+        await expect(bob.joinWithPassword("r", "wrong")).rejects.toThrow(/invalid room or password/);
+      }
+      bob.close(); // drop the connection entirely
+      // Reconnect as the SAME identity (same token) on a brand-new socket — the lockout must persist,
+      // because the counter is keyed to the authenticated identity, not the socket.
+      bob = new BrokerClient({ url, token: tokenB, log: () => {} });
+      await bob.connect();
+      await expect(bob.joinWithPassword("r", "secret")).rejects.toThrow(/too many attempts/);
+      expect(await store.getMembers("r")).not.toContain("bob@x.com");
+    } finally {
+      bob.close();
+      broker.stop();
+      await store.close();
+    }
+  });
+
+  test("lockout EXPIRES — after the window a legitimate user gets a fresh attempt budget", async () => {
+    const store = new InMemoryStore();
+    const svc = new IdentityService(store);
+    await svc.registerIdentity("bob@x.com", "Bob");
+    const tokenB = await svc.issueToken("bob@x.com");
+    const rooms = new RoomService(store);
+    await rooms.createRoom("r", "Room", "alice@x.com");
+    await store.setRoomPassword("r", hashPassword("secret"));
+    const broker = new Broker({
+      store,
+      identityProvider: new StorePskIdentityProvider(store),
+      host: "127.0.0.1",
+      port: 0,
+      memberCacheTtlMs: 0,
+      joinLockoutMs: 80, // short lockout so the test can wait it out
+      log: () => {},
+    });
+    const { port } = broker.start();
+    const bob = new BrokerClient({ url: `ws://127.0.0.1:${port}/ws`, token: tokenB, log: () => {} });
+    try {
+      await bob.connect();
+      for (let i = 0; i < 5; i++) {
+        await expect(bob.joinWithPassword("r", "wrong")).rejects.toThrow(/invalid room or password/);
+      }
+      await expect(bob.joinWithPassword("r", "secret")).rejects.toThrow(/too many attempts/); // locked
+      await sleep(130); // wait out the 80ms lockout window
+      await bob.joinWithPassword("r", "secret"); // recovered → the right password now succeeds
+      expect(await store.getMembers("r")).toContain("bob@x.com");
+    } finally {
+      bob.close();
+      broker.stop();
+      await store.close();
+    }
+  });
+
+  test("an empty password is rejected by the broker", async () => {
+    const { broker, tokenB, url } = await startBroker();
+    const bob = new BrokerClient({ url, token: tokenB, log: () => {} });
+    try {
+      await bob.connect();
+      await expect(bob.joinWithPassword("r", "")).rejects.toThrow(/missing password/);
+    } finally {
+      bob.close();
+      broker.stop();
+    }
+  });
+
+  test("joinWithPassword before connect() rejects (no live socket)", async () => {
+    const { broker, tokenB, url } = await startBroker();
+    const bob = new BrokerClient({ url, token: tokenB, log: () => {} });
+    try {
+      await expect(bob.joinWithPassword("r", "secret")).rejects.toThrow(/not connected/);
+    } finally {
+      bob.close();
+      broker.stop();
+    }
+  });
+
+  test("joinRoomWithPassword (CLI): edge self-joins via the broker — broker store gets membership, edge store only maps cwd", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "abg-pwjoin-broker-"));
+    const edgeDir = mkdtempSync(join(tmpdir(), "abg-pwjoin-edge-"));
+    const brokerDb = join(dir, "collab.db");
+    const edgeDb = join(edgeDir, "collab.db");
+    const store = new SqliteStore(brokerDb);
+    const svc = new IdentityService(store);
+    await svc.registerIdentity("alice@x.com", "Alice");
+    await svc.registerIdentity("bob@x.com", "Bob");
+    const tokenB = await svc.issueToken("bob@x.com");
+    const rooms = new RoomService(store);
+    await rooms.createRoom("vault", "Vault", "alice@x.com");
+    await rooms.join("vault", "alice@x.com");
+    await store.setRoomPassword("vault", hashPassword("opensesame"));
+    const broker = new Broker({
+      store,
+      identityProvider: new StorePskIdentityProvider(store),
+      host: "127.0.0.1",
+      port: 0,
+      memberCacheTtlMs: 0,
+      log: () => {},
+    });
+    const { port } = broker.start();
+    const url = `ws://127.0.0.1:${port}/ws`;
+    writeFileSync(join(edgeDir, "auth-token"), tokenB, { mode: 0o600 }); // bob's broker-issued token, edge-side
+    try {
+      await joinRoomWithPassword({ roomId: "vault", password: "opensesame", cwd: edgeDir, dbPath: edgeDb, brokerUrl: url });
+      // membership granted in the BROKER store …
+      expect(await new RoomService(store).getMembers("vault")).toContain("bob@x.com");
+      // … while the EDGE store only records the cwd→room hint (no local membership — broker is authoritative)
+      const edge = new SqliteStore(edgeDb);
+      try {
+        expect(await new RoomService(edge).resolveRoomForCwd(edgeDir)).toBe("vault");
+        expect(await new RoomService(edge).getMembers("vault")).toEqual([]);
+      } finally {
+        await edge.close();
+      }
+      // wrong password → throws the broker's reason (a fresh connection, so not throttled)
+      await expect(
+        joinRoomWithPassword({ roomId: "vault", password: "WRONG", cwd: edgeDir, dbPath: edgeDb, brokerUrl: url }),
+      ).rejects.toThrow(/invalid room or password/);
+    } finally {
+      broker.stop();
+      await store.close();
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(edgeDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/room-service.ts
+++ b/src/room-service.ts
@@ -52,6 +52,13 @@ export class RoomService {
   async listRooms(): Promise<RoomRecord[]> {
     return this.store.listRooms();
   }
+  /** Set (hashed) or clear (null) a room's self-service-join password (§11.2). */
+  async setRoomPassword(roomId: string, passwordHash: string | null): Promise<void> {
+    await this.store.setRoomPassword(roomId, passwordHash);
+  }
+  async getRoomPasswordHash(roomId: string): Promise<string | null> {
+    return this.store.getRoomPasswordHash(roomId);
+  }
 
   // --- membership (persistent, bound to logical agent id) ---
   async join(roomId: string, agentId: string): Promise<void> {

--- a/src/unit-test/cli-room.test.ts
+++ b/src/unit-test/cli-room.test.ts
@@ -2,11 +2,12 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { addRoomMember, createRoom, inviteRoomMember, isLoopbackBrokerUrl, joinRoom, listRooms, removeRoomMember, runRoom } from "../cli/room";
+import { addRoomMember, createRoom, inviteRoomMember, isLoopbackBrokerUrl, joinRoom, listRooms, removeRoomMember, runRoom, setRoomPasswordCli } from "../cli/room";
 import { IdentityService } from "../backbone/identity-service";
 import { RoomService } from "../room-service";
 import { StorePskIdentityProvider } from "../backbone/identity/store-psk-identity-provider";
 import { SqliteStore } from "../backbone/store/sqlite-store";
+import { verifyPassword } from "../backbone/password";
 import { atomicWriteText } from "../atomic-json";
 
 /** Mimic `abg auth login`: register an identity, issue a token, persist it. */
@@ -277,6 +278,77 @@ describe("cli/room", () => {
     await expect(
       removeRoomMember({ roomId: "ghost", identityId: "bob@x.com", dbPath }),
     ).rejects.toThrow(/房间不存在/);
+  });
+
+  it("create --password: stores a verifiable hash, never the plaintext", async () => {
+    dir = mkdtempSync(join(tmpdir(), "agentbridge-room-"));
+    const dbPath = join(dir, "collab.db");
+    await seedLogin(dir, dbPath);
+    await createRoom({ name: "vault", cwd: dir, dbPath, password: "s3cret!" });
+
+    const store = new SqliteStore(dbPath);
+    try {
+      const hash = await new RoomService(store).getRoomPasswordHash("vault");
+      expect(hash).toBeTruthy();
+      expect(hash).not.toContain("s3cret!"); // hashed at rest, not plaintext
+      expect(verifyPassword("s3cret!", hash!)).toBe(true);
+      expect(verifyPassword("wrong", hash!)).toBe(false);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("set-password: a member sets then clears the room password", async () => {
+    dir = mkdtempSync(join(tmpdir(), "agentbridge-room-"));
+    const dbPath = join(dir, "collab.db");
+    await seedLogin(dir, dbPath); // alice = creator → member
+    await createRoom({ name: "room", dbPath });
+
+    await setRoomPasswordCli({ roomId: "room", password: "pw1", dbPath });
+    let store = new SqliteStore(dbPath);
+    try {
+      expect(verifyPassword("pw1", (await new RoomService(store).getRoomPasswordHash("room"))!)).toBe(true);
+    } finally {
+      await store.close();
+    }
+
+    await setRoomPasswordCli({ roomId: "room", password: null, dbPath }); // clear → invite-only
+    store = new SqliteStore(dbPath);
+    try {
+      expect(await new RoomService(store).getRoomPasswordHash("room")).toBeNull();
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("set-password: rejects a non-member caller and a non-existent room", async () => {
+    dir = mkdtempSync(join(tmpdir(), "agentbridge-room-"));
+    const dbPath = join(dir, "collab.db");
+    await seedLogin(dir, dbPath); // alice logged in but NOT a member of the target room
+
+    const store = new SqliteStore(dbPath);
+    try {
+      await new RoomService(store).createRoom("secret", "Secret", "owner@x.com");
+    } finally {
+      await store.close();
+    }
+    await expect(setRoomPasswordCli({ roomId: "secret", password: "pw", dbPath })).rejects.toThrow(/只有房间成员能设置口令/);
+    await expect(setRoomPasswordCli({ roomId: "ghost", password: "pw", dbPath })).rejects.toThrow(/房间不存在/);
+  });
+
+  it("remove: reports roomHasPassword so the CLI can warn that removal alone isn't revocation (R3)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "agentbridge-room-"));
+    const dbPath = join(dir, "collab.db");
+    await seedLogin(dir, dbPath); // alice = creator/member
+
+    await createRoom({ name: "guarded", dbPath, password: "pw" });
+    await addRoomMember({ roomId: "guarded", identityId: "bob@x.com", dbPath });
+    // removing bob from a PASSWORD-protected room flags that the password must also be rotated/cleared
+    expect((await removeRoomMember({ roomId: "guarded", identityId: "bob@x.com", dbPath })).roomHasPassword).toBe(true);
+
+    await createRoom({ name: "open", dbPath }); // no password → no warning
+    await addRoomMember({ roomId: "open", identityId: "bob@x.com", dbPath });
+    expect((await removeRoomMember({ roomId: "open", identityId: "bob@x.com", dbPath })).roomHasPassword).toBe(false);
   });
 });
 

--- a/src/unit-test/password.test.ts
+++ b/src/unit-test/password.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { hashPassword, verifyPassword } from "../backbone/password";
+
+describe("backbone/password — room-password hashing (§11.2/§11.3)", () => {
+  test("hashPassword: scrypt$salt$hash shape, salted (distinct each call), never plaintext", () => {
+    const h1 = hashPassword("hunter2");
+    const h2 = hashPassword("hunter2");
+    expect(h1.split("$")).toHaveLength(3);
+    expect(h1.startsWith("scrypt$")).toBe(true);
+    expect(h1).not.toContain("hunter2"); // never store plaintext
+    expect(h1).not.toBe(h2); // random salt → different hash for the same password
+  });
+
+  test("verifyPassword: true for the right password, false for the wrong one", () => {
+    const stored = hashPassword("correct horse");
+    expect(verifyPassword("correct horse", stored)).toBe(true);
+    expect(verifyPassword("correct hors", stored)).toBe(false);
+    expect(verifyPassword("", stored)).toBe(false);
+    expect(verifyPassword("CORRECT HORSE", stored)).toBe(false); // case-sensitive
+  });
+
+  test("verifyPassword: false (never throws) on any malformed stored value", () => {
+    expect(verifyPassword("pw", "")).toBe(false);
+    expect(verifyPassword("pw", "not-a-hash")).toBe(false);
+    expect(verifyPassword("pw", "scrypt$onlytwo")).toBe(false);
+    expect(verifyPassword("pw", "bcrypt$aa$bb")).toBe(false); // wrong scheme
+    expect(verifyPassword("pw", "scrypt$zz$zz")).toBe(false); // non-hex / wrong length
+    expect(verifyPassword("pw", "scrypt$" + "00".repeat(16) + "$" + "00".repeat(8))).toBe(false); // hash too short
+  });
+
+  test("verifyPassword: unicode + long passwords round-trip", () => {
+    const pw = "口令🔐 with spaces and 中文 " + "x".repeat(200);
+    expect(verifyPassword(pw, hashPassword(pw))).toBe(true);
+    expect(verifyPassword(pw + "!", hashPassword(pw))).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景 / Why

跨机 onboarding（#206）仍需成员在 broker 机上对**每个**新人跑 `abg room invite` / `abg room add`。本 PR 加**房间口令自助加入**（§11.2）：房间设一个口令后，**已认证（持 broker 签发 PSK token）**的身份可凭口令把自己加进房间，免逐人 add。

Cross-machine onboarding (#206) still needs a member to run `abg room invite` / `abg room add` for **each** newcomer. This PR adds **room-password self-service join**: with a room password set, an already-authenticated identity can add itself by presenting the password.

## 改了什么 / What

- **`abg room create <name> --password <pw>`** / **`--password-stdin`**：建房并设自助加入口令。
- **`abg room set-password <roomId> --password <pw>|--password-stdin|--clear`**：成员设/改/清口令。
- **`abg join <roomId> --password <pw>|--password-stdin`**：连 broker（PSK 认证）+ 交口令 → broker 校验 → 授**持久成员资格** + 映射 cwd。
- 口令 `scrypt$salt$hash` 加盐哈希存（`backbone/password.ts`），常量时间校验，malformed 安全返回 false。
- Store 加 `setRoomPassword`/`getRoomPasswordHash`（sqlite 加列 + idempotent `ALTER` 迁移老库；memory；postgres stub）。
- broker 新 `join` wire 消息：校验→`addMember`→缓存失效；broker-client `joinWithPassword`（pending 按 topic 关联、断连兜底）。

## 安全边界 / Security

- **双闸不可绕**：join 在 hello（PSK `authenticate`）之后，无 token 发不了 join；口令是第二道闸。
- **按身份跨连接限流**：5 次错口令 → 该**身份**锁 60s（键为 PSK 认证 id，重连不重置）；fail-closed（store 错不授权、不烧计数）。
- **时序等化**：无房 / 仅邀请 / 错口令三路都跑同样 scrypt（`DUMMY_PW_HASH`）+ 收敛到同一 `invalid room or password`——无「哪些 slug 是带口令房」的枚举 oracle；broker 对「房不存在」与「非成员」subscribe 也回同一 reason。
- **口令防泄漏**：`scrypt` 哈希存、不落日志、store 外不可解析；`--password-stdin` 避免 argv（`ps`/`/proc`）+ shell history 明文。
- **撤销**：`room remove` 单独**不是**有效撤销（被移除者持 token + 知口令可自助加回）——remove 时打告警，提示同时 `set-password --clear`/轮换。

## 测试 / Tests

- `password.test.ts` 4 + `broker-password-join.test.ts` 9（对/错/无口令/限流/**重连不重置**/**锁定过期恢复**/空/未连/**真 CLI 跨机自助加入：broker store 授成员、edge store 仅映射 cwd**）+ `cli-room.test.ts` 新 5。
- `bun run check`：全绿，typecheck 干净，plugin-sync OK。
- Cross-review：3 轮各 2 独立 reviewer。轮1 安全审抓 **3 真实 MEDIUM**（R1 连接级限流可重连复位 / R2 argv 口令泄漏 / R3 remove 非有效撤销）→ 全修；轮2 双 0；polish 轮双 0 收敛。

## 栈 / Stack

base = `feat/v3-xnet-onboarding`（#206）。逻辑上叠在跨机 join 流程之上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
