### PR TITLE
fix(site): logo 去掉光点 / drop pulse dot from logo

### DIFF
--- a/site/assets/logo.svg
+++ b/site/assets/logo.svg
@@ -2,5 +2,4 @@
   <path d="M13 26 L25 35 L13 44" stroke="#b892ff" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
   <path d="M51 26 L39 35 L51 44" stroke="#6cc5e0" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
   <path d="M13 20 Q32 4 51 20" stroke="#3ddc97" stroke-width="5.5" stroke-linecap="round" fill="none"/>
-  <circle cx="32" cy="12" r="5.5" fill="#3ddc97"/>
 </svg>

--- a/site/index.html
+++ b/site/index.html
@@ -31,7 +31,7 @@
 <meta name="twitter:image" content="https://quilin-ai.github.io/agent-bridge/assets/og.svg" />
 <meta name="twitter:creator" content="@raysonmeng" />
 
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M13 26 L25 35 L13 44' stroke='%23b892ff' stroke-width='7' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cpath d='M51 26 L39 35 L51 44' stroke='%236cc5e0' stroke-width='7' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cpath d='M13 20 Q32 4 51 20' stroke='%233ddc97' stroke-width='6' stroke-linecap='round' fill='none'/%3E%3Ccircle cx='32' cy='12' r='6' fill='%233ddc97'/%3E%3C/svg%3E" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M13 26 L25 35 L13 44' stroke='%23b892ff' stroke-width='7' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cpath d='M51 26 L39 35 L51 44' stroke='%236cc5e0' stroke-width='7' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cpath d='M13 20 Q32 4 51 20' stroke='%233ddc97' stroke-width='6' stroke-linecap='round' fill='none'/%3E%3C/svg%3E" />
 
 <script type="application/ld+json">
 {
@@ -432,7 +432,7 @@ footer { border-top: 1px solid var(--border); padding: 44px 0; color: var(--dim)
 
 <header>
   <nav class="nav wrap">
-    <a class="brand" href="/agent-bridge/"><svg width="22" height="22" viewBox="0 0 64 64" aria-hidden="true"><path d="M13 26 L25 35 L13 44" stroke="#b892ff" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M51 26 L39 35 L51 44" stroke="#6cc5e0" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13 20 Q32 4 51 20" stroke="#3ddc97" stroke-width="5.5" stroke-linecap="round" fill="none"/><circle cx="32" cy="12" r="5.5" fill="#3ddc97"/></svg> AgentBridge</a>
+    <a class="brand" href="/agent-bridge/"><svg width="22" height="22" viewBox="0 0 64 64" aria-hidden="true"><path d="M13 26 L25 35 L13 44" stroke="#b892ff" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M51 26 L39 35 L51 44" stroke="#6cc5e0" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13 20 Q32 4 51 20" stroke="#3ddc97" stroke-width="5.5" stroke-linecap="round" fill="none"/></svg> AgentBridge</a>
     <div class="nav-links">
       <a class="nav-hide" href="#benefits">Features</a>
       <a class="nav-hide" href="#why">Why</a>
@@ -809,7 +809,7 @@ footer { border-top: 1px solid var(--border); padding: 44px 0; color: var(--dim)
 <footer>
   <div class="wrap foot-grid">
     <div>
-      <div class="brand" style="margin-bottom:6px"><svg width="20" height="20" viewBox="0 0 64 64" aria-hidden="true"><path d="M13 26 L25 35 L13 44" stroke="#b892ff" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M51 26 L39 35 L51 44" stroke="#6cc5e0" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13 20 Q32 4 51 20" stroke="#3ddc97" stroke-width="5.5" stroke-linecap="round" fill="none"/><circle cx="32" cy="12" r="5.5" fill="#3ddc97"/></svg> AgentBridge</div>
+      <div class="brand" style="margin-bottom:6px"><svg width="20" height="20" viewBox="0 0 64 64" aria-hidden="true"><path d="M13 26 L25 35 L13 44" stroke="#b892ff" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M51 26 L39 35 L51 44" stroke="#6cc5e0" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13 20 Q32 4 51 20" stroke="#3ddc97" stroke-width="5.5" stroke-linecap="round" fill="none"/></svg> AgentBridge</div>
       <div>Local bridge for Claude Code ↔ Codex collaboration. MIT licensed.</div>
       <div class="mono" style="margin-top:8px;font-size:.78rem;color:var(--dim)">Built by this bridge itself — Claude Code ⇄ Codex, collaborating through it.</div>
     </div>

--- a/site/zh/index.html
+++ b/site/zh/index.html
@@ -30,7 +30,7 @@
 <meta name="twitter:image" content="https://quilin-ai.github.io/agent-bridge/assets/og.svg" />
 <meta name="twitter:creator" content="@raysonmeng" />
 
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M13 26 L25 35 L13 44' stroke='%23b892ff' stroke-width='7' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cpath d='M51 26 L39 35 L51 44' stroke='%236cc5e0' stroke-width='7' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cpath d='M13 20 Q32 4 51 20' stroke='%233ddc97' stroke-width='6' stroke-linecap='round' fill='none'/%3E%3Ccircle cx='32' cy='12' r='6' fill='%233ddc97'/%3E%3C/svg%3E" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M13 26 L25 35 L13 44' stroke='%23b892ff' stroke-width='7' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cpath d='M51 26 L39 35 L51 44' stroke='%236cc5e0' stroke-width='7' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cpath d='M13 20 Q32 4 51 20' stroke='%233ddc97' stroke-width='6' stroke-linecap='round' fill='none'/%3E%3C/svg%3E" />
 
 <script type="application/ld+json">
 {
@@ -408,7 +408,7 @@ footer { border-top: 1px solid var(--border); padding: 44px 0; color: var(--dim)
 
 <header>
   <nav class="nav wrap">
-    <a class="brand" href="/agent-bridge/zh/"><svg width="22" height="22" viewBox="0 0 64 64" aria-hidden="true"><path d="M13 26 L25 35 L13 44" stroke="#b892ff" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M51 26 L39 35 L51 44" stroke="#6cc5e0" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13 20 Q32 4 51 20" stroke="#3ddc97" stroke-width="5.5" stroke-linecap="round" fill="none"/><circle cx="32" cy="12" r="5.5" fill="#3ddc97"/></svg> AgentBridge</a>
+    <a class="brand" href="/agent-bridge/zh/"><svg width="22" height="22" viewBox="0 0 64 64" aria-hidden="true"><path d="M13 26 L25 35 L13 44" stroke="#b892ff" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M51 26 L39 35 L51 44" stroke="#6cc5e0" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13 20 Q32 4 51 20" stroke="#3ddc97" stroke-width="5.5" stroke-linecap="round" fill="none"/></svg> AgentBridge</a>
     <div class="nav-links">
       <a class="nav-hide" href="#benefits">能力</a>
       <a class="nav-hide" href="#why">对比</a>
@@ -785,7 +785,7 @@ footer { border-top: 1px solid var(--border); padding: 44px 0; color: var(--dim)
 <footer>
   <div class="wrap foot-grid">
     <div>
-      <div class="brand" style="margin-bottom:6px"><svg width="20" height="20" viewBox="0 0 64 64" aria-hidden="true"><path d="M13 26 L25 35 L13 44" stroke="#b892ff" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M51 26 L39 35 L51 44" stroke="#6cc5e0" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13 20 Q32 4 51 20" stroke="#3ddc97" stroke-width="5.5" stroke-linecap="round" fill="none"/><circle cx="32" cy="12" r="5.5" fill="#3ddc97"/></svg> AgentBridge</div>
+      <div class="brand" style="margin-bottom:6px"><svg width="20" height="20" viewBox="0 0 64 64" aria-hidden="true"><path d="M13 26 L25 35 L13 44" stroke="#b892ff" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M51 26 L39 35 L51 44" stroke="#6cc5e0" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13 20 Q32 4 51 20" stroke="#3ddc97" stroke-width="5.5" stroke-linecap="round" fill="none"/></svg> AgentBridge</div>
       <div>连接 Claude Code ↔ Codex 协作的本地桥接工具。MIT 开源。</div>
       <div class="mono" style="margin-top:8px;font-size:.78rem;color:var(--dim)">这座桥由它自己建成 —— Claude Code ⇄ Codex 通过它协作完成。</div>
     </div>


### PR DESCRIPTION
按 owner 要求去掉 logo 的绿色光点，保留双提示符 + 桥拱。四处同步：assets/logo.svg、双页导航与页脚内联 SVG、favicon data URI。lovart 正式版 logo 到位后整体替换。

Per owner: remove the green pulse dot; keep chevrons + arc. Updated in all four places. Will be superseded by the lovart logo when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)