### PR TITLE
docs: Quick Start 补 abg init 步骤

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ What that buys you, concretely:
 
 ## Quick Start
 
-Four steps from nothing to a running pair:
+Five steps from nothing to a running pair:
 
 ```bash
 # 1. Install Bun (the runtime; Node alone won't work)
@@ -77,10 +77,13 @@ curl -fsSL https://bun.sh/install | bash
 #    marketplace AND installs the plugin (best-effort; needs bun + claude present).
 npm install -g @raysonmeng/agentbridge
 
-# 3. Start Claude Code with the AgentBridge channel enabled
+# 3. Initialize the project (check deps, install plugin if needed, write .agentbridge/config.json)
+abg init
+
+# 4. Start Claude Code with the AgentBridge channel enabled
 abg claude
 
-# 4. In another terminal, start Codex TUI connected to the same bridge
+# 5. In another terminal, start Codex TUI connected to the same bridge
 abg codex
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,7 +67,7 @@ English version: [README.md](README.md)
 
 ## Quick Start
 
-从零到一对跑起来，四步：
+从零到一对跑起来，五步：
 
 ```bash
 # 1. 装 Bun（运行时，只有 Node 不行）
@@ -77,10 +77,13 @@ curl -fsSL https://bun.sh/install | bash
 #    （best-effort;需要本机已有 bun + claude）。
 npm install -g @raysonmeng/agentbridge
 
-# 3. 启动 Claude Code 并启用 AgentBridge channel
+# 3. 初始化项目(检查依赖、必要时补装插件、写入 .agentbridge/config.json)
+abg init
+
+# 4. 启动 Claude Code 并启用 AgentBridge channel
 abg claude
 
-# 4. 在另一个终端启动 Codex TUI 连接同一个 bridge
+# 5. 在另一个终端启动 Codex TUI 连接同一个 bridge
 abg codex
 ```
 

--- a/site/index.html
+++ b/site/index.html
@@ -683,7 +683,7 @@ footer { border-top: 1px solid var(--border); padding: 44px 0; color: var(--dim)
 <section id="quickstart">
   <div class="wrap">
     <p class="eyebrow reveal">quick start</p>
-    <h2 class="reveal">Four steps to a running pair</h2>
+    <h2 class="reveal">Five steps to a running pair</h2>
     <p class="lead reveal">The daemon starts automatically when needed and reconnects if restarted.</p>
     <div class="steps">
       <div class="step reveal">
@@ -704,12 +704,20 @@ footer { border-top: 1px solid var(--border); padding: 44px 0; color: var(--dim)
       <div class="step reveal">
         <div class="n">03</div>
         <div class="body">
+          <h3>Initialize the project</h3>
+          <p style="margin:0 0 10px;color:var(--dim);font-size:.9rem">Checks dependencies (bun/claude/codex), installs the plugin if the postinstall skipped it, and writes <code class="mono">.agentbridge/config.json</code>. Run once per project.</p>
+          <pre><span class="cmd">abg init</span></pre>
+        </div>
+      </div>
+      <div class="step reveal">
+        <div class="n">04</div>
+        <div class="body">
           <h3>Start Claude Code with the AgentBridge channel</h3>
           <pre><span class="cmd">abg claude</span></pre>
         </div>
       </div>
       <div class="step reveal">
-        <div class="n">04</div>
+        <div class="n">05</div>
         <div class="body">
           <h3>In another terminal, start Codex connected to the same bridge</h3>
           <pre><span class="cmd">abg codex</span></pre>

--- a/site/zh/index.html
+++ b/site/zh/index.html
@@ -660,7 +660,7 @@ footer { border-top: 1px solid var(--border); padding: 44px 0; color: var(--dim)
 <section id="quickstart">
   <div class="wrap">
     <p class="eyebrow reveal">快速开始</p>
-    <h2 class="reveal">四步跑起一对 agent</h2>
+    <h2 class="reveal">五步跑起一对 agent</h2>
     <p class="lead reveal">daemon 需要时自动启动，重启后自动重连。</p>
     <div class="steps">
       <div class="step reveal">
@@ -681,12 +681,20 @@ footer { border-top: 1px solid var(--border); padding: 44px 0; color: var(--dim)
       <div class="step reveal">
         <div class="n">03</div>
         <div class="body">
+          <h3>初始化项目</h3>
+          <p style="margin:0 0 10px;color:var(--dim);font-size:.9rem">检查依赖（bun/claude/codex），postinstall 没装成插件的话补装，并写入 <code class="mono">.agentbridge/config.json</code>。每个项目跑一次。</p>
+          <pre><span class="cmd">abg init</span></pre>
+        </div>
+      </div>
+      <div class="step reveal">
+        <div class="n">04</div>
+        <div class="body">
           <h3>启动带 AgentBridge channel 的 Claude Code</h3>
           <pre><span class="cmd">abg claude</span></pre>
         </div>
       </div>
       <div class="step reveal">
-        <div class="n">04</div>
+        <div class="n">05</div>
         <div class="body">
           <h3>另开一个终端，启动接入同一 bridge 的 Codex</h3>
           <pre><span class="cmd">abg codex</span></pre>


### PR DESCRIPTION
abg init 检查依赖、必要时补装插件、写入 .agentbridge/config.json,漏掉会影响首次体验。官网双页 + 双语 README 的 Quick Start 从四步改五步。