### PR TITLE
[website] SEO+GEO 官网静态站 + GitHub Pages 部署 / static site + Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,35 @@
+name: Deploy website to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+# Allow the workflow to publish to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One live deployment at a time; don't cancel an in-progress publish
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/assets/og.svg
+++ b/site/assets/og.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif">
+  <!-- Placeholder OG image (text-only). Swap for a real demo screenshot before launch. -->
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b0d11"/>
+      <stop offset="1" stop-color="#12151b"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="0" y="0" width="1200" height="6" fill="#3ddc97"/>
+
+  <!-- terminal window mock -->
+  <g transform="translate(72,150)">
+    <rect x="0" y="0" width="480" height="330" rx="16" fill="#0e1016" stroke="#232833" stroke-width="1.5"/>
+    <circle cx="28" cy="30" r="7" fill="#ff5f57"/>
+    <circle cx="52" cy="30" r="7" fill="#febc2e"/>
+    <circle cx="76" cy="30" r="7" fill="#28c840"/>
+    <text x="104" y="35" fill="#8b95a3" font-size="18" font-family="ui-monospace, Menlo, monospace">agentbridge — live session</text>
+    <g font-family="ui-monospace, Menlo, monospace" font-size="19">
+      <text x="30" y="92"  fill="#b892ff">claude</text><text x="120" y="92" fill="#8b95a3">→ reviewing diff…</text>
+      <text x="30" y="128" fill="#b892ff">claude</text><text x="120" y="128" fill="#5fd39a">reply: retry after 429 unbounded</text>
+      <text x="30" y="164" fill="#6cc5e0">codex</text><text x="120" y="164" fill="#d6dbe4">→ fixed, capped at 5 retries</text>
+      <text x="30" y="216" fill="#8b95a3">quota window low —</text>
+      <text x="30" y="248" fill="#5fd39a">bridge</text><text x="120" y="248" fill="#d6dbe4">→ handing off, auto-resume queued</text>
+    </g>
+  </g>
+
+  <!-- headline -->
+  <g transform="translate(600,150)">
+    <text x="0" y="70" fill="#3ddc97" font-size="40" font-weight="700">🌉 AgentBridge</text>
+    <text x="0" y="150" fill="#e7eaf0" font-size="52" font-weight="700">Claude Code &amp; Codex,</text>
+    <text x="0" y="212" fill="#e7eaf0" font-size="52" font-weight="700">collaborating in</text>
+    <text x="0" y="274" fill="#e7eaf0" font-size="52" font-weight="700">one session.</text>
+    <text x="0" y="336" fill="#99a2b0" font-size="26">Cross-review · task splits · quota relay</text>
+    <text x="0" y="384" fill="#99a2b0" font-size="22" font-family="ui-monospace, Menlo, monospace">npm install -g @raysonmeng/agentbridge</text>
+    <text x="0" y="430" fill="#5b636e" font-size="20">MIT · runs locally · zero runtime deps · 1,700+ tests</text>
+  </g>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,616 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>AgentBridge — Claude Code &amp; Codex, collaborating in one session</title>
+<meta name="description" content="AgentBridge is a local, MIT-licensed bridge that lets Claude Code and Codex collaborate in real time inside one session: cross-review, task splits, and quota relay for overnight runs. Zero runtime deps, 1,700+ tests." />
+<meta name="keywords" content="AgentBridge, Claude Code, Codex, multi-agent collaboration, cross-review, task split, quota relay, MCP, local AI tooling" />
+<meta name="author" content="raysonmeng" />
+<link rel="canonical" href="https://quilin-ai.github.io/agent-bridge/" />
+<link rel="alternate" hreflang="en" href="https://quilin-ai.github.io/agent-bridge/" />
+<link rel="alternate" hreflang="zh-Hans" href="https://quilin-ai.github.io/agent-bridge/zh/" />
+<link rel="alternate" hreflang="x-default" href="https://quilin-ai.github.io/agent-bridge/" />
+
+<!-- Open Graph -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="AgentBridge" />
+<meta property="og:title" content="AgentBridge — Claude Code &amp; Codex, collaborating in one session" />
+<meta property="og:description" content="A local bridge for real-time collaboration between Claude Code and Codex: cross-review, task splits, and quota relay. Local, MIT, zero runtime deps." />
+<meta property="og:url" content="https://quilin-ai.github.io/agent-bridge/" />
+<!-- og.svg is a text placeholder; swap for a real demo screenshot once recorded -->
+<meta property="og:image" content="https://quilin-ai.github.io/agent-bridge/assets/og.svg" />
+<meta property="og:image:alt" content="AgentBridge — Claude Code and Codex collaborating in one session" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:locale:alternate" content="zh_CN" />
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="AgentBridge — Claude Code &amp; Codex, collaborating in one session" />
+<meta name="twitter:description" content="A local bridge for real-time collaboration between Claude Code and Codex: cross-review, task splits, and quota relay." />
+<meta name="twitter:image" content="https://quilin-ai.github.io/agent-bridge/assets/og.svg" />
+<meta name="twitter:creator" content="@raysonmeng" />
+
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ctext y='26' font-size='26'%3E%F0%9F%8C%89%3C/text%3E%3C/svg%3E" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      "name": "AgentBridge",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "macOS, Linux",
+      "description": "A local bridge for bidirectional, real-time collaboration between Claude Code and Codex inside one working session: cross-review, task splits, and quota relay for long-running tasks.",
+      "url": "https://quilin-ai.github.io/agent-bridge/",
+      "downloadUrl": "https://www.npmjs.com/package/@raysonmeng/agentbridge",
+      "softwareVersion": "0.1.24",
+      "license": "https://opensource.org/licenses/MIT",
+      "isAccessibleForFree": true,
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+      "author": { "@type": "Person", "name": "raysonmeng", "url": "https://x.com/raysonmeng" },
+      "codeRepository": "https://github.com/quilin-ai/agent-bridge"
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "abg installed but won't run — what's wrong?",
+          "acceptedAnswer": { "@type": "Answer", "text": "You are almost certainly missing Bun. AgentBridge's daemon and plugin server run on the Bun runtime; Node.js alone is not enough. Install Bun with 'curl -fsSL https://bun.sh/install | bash', then re-run abg claude." }
+        },
+        {
+          "@type": "Question",
+          "name": "Does AgentBridge support Windows?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Windows is not an officially supported platform yet. AgentBridge runs on macOS and Linux today. WSL2 may work but is untested." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is it safe? What does --safe do?",
+          "acceptedAnswer": { "@type": "Answer", "text": "By default abg claude launches with --dangerously-skip-permissions and abg codex with --yolo, so an unattended agent pair does not stop for each prompt. Only do this in a workspace you trust. Add --safe (or set AGENTBRIDGE_SAFE=1) to launch with normal permission prompts. AgentBridge runs entirely on your machine and is not a hardened boundary between untrusted tools." }
+        },
+        {
+          "@type": "Question",
+          "name": "How does quota relay work?",
+          "acceptedAnswer": { "@type": "Answer", "text": "With the companion agent-quota-guard installed, the daemon polls both agents' 5h and weekly subscription windows. Near a limit the guard lets the current turn finish, stops cleanly at the turn boundary, writes a .agent/checkpoint.md, and drops a pending record. When the window refreshes, the bridge auto-resumes the task in the original interactive TUI." }
+        },
+        {
+          "@type": "Question",
+          "name": "Which agents does AgentBridge support?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Today the shipping in-session integration connects Claude Code and Codex. A public adapter vote (issue #212) decides which agent — OpenCode, Gemini CLI, and others are candidates — is wired in next." }
+        },
+        {
+          "@type": "Question",
+          "name": "How is this different from codex-plugin-cc?",
+          "acceptedAnswer": { "@type": "Answer", "text": "One-way delegation plugins like openai/codex-plugin-cc let a host call Codex and get one answer back — request in, response out, no standing peer. AgentBridge keeps both agents live as persistent peers, and either side can push a message mid-turn (a review comment lands while the other is still working), not only at call boundaries." }
+        },
+        {
+          "@type": "Question",
+          "name": "Do I need an account or API keys for AgentBridge itself?",
+          "acceptedAnswer": { "@type": "Answer", "text": "No. AgentBridge is a local tool with zero runtime dependencies and no hosted service. You use your existing Claude Code and Codex logins; AgentBridge only relays messages between them on your machine." }
+        }
+      ]
+    }
+  ]
+}
+</script>
+
+<style>
+:root {
+  --bg: #ffffff;
+  --bg-soft: #f5f6f8;
+  --panel: #ffffff;
+  --text: #14181d;
+  --muted: #5b636e;
+  --border: #e3e7ec;
+  --accent: #0a7d55;
+  --accent-soft: #e5f5ee;
+  --term-bg: #12151b;
+  --term-text: #d6dbe4;
+  --term-green: #5fd39a;
+  --term-cyan: #6cc5e0;
+  --term-muted: #8b95a3;
+  --shadow: 0 1px 2px rgba(20,24,29,.05), 0 8px 28px rgba(20,24,29,.06);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b0d11;
+    --bg-soft: #10131a;
+    --panel: #13161d;
+    --text: #e7eaf0;
+    --muted: #99a2b0;
+    --border: #232833;
+    --accent: #3ddc97;
+    --accent-soft: #12241c;
+    --term-bg: #0e1016;
+    --term-text: #d6dbe4;
+    --shadow: 0 1px 2px rgba(0,0,0,.3), 0 10px 30px rgba(0,0,0,.35);
+  }
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.wrap { max-width: 960px; margin: 0 auto; padding: 0 20px; }
+h1, h2, h3 { line-height: 1.25; letter-spacing: -.01em; }
+h2 { font-size: 1.75rem; margin: 0 0 .5rem; }
+section { padding: 64px 0; border-top: 1px solid var(--border); }
+.lead { color: var(--muted); font-size: 1.05rem; max-width: 46rem; }
+
+/* header */
+header {
+  position: sticky; top: 0; z-index: 20;
+  backdrop-filter: saturate(1.4) blur(10px);
+  background: var(--bg);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  border-bottom: 1px solid var(--border);
+}
+.nav { display: flex; align-items: center; gap: 18px; height: 58px; }
+.brand { font-weight: 700; font-size: 1.05rem; display: flex; align-items: center; gap: 8px; color: var(--text); }
+.brand:hover { text-decoration: none; }
+.nav-links { display: flex; gap: 18px; margin-left: auto; align-items: center; }
+.nav-links a { color: var(--muted); font-size: .92rem; }
+.nav-links a:hover { color: var(--text); text-decoration: none; }
+.nav-cta { color: var(--text) !important; font-weight: 600; }
+@media (max-width: 720px) { .nav-hide { display: none; } }
+
+/* hero */
+.hero { padding: 72px 0 56px; border-top: none; text-align: center; }
+.hero h1 { font-size: 2.7rem; margin: 0 0 16px; }
+.hero .lead { margin: 0 auto 28px; font-size: 1.18rem; }
+.tag { color: var(--accent); font-weight: 600; }
+.badges { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 22px 0 4px; }
+.badge {
+  font-size: .78rem; font-weight: 600; color: var(--muted);
+  border: 1px solid var(--border); border-radius: 999px; padding: 4px 11px; background: var(--bg-soft);
+}
+.btns { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin-top: 26px; }
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 11px 20px; border-radius: 10px; font-weight: 600; font-size: .95rem;
+  border: 1px solid var(--border); background: var(--panel); color: var(--text);
+}
+.btn:hover { text-decoration: none; border-color: var(--accent); }
+.btn-primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+@media (prefers-color-scheme: dark) { .btn-primary { color: #06120d; } }
+.btn-primary:hover { filter: brightness(1.06); }
+
+/* install line */
+.install {
+  display: inline-flex; align-items: center; gap: 12px;
+  background: var(--term-bg); color: var(--term-text);
+  border-radius: 12px; padding: 13px 16px; margin: 6px auto 0;
+  box-shadow: var(--shadow); max-width: 100%;
+}
+.install code { font-size: .98rem; white-space: nowrap; overflow-x: auto; }
+.install code::before { content: "$ "; color: var(--term-green); }
+.copy {
+  border: 1px solid #333a46; background: #1b2028; color: var(--term-muted);
+  border-radius: 7px; padding: 5px 10px; font-size: .78rem; cursor: pointer; flex: none;
+}
+.copy:hover { color: var(--term-text); border-color: #4a5261; }
+
+/* terminal window */
+.term {
+  background: var(--term-bg); border-radius: 12px; overflow: hidden;
+  box-shadow: var(--shadow); border: 1px solid rgba(255,255,255,.05); margin-top: 10px;
+}
+.term-bar { display: flex; align-items: center; gap: 7px; padding: 10px 14px; background: rgba(255,255,255,.03); border-bottom: 1px solid rgba(255,255,255,.05); }
+.dot { width: 11px; height: 11px; border-radius: 50%; display: inline-block; }
+.dot.r { background: #ff5f57; } .dot.y { background: #febc2e; } .dot.g { background: #28c840; }
+.term-title { color: var(--term-muted); font-size: .78rem; margin-left: 8px; }
+.term pre {
+  margin: 0; padding: 16px; overflow-x: auto; color: var(--term-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .86rem; line-height: 1.7;
+}
+.c-claude { color: #b892ff; } .c-codex { color: var(--term-cyan); } .c-green { color: var(--term-green); }
+.c-muted { color: var(--term-muted); }
+
+/* demo placeholder */
+.demo {
+  margin: 34px auto 0; max-width: 760px; border: 1px dashed var(--border); border-radius: 14px;
+  background: var(--bg-soft); overflow: hidden;
+}
+.demo .ph { display: grid; place-items: center; padding: 46px 20px; color: var(--muted); text-align: center; }
+.demo .ph .k { font-weight: 700; color: var(--text); }
+
+/* benefit cards */
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 20px; margin-top: 30px; }
+.card { border: 1px solid var(--border); border-radius: 14px; padding: 22px; background: var(--panel); }
+.card h3 { margin: 0 0 8px; font-size: 1.12rem; }
+.card p { margin: 0 0 14px; color: var(--muted); font-size: .96rem; }
+.card .term { margin-top: auto; }
+
+/* comparison table */
+.table-scroll { overflow-x: auto; margin-top: 26px; border: 1px solid var(--border); border-radius: 14px; }
+table { border-collapse: collapse; width: 100%; min-width: 620px; font-size: .93rem; }
+th, td { text-align: left; padding: 13px 16px; border-bottom: 1px solid var(--border); vertical-align: top; }
+thead th { background: var(--bg-soft); font-size: .82rem; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+tbody tr:last-child td { border-bottom: none; }
+td.yes { color: var(--accent); font-weight: 600; }
+.rowhead { font-weight: 600; white-space: nowrap; }
+
+/* steps */
+.steps { counter-reset: step; margin-top: 26px; display: grid; gap: 18px; }
+.step { display: grid; grid-template-columns: 40px 1fr; gap: 16px; align-items: start; }
+.step .n {
+  counter-increment: step; width: 34px; height: 34px; border-radius: 50%;
+  display: grid; place-items: center; font-weight: 700; background: var(--accent-soft); color: var(--accent); border: 1px solid var(--border);
+}
+.step .n::before { content: counter(step); }
+.step .body h3 { margin: 4px 0 8px; font-size: 1.05rem; }
+.step pre {
+  margin: 0; background: var(--term-bg); color: var(--term-text); border-radius: 10px; padding: 13px 15px;
+  overflow-x: auto; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: .85rem; line-height: 1.7;
+}
+.step .cmd::before { content: "$ "; color: var(--term-green); }
+
+/* story */
+.story { background: var(--bg-soft); }
+.story blockquote {
+  margin: 22px 0 0; padding: 20px 24px; border-left: 3px solid var(--accent);
+  background: var(--panel); border-radius: 0 12px 12px 0; font-size: 1.08rem;
+}
+.story blockquote strong { color: var(--text); }
+
+/* roadmap */
+.road { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px,1fr)); gap: 18px; margin-top: 26px; }
+.road .item { border: 1px solid var(--border); border-radius: 14px; padding: 20px; background: var(--panel); }
+.road .item .when { font-size: .78rem; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: var(--accent); }
+.road .item h3 { margin: 6px 0 8px; font-size: 1.08rem; }
+.road .item p { margin: 0; color: var(--muted); font-size: .94rem; }
+
+/* faq */
+.faq { margin-top: 22px; }
+details { border: 1px solid var(--border); border-radius: 12px; padding: 4px 18px; margin-bottom: 12px; background: var(--panel); }
+details[open] { border-color: var(--accent); }
+summary { cursor: pointer; font-weight: 600; padding: 14px 0; list-style: none; display: flex; justify-content: space-between; gap: 12px; }
+summary::-webkit-details-marker { display: none; }
+summary::after { content: "+"; color: var(--accent); font-weight: 700; }
+details[open] summary::after { content: "\2013"; }
+details p { margin: 0 0 16px; color: var(--muted); }
+
+/* footer */
+footer { border-top: 1px solid var(--border); padding: 40px 0; color: var(--muted); font-size: .9rem; }
+.foot-grid { display: flex; flex-wrap: wrap; gap: 26px; align-items: center; justify-content: space-between; }
+.foot-links { display: flex; flex-wrap: wrap; gap: 18px; }
+.foot-links a { color: var(--muted); }
+.foot-links a:hover { color: var(--text); }
+
+.center { text-align: center; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
+</style>
+</head>
+<body>
+
+<header>
+  <nav class="nav wrap">
+    <a class="brand" href="/agent-bridge/">🌉 AgentBridge</a>
+    <div class="nav-links">
+      <a class="nav-hide" href="#benefits">Features</a>
+      <a class="nav-hide" href="#why">Why</a>
+      <a class="nav-hide" href="#quickstart">Quick Start</a>
+      <a class="nav-hide" href="#faq">FAQ</a>
+      <a href="/agent-bridge/zh/">中文</a>
+      <a class="nav-cta" href="https://github.com/quilin-ai/agent-bridge">GitHub</a>
+    </div>
+  </nav>
+</header>
+
+<main>
+<section class="hero">
+  <div class="wrap">
+    <h1>Two AI agents. <span class="tag">One session.</span><br />No copy-paste.</h1>
+    <p class="lead">AgentBridge is a local bridge that lets <strong>Claude Code</strong> and <strong>Codex</strong> collaborate in real time inside one working session — cross-reviewing each other's diffs, splitting tasks between them, and relaying work across quota limits.</p>
+
+    <div class="install">
+      <code class="mono" id="installcmd">npm install -g @raysonmeng/agentbridge</code>
+      <button class="copy" data-copy="npm install -g @raysonmeng/agentbridge" aria-label="Copy install command">Copy</button>
+    </div>
+
+    <div class="btns">
+      <a class="btn btn-primary" href="#quickstart">Get started</a>
+      <a class="btn" href="https://github.com/quilin-ai/agent-bridge">★ GitHub</a>
+      <a class="btn" href="https://www.npmjs.com/package/@raysonmeng/agentbridge">npm</a>
+    </div>
+
+    <div class="badges">
+      <span class="badge">MIT licensed</span>
+      <span class="badge">Runs 100% locally</span>
+      <span class="badge">Zero runtime deps</span>
+      <span class="badge">1,700+ tests</span>
+      <span class="badge">v0.1.24</span>
+    </div>
+
+    <!-- assets/demo.gif — replace this placeholder once the demo is recorded (see docs/demo/RECORDING.md) -->
+    <div class="demo" aria-label="Product demo placeholder">
+      <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="term-title mono">agentbridge — live session</span></div>
+      <div class="ph">
+        <div>
+          <div class="k">▶ Demo coming soon</div>
+          <div style="margin-top:6px">A recorded session — Claude and Codex reviewing each other live — lands here (<code class="mono">assets/demo.gif</code>).</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="benefits">
+  <div class="wrap">
+    <h2>What that buys you, concretely</h2>
+    <p class="lead">Not two chatbots talking. Two full agents from different providers holding each other accountable while you steer.</p>
+    <div class="cards">
+
+      <div class="card">
+        <h3>Cross-review, not just cross-talk</h3>
+        <p>Codex implements; Claude reviews the diff in real time <em>inside the same session</em> and pushes change requests straight back into Codex's thread. Two providers checking each other — no copy-paste.</p>
+        <div class="term">
+          <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="term-title mono">cross-review</span></div>
+<pre><span class="c-codex">codex</span>  <span class="c-muted">→</span> implemented rate-limit guard, 3 files
+<span class="c-claude">claude</span> <span class="c-muted">→</span> reviewing diff…
+<span class="c-claude">claude</span> <span class="c-muted">→</span> <span class="c-green">reply</span>: edge case — retry after 429 unbounded
+<span class="c-codex">codex</span>  <span class="c-muted">→</span> fixed, capped at 5 retries</pre>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>Task splits from one prompt</h3>
+        <p>Ask either agent to propose a division of labor with the other, and they negotiate who does what before writing code. You steer; they coordinate.</p>
+        <div class="term">
+          <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="term-title mono">task-split</span></div>
+<pre><span class="c-muted">you →</span> propose a split with Codex for the auth refactor
+<span class="c-claude">claude</span> <span class="c-muted">→</span> I'll take the token model + tests;
+        Codex takes the middleware. Agreed?
+<span class="c-codex">codex</span>  <span class="c-muted">→</span> <span class="c-green">agreed</span> — starting middleware now</pre>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>Quota relay for overnight runs</h3>
+        <p>When one side's subscription window runs dry, it stops cleanly at a turn boundary and hands the task off — so a long job keeps moving instead of dying at a limit.</p>
+        <div class="term">
+          <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="term-title mono">quota-relay</span></div>
+<pre><span class="c-codex">codex</span>  <span class="c-muted">→</span> 5h window low — checkpoint written
+<span class="c-green">bridge</span> <span class="c-muted">→</span> handing off to Claude…
+<span class="c-claude">claude</span> <span class="c-muted">→</span> resumed from .agent/checkpoint.md
+<span class="c-green">bridge</span> <span class="c-muted">→</span> auto-resume Codex when window refreshes</pre>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section id="quota">
+  <div class="wrap">
+    <h2>Quota relay — the part nothing else does</h2>
+    <p class="lead">A long task shouldn't die because one agent hit its 5-hour or weekly subscription limit at 2am. AgentBridge keeps it moving.</p>
+    <div class="cards" style="margin-top:24px">
+      <div class="card">
+        <h3>No mid-task cut</h3>
+        <p>Near the quota hard-line, the companion <a href="https://www.npmjs.com/package/agent-quota-guard">agent-quota-guard</a> does <em>not</em> deny mid-tool-call. It lets the current turn finish, stops cleanly at the boundary, writes a <code class="mono">.agent/checkpoint.md</code>, and drops a <code class="mono">pending</code> record the bridge detects.</p>
+      </div>
+      <div class="card">
+        <h3>Automatic resume</h3>
+        <p>When the paused side's window refreshes, the bridge resumes the task <strong>in the original interactive TUI</strong> — Codex via a queued <code class="mono">turn/start</code>, Claude via a channel push it acks with <code class="mono">ack_resume</code>. Idempotency tombstones inject each resume at most once.</p>
+      </div>
+      <div class="card">
+        <h3>Both windows in one glance</h3>
+        <p>The daemon polls both agents' account-level 5h and weekly quota. <code class="mono">abg budget --json</code> prints the live snapshot: both windows, drift between the two sides, and pause state.</p>
+      </div>
+    </div>
+    <p style="margin-top:20px; color:var(--muted); font-size:.92rem"><strong>Opt-in.</strong> Quota relay is a companion-guard feature — install <a href="https://github.com/quilin-ai/agent-quota-guard">agent-quota-guard</a> to enable it. Without it, everything else still works.</p>
+  </div>
+</section>
+
+<section id="why">
+  <div class="wrap">
+    <h2>Why AgentBridge, and not…</h2>
+    <p class="lead">Three things people reach for instead — and where each one leaves you doing the work by hand.</p>
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr>
+            <th>&nbsp;</th>
+            <th>Two terminals + copy-paste</th>
+            <th>One-way delegation plugin<br /><span class="mono" style="font-weight:400">(e.g. codex-plugin-cc)</span></th>
+            <th>External orchestrator</th>
+            <th>AgentBridge</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="rowhead">Message relay</td>
+            <td>You are the message bus</td>
+            <td>Request in, response out</td>
+            <td>Scripted per hop</td>
+            <td class="yes">Automatic, both ways</td>
+          </tr>
+          <tr>
+            <td class="rowhead">Both agents live as peers</td>
+            <td>Yes, but disconnected</td>
+            <td>No — one standing host, one callee</td>
+            <td>No — one brain, N dumb workers</td>
+            <td class="yes">Yes — persistent peers</td>
+          </tr>
+          <tr>
+            <td class="rowhead">Push mid-turn</td>
+            <td>Manual, guess when it's safe</td>
+            <td>Only at call boundaries</td>
+            <td>Only at scheduled steps</td>
+            <td class="yes">Yes — review lands mid-turn</td>
+          </tr>
+          <tr>
+            <td class="rowhead">Agents propose their own splits</td>
+            <td>No</td>
+            <td>No</td>
+            <td>No — top-down</td>
+            <td class="yes">Yes — they negotiate</td>
+          </tr>
+          <tr>
+            <td class="rowhead">Survives a quota limit</td>
+            <td>No — you restart by hand</td>
+            <td>No</td>
+            <td>Depends on your script</td>
+            <td class="yes">Yes — checkpoint + auto-resume</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section id="quickstart">
+  <div class="wrap">
+    <h2>Quick Start</h2>
+    <p class="lead">Four steps from nothing to a running pair. The daemon starts automatically when needed and reconnects if restarted.</p>
+    <div class="steps">
+      <div class="step">
+        <div class="n"></div>
+        <div class="body">
+          <h3>Install Bun (the runtime — Node alone won't work)</h3>
+          <pre><span class="cmd">curl -fsSL https://bun.sh/install | bash</span></pre>
+        </div>
+      </div>
+      <div class="step">
+        <div class="n"></div>
+        <div class="body">
+          <h3>Install the CLI</h3>
+          <p style="margin:0 0 8px;color:var(--muted);font-size:.92rem">postinstall auto-registers the Claude Code plugin marketplace and installs the plugin (best-effort; needs bun + claude present).</p>
+          <pre><span class="cmd">npm install -g @raysonmeng/agentbridge</span></pre>
+        </div>
+      </div>
+      <div class="step">
+        <div class="n"></div>
+        <div class="body">
+          <h3>Start Claude Code with the AgentBridge channel</h3>
+          <pre><span class="cmd">abg claude</span></pre>
+        </div>
+      </div>
+      <div class="step">
+        <div class="n"></div>
+        <div class="body">
+          <h3>In another terminal, start Codex connected to the same bridge</h3>
+          <pre><span class="cmd">abg codex</span></pre>
+        </div>
+      </div>
+    </div>
+    <p style="margin-top:22px;color:var(--muted)"><strong>Your first collaboration:</strong> with both sides running, ask Claude — <em>"Propose a task split with Codex for &lt;your task&gt;, then have Codex implement its part while you review."</em> You'll see the split flow into Codex's session, Codex start working, and its completion push back to Claude for review — all without you relaying anything by hand.</p>
+    <p style="color:var(--muted);font-size:.92rem"><code class="mono">abg</code> is a short alias for <code class="mono">agentbridge</code>. Both agents launch with max-permission defaults so an unattended pair doesn't stop for each prompt — add <code class="mono">--safe</code> to launch with normal prompts. See the <a href="https://github.com/quilin-ai/agent-bridge/blob/master/docs/TROUBLESHOOTING.md">Troubleshooting guide</a> if <code class="mono">abg</code> installs but won't run.</p>
+  </div>
+</section>
+
+<section id="story" class="story">
+  <div class="wrap">
+    <h2>AgentBridge is its own proof of concept</h2>
+    <p class="lead">The strongest thing we can say about it is that we didn't build it the normal way.</p>
+    <blockquote>
+      This tool was largely built by <strong>Claude Code</strong> (Anthropic) and <strong>Codex</strong> (OpenAI) collaborating <em>through it</em> — the very bridge they were building together. <strong>Every PR written by one agent was reviewed by the other.</strong> A human steered: assigning tasks, reviewing progress, and directing the two to work in parallel and check each other's output.
+    </blockquote>
+    <p style="margin-top:18px;color:var(--muted)">Two AI agents from different providers, connected in real time, shipping code side by side — and reviewing each other's PRs across the wire. That's not a marketing metaphor; it's the commit history.</p>
+  </div>
+</section>
+
+<section id="roadmap">
+  <div class="wrap">
+    <h2>Roadmap</h2>
+    <p class="lead">Claude Code ↔ Codex ships today. Here's where it goes next.</p>
+    <div class="road">
+      <div class="item">
+        <div class="when">Next up · vote</div>
+        <h3>More adapters</h3>
+        <p>Which agent gets wired in next is a public vote — OpenCode, Gemini CLI, and others are candidates. Cast yours on <a href="https://github.com/quilin-ai/agent-bridge/issues/212">issue #212</a>.</p>
+      </div>
+      <div class="item">
+        <div class="when">Longer term</div>
+        <h3>Capability mesh</h3>
+        <p>Beyond a single pair: rooms of agents across machines, each advertising what it's good at, routing work to the right capability instead of a fixed pairing. A v3 cross-network preview already ships behind experimental commands.</p>
+      </div>
+      <div class="item">
+        <div class="when">Ongoing</div>
+        <h3>Sharper collaboration</h3>
+        <p>Less noise, better turn discipline, richer coordination policies, and stronger recovery semantics across runtimes.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="faq">
+  <div class="wrap">
+    <h2>FAQ</h2>
+    <div class="faq">
+      <details>
+        <summary><span><code class="mono">abg</code> installed but won't run — what's wrong?</span></summary>
+        <p>You're almost certainly missing <strong>Bun</strong>. AgentBridge's daemon and plugin server run on the Bun runtime; Node.js alone is not enough. Install it with <code class="mono">curl -fsSL https://bun.sh/install | bash</code>, then re-run <code class="mono">abg claude</code>. This is the single most common install failure.</p>
+      </details>
+      <details>
+        <summary><span>Does AgentBridge support Windows?</span></summary>
+        <p>Not officially yet. AgentBridge runs on <strong>macOS and Linux</strong> today. WSL2 may work but is untested and unsupported.</p>
+      </details>
+      <details>
+        <summary><span>Is it safe? What does <code class="mono">--safe</code> do?</span></summary>
+        <p>By default <code class="mono">abg claude</code> launches with <code class="mono">--dangerously-skip-permissions</code> and <code class="mono">abg codex</code> with <code class="mono">--yolo</code> — deliberate, because an unattended agent pair can't stop to ask you for each permission. Both can then run commands and edit files without prompting, so <strong>only do this in a workspace you trust</strong>. Add <code class="mono">--safe</code> (or set <code class="mono">AGENTBRIDGE_SAFE=1</code>) to launch with normal prompts. AgentBridge is a local dev tool, not a hardened boundary between untrusted tools.</p>
+      </details>
+      <details>
+        <summary><span>How does quota relay actually work?</span></summary>
+        <p>With the companion <a href="https://github.com/quilin-ai/agent-quota-guard">agent-quota-guard</a> installed, the daemon polls both agents' 5h and weekly subscription windows. Near a limit the guard lets the current turn finish, stops cleanly at the turn boundary, writes a <code class="mono">.agent/checkpoint.md</code>, and drops a <code class="mono">pending</code> record. When the window refreshes, the bridge auto-resumes the task in the original interactive TUI — Codex via a queued <code class="mono">turn/start</code>, Claude via an acked channel push.</p>
+      </details>
+      <details>
+        <summary><span>Which agents does it support?</span></summary>
+        <p>Today the shipping in-session integration connects <strong>Claude Code and Codex</strong>. Which agent comes next is a public vote — see the adapter roadmap on <a href="https://github.com/quilin-ai/agent-bridge/issues/212">issue #212</a> (OpenCode, Gemini CLI, and more are candidates).</p>
+      </details>
+      <details>
+        <summary><span>How is this different from <code class="mono">codex-plugin-cc</code>?</span></summary>
+        <p>One-way delegation plugins like <code class="mono">openai/codex-plugin-cc</code> let a host <em>call</em> Codex and get one answer back — request in, response out, no standing peer on the other side. AgentBridge keeps <strong>both</strong> agents live as persistent peers, and either side can push a message <strong>mid-turn</strong> (a review comment lands while the other is still working), not only at call boundaries.</p>
+      </details>
+      <details>
+        <summary><span>Do I need an account or API keys for AgentBridge itself?</span></summary>
+        <p>No. AgentBridge is a local tool with zero runtime dependencies and no hosted service. You use your existing Claude Code and Codex logins; AgentBridge only relays messages between them on your machine — raw work never leaves the box.</p>
+      </details>
+      <details>
+        <summary><span>Can I run more than one pair at once?</span></summary>
+        <p>Yes. One Claude+Codex pair per project directory, with ports allocated per pair in +10 strides from 4500. Target a specific pair with <code class="mono">--pair &lt;name&gt;</code> on the pair-aware commands.</p>
+      </details>
+    </div>
+  </div>
+</section>
+</main>
+
+<footer>
+  <div class="wrap foot-grid">
+    <div>
+      <div class="brand" style="margin-bottom:6px">🌉 AgentBridge</div>
+      <div>Local bridge for Claude Code ↔ Codex collaboration. MIT licensed.</div>
+    </div>
+    <div class="foot-links">
+      <a href="https://github.com/quilin-ai/agent-bridge">GitHub</a>
+      <a href="https://www.npmjs.com/package/@raysonmeng/agentbridge">npm</a>
+      <a href="https://github.com/quilin-ai/agent-bridge/blob/master/docs/TROUBLESHOOTING.md">Troubleshooting</a>
+      <a href="/agent-bridge/zh/">中文</a>
+      <a href="https://x.com/raysonmeng">@raysonmeng</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+// ponytail: tiny inline copy handler, no lib — command is plain text if JS is off
+document.querySelectorAll('.copy').forEach(function (b) {
+  b.addEventListener('click', function () {
+    navigator.clipboard && navigator.clipboard.writeText(b.dataset.copy).then(function () {
+      var t = b.textContent; b.textContent = 'Copied'; setTimeout(function () { b.textContent = t; }, 1400);
+    });
+  });
+});
+</script>
+</body>
+</html>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,74 @@
+# AgentBridge
+
+> A local, MIT-licensed developer tool that lets two AI coding agents — Claude Code (Anthropic) and Codex (OpenAI) — collaborate in real time inside one working session. It relays messages between an MCP channel and the Codex app-server protocol so the two agents can cross-review each other's diffs, split tasks, and hand work off across quota limits. It runs entirely on the developer's machine, has zero runtime dependencies, and is not a hosted service.
+
+## Facts
+
+- Name: AgentBridge
+- License: MIT
+- Latest version: v0.1.24
+- Install (CLI): `npm install -g @raysonmeng/agentbridge`
+- npm package: @raysonmeng/agentbridge
+- Repository: https://github.com/quilin-ai/agent-bridge
+- Website: https://quilin-ai.github.io/agent-bridge/
+- Author: raysonmeng (https://x.com/raysonmeng)
+- Platforms: macOS and Linux (Windows not officially supported yet)
+- Runtime: Bun (required — Node.js alone is not sufficient)
+- Tests: 1,700+
+- Runs 100% locally; no accounts, API keys, or servers needed for AgentBridge itself (uses your existing Claude Code and Codex logins). Raw work never leaves the machine.
+
+## What it is
+
+- A local bridge that connects Claude Code and Codex in one workflow, in the same working session.
+- Two-process architecture: a foreground MCP client (`bridge.ts`, started by Claude Code via the AgentBridge plugin) and a persistent background daemon (`daemon.ts`) that owns the Codex app-server proxy and bridge state. The daemon survives Claude Code restarts; the foreground reconnects with exponential backoff.
+- An experimental setup for human-in-the-loop collaboration between multiple agents. The human steers; the agents coordinate.
+
+## What it is NOT
+
+- Not a hosted service or multi-tenant system.
+- Not a generic orchestration framework for arbitrary agent backends.
+- Not a hardened security boundary between tools you do not trust.
+
+## Three core benefits
+
+- Cross-review, not just cross-talk: Codex implements; Claude reviews the diff in real time inside the same session and pushes change requests straight back into Codex's thread. Two providers holding each other accountable, no copy-paste.
+- Task splits from one prompt: ask either agent to propose a division of labor with the other; they negotiate who does what before writing code.
+- Quota relay for overnight runs: when one side's subscription window runs dry it stops cleanly at a turn boundary, writes a checkpoint, and hands off, so a long job keeps moving instead of dying at a limit. Requires the companion tool agent-quota-guard.
+
+## How it compares
+
+- vs two terminals + copy-paste: with two terminals the human is the message bus, ferrying text by hand. AgentBridge automates the relay — messages flow on their own, a busy-guard blocks replies during an active turn, and noisy intermediate events are filtered.
+- vs a one-way delegation plugin (e.g. openai/codex-plugin-cc): those let a host call Codex and get one answer back (request in, response out, no standing peer). AgentBridge keeps both agents live as persistent peers, and either side can push a message mid-turn, not only at call boundaries.
+- vs an external orchestrator: a god-process scheduling dumb terminals is top-down (one brain, N workers that never talk). AgentBridge is peer-to-peer — two full agents converse in-session, propose their own splits, and review each other.
+
+## Quick start (4 steps)
+
+1. Install Bun: `curl -fsSL https://bun.sh/install | bash`
+2. Install the CLI: `npm install -g @raysonmeng/agentbridge` (postinstall best-effort registers the Claude Code plugin)
+3. Start Claude Code with the bridge channel: `abg claude`
+4. In another terminal, start Codex on the same bridge: `abg codex`
+
+`abg` is a short alias for `agentbridge`. Both agents launch with max-permission defaults so an unattended pair does not stop for each prompt; add `--safe` (or set AGENTBRIDGE_SAFE=1) for normal permission prompts. Only run the default mode in a workspace you trust.
+
+## Key CLI commands
+
+- `abg init` — install plugin, check dependencies, generate `.agentbridge/config.json`
+- `abg claude [args]` — start Claude Code with the push channel enabled
+- `abg codex [args]` — start Codex TUI connected to the AgentBridge daemon (auto-resumes the pair's last thread; `--new` for a fresh one)
+- `abg budget [--json]` — both agents' subscription quota snapshot (5h/weekly windows, drift, pause state)
+- `abg doctor [--json]` — read-only diagnosis of env, daemon health, build drift
+- `abg pairs` — list/remove/prune registered pairs (one pair per project directory)
+- `abg kill [--all]` — stop the pair's daemon and managed Codex TUI
+
+## How it was built
+
+AgentBridge was largely built by Claude Code and Codex collaborating through it — the very tool they were building together. Every PR written by one agent was reviewed by the other, with a human steering. It is its own proof of concept.
+
+## Roadmap
+
+- More adapters: which agent is wired in next is a public vote at https://github.com/quilin-ai/agent-bridge/issues/212 (candidates include OpenCode and Gemini CLI).
+- Capability mesh: rooms of agents across machines that advertise capabilities and route work accordingly (v3 cross-network preview ships behind experimental commands today).
+
+## Companion tool
+
+- agent-quota-guard (https://github.com/quilin-ai/agent-quota-guard) — enables the quota-relay / slowdown-line / auto-resume feature. Optional; everything else works without it.

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://quilin-ai.github.io/agent-bridge/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://quilin-ai.github.io/agent-bridge/</loc>
+    <lastmod>2026-07-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://quilin-ai.github.io/agent-bridge/"/>
+    <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://quilin-ai.github.io/agent-bridge/zh/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://quilin-ai.github.io/agent-bridge/"/>
+  </url>
+  <url>
+    <loc>https://quilin-ai.github.io/agent-bridge/zh/</loc>
+    <lastmod>2026-07-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://quilin-ai.github.io/agent-bridge/"/>
+    <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://quilin-ai.github.io/agent-bridge/zh/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://quilin-ai.github.io/agent-bridge/"/>
+  </url>
+</urlset>

--- a/site/zh/index.html
+++ b/site/zh/index.html
@@ -1,0 +1,534 @@
+<!doctype html>
+<html lang="zh-Hans">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>AgentBridge — 让 Claude Code 和 Codex 在同一会话里协作</title>
+<meta name="description" content="AgentBridge 是一个本地运行的桥接工具，让 Claude Code 和 Codex 在同一个会话里实时协作：交叉 review、任务拆分、额度接力，告别双开终端手动复制粘贴。MIT 开源、零运行时依赖、1,700+ 测试。" />
+<meta name="keywords" content="AgentBridge, Claude Code, Codex, 多 agent 协作, 交叉 review, 双开, 任务拆分, 额度接力, MCP, 本地 AI 工具" />
+<meta name="author" content="raysonmeng" />
+<link rel="canonical" href="https://quilin-ai.github.io/agent-bridge/zh/" />
+<link rel="alternate" hreflang="en" href="https://quilin-ai.github.io/agent-bridge/" />
+<link rel="alternate" hreflang="zh-Hans" href="https://quilin-ai.github.io/agent-bridge/zh/" />
+<link rel="alternate" hreflang="x-default" href="https://quilin-ai.github.io/agent-bridge/" />
+
+<!-- Open Graph -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="AgentBridge" />
+<meta property="og:title" content="AgentBridge — 让 Claude Code 和 Codex 在同一会话里协作" />
+<meta property="og:description" content="本地运行的桥接工具：让 Claude Code 和 Codex 在同一会话里实时协作 —— 交叉 review、任务拆分、额度接力。MIT、零运行时依赖。" />
+<meta property="og:url" content="https://quilin-ai.github.io/agent-bridge/zh/" />
+<meta property="og:image" content="https://quilin-ai.github.io/agent-bridge/assets/og.svg" />
+<meta property="og:image:alt" content="AgentBridge — Claude Code 与 Codex 在同一会话协作" />
+<meta property="og:locale" content="zh_CN" />
+<meta property="og:locale:alternate" content="en_US" />
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="AgentBridge — 让 Claude Code 和 Codex 在同一会话里协作" />
+<meta name="twitter:description" content="本地桥接工具：让 Claude Code 和 Codex 在同一会话里实时协作 —— 交叉 review、任务拆分、额度接力。" />
+<meta name="twitter:image" content="https://quilin-ai.github.io/agent-bridge/assets/og.svg" />
+<meta name="twitter:creator" content="@raysonmeng" />
+
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ctext y='26' font-size='26'%3E%F0%9F%8C%89%3C/text%3E%3C/svg%3E" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      "name": "AgentBridge",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "macOS, Linux",
+      "description": "一个本地运行的桥接工具，让 Claude Code 和 Codex 在同一个工作会话里双向实时协作：交叉 review、任务拆分、跨额度窗口的任务接力。",
+      "url": "https://quilin-ai.github.io/agent-bridge/zh/",
+      "downloadUrl": "https://www.npmjs.com/package/@raysonmeng/agentbridge",
+      "softwareVersion": "0.1.24",
+      "license": "https://opensource.org/licenses/MIT",
+      "isAccessibleForFree": true,
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+      "author": { "@type": "Person", "name": "raysonmeng", "url": "https://x.com/raysonmeng" },
+      "codeRepository": "https://github.com/quilin-ai/agent-bridge"
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "abg 装好了却跑不起来，是什么原因？",
+          "acceptedAnswer": { "@type": "Answer", "text": "大概率是没装 Bun。AgentBridge 的 daemon 和插件服务跑在 Bun 运行时上，只有 Node.js 不够。用 curl -fsSL https://bun.sh/install | bash 装好 Bun，再重新执行 abg claude。" }
+        },
+        {
+          "@type": "Question",
+          "name": "支持 Windows 吗？",
+          "acceptedAnswer": { "@type": "Answer", "text": "暂未正式支持 Windows。目前在 macOS 和 Linux 上运行。WSL2 可能可用但未经测试。" }
+        },
+        {
+          "@type": "Question",
+          "name": "安全吗？--safe 是干什么的？",
+          "acceptedAnswer": { "@type": "Answer", "text": "默认情况下 abg claude 带 --dangerously-skip-permissions、abg codex 带 --yolo 启动，让无人值守的一对 agent 不必逐条询问权限。这意味着两个 agent 可以不经确认执行命令、改文件，所以只在你信任的工作区里这么用。加 --safe（或设 AGENTBRIDGE_SAFE=1）即可恢复正常权限提示。AgentBridge 完全本地运行，不是隔离不可信工具的安全边界。" }
+        },
+        {
+          "@type": "Question",
+          "name": "额度接力是怎么工作的？",
+          "acceptedAnswer": { "@type": "Answer", "text": "装上配套的 agent-quota-guard 后，daemon 会轮询两个 agent 的 5 小时和每周订阅额度。临近上限时，guard 不会在工具调用中途拒绝，而是让当前 turn 收尾，在回合边界干净停下，写入 .agent/checkpoint.md 并留下一条 pending 记录。等额度窗口刷新，bridge 会在原来的交互式 TUI 里自动续接任务。" }
+        },
+        {
+          "@type": "Question",
+          "name": "支持哪些 agent？",
+          "acceptedAnswer": { "@type": "Answer", "text": "目前已上线的会话内集成连接的是 Claude Code 和 Codex。下一个接哪个 agent 由公开投票决定（issue #212），OpenCode、Gemini CLI 等都是候选。" }
+        },
+        {
+          "@type": "Question",
+          "name": "和 codex-plugin-cc 有什么区别？",
+          "acceptedAnswer": { "@type": "Answer", "text": "codex-plugin-cc 这类单向委派插件是宿主调用 Codex、拿一个结果回来 —— 请求进、响应出，对面没有常驻的对等体。AgentBridge 让两个 agent 都作为持久对等体在线，任意一方都能在对方 turn 进行中途推消息（review 意见能在对方还在干活时就送达），而不只是在调用边界。" }
+        }
+      ]
+    }
+  ]
+}
+</script>
+
+<style>
+:root {
+  --bg: #ffffff; --bg-soft: #f5f6f8; --panel: #ffffff;
+  --text: #14181d; --muted: #5b636e; --border: #e3e7ec;
+  --accent: #0a7d55; --accent-soft: #e5f5ee;
+  --term-bg: #12151b; --term-text: #d6dbe4; --term-green: #5fd39a; --term-cyan: #6cc5e0; --term-muted: #8b95a3;
+  --shadow: 0 1px 2px rgba(20,24,29,.05), 0 8px 28px rgba(20,24,29,.06);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b0d11; --bg-soft: #10131a; --panel: #13161d;
+    --text: #e7eaf0; --muted: #99a2b0; --border: #232833;
+    --accent: #3ddc97; --accent-soft: #12241c;
+    --term-bg: #0e1016; --shadow: 0 1px 2px rgba(0,0,0,.3), 0 10px 30px rgba(0,0,0,.35);
+  }
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg); color: var(--text); line-height: 1.75; -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.wrap { max-width: 960px; margin: 0 auto; padding: 0 20px; }
+h1, h2, h3 { line-height: 1.35; }
+h2 { font-size: 1.7rem; margin: 0 0 .5rem; }
+section { padding: 64px 0; border-top: 1px solid var(--border); }
+.lead { color: var(--muted); font-size: 1.05rem; max-width: 46rem; }
+
+header { position: sticky; top: 0; z-index: 20; backdrop-filter: saturate(1.4) blur(10px); background: var(--bg); background: color-mix(in srgb, var(--bg) 82%, transparent); border-bottom: 1px solid var(--border); }
+.nav { display: flex; align-items: center; gap: 18px; height: 58px; }
+.brand { font-weight: 700; font-size: 1.05rem; display: flex; align-items: center; gap: 8px; color: var(--text); }
+.brand:hover { text-decoration: none; }
+.nav-links { display: flex; gap: 18px; margin-left: auto; align-items: center; }
+.nav-links a { color: var(--muted); font-size: .92rem; }
+.nav-links a:hover { color: var(--text); text-decoration: none; }
+.nav-cta { color: var(--text) !important; font-weight: 600; }
+@media (max-width: 720px) { .nav-hide { display: none; } }
+
+.hero { padding: 72px 0 56px; border-top: none; text-align: center; }
+.hero h1 { font-size: 2.5rem; margin: 0 0 16px; }
+.hero .lead { margin: 0 auto 28px; font-size: 1.16rem; }
+.tag { color: var(--accent); }
+.badges { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 22px 0 4px; }
+.badge { font-size: .8rem; font-weight: 600; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 4px 12px; background: var(--bg-soft); }
+.btns { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin-top: 26px; }
+.btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 10px; font-weight: 600; font-size: .95rem; border: 1px solid var(--border); background: var(--panel); color: var(--text); }
+.btn:hover { text-decoration: none; border-color: var(--accent); }
+.btn-primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+@media (prefers-color-scheme: dark) { .btn-primary { color: #06120d; } }
+.btn-primary:hover { filter: brightness(1.06); }
+
+.install { display: inline-flex; align-items: center; gap: 12px; background: var(--term-bg); color: var(--term-text); border-radius: 12px; padding: 13px 16px; margin: 6px auto 0; box-shadow: var(--shadow); max-width: 100%; }
+.install code { font-size: .98rem; white-space: nowrap; overflow-x: auto; }
+.install code::before { content: "$ "; color: var(--term-green); }
+.copy { border: 1px solid #333a46; background: #1b2028; color: var(--term-muted); border-radius: 7px; padding: 5px 10px; font-size: .78rem; cursor: pointer; flex: none; }
+.copy:hover { color: var(--term-text); border-color: #4a5261; }
+
+.term { background: var(--term-bg); border-radius: 12px; overflow: hidden; box-shadow: var(--shadow); border: 1px solid rgba(255,255,255,.05); margin-top: 10px; }
+.term-bar { display: flex; align-items: center; gap: 7px; padding: 10px 14px; background: rgba(255,255,255,.03); border-bottom: 1px solid rgba(255,255,255,.05); }
+.dot { width: 11px; height: 11px; border-radius: 50%; display: inline-block; }
+.dot.r { background: #ff5f57; } .dot.y { background: #febc2e; } .dot.g { background: #28c840; }
+.term-title { color: var(--term-muted); font-size: .78rem; margin-left: 8px; }
+.term pre { margin: 0; padding: 16px; overflow-x: auto; color: var(--term-text); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .86rem; line-height: 1.7; }
+.c-claude { color: #b892ff; } .c-codex { color: var(--term-cyan); } .c-green { color: var(--term-green); } .c-muted { color: var(--term-muted); }
+
+.demo { margin: 34px auto 0; max-width: 760px; border: 1px dashed var(--border); border-radius: 14px; background: var(--bg-soft); overflow: hidden; }
+.demo .ph { display: grid; place-items: center; padding: 46px 20px; color: var(--muted); text-align: center; }
+.demo .ph .k { font-weight: 700; color: var(--text); }
+
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 20px; margin-top: 30px; }
+.card { border: 1px solid var(--border); border-radius: 14px; padding: 22px; background: var(--panel); }
+.card h3 { margin: 0 0 8px; font-size: 1.12rem; }
+.card p { margin: 0 0 14px; color: var(--muted); font-size: .96rem; }
+
+.table-scroll { overflow-x: auto; margin-top: 26px; border: 1px solid var(--border); border-radius: 14px; }
+table { border-collapse: collapse; width: 100%; min-width: 640px; font-size: .93rem; }
+th, td { text-align: left; padding: 13px 16px; border-bottom: 1px solid var(--border); vertical-align: top; }
+thead th { background: var(--bg-soft); font-size: .82rem; color: var(--muted); }
+tbody tr:last-child td { border-bottom: none; }
+td.yes { color: var(--accent); font-weight: 600; }
+.rowhead { font-weight: 600; white-space: nowrap; }
+
+.steps { counter-reset: step; margin-top: 26px; display: grid; gap: 18px; }
+.step { display: grid; grid-template-columns: 40px 1fr; gap: 16px; align-items: start; }
+.step .n { counter-increment: step; width: 34px; height: 34px; border-radius: 50%; display: grid; place-items: center; font-weight: 700; background: var(--accent-soft); color: var(--accent); border: 1px solid var(--border); }
+.step .n::before { content: counter(step); }
+.step .body h3 { margin: 4px 0 8px; font-size: 1.05rem; }
+.step pre { margin: 0; background: var(--term-bg); color: var(--term-text); border-radius: 10px; padding: 13px 15px; overflow-x: auto; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: .85rem; line-height: 1.7; }
+.step .cmd::before { content: "$ "; color: var(--term-green); }
+
+.story { background: var(--bg-soft); }
+.story blockquote { margin: 22px 0 0; padding: 20px 24px; border-left: 3px solid var(--accent); background: var(--panel); border-radius: 0 12px 12px 0; font-size: 1.06rem; }
+.story blockquote strong { color: var(--text); }
+
+.road { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px,1fr)); gap: 18px; margin-top: 26px; }
+.road .item { border: 1px solid var(--border); border-radius: 14px; padding: 20px; background: var(--panel); }
+.road .item .when { font-size: .78rem; font-weight: 700; letter-spacing: .05em; color: var(--accent); }
+.road .item h3 { margin: 6px 0 8px; font-size: 1.08rem; }
+.road .item p { margin: 0; color: var(--muted); font-size: .94rem; }
+
+.faq { margin-top: 22px; }
+details { border: 1px solid var(--border); border-radius: 12px; padding: 4px 18px; margin-bottom: 12px; background: var(--panel); }
+details[open] { border-color: var(--accent); }
+summary { cursor: pointer; font-weight: 600; padding: 14px 0; list-style: none; display: flex; justify-content: space-between; gap: 12px; }
+summary::-webkit-details-marker { display: none; }
+summary::after { content: "+"; color: var(--accent); font-weight: 700; }
+details[open] summary::after { content: "\2013"; }
+details p { margin: 0 0 16px; color: var(--muted); }
+
+footer { border-top: 1px solid var(--border); padding: 40px 0; color: var(--muted); font-size: .9rem; }
+.foot-grid { display: flex; flex-wrap: wrap; gap: 26px; align-items: center; justify-content: space-between; }
+.foot-links { display: flex; flex-wrap: wrap; gap: 18px; }
+.foot-links a { color: var(--muted); }
+.foot-links a:hover { color: var(--text); }
+</style>
+</head>
+<body>
+
+<header>
+  <nav class="nav wrap">
+    <a class="brand" href="/agent-bridge/zh/">🌉 AgentBridge</a>
+    <div class="nav-links">
+      <a class="nav-hide" href="#benefits">能力</a>
+      <a class="nav-hide" href="#why">对比</a>
+      <a class="nav-hide" href="#quickstart">快速开始</a>
+      <a class="nav-hide" href="#faq">常见问题</a>
+      <a href="/agent-bridge/">EN</a>
+      <a class="nav-cta" href="https://github.com/quilin-ai/agent-bridge">GitHub</a>
+    </div>
+  </nav>
+</header>
+
+<main>
+<section class="hero">
+  <div class="wrap">
+    <h1>两个 AI agent，<span class="tag">同一个会话</span>，<br />不用手动复制粘贴</h1>
+    <p class="lead">AgentBridge 是一个本地桥接工具，让 <strong>Claude Code</strong> 和 <strong>Codex</strong> 在同一个工作会话里实时协作 —— 互相 review 对方的 diff、把任务拆给彼此、在额度撞线时把活儿接力下去。告别双开终端来回搬运。</p>
+
+    <div class="install">
+      <code class="mono" id="installcmd">npm install -g @raysonmeng/agentbridge</code>
+      <button class="copy" data-copy="npm install -g @raysonmeng/agentbridge" aria-label="复制安装命令">复制</button>
+    </div>
+
+    <div class="btns">
+      <a class="btn btn-primary" href="#quickstart">快速开始</a>
+      <a class="btn" href="https://github.com/quilin-ai/agent-bridge">★ GitHub</a>
+      <a class="btn" href="https://www.npmjs.com/package/@raysonmeng/agentbridge">npm</a>
+    </div>
+
+    <div class="badges">
+      <span class="badge">MIT 开源</span>
+      <span class="badge">纯本地运行</span>
+      <span class="badge">零运行时依赖</span>
+      <span class="badge">1,700+ 测试</span>
+      <span class="badge">v0.1.24</span>
+    </div>
+
+    <!-- assets/demo.gif —— demo 录好后替换此占位块（见 docs/demo/RECORDING.md） -->
+    <div class="demo" aria-label="产品演示占位">
+      <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="term-title mono">agentbridge — 实时会话</span></div>
+      <div class="ph">
+        <div>
+          <div class="k">▶ 演示即将上线</div>
+          <div style="margin-top:6px">这里会放一段实录：Claude 和 Codex 实时互相 review（<code class="mono">assets/demo.gif</code>）。</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="benefits">
+  <div class="wrap">
+    <h2>具体能换来什么</h2>
+    <p class="lead">不是两个聊天机器人对话，而是来自不同厂商的两个完整 agent 互相盯着对方干活，你只负责掌舵。</p>
+    <div class="cards">
+
+      <div class="card">
+        <h3>交叉 review，不只是互相喊话</h3>
+        <p>Codex 写实现，Claude 在<em>同一个会话里</em>实时 review 它的 diff，把修改意见直接推回 Codex 的 thread。两个厂商互相把关 —— 全程不用复制粘贴。</p>
+        <div class="term">
+          <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="term-title mono">交叉 review</span></div>
+<pre><span class="c-codex">codex</span>  <span class="c-muted">→</span> 实现了限流保护，改了 3 个文件
+<span class="c-claude">claude</span> <span class="c-muted">→</span> 正在 review diff…
+<span class="c-claude">claude</span> <span class="c-muted">→</span> <span class="c-green">reply</span>：边界情况 —— 429 后重试没有上限
+<span class="c-codex">codex</span>  <span class="c-muted">→</span> 已修，限制为最多重试 5 次</pre>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>一句话就能拆分任务</h3>
+        <p>让任意一方向另一方提出分工方案，两个 agent 先商量谁做什么，再动手写代码。你掌舵，它们协调。</p>
+        <div class="term">
+          <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="term-title mono">任务拆分</span></div>
+<pre><span class="c-muted">你 →</span> 就这个鉴权重构，和 Codex 商量个分工
+<span class="c-claude">claude</span> <span class="c-muted">→</span> 我来做 token 模型 + 测试，
+        Codex 负责中间件，行吗？
+<span class="c-codex">codex</span>  <span class="c-muted">→</span> <span class="c-green">同意</span> —— 这就开始写中间件</pre>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>额度接力，通宵长任务不中断</h3>
+        <p>当一方的订阅额度窗口跑空，它会在回合边界干净停下、把任务交接给另一方 —— 长任务继续推进，而不是撞到上限就死掉。</p>
+        <div class="term">
+          <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="term-title mono">额度接力</span></div>
+<pre><span class="c-codex">codex</span>  <span class="c-muted">→</span> 5 小时窗口告急 —— 已写检查点
+<span class="c-green">bridge</span> <span class="c-muted">→</span> 交接给 Claude…
+<span class="c-claude">claude</span> <span class="c-muted">→</span> 从 .agent/checkpoint.md 续接
+<span class="c-green">bridge</span> <span class="c-muted">→</span> 窗口刷新后自动续接 Codex</pre>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section id="quota">
+  <div class="wrap">
+    <h2>额度接力 —— 别的工具没有这一环</h2>
+    <p class="lead">长任务不该因为某个 agent 半夜撞上 5 小时或每周订阅上限就断掉。AgentBridge 让它继续跑。</p>
+    <div class="cards" style="margin-top:24px">
+      <div class="card">
+        <h3>不在中途硬切</h3>
+        <p>临近额度硬线时，配套的 <a href="https://www.npmjs.com/package/agent-quota-guard">agent-quota-guard</a> <em>不会</em>在工具调用中途拒绝。它让当前 turn 收尾，在回合边界干净停下，写入 <code class="mono">.agent/checkpoint.md</code>，并留下一条 bridge 能感知的 <code class="mono">pending</code> 记录。</p>
+      </div>
+      <div class="card">
+        <h3>自动续接</h3>
+        <p>暂停一方的额度窗口刷新后，bridge 会在<strong>原来的交互式 TUI</strong> 里续接任务 —— Codex 通过排队的 <code class="mono">turn/start</code> 注入，Claude 通过它用 <code class="mono">ack_resume</code> 确认的 channel push。幂等墓碑保证每次续接最多注入一次。</p>
+      </div>
+      <div class="card">
+        <h3>两个窗口一眼看清</h3>
+        <p>daemon 轮询两个 agent 账户级的 5 小时和每周额度。<code class="mono">abg budget --json</code> 打印实时快照：两个窗口、两侧的用量偏差、以及暂停状态。</p>
+      </div>
+    </div>
+    <p style="margin-top:20px; color:var(--muted); font-size:.92rem"><strong>可选功能。</strong>额度接力依赖配套的 <a href="https://github.com/quilin-ai/agent-quota-guard">agent-quota-guard</a> —— 装上才启用。不装它，其余功能照常工作。</p>
+  </div>
+</section>
+
+<section id="why">
+  <div class="wrap">
+    <h2>为什么用 AgentBridge，而不是……</h2>
+    <p class="lead">大家通常会用另外三种方式凑合 —— 看看每一种会把哪些活儿甩回给你手动做。</p>
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr>
+            <th>&nbsp;</th>
+            <th>双开终端 + 复制粘贴</th>
+            <th>单向委派插件<br /><span class="mono" style="font-weight:400">（如 codex-plugin-cc）</span></th>
+            <th>外部编排器</th>
+            <th>AgentBridge</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="rowhead">消息传递</td>
+            <td>你就是那根消息总线</td>
+            <td>请求进、响应出</td>
+            <td>每一跳都要写脚本</td>
+            <td class="yes">自动，双向</td>
+          </tr>
+          <tr>
+            <td class="rowhead">两个 agent 都作为对等体在线</td>
+            <td>在，但彼此断开</td>
+            <td>否 —— 一个宿主一个被调方</td>
+            <td>否 —— 一个大脑 N 个工人</td>
+            <td class="yes">是 —— 持久对等体</td>
+          </tr>
+          <tr>
+            <td class="rowhead">turn 进行中途推消息</td>
+            <td>靠手动，还得猜时机</td>
+            <td>只能在调用边界</td>
+            <td>只能在预定步骤</td>
+            <td class="yes">可以 —— review 中途送达</td>
+          </tr>
+          <tr>
+            <td class="rowhead">agent 自己提分工</td>
+            <td>不能</td>
+            <td>不能</td>
+            <td>不能 —— 自上而下</td>
+            <td class="yes">可以 —— 它们自己商量</td>
+          </tr>
+          <tr>
+            <td class="rowhead">扛得住额度撞线</td>
+            <td>不行 —— 得你手动重启</td>
+            <td>不行</td>
+            <td>看你脚本写得怎么样</td>
+            <td class="yes">行 —— 检查点 + 自动续接</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section id="quickstart">
+  <div class="wrap">
+    <h2>快速开始</h2>
+    <p class="lead">从零到一对 agent 跑起来，四步搞定。daemon 需要时自动启动，重启后自动重连。</p>
+    <div class="steps">
+      <div class="step">
+        <div class="n"></div>
+        <div class="body">
+          <h3>装 Bun（运行时 —— 只有 Node 跑不起来）</h3>
+          <pre><span class="cmd">curl -fsSL https://bun.sh/install | bash</span></pre>
+        </div>
+      </div>
+      <div class="step">
+        <div class="n"></div>
+        <div class="body">
+          <h3>装 CLI</h3>
+          <p style="margin:0 0 8px;color:var(--muted);font-size:.92rem">postinstall 会尽力自动注册 Claude Code 插件市场并安装插件（需要本机已有 bun 和 claude）。</p>
+          <pre><span class="cmd">npm install -g @raysonmeng/agentbridge</span></pre>
+        </div>
+      </div>
+      <div class="step">
+        <div class="n"></div>
+        <div class="body">
+          <h3>启动带 AgentBridge channel 的 Claude Code</h3>
+          <pre><span class="cmd">abg claude</span></pre>
+        </div>
+      </div>
+      <div class="step">
+        <div class="n"></div>
+        <div class="body">
+          <h3>另开一个终端，启动接入同一 bridge 的 Codex</h3>
+          <pre><span class="cmd">abg codex</span></pre>
+        </div>
+      </div>
+    </div>
+    <p style="margin-top:22px;color:var(--muted)"><strong>你的第一次协作：</strong>两边都跑起来后，对 Claude 说 —— <em>「就 &lt;某个任务&gt; 和 Codex 商量个分工，然后让 Codex 实现它那部分，你来 review。」</em> 你会看到分工方案流进 Codex 的会话、Codex 开始干活、干完后又推回 Claude 这边等 review —— 全程你不用手动搬运一句话。</p>
+    <p style="color:var(--muted);font-size:.92rem"><code class="mono">abg</code> 是 <code class="mono">agentbridge</code> 的短别名。两个 agent 默认以最高权限启动，好让无人值守的一对不必逐条问你 —— 加 <code class="mono">--safe</code> 恢复正常权限提示。如果 <code class="mono">abg</code> 装好却跑不起来，看 <a href="https://github.com/quilin-ai/agent-bridge/blob/master/docs/TROUBLESHOOTING.md">排错指南</a>。</p>
+  </div>
+</section>
+
+<section id="story" class="story">
+  <div class="wrap">
+    <h2>AgentBridge 本身就是它自己的概念验证</h2>
+    <p class="lead">关于它，我们能说的最有力的一句话是：它不是按常规方式写出来的。</p>
+    <blockquote>
+      这个工具很大程度上是 <strong>Claude Code</strong>（Anthropic）和 <strong>Codex</strong>（OpenAI）<em>通过它自己</em>协作写出来的 —— 它们正是在用这座桥搭这座桥。<strong>其中一个 agent 写的每一个 PR，都由另一个 agent review。</strong> 一位人类开发者掌舵：分派任务、审阅进度、指挥两边并行工作、互相把关。
+    </blockquote>
+    <p style="margin-top:18px;color:var(--muted)">来自两个不同厂商的 AI agent，实时相连，并肩写代码 —— 还隔着这根线互相 review PR。这不是营销比喻，而是提交历史里实打实的记录。</p>
+  </div>
+</section>
+
+<section id="roadmap">
+  <div class="wrap">
+    <h2>路线图</h2>
+    <p class="lead">Claude Code ↔ Codex 今天已上线。接下来往哪走。</p>
+    <div class="road">
+      <div class="item">
+        <div class="when">下一步 · 投票</div>
+        <h3>更多 adapter</h3>
+        <p>下一个接哪个 agent 由公开投票决定 —— OpenCode、Gemini CLI 等都是候选。去 <a href="https://github.com/quilin-ai/agent-bridge/issues/212">issue #212</a> 投你想要的那个。</p>
+      </div>
+      <div class="item">
+        <div class="when">更长期</div>
+        <h3>能力网格（capability mesh）</h3>
+        <p>不止一对 agent：跨机器的多 agent 房间，每个 agent 宣告自己擅长什么，按能力把活儿路由到对的一方，而不是固定配对。v3 跨网协作预览已在实验命令后上线。</p>
+      </div>
+      <div class="item">
+        <div class="when">持续</div>
+        <h3>更精细的协作</h3>
+        <p>更少噪声、更好的回合纪律、更丰富的协调策略，以及跨运行时更强的恢复语义。</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="faq">
+  <div class="wrap">
+    <h2>常见问题</h2>
+    <div class="faq">
+      <details>
+        <summary><span><code class="mono">abg</code> 装好了却跑不起来？</span></summary>
+        <p>大概率是<strong>没装 Bun</strong>。AgentBridge 的 daemon 和插件服务跑在 Bun 运行时上，只有 Node.js 不够。用 <code class="mono">curl -fsSL https://bun.sh/install | bash</code> 装好，再重新执行 <code class="mono">abg claude</code>。这是最常见的安装失败原因。</p>
+      </details>
+      <details>
+        <summary><span>支持 Windows 吗？</span></summary>
+        <p>暂未正式支持。目前跑在 <strong>macOS 和 Linux</strong> 上。WSL2 可能可用，但未经测试、不做支持。</p>
+      </details>
+      <details>
+        <summary><span>安全吗？<code class="mono">--safe</code> 是干什么的？</span></summary>
+        <p>默认 <code class="mono">abg claude</code> 带 <code class="mono">--dangerously-skip-permissions</code>、<code class="mono">abg codex</code> 带 <code class="mono">--yolo</code> 启动 —— 这是有意为之，无人值守的一对 agent 没法逐条停下来问你权限。代价是两个 agent 可以不经确认执行命令、改文件，所以<strong>只在你信任的工作区里这么用</strong>。加 <code class="mono">--safe</code>（或设 <code class="mono">AGENTBRIDGE_SAFE=1</code>）恢复正常权限提示。它是本地开发工具，不是隔离不可信工具的安全边界。</p>
+      </details>
+      <details>
+        <summary><span>额度接力到底怎么工作？</span></summary>
+        <p>装上配套的 <a href="https://github.com/quilin-ai/agent-quota-guard">agent-quota-guard</a> 后，daemon 轮询两个 agent 的 5 小时和每周订阅额度。临近上限时，guard 让当前 turn 收尾、在回合边界干净停下、写入 <code class="mono">.agent/checkpoint.md</code>、留下一条 <code class="mono">pending</code> 记录。等窗口刷新，bridge 在原来的交互式 TUI 里自动续接 —— Codex 靠排队的 <code class="mono">turn/start</code>，Claude 靠一条被确认的 channel push。</p>
+      </details>
+      <details>
+        <summary><span>支持哪些 agent？</span></summary>
+        <p>目前已上线的会话内集成连接的是 <strong>Claude Code 和 Codex</strong>。下一个接哪个由公开投票决定 —— 见 <a href="https://github.com/quilin-ai/agent-bridge/issues/212">issue #212</a>（OpenCode、Gemini CLI 等都是候选）。</p>
+      </details>
+      <details>
+        <summary><span>和 <code class="mono">codex-plugin-cc</code> 有什么区别？</span></summary>
+        <p><code class="mono">openai/codex-plugin-cc</code> 这类单向委派插件是宿主<em>调用</em> Codex、拿一个结果回来 —— 请求进、响应出，对面没有常驻对等体。AgentBridge 让<strong>两个</strong> agent 都作为持久对等体在线，任意一方都能在对方 turn <strong>进行中途</strong>推消息（review 意见能在对方还在干活时就送达），而不只是在调用边界。</p>
+      </details>
+      <details>
+        <summary><span>用 AgentBridge 本身需要账号或 API key 吗？</span></summary>
+        <p>不需要。它是本地工具，零运行时依赖，也没有任何托管服务。你用现成的 Claude Code 和 Codex 登录即可；AgentBridge 只在你机器上转发它们之间的消息 —— 原始工作内容不出本机。</p>
+      </details>
+      <details>
+        <summary><span>能同时跑多对吗？</span></summary>
+        <p>能。每个项目目录一对 Claude+Codex，端口按 +10 步长从 4500 分配。在支持 pair 的命令上用 <code class="mono">--pair &lt;名字&gt;</code> 指定某一对。</p>
+      </details>
+    </div>
+  </div>
+</section>
+</main>
+
+<footer>
+  <div class="wrap foot-grid">
+    <div>
+      <div class="brand" style="margin-bottom:6px">🌉 AgentBridge</div>
+      <div>连接 Claude Code ↔ Codex 协作的本地桥接工具。MIT 开源。</div>
+    </div>
+    <div class="foot-links">
+      <a href="https://github.com/quilin-ai/agent-bridge">GitHub</a>
+      <a href="https://www.npmjs.com/package/@raysonmeng/agentbridge">npm</a>
+      <a href="https://github.com/quilin-ai/agent-bridge/blob/master/docs/TROUBLESHOOTING.md">排错指南</a>
+      <a href="/agent-bridge/">English</a>
+      <a href="https://x.com/raysonmeng">@raysonmeng</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+document.querySelectorAll('.copy').forEach(function (b) {
+  b.addEventListener('click', function () {
+    navigator.clipboard && navigator.clipboard.writeText(b.dataset.copy).then(function () {
+      var t = b.textContent; b.textContent = '已复制'; setTimeout(function () { b.textContent = t; }, 1400);
+    });
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 概述 / Summary

为 AgentBridge 新建一个 **SEO + GEO 优化的静态官网**，放在 `site/`，并配 GitHub Actions 自动部署到 GitHub Pages。**只新增 `site/**` 和一个 workflow，不动 `src/`、不动现有文档。**

A new **SEO + GEO optimized static website** under `site/`, plus a GitHub Actions workflow that publishes it to GitHub Pages. **Only adds `site/**` and one workflow — no `src/` or existing-docs changes.**

文案素材取自 `README.md` 和 PR #213 的 GTM 重排（一句话定位、三大收益、"Why not just…" 对比、自举故事、Quick Start、Roadmap）。
Copy is sourced from `README.md` and the PR #213 GTM overhaul.

## 交付物 / Deliverables

| 文件 | 说明 |
|------|------|
| `site/index.html` | 英文主站：hero + 安装命令 + demo 占位、三大收益（cross-review / task splits / quota relay）、quota relay 专节、对比表、Quick Start 4 步、自举故事、Roadmap、8 条 FAQ |
| `site/zh/index.html` | 中文站（按中文开发者语境重写，非逐句翻译；覆盖 双开 / 交叉 review / 额度接力 / 多 agent 协作 等关键词）|
| `site/llms.txt` | GEO 事实版产品说明，供 AI 助手抓取后准确推荐 |
| `site/sitemap.xml` / `site/robots.txt` | 站点地图 + 抓取指引 |
| `site/assets/og.svg` | 纯文字版 OG 占位图 |
| `.github/workflows/pages.yml` | push 到 `master` 且 `site/**` 变更时自动发布 |

**SEO**：每页独立 title / meta description / canonical + hreflang 互链；Open Graph + Twitter Card；语义化 HTML（每页唯一 `h1`）。
**GEO**：`llms.txt` + JSON-LD 结构化数据（`SoftwareApplication` + `FAQPage`）。
**设计**：`prefers-color-scheme` 深浅色自适应、系统字体栈、单文件内联 CSS、零外部依赖（无 CDN，兼顾中国大陆访问）、移动端可读、Lighthouse 友好（唯一内联脚本是复制按钮）。

## 部署状态 / Deploy status

- ✅ Pages 已通过 API 启用为 **GitHub Actions** 构建源（`build_type: workflow`）。
- 🌐 上线地址（canonical 基准）：**https://quilin-ai.github.io/agent-bridge/**（中文：`/zh/`）。
- ⏳ 部署工作流仅在 **合并到 `master`** 后触发（`on: push` + `paths: site/**`），也可在 Actions 页手动 `workflow_dispatch`。合并前不会有线上构建。
- 所有对外 URL 以 `https://quilin-ai.github.io/agent-bridge/` 为基准，将来换自定义域名时全局替换即可。

> If the workflow trigger ever needs re-checking: repo **Settings → Pages → Build and deployment → Source = GitHub Actions** (already set via API, one-click to confirm).

## 上线后待办 / Post-launch TODO

- [ ] **换 demo GIF**：`site/assets/demo.gif` 就位后替换 hero 里的占位块（HTML 内已注释标注）。
- [ ] **换 OG 图**：`site/assets/og.svg` 目前是纯文字占位，换成 demo 实拍截图（1200×630，注意部分平台不渲染 SVG OG，建议出一张 PNG）。
- [ ] **设 repo homepage 字段**：把仓库 About 的 homepage 指到 `https://quilin-ai.github.io/agent-bridge/`。
- [ ] **TROUBLESHOOTING 链接**：footer / Quick Start 指向 `docs/TROUBLESHOOTING.md`，该文件由 **PR #213** 引入 —— #213 合并后链接即生效（站内 FAQ 已内联覆盖"没装 Bun"这一最常见排错）。

## 说明 / Notes

- 仅开 PR，**未合并、未 push master**（在 worktree 独立目录、从 `master` HEAD 切 `feat/website`）。
- GitHub 仓库链接指向 `quilin-ai/agent-bridge`；npm 包沿用 `@raysonmeng/agentbridge`，插件市场命令沿用 README 现状 `raysonmeng/agent-bridge`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
