### PR TITLE
fix(site): 主标题 In-session comms 不再折行 / h1 tagline stays on one line

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -189,11 +189,10 @@ header {
 }
 .hero-fx canvas { width: 100%; height: 100%; display: block; }
 .hero h1 {
-  font-size: clamp(2.55rem, 6.4vw, 4.35rem);
-  letter-spacing: -.035em; line-height: 1.04; margin: 0 0 22px;
-  text-wrap: balance;
+  font-size: clamp(2.3rem, 5.2vw, 3.4rem);
+  letter-spacing: -.035em; line-height: 1.06; margin: 0 0 22px;
 }
-.tag { color: var(--accent); }
+.tag { color: var(--accent); white-space: nowrap; }
 .hero .lead { margin: 0 auto 34px; font-size: clamp(1.03rem, 1.6vw, 1.2rem); }
 .hero .lead strong { color: var(--text); }
 

--- a/site/zh/index.html
+++ b/site/zh/index.html
@@ -166,11 +166,10 @@ header {
 }
 .hero-fx canvas { width: 100%; height: 100%; display: block; }
 .hero h1 {
-  font-size: clamp(2.55rem, 6.4vw, 4.35rem);
-  letter-spacing: -.035em; line-height: 1.04; margin: 0 0 22px;
-  text-wrap: balance;
+  font-size: clamp(2.3rem, 5.2vw, 3.4rem);
+  letter-spacing: -.035em; line-height: 1.06; margin: 0 0 22px;
 }
-.tag { color: var(--accent); }
+.tag { color: var(--accent); white-space: nowrap; }
 .hero .lead { margin: 0 auto 34px; font-size: clamp(1.03rem, 1.6vw, 1.2rem); }
 .hero .lead strong { color: var(--text); }
 


### PR DESCRIPTION
clamp 上限 4.35rem→3.4rem + .tag 加 white-space:nowrap，杜绝 In- 连字符断行；窄屏整短语整体换行。顺带本次合并触发的 Pages 部署会把 #218 的 og 卡与 README 一起带上线（上一次部署又遇平台瞬时失败）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)