### PR TITLE
chore: 加 CLA + 自动签署工作流

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: read       # 'write' only needed if storing signatures inside this repo (see below)
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/raysonmeng/agent-bridge/blob/master/CLA.md'
+          branch: 'cla-signatures'
+          allowlist: raysonmeng,dependabot[bot],github-actions[bot]
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-notsigned-prcomment: 'Thanks for the PR! Before we can merge it, please sign our lightweight [Contributor License Agreement](https://github.com/raysonmeng/agent-bridge/blob/master/CLA.md) — it keeps the project able to offer a future commercial edition alongside the open-source one. Reply here with:'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,65 @@
+# Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to AgentBridge ("the Project"),
+maintained by Rayson Meng ("the Maintainer").
+
+To keep the Project's licensing options open — including the ability to offer
+the Project under different terms in the future (for example, a commercial or
+enterprise edition alongside the open-source edition) — we ask every contributor
+to agree to this Contributor License Agreement before their contribution is
+merged.
+
+This is a lightweight, widely used agreement (modeled on the common
+"individual CLA" pattern). It does **not** change the open-source license of the
+Project, and it does **not** take your work away from you — you keep full rights
+to your own contributions. It only grants the Maintainer the permissions needed
+to relicense and distribute the combined Project.
+
+## Agreement
+
+By submitting a contribution (a pull request, patch, or any other form of
+change) to this Project, You agree to the following, with respect to that and
+all future contributions You submit to this Project:
+
+1. **You have the right to contribute.** The contribution is Your original
+   creation, or You otherwise have the legal right to submit it, and submitting
+   it does not violate any third party's rights or any agreement You are bound
+   by (including any employer IP agreement).
+
+2. **Copyright license.** You grant the Maintainer and recipients of software
+   distributed by the Maintainer a perpetual, worldwide, non-exclusive,
+   royalty-free, irrevocable copyright license to reproduce, prepare derivative
+   works of, publicly display, publicly perform, sublicense, **relicense**, and
+   distribute Your contribution and such derivative works, in source or object
+   form, under **any license terms** the Maintainer chooses — including
+   proprietary/commercial terms — as well as under the Project's current
+   open-source license.
+
+3. **Patent license.** You grant the Maintainer and recipients a perpetual,
+   worldwide, non-exclusive, royalty-free, irrevocable patent license to make,
+   use, sell, offer to sell, import, and otherwise transfer Your contribution,
+   for any patent claims You can license that are necessarily infringed by Your
+   contribution alone or by its combination with the Project.
+
+4. **You retain your rights.** You keep all right, title, and interest in Your
+   contribution. Nothing here assigns Your copyright to the Maintainer; You are
+   granting a broad license, not giving up ownership. You are free to use Your
+   own contribution for any other purpose.
+
+5. **No warranty.** Except as stated in Section 1, Your contribution is provided
+   "as is", without warranties or conditions of any kind.
+
+## How to sign
+
+You sign **once**. When you open your first pull request, the CLA-assistant bot
+will post a comment. Reply on that pull request with exactly:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Your GitHub username and the signing are recorded, and the check turns green.
+All your future pull requests are then covered automatically.
+
+If you are contributing on behalf of a company, make sure you are authorized to
+agree to this CLA for work you submit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 Thanks for contributing to AgentBridge.
 
+## Contributor License Agreement
+
+Before your first pull request can be merged, please sign our lightweight
+[Contributor License Agreement](CLA.md). A bot will prompt you on the PR; you
+reply once and all future PRs are covered. The CLA keeps the project's licensing
+options open (e.g. a future commercial edition alongside the open-source one)
+while you keep full ownership of your own contributions.
+
 ## Prerequisites
 
 - [Bun](https://bun.sh) v1.0+


### PR DESCRIPTION
保留未来'开源版 + 企业版'双轨的法律选项。贡献者提 PR 时授予再授权权(含专有条款),但保留自己代码所有权,不改变当前 MIT 开源协议。CLA Assistant Lite 自动化:首个 PR 评论一次签署,后续自动覆盖,签名存独立分支。趁零外部贡献者窗口加。