### PR TITLE
docs: README 加 LINUX DO 友链

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 **🌐 Website: [raysonmeng.github.io/agent-bridge](https://raysonmeng.github.io/agent-bridge/)**, with an animated replay of a real session.
 
+> Discussed on [LINUX DO](https://linux.do) — the developer community. / 在 [LINUX DO](https://linux.do) 开发者社区交流。
+
 Local bridge for bidirectional communication between Claude Code and Codex inside the same working session.
 
 What that buys you, concretely:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,8 @@ English version: [README.md](README.md)
 
 **🌐 官网：[raysonmeng.github.io/agent-bridge/zh/](https://raysonmeng.github.io/agent-bridge/zh/)**，附真实会话的动画重放。
 
+> 在 [LINUX DO](https://linux.do) 开发者社区交流讨论。
+
 让 Claude Code 和 Codex 在同一个工作会话中进行双向通信的本地 Bridge。
 
 具体能换来什么：


### PR DESCRIPTION
Linux.do 开源推广规则要求项目 README 挂指回社区的友链,双语 README 顶部各加一行。